### PR TITLE
Manifests.Update() on fresh Manifests copy

### DIFF
--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -53,14 +53,15 @@ const (
 // NUMAResourcesOperatorReconciler reconciles a NUMAResourcesOperator object
 type NUMAResourcesOperatorReconciler struct {
 	client.Client
-	Log          logr.Logger
-	Scheme       *runtime.Scheme
-	Platform     platform.Platform
-	APIManifests apimanifests.Manifests
-	RTEManifests rtemanifests.Manifests
-	Helper       *deployer.Helper
-	Namespace    string
-	ImageSpec    string
+	Log                 logr.Logger
+	Scheme              *runtime.Scheme
+	Platform            platform.Platform
+	APIManifests        apimanifests.Manifests
+	RTEManifests        rtemanifests.Manifests
+	InitialRTEManifests rtemanifests.Manifests
+	Helper              *deployer.Helper
+	Namespace           string
+	ImageSpec           string
 }
 
 // TODO: narrow down
@@ -133,7 +134,7 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 func (r *NUMAResourcesOperatorReconciler) RenderManifests(namespace string) rtemanifests.Manifests {
 	logger := r.Log.WithValues("rte", namespace)
 	logger.Info("Updating manifests")
-	mf := r.RTEManifests.Update(rtemanifests.UpdateOptions{
+	mf := r.InitialRTEManifests.Update(rtemanifests.UpdateOptions{
 		Namespace: namespace,
 	})
 	rtestate.UpdateDaemonSetImage(mf.DaemonSet, r.ImageSpec)

--- a/main.go
+++ b/main.go
@@ -124,11 +124,12 @@ func main() {
 
 	if renderManifestsFor != "" {
 		reconciler := &controllers.NUMAResourcesOperatorReconciler{
-			Log:          ctrl.Log.WithName("controllers").WithName("RTE"),
-			APIManifests: apiManifests,
-			RTEManifests: rteManifests,
-			Platform:     clusterPlatform,
-			ImageSpec:    images.ResourceTopologyExporterDefaultImageSHA,
+			Log:                 ctrl.Log.WithName("controllers").WithName("RTE"),
+			APIManifests:        apiManifests,
+			RTEManifests:        rteManifests,
+			InitialRTEManifests: rteManifests.Clone(),
+			Platform:            clusterPlatform,
+			ImageSpec:           images.ResourceTopologyExporterDefaultImageSHA,
 		}
 
 		err := renderObjects(reconciler.RenderManifests(renderManifestsFor).ToObjects())
@@ -160,14 +161,15 @@ func main() {
 	setupLog.Info("using RTE image", "spec", imageSpec)
 
 	if err = (&controllers.NUMAResourcesOperatorReconciler{
-		Client:       mgr.GetClient(),
-		Scheme:       mgr.GetScheme(),
-		Log:          ctrl.Log.WithName("controllers").WithName("RTE"),
-		APIManifests: apiManifests,
-		RTEManifests: rteManifests,
-		Platform:     clusterPlatform,
-		Helper:       deployer.NewHelperWithClient(mgr.GetClient(), "", tlog.NewNullLogAdapter()),
-		ImageSpec:    imageSpec,
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
+		Log:                 ctrl.Log.WithName("controllers").WithName("RTE"),
+		APIManifests:        apiManifests,
+		RTEManifests:        rteManifests,
+		InitialRTEManifests: rteManifests.Clone(),
+		Platform:            clusterPlatform,
+		Helper:              deployer.NewHelperWithClient(mgr.GetClient(), "", tlog.NewNullLogAdapter()),
+		ImageSpec:           imageSpec,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NUMAResourcesOperator")
 		os.Exit(1)


### PR DESCRIPTION
The operator is performing multiple updates on the same manifests instance - IOW the Update() function processed a dirty copy of Manifests object if more than a single Update() call being executed.
This led to multiple bugs which I initially thought their source is in the deployer:
1. https://github.com/k8stopologyawareschedwg/deployer/pull/55
2. https://github.com/k8stopologyawareschedwg/deployer/pull/56

In order to solve this issue we change the Update() logic to always work on a fresh copy of Manifests object, hence we won't carry former changes during the Update() call.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>