### PR TITLE
Rename operator bundle image to use openshift-kni quay repo

### DIFF
--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -198,7 +198,7 @@ spec:
                 - --leader-elect
                 command:
                 - /bin/numaresources-operator
-                image: quay.io/fromani/numaresources-operator:4.10-snapshot
+                image: quay.io/openshift-kni/numaresources-operator:4.10-snapshot
                 livenessProbe:
                   httpGet:
                     path: /healthz


### PR DESCRIPTION
The image is now stored in quay.io/openshift-kni