### PR TITLE
Move the CRD to cluster scoped

### DIFF
--- a/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_types.go
+++ b/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_types.go
@@ -62,9 +62,10 @@ type NUMAResourcesOperatorStatus struct {
 }
 
 //+genclient
+//+genclient:nonNamespaced
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:shortName=numaresop,path=numaresourcesoperators
+//+kubebuilder:resource:shortName=numaresop,path=numaresourcesoperators,scope=Cluster
 
 // NUMAResourcesOperator is the Schema for the numaresourcesoperators API
 type NUMAResourcesOperator struct {

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -16,7 +16,7 @@ spec:
     shortNames:
     - numaresop
     singular: numaresourcesoperator
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1alpha1
     schema:

--- a/main.go
+++ b/main.go
@@ -49,7 +49,6 @@ import (
 	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 	"github.com/openshift-kni/numaresources-operator/controllers"
 	"github.com/openshift-kni/numaresources-operator/pkg/images"
-
 	//+kubebuilder:scaffold:imports
 )
 

--- a/pkg/k8sclientset/generated/clientset/versioned/typed/numaresourcesoperator/v1alpha1/fake/fake_numaresourcesoperator.go
+++ b/pkg/k8sclientset/generated/clientset/versioned/typed/numaresourcesoperator/v1alpha1/fake/fake_numaresourcesoperator.go
@@ -32,7 +32,6 @@ import (
 // FakeNUMAResourcesOperators implements NUMAResourcesOperatorInterface
 type FakeNUMAResourcesOperators struct {
 	Fake *FakeNumaresourcesoperatorV1alpha1
-	ns   string
 }
 
 var numaresourcesoperatorsResource = schema.GroupVersionResource{Group: "numaresourcesoperator", Version: "v1alpha1", Resource: "numaresourcesoperators"}
@@ -42,8 +41,7 @@ var numaresourcesoperatorsKind = schema.GroupVersionKind{Group: "numaresourcesop
 // Get takes name of the nUMAResourcesOperator, and returns the corresponding nUMAResourcesOperator object, and an error if there is any.
 func (c *FakeNUMAResourcesOperators) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.NUMAResourcesOperator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(numaresourcesoperatorsResource, c.ns, name), &v1alpha1.NUMAResourcesOperator{})
-
+		Invokes(testing.NewRootGetAction(numaresourcesoperatorsResource, name), &v1alpha1.NUMAResourcesOperator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -53,8 +51,7 @@ func (c *FakeNUMAResourcesOperators) Get(ctx context.Context, name string, optio
 // List takes label and field selectors, and returns the list of NUMAResourcesOperators that match those selectors.
 func (c *FakeNUMAResourcesOperators) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.NUMAResourcesOperatorList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(numaresourcesoperatorsResource, numaresourcesoperatorsKind, c.ns, opts), &v1alpha1.NUMAResourcesOperatorList{})
-
+		Invokes(testing.NewRootListAction(numaresourcesoperatorsResource, numaresourcesoperatorsKind, opts), &v1alpha1.NUMAResourcesOperatorList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -75,15 +72,13 @@ func (c *FakeNUMAResourcesOperators) List(ctx context.Context, opts v1.ListOptio
 // Watch returns a watch.Interface that watches the requested nUMAResourcesOperators.
 func (c *FakeNUMAResourcesOperators) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(numaresourcesoperatorsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(numaresourcesoperatorsResource, opts))
 }
 
 // Create takes the representation of a nUMAResourcesOperator and creates it.  Returns the server's representation of the nUMAResourcesOperator, and an error, if there is any.
 func (c *FakeNUMAResourcesOperators) Create(ctx context.Context, nUMAResourcesOperator *v1alpha1.NUMAResourcesOperator, opts v1.CreateOptions) (result *v1alpha1.NUMAResourcesOperator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(numaresourcesoperatorsResource, c.ns, nUMAResourcesOperator), &v1alpha1.NUMAResourcesOperator{})
-
+		Invokes(testing.NewRootCreateAction(numaresourcesoperatorsResource, nUMAResourcesOperator), &v1alpha1.NUMAResourcesOperator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -93,8 +88,7 @@ func (c *FakeNUMAResourcesOperators) Create(ctx context.Context, nUMAResourcesOp
 // Update takes the representation of a nUMAResourcesOperator and updates it. Returns the server's representation of the nUMAResourcesOperator, and an error, if there is any.
 func (c *FakeNUMAResourcesOperators) Update(ctx context.Context, nUMAResourcesOperator *v1alpha1.NUMAResourcesOperator, opts v1.UpdateOptions) (result *v1alpha1.NUMAResourcesOperator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(numaresourcesoperatorsResource, c.ns, nUMAResourcesOperator), &v1alpha1.NUMAResourcesOperator{})
-
+		Invokes(testing.NewRootUpdateAction(numaresourcesoperatorsResource, nUMAResourcesOperator), &v1alpha1.NUMAResourcesOperator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -105,8 +99,7 @@ func (c *FakeNUMAResourcesOperators) Update(ctx context.Context, nUMAResourcesOp
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeNUMAResourcesOperators) UpdateStatus(ctx context.Context, nUMAResourcesOperator *v1alpha1.NUMAResourcesOperator, opts v1.UpdateOptions) (*v1alpha1.NUMAResourcesOperator, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(numaresourcesoperatorsResource, "status", c.ns, nUMAResourcesOperator), &v1alpha1.NUMAResourcesOperator{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(numaresourcesoperatorsResource, "status", nUMAResourcesOperator), &v1alpha1.NUMAResourcesOperator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -116,14 +109,13 @@ func (c *FakeNUMAResourcesOperators) UpdateStatus(ctx context.Context, nUMAResou
 // Delete takes name of the nUMAResourcesOperator and deletes it. Returns an error if one occurs.
 func (c *FakeNUMAResourcesOperators) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(numaresourcesoperatorsResource, c.ns, name), &v1alpha1.NUMAResourcesOperator{})
-
+		Invokes(testing.NewRootDeleteAction(numaresourcesoperatorsResource, name), &v1alpha1.NUMAResourcesOperator{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeNUMAResourcesOperators) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(numaresourcesoperatorsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(numaresourcesoperatorsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.NUMAResourcesOperatorList{})
 	return err
@@ -132,8 +124,7 @@ func (c *FakeNUMAResourcesOperators) DeleteCollection(ctx context.Context, opts 
 // Patch applies the patch and returns the patched nUMAResourcesOperator.
 func (c *FakeNUMAResourcesOperators) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.NUMAResourcesOperator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(numaresourcesoperatorsResource, c.ns, name, pt, data, subresources...), &v1alpha1.NUMAResourcesOperator{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(numaresourcesoperatorsResource, name, pt, data, subresources...), &v1alpha1.NUMAResourcesOperator{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/k8sclientset/generated/clientset/versioned/typed/numaresourcesoperator/v1alpha1/fake/fake_numaresourcesoperator_client.go
+++ b/pkg/k8sclientset/generated/clientset/versioned/typed/numaresourcesoperator/v1alpha1/fake/fake_numaresourcesoperator_client.go
@@ -27,8 +27,8 @@ type FakeNumaresourcesoperatorV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeNumaresourcesoperatorV1alpha1) NUMAResourcesOperators(namespace string) v1alpha1.NUMAResourcesOperatorInterface {
-	return &FakeNUMAResourcesOperators{c, namespace}
+func (c *FakeNumaresourcesoperatorV1alpha1) NUMAResourcesOperators() v1alpha1.NUMAResourcesOperatorInterface {
+	return &FakeNUMAResourcesOperators{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/k8sclientset/generated/clientset/versioned/typed/numaresourcesoperator/v1alpha1/numaresourcesoperator.go
+++ b/pkg/k8sclientset/generated/clientset/versioned/typed/numaresourcesoperator/v1alpha1/numaresourcesoperator.go
@@ -32,7 +32,7 @@ import (
 // NUMAResourcesOperatorsGetter has a method to return a NUMAResourcesOperatorInterface.
 // A group's client should implement this interface.
 type NUMAResourcesOperatorsGetter interface {
-	NUMAResourcesOperators(namespace string) NUMAResourcesOperatorInterface
+	NUMAResourcesOperators() NUMAResourcesOperatorInterface
 }
 
 // NUMAResourcesOperatorInterface has methods to work with NUMAResourcesOperator resources.
@@ -52,14 +52,12 @@ type NUMAResourcesOperatorInterface interface {
 // nUMAResourcesOperators implements NUMAResourcesOperatorInterface
 type nUMAResourcesOperators struct {
 	client rest.Interface
-	ns     string
 }
 
 // newNUMAResourcesOperators returns a NUMAResourcesOperators
-func newNUMAResourcesOperators(c *NumaresourcesoperatorV1alpha1Client, namespace string) *nUMAResourcesOperators {
+func newNUMAResourcesOperators(c *NumaresourcesoperatorV1alpha1Client) *nUMAResourcesOperators {
 	return &nUMAResourcesOperators{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -67,7 +65,6 @@ func newNUMAResourcesOperators(c *NumaresourcesoperatorV1alpha1Client, namespace
 func (c *nUMAResourcesOperators) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.NUMAResourcesOperator, err error) {
 	result = &v1alpha1.NUMAResourcesOperator{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("numaresourcesoperators").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -84,7 +81,6 @@ func (c *nUMAResourcesOperators) List(ctx context.Context, opts v1.ListOptions) 
 	}
 	result = &v1alpha1.NUMAResourcesOperatorList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("numaresourcesoperators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,7 +97,6 @@ func (c *nUMAResourcesOperators) Watch(ctx context.Context, opts v1.ListOptions)
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("numaresourcesoperators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -112,7 +107,6 @@ func (c *nUMAResourcesOperators) Watch(ctx context.Context, opts v1.ListOptions)
 func (c *nUMAResourcesOperators) Create(ctx context.Context, nUMAResourcesOperator *v1alpha1.NUMAResourcesOperator, opts v1.CreateOptions) (result *v1alpha1.NUMAResourcesOperator, err error) {
 	result = &v1alpha1.NUMAResourcesOperator{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("numaresourcesoperators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(nUMAResourcesOperator).
@@ -125,7 +119,6 @@ func (c *nUMAResourcesOperators) Create(ctx context.Context, nUMAResourcesOperat
 func (c *nUMAResourcesOperators) Update(ctx context.Context, nUMAResourcesOperator *v1alpha1.NUMAResourcesOperator, opts v1.UpdateOptions) (result *v1alpha1.NUMAResourcesOperator, err error) {
 	result = &v1alpha1.NUMAResourcesOperator{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("numaresourcesoperators").
 		Name(nUMAResourcesOperator.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -140,7 +133,6 @@ func (c *nUMAResourcesOperators) Update(ctx context.Context, nUMAResourcesOperat
 func (c *nUMAResourcesOperators) UpdateStatus(ctx context.Context, nUMAResourcesOperator *v1alpha1.NUMAResourcesOperator, opts v1.UpdateOptions) (result *v1alpha1.NUMAResourcesOperator, err error) {
 	result = &v1alpha1.NUMAResourcesOperator{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("numaresourcesoperators").
 		Name(nUMAResourcesOperator.Name).
 		SubResource("status").
@@ -154,7 +146,6 @@ func (c *nUMAResourcesOperators) UpdateStatus(ctx context.Context, nUMAResources
 // Delete takes name of the nUMAResourcesOperator and deletes it. Returns an error if one occurs.
 func (c *nUMAResourcesOperators) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("numaresourcesoperators").
 		Name(name).
 		Body(&opts).
@@ -169,7 +160,6 @@ func (c *nUMAResourcesOperators) DeleteCollection(ctx context.Context, opts v1.D
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("numaresourcesoperators").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -182,7 +172,6 @@ func (c *nUMAResourcesOperators) DeleteCollection(ctx context.Context, opts v1.D
 func (c *nUMAResourcesOperators) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.NUMAResourcesOperator, err error) {
 	result = &v1alpha1.NUMAResourcesOperator{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("numaresourcesoperators").
 		Name(name).
 		SubResource(subresources...).

--- a/pkg/k8sclientset/generated/clientset/versioned/typed/numaresourcesoperator/v1alpha1/numaresourcesoperator_client.go
+++ b/pkg/k8sclientset/generated/clientset/versioned/typed/numaresourcesoperator/v1alpha1/numaresourcesoperator_client.go
@@ -33,8 +33,8 @@ type NumaresourcesoperatorV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *NumaresourcesoperatorV1alpha1Client) NUMAResourcesOperators(namespace string) NUMAResourcesOperatorInterface {
-	return newNUMAResourcesOperators(c, namespace)
+func (c *NumaresourcesoperatorV1alpha1Client) NUMAResourcesOperators() NUMAResourcesOperatorInterface {
+	return newNUMAResourcesOperators(c)
 }
 
 // NewForConfig creates a new NumaresourcesoperatorV1alpha1Client for the given config.

--- a/test/e2e/basic_install/install.go
+++ b/test/e2e/basic_install/install.go
@@ -76,12 +76,12 @@ var _ = ginkgo.Describe("[BasicInstall] Installation", func() {
 
 		ginkgo.It("should perform overall deployment and verify the condition is reported as available", func() {
 			ginkgo.By("creating the RTE object")
-			_, err := rteClient.NUMAResourcesOperators(rteObj.Namespace).Create(context.TODO(), rteObj, metav1.CreateOptions{})
+			_, err := rteClient.NUMAResourcesOperators().Create(context.TODO(), rteObj, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("checking that the condition Available=true")
 			gomega.Eventually(func() bool {
-				rteUpdated, err := rteClient.NUMAResourcesOperators(rteObj.Namespace).Get(context.TODO(), rteObj.Name, metav1.GetOptions{})
+				rteUpdated, err := rteClient.NUMAResourcesOperators().Get(context.TODO(), rteObj.Name, metav1.GetOptions{})
 				if err != nil {
 					framework.Logf("failed to get the RTE resource: %v", err)
 					return false


### PR DESCRIPTION
Since "enable numa-aware scheduling" is a cluster property, we
move the scope to cluster. Previously it was Namespaced for no
reall well thought reason.