### PR TITLE
API: allow to override rte image

### DIFF
--- a/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_types.go
+++ b/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_types.go
@@ -44,6 +44,8 @@ func (n NamespacedName) String() string {
 // NUMAResourcesOperatorSpec defines the desired state of NUMAResourcesOperator
 type NUMAResourcesOperatorSpec struct {
 	NodeGroups []NodeGroup `json:"nodeGroups,omitempty"`
+
+	ExporterImage string `json:"imageSpec,omitempty"`
 }
 
 // NodeGroup defines group of nodes that will run resource topology exporter daemon set

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -39,6 +39,8 @@ spec:
           spec:
             description: NUMAResourcesOperatorSpec defines the desired state of NUMAResourcesOperator
             properties:
+              imageSpec:
+                type: string
               nodeGroups:
                 items:
                   description: NodeGroup defines group of nodes that will run resource

--- a/main.go
+++ b/main.go
@@ -77,7 +77,8 @@ func main() {
 	var probeAddr string
 	var platformName string
 	var detectPlatformOnly bool
-	var renderManifestsFor string
+	var renderMode bool
+	var renderNamespace string
 	var renderImage string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -86,8 +87,10 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&platformName, "platform", "", "platform to deploy on - leave empty to autodetect")
 	flag.BoolVar(&detectPlatformOnly, "detect-platform-only", false, "detect and report the platform, then exits")
-	flag.StringVar(&renderManifestsFor, "render-manifests-for", defaultNamespace, "outputs the manifests rendered for given namespace, then exits")
+	flag.BoolVar(&renderMode, "render", false, "outputs the rendered manifests, then exits")
+	flag.StringVar(&renderNamespace, "render-namespace", defaultNamespace, "outputs the manifests rendered using the given namespace")
 	flag.StringVar(&renderImage, "render-image", defaultImage, "outputs the manifests rendered using the given image")
+
 	opts := zap.Options{
 		Development: true,
 	}
@@ -131,11 +134,11 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	if renderManifestsFor != "" {
+	if renderMode {
 		if err := renderObjects(
 			renderManifests(
 				rteManifests,
-				renderManifestsFor,
+				renderNamespace,
 				renderImage,
 			).ToObjects()); err != nil {
 			setupLog.Error(err, "unable to render manifests")

--- a/pkg/objectstate/rte/rte.go
+++ b/pkg/objectstate/rte/rte.go
@@ -286,8 +286,7 @@ func DaemonSetNamespacedNameFromObject(obj client.Object) (nropv1alpha1.Namespac
 	return res, ok
 }
 
-func UpdateDaemonSetImage(ds *appsv1.DaemonSet, pullSpec string) *appsv1.DaemonSet {
+func UpdateDaemonSetImage(ds *appsv1.DaemonSet, pullSpec string) {
 	// TODO: better match by name than assume container#0 is RTE proper (not minion)
 	ds.Spec.Template.Spec.Containers[0].Image = pullSpec
-	return ds
 }


### PR DESCRIPTION
Add a field in our API to optionally allow to override the RTE image to deploy, mirroring wath the secondary-scheduler-operator does.
This gives us flexibiltiy at almost no cost, allowing easier test, enabling troubleshooting and hotfix delivery.