### PR TITLE
lint: do not check the return value

### DIFF
--- a/rte/main.go
+++ b/rte/main.go
@@ -75,9 +75,7 @@ func main() {
 	}
 
 	err = resourcetopologyexporter.Execute(cli, nrtupdaterArgs, resourcemonitorArgs, rteArgs)
-	if err != nil {
-		log.Fatalf("failed to execute: %v", err)
-	}
+	log.Fatalf("failed to execute: %v", err)
 }
 
 const helpTemplate string = `{{.ProgramName}}


### PR DESCRIPTION
Under normal circumstances the ```Execute()``` should never return.
But if it did return, it is guaranteed that ```err != nil```, so let's skip this check and just spit the log out.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>