### PR TITLE
Detect topology manager policy 

### DIFF
--- a/pkg/objectstate/rte/rte_test.go
+++ b/pkg/objectstate/rte/rte_test.go
@@ -1,0 +1,141 @@
+package rte
+
+import (
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openshift-kni/numaresources-operator/pkg/tmpolicy"
+)
+
+func TestUpdateDaemonSetTopologyPolicy(t *testing.T) {
+	type testCase struct {
+		name     string
+		envVars  []v1.EnvVar
+		value    string
+		expected []v1.EnvVar
+	}
+
+	testCases := []testCase{
+		{
+			name: "environment variable exists",
+			envVars: []v1.EnvVar{
+				{
+					Name:  "foo-42",
+					Value: "something1",
+				},
+				{
+					Name:  tmpolicy.PolicyEnv,
+					Value: "something2",
+				},
+			},
+			value: "foo",
+			expected: []v1.EnvVar{
+				{
+					Name:  "foo-42",
+					Value: "something1",
+				},
+				{
+					Name:  tmpolicy.PolicyEnv,
+					Value: "foo",
+				},
+			},
+		},
+		{
+			name: "environment variable doesn't exists",
+			envVars: []v1.EnvVar{
+				{
+					Name:  "foo-42",
+					Value: "something1",
+				},
+			},
+			value: "bar",
+			expected: []v1.EnvVar{
+				{
+					Name:  "foo-42",
+					Value: "something1",
+				},
+				{
+					Name:  tmpolicy.PolicyEnv,
+					Value: "bar",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("when %s", tc.name), func(t *testing.T) {
+			UpdateDaemonSetTopologyPolicy(&tc.envVars, tc.value)
+			if diff := cmp.Diff(tc.expected, tc.envVars); diff != "" {
+				t.Errorf("want %v\n; got %v\n; diff %v\n", tc.expected, tc.envVars, diff)
+			}
+		})
+	}
+}
+
+func TestUpdateDaemonSetTopologyScope(t *testing.T) {
+	type testCase struct {
+		name     string
+		envVars  []v1.EnvVar
+		value    string
+		expected []v1.EnvVar
+	}
+
+	testCases := []testCase{
+		{
+			name: "environment variable exists",
+			envVars: []v1.EnvVar{
+				{
+					Name:  "bar-55",
+					Value: "something1",
+				},
+				{
+					Name:  tmpolicy.ScopeEnv,
+					Value: "something2",
+				},
+			},
+			value: "foo",
+			expected: []v1.EnvVar{
+				{
+					Name:  "bar-55",
+					Value: "something1",
+				},
+				{
+					Name:  tmpolicy.ScopeEnv,
+					Value: "foo",
+				},
+			},
+		},
+		{
+			name: "environment variable doesn't exists",
+			envVars: []v1.EnvVar{
+				{
+					Name:  "bar-55",
+					Value: "something1",
+				},
+			},
+			value: "bar",
+			expected: []v1.EnvVar{
+				{
+					Name:  "bar-55",
+					Value: "something1",
+				},
+				{
+					Name:  tmpolicy.ScopeEnv,
+					Value: "bar",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("when %s", tc.name), func(t *testing.T) {
+			UpdateDaemonSetTopologyScope(&tc.envVars, tc.value)
+			if diff := cmp.Diff(tc.expected, tc.envVars); diff != "" {
+				t.Errorf("want %v\n; got %v\n; diff %v\n", tc.expected, tc.envVars, diff)
+			}
+		})
+	}
+}

--- a/pkg/tmpolicy/tmpolicy.go
+++ b/pkg/tmpolicy/tmpolicy.go
@@ -1,0 +1,90 @@
+package tmpolicy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+
+	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+)
+
+const (
+	PolicyEnv = "TOPOLOGY_MANAGER_POLICY"
+	ScopeEnv  = "TOPOLOGY_MANAGER_SCOPE"
+)
+
+func AutoDetectPolicy(ctx context.Context, cli client.Client, mcpLabels map[string]string) (string, error) {
+	kcs := &mcov1.KubeletConfigList{}
+	if err := cli.List(ctx, kcs); err != nil {
+		return "", err
+	}
+
+	kc, err := getKubeletConfigByMCP(kcs, mcpLabels)
+	if err != nil {
+		return "", err
+	}
+	if kc == nil {
+		return "", fmt.Errorf("no matching kubeletconfig found")
+	}
+
+	kubeconfig, err := mcoKubeletConfToKubeletConf(kc)
+	if err != nil {
+		return "", err
+	}
+
+	return kubeconfig.TopologyManagerPolicy, nil
+}
+
+// AutoDetectScope will try to detect the topology manager scope configured for the nodes with the given MCP selector
+func AutoDetectScope(ctx context.Context, cli client.Client, mcpLabels map[string]string) (string, error) {
+	kcs := &mcov1.KubeletConfigList{}
+	if err := cli.List(ctx, kcs); err != nil {
+		return "", err
+	}
+
+	kc, err := getKubeletConfigByMCP(kcs, mcpLabels)
+	if err != nil {
+		return "", err
+	}
+	if kc == nil {
+		return "", fmt.Errorf("no matching kubeletconfig found")
+	}
+
+	kubeconfig, err := mcoKubeletConfToKubeletConf(kc)
+	if err != nil {
+		return "", err
+	}
+
+	return kubeconfig.TopologyManagerScope, nil
+}
+
+func mcoKubeletConfToKubeletConf(mcoKc *mcov1.KubeletConfig) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
+	kc := &kubeletconfigv1beta1.KubeletConfiguration{}
+	err := json.Unmarshal(mcoKc.Spec.KubeletConfig.Raw, kc)
+	return kc, err
+}
+
+func getKubeletConfigByMCP(kcs *mcov1.KubeletConfigList, mcpLabels map[string]string) (*mcov1.KubeletConfig, error) {
+	var selectedKc *mcov1.KubeletConfig
+	for _, kc := range kcs.Items {
+		if kc.Spec.MachineConfigPoolSelector == nil {
+			continue
+		}
+
+		selector, err := metav1.LabelSelectorAsSelector(kc.Spec.MachineConfigPoolSelector)
+		if err != nil {
+			return selectedKc, err
+		}
+
+		if selector.Matches(labels.Set(mcpLabels)) {
+			selectedKc = &kc
+			break
+		}
+	}
+	return selectedKc, nil
+}


### PR DESCRIPTION
We'll intersect between the MCP label and kubeletconfig MCP selector in order to find the correct kubeletconfig.
Then we'll retrieve the tm policy from the kubeletconfig object and update it in the correct DaemonSets.