### PR TITLE
autodetection: fix typo

### DIFF
--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -90,7 +90,7 @@ spec:
         - apiGroups:
           - config.openshift.io
           resources:
-          - clusterversionss
+          - clusterversions
           verbs:
           - list
         - apiGroups:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -33,7 +33,7 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
-  - clusterversionss
+  - clusterversions
   verbs:
   - list
 - apiGroups:

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -77,7 +77,7 @@ type NUMAResourcesOperatorReconciler struct {
 
 // Cluster Scoped
 //+kubebuilder:rbac:groups=topology.node.k8s.io,resources=noderesourcetopologies,verbs=get;list;create;update
-//+kubebuilder:rbac:groups=config.openshift.io,resources=clusterversionss,verbs=list
+//+kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=list
 //+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigs,verbs=*
 //+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigpools,verbs=get;list;watch
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=*


### PR DESCRIPTION
A silly typo in the RBAC tags prevented the platform autodetection to
work. Fix it.

Signed-off-by: Francesco Romani <fromani@redhat.com>