### PR TITLE
sysinfo: allow configure from the command line

### DIFF
--- a/rte/pkg/config/config.go
+++ b/rte/pkg/config/config.go
@@ -26,10 +26,10 @@ import (
 )
 
 type Config struct {
-	ExcludeList           map[string][]string
-	Resources             sysinfo.Config
-	TopologyManagerPolicy string
-	TopologyManagerScope  string
+	ExcludeList           map[string][]string `yaml:"excludeList,omitempty"`
+	Resources             sysinfo.Config      `yaml:"resources,omitempty"`
+	TopologyManagerPolicy string              `yaml:"topologyManagerPolicy,omitempty"`
+	TopologyManagerScope  string              `yaml:"topologyManagerScope,omitempty"`
 }
 
 func ReadConfig(configPath string) (Config, error) {

--- a/rte/pkg/sysinfo/sysinfo.go
+++ b/rte/pkg/sysinfo/sysinfo.go
@@ -17,8 +17,10 @@ package sysinfo
 import (
 	"fmt"
 	"io/ioutil"
+	"sort"
 	"strings"
 
+	"github.com/ghodss/yaml"
 	"github.com/jaypipes/ghw/pkg/pci"
 
 	"k8s.io/klog/v2"
@@ -30,13 +32,55 @@ const (
 )
 
 type Config struct {
-	ReservedCPUs string
+	ReservedCPUs string `yaml:"reservedCpus,omitempty"`
 	// vendor:device -> resourcename
-	ResourceMapping map[string]string
+	ResourceMapping map[string]string `yaml:"resourceMapping,omitempty"`
+}
+
+func (cfg Config) ToYAML() ([]byte, error) {
+	return yaml.Marshal(cfg)
+}
+
+func ResourceMappingFromString(s string) map[string]string {
+	// comma-separated 'vendor:device=resourcename'
+	rmap := make(map[string]string)
+	for _, keyvalue := range strings.Split(strings.TrimSpace(s), ",") {
+		if len(keyvalue) == 0 {
+			continue
+		}
+		items := strings.SplitN(keyvalue, "=", 2)
+		if len(items) != 2 {
+			klog.Infof("malformed resource mapping item %q, skipped", keyvalue)
+			continue
+		}
+		rmap[strings.TrimSpace(items[0])] = strings.TrimSpace(items[1])
+	}
+	return rmap
+}
+
+func ResourceMappingToString(rmap map[string]string) string {
+	var keys []string
+	for key := range rmap {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var items []string
+	for _, key := range keys {
+		items = append(items, "%s=%s", key, rmap[key])
+	}
+	return strings.Join(items, ",")
 }
 
 func (cfg Config) IsEmpty() bool {
 	return cfg.ReservedCPUs == "" && len(cfg.ResourceMapping) == 0
+}
+
+func (cfg Config) ToYAMLString() string {
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return "<MALFORMED>"
+	}
+	return string(data)
 }
 
 // NUMA Cell -> deviceIDs


### PR DESCRIPTION
So we have options: we can either reconfigure the tool
using only command-line arguments or (re)generate the configmap,
whatever it's easier in the short term until OCP rebases
on top of kube 1.23.

Signed-off-by: Francesco Romani <fromani@redhat.com>