### PR TITLE
rte: move kni-specific packages to klog

### DIFF
--- a/rte/pkg/config/config.go
+++ b/rte/pkg/config/config.go
@@ -17,9 +17,9 @@ package config
 import (
 	"errors"
 	"io/ioutil"
-	"log"
 	"os"
 
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 
 	"github.com/openshift-kni/numaresources-operator/rte/pkg/sysinfo"
@@ -39,7 +39,7 @@ func ReadConfig(configPath string) (Config, error) {
 	if err != nil {
 		// config is optional
 		if errors.Is(err, os.ErrNotExist) {
-			log.Printf("Info: couldn't find configuration in %q", configPath)
+			klog.Warningf("Info: couldn't find configuration in %q", configPath)
 			return conf, nil
 		}
 		return conf, err

--- a/rte/pkg/podrescompat/client.go
+++ b/rte/pkg/podrescompat/client.go
@@ -16,10 +16,10 @@ package podrescompat
 
 import (
 	"context"
-	"log"
 
 	"google.golang.org/grpc"
 
+	"k8s.io/klog/v2"
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 
 	"github.com/openshift-kni/numaresources-operator/rte/pkg/sysinfo"
@@ -44,10 +44,10 @@ func (sc *sysinfoClient) List(ctx context.Context, in *podresourcesapi.ListPodRe
 func (sc *sysinfoClient) GetAllocatableResources(ctx context.Context, in *podresourcesapi.AllocatableResourcesRequest, opts ...grpc.CallOption) (*podresourcesapi.AllocatableResourcesResponse, error) {
 	resp, err := sc.cli.GetAllocatableResources(ctx, in, opts...)
 	if err != nil {
-		log.Printf("podresourcesapi GetAllocatableResources() failed with %v - using sysinfo", err)
+		klog.Warningf("podresourcesapi GetAllocatableResources() failed with %v - using sysinfo", err)
 		sysResp, sysErr := sc.makeAllocatableResourcesResponse()
 		if sysErr != nil {
-			log.Printf("sysinfo makeAllocatableResourcesResponse failed with %v", sysErr)
+			klog.Warningf("sysinfo makeAllocatableResourcesResponse failed with %v", sysErr)
 			return resp, err
 		}
 		return sysResp, nil

--- a/rte/pkg/sysinfo/sysinfo.go
+++ b/rte/pkg/sysinfo/sysinfo.go
@@ -17,11 +17,11 @@ package sysinfo
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"strings"
 
 	"github.com/jaypipes/ghw/pkg/pci"
 
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
 
@@ -84,13 +84,13 @@ func GetCPUResources(resCPUs string, getCPUs func() (cpuset.CPUSet, error)) (cpu
 	if err != nil {
 		return cpuset.CPUSet{}, err
 	}
-	log.Printf("cpus: reserved %q", reservedCPUs.String())
+	klog.Infof("cpus: reserved %q", reservedCPUs.String())
 
 	cpus, err := getCPUs()
 	if err != nil {
 		return cpuset.CPUSet{}, err
 	}
-	log.Printf("cpus: online %q", cpus.String())
+	klog.Infof("cpus: online %q", cpus.String())
 
 	return cpus.Difference(reservedCPUs), nil
 }
@@ -127,11 +127,11 @@ func GetPCIResources(resourceMap map[string]string, getPCIs func() ([]*pci.Devic
 func ResourceNameForDevice(dev *pci.Device, resourceMap map[string]string) (string, bool) {
 	devID := fmt.Sprintf("%s:%s", dev.Vendor.ID, dev.Product.ID)
 	if resourceName, ok := resourceMap[devID]; ok {
-		log.Printf("devs: resource for %s is %q", devID, resourceName)
+		klog.Infof("devs: resource for %s is %q", devID, resourceName)
 		return resourceName, true
 	}
 	if resourceName, ok := resourceMap[dev.Vendor.ID]; ok {
-		log.Printf("devs: resource for %s is %q", dev.Vendor.ID, resourceName)
+		klog.Infof("devs: resource for %s is %q", dev.Vendor.ID, resourceName)
 		return resourceName, true
 	}
 	return "", false

--- a/test/e2e/basic_install/install.go
+++ b/test/e2e/basic_install/install.go
@@ -18,13 +18,13 @@ package basic_install
 
 import (
 	"context"
-	"log"
 	"time"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
@@ -59,17 +59,17 @@ var _ = ginkgo.Describe("[BasicInstall] Installation", func() {
 				}
 				err := e2eclient.Client.Get(context.TODO(), key, updatedNROObj)
 				if err != nil {
-					log.Printf("failed to get the RTE resource: %v", err)
+					klog.Warningf("failed to get the RTE resource: %v", err)
 					return false
 				}
 
 				cond := status.FindCondition(updatedNROObj.Status.Conditions, status.ConditionAvailable)
 				if cond == nil {
-					log.Printf("missing conditions in %v", updatedNROObj)
+					klog.Warningf("missing conditions in %v", updatedNROObj)
 					return false
 				}
 
-				log.Printf("condition: %v", cond)
+				klog.Infof("condition: %v", cond)
 
 				return cond.Status == metav1.ConditionTrue
 			}, 5*time.Minute, 10*time.Second).Should(gomega.BeTrue(), "RTE condition did not become available")

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -19,13 +19,13 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"log"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
 
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/e2e/utils/clients"
 	"github.com/openshift-kni/numaresources-operator/test/e2e/utils/objects"
@@ -62,10 +62,10 @@ var _ = AfterSuite(func() {
 	mcpObj := objects.TestMCP()
 
 	if err := e2eclient.Client.Delete(context.TODO(), mcpObj); err != nil && !errors.IsNotFound(err) {
-		log.Printf("failed to delete the machine config pool %q", mcpObj.Name)
+		klog.Warningf("failed to delete the machine config pool %q", mcpObj.Name)
 	}
 
 	if err := e2eclient.Client.Delete(context.TODO(), nroObj); err != nil && !errors.IsNotFound(err) {
-		log.Printf("failed to delete the numaresourcesoperators %q", nroObj.Name)
+		klog.Warningf("failed to delete the numaresourcesoperators %q", nroObj.Name)
 	}
 })


### PR DESCRIPTION
it's just ugly to mix `log` and `klog`, and
we have no real reason to be stuck with `log`.

Signed-off-by: Francesco Romani <fromani@redhat.com>