### PR TITLE
rte: use operator image as rte image

### DIFF
--- a/Dockerfile.openshift.rte
+++ b/Dockerfile.openshift.rte
@@ -1,0 +1,6 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+COPY exporter /bin/resource-topology-exporter
+RUN mkdir /etc/resource-topology-exporter/ && \
+    touch /etc/resource-topology-exporter/config.yaml
+RUN microdnf install pciutils
+ENTRYPOINT ["/bin/resource-topology-exporter"]

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -55,6 +55,14 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
           - serviceaccounts
           verbs:
           - '*'
@@ -177,6 +185,10 @@ spec:
                 command:
                 - /bin/numaresources-operator
                 env:
+                - name: PODNAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
                 - name: NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,6 +34,10 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         env:
+        - name: PODNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: NAMESPACE
           valueFrom:
             fieldRef:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -22,6 +22,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts
   verbs:
   - '*'

--- a/pkg/objectstate/rte/rte.go
+++ b/pkg/objectstate/rte/rte.go
@@ -309,6 +309,26 @@ func UpdateDaemonSetUserImageSettings(ds *appsv1.DaemonSet, userImageSpec, built
 	cnt.Image = builtinImageSpec
 	cnt.ImagePullPolicy = builtinPullPolicy
 	klog.V(3).InfoS("Exporter image", "reason", "builtin", "pullSpec", builtinImageSpec, "pullPolicy", builtinPullPolicy)
+	// if we run with operator-as-operand, we know we NEED this.
+	UpdateDaemonSetRunAsIDs(ds)
+}
+
+// UpdateDaemonSetRunAsIDs bump the ds container privileges to 0/0.
+// We need this in the operator-as-operand flow because the operator image itself
+// is built to run with non-root user/group, and we should keep it like this.
+// OTOH, the rte image needs to have access to the files using *both* DAC and MAC;
+// the SCC/SELinux context take cares of the MAC (when needed, e.g. on OCP), while
+// we take care of DAC here.
+func UpdateDaemonSetRunAsIDs(ds *appsv1.DaemonSet) {
+	// TODO: better match by name than assume container#0 is RTE proper (not minion)
+	cnt := &ds.Spec.Template.Spec.Containers[0]
+	if cnt.SecurityContext == nil {
+		cnt.SecurityContext = &corev1.SecurityContext{}
+	}
+	var rootID int64 = 0
+	cnt.SecurityContext.RunAsUser = &rootID
+	cnt.SecurityContext.RunAsGroup = &rootID
+	klog.InfoS("RTE container elevated privileges", "container", cnt.Name, "user", rootID, "group", rootID)
 }
 
 func GetMachineConfigName(instanceName, mcpName string) string {


### PR DESCRIPTION
Revamp the code handling user-supplied RTE image, to streamline the flow and make room for future enhancement needed to fully fix the operator-as-operand flow.

Expose and adjust the environment variables we use to introspect the image.

Important fix: We need to passthrough the ImagePullPolicy in the operator-as-operand flow; this is correct in general, the image needs to be handled consistently, and unbreaks our CI flows.

Change UID/GID when running RTE reusing the same operator image:
The RTE need to access entries in the filesystem which are owned by root - surely the podresources socket, on k8s also the kubelet config.

However the operator should run as non-root, and its configuration reflects so.

When we use the operator image as operand (RTE), this settings "leaks" (positively for a change!) into RTE.

The access to the files (podresources socket) needed by RTE is guarded by both SELinux and unix permission control.
We already fixed the former when needed, but to pass the latter, we need to run RTE with uid and gid 0 (as root).

Note we do NOT want full root privileges: we rely on general kube settings to drop all the other privileges; should unneeded
privilege not have been dropped, it will be fixed on separate PRs.

Signed-off-by: Francesco Romani <fromani@redhat.com>