### PR TITLE
WIP Reconcile kubelet config

### DIFF
--- a/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -179,6 +179,55 @@ spec:
                       type: string
                   type: object
                 type: array
+              machineconfigpools:
+                items:
+                  description: MachineConfigPool defines the observed state of each
+                    MachineConfigPool selected by node groups
+                  properties:
+                    conditions:
+                      description: Conditions represents the latest available observations
+                        of MachineConfigPool current state.
+                      items:
+                        description: MachineConfigPoolCondition contains condition
+                          information for an MachineConfigPool.
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the timestamp corresponding
+                              to the last status change of this condition.
+                            format: date-time
+                            nullable: true
+                            type: string
+                          message:
+                            description: message is a human readable description of
+                              the details of the last transition, complementing reason.
+                            type: string
+                          reason:
+                            description: reason is a brief machine readable explanation
+                              for the condition's last transition.
+                            type: string
+                          status:
+                            description: status of the condition, one of ('True',
+                              'False', 'Unknown').
+                            type: string
+                          type:
+                            description: type of the condition, currently ('Done',
+                              'Updating', 'Failed').
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    name:
+                      description: Name the name of the machine config pool
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
             type: object
         type: object
     served: true

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -48,6 +48,13 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
           - serviceaccounts
           verbs:
           - '*'
@@ -69,6 +76,14 @@ spec:
           - clusterversions
           verbs:
           - list
+        - apiGroups:
+          - machineconfiguration.openshift.io
+          resources:
+          - kubeletconfigs
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups:
           - machineconfiguration.openshift.io
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -15,6 +15,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts
   verbs:
   - '*'
@@ -36,6 +43,14 @@ rules:
   - clusterversions
   verbs:
   - list
+- apiGroups:
+  - machineconfiguration.openshift.io
+  resources:
+  - kubeletconfigs
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - machineconfiguration.openshift.io
   resources:

--- a/controllers/kubeletconfig_controller.go
+++ b/controllers/kubeletconfig_controller.go
@@ -1,0 +1,97 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+)
+
+// KubeletConfigReconciler reconciles a KubeletConfig object
+type KubeletConfigReconciler struct {
+	client.Client
+	Scheme    *runtime.Scheme
+	Recorder  record.EventRecorder
+	Namespace string
+}
+
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=*
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=kubeletconfigs,verbs=get;list;watch
+
+func (r *KubeletConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	klog.V(3).InfoS("Starting KubeletConfig reconcile loop", "object", req.NamespacedName)
+	defer klog.V(3).InfoS("Finish KubeletConfig reconcile loop", "object", req.NamespacedName)
+
+	nname := types.NamespacedName{
+		Name: defaultNUMAResourcesOperatorCrName,
+	}
+	instance := &nropv1alpha1.NUMAResourcesOperator{}
+	err := r.Get(ctx, nname, instance)
+	if err != nil {
+		// TODO: review
+		if apierrors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			return ctrl.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return ctrl.Result{}, err
+	}
+
+	// KubeletConfig changes are expected to be sporadic, yet are important enough
+	// to be made visible at kubernetes level. So we generate events to handle them
+
+	helper := configMapHelper{
+		cli:       r.Client,
+		scm:       r.Scheme,
+		namespace: r.Namespace,
+		instance:  instance,
+	}
+	cm, err := helper.reconcileConfigMap(ctx, req.NamespacedName)
+	if err != nil {
+		klog.ErrorS(err, "failed to reconcile configmap", "controller", "kubeletconfig")
+
+		msg := fmt.Sprintf("Failed to update RTE config from kubelet config %s/%s", req.NamespacedName.Namespace, req.NamespacedName.Name)
+		r.Recorder.Event(instance, "Warning", "ProcessFailed", msg)
+		return ctrl.Result{RequeueAfter: RetryPeriod}, err
+	}
+
+	msg := fmt.Sprintf("Updated RTE config %s/%s from kubelet config %s/%s", cm.Namespace, cm.Name, req.NamespacedName.Namespace, req.NamespacedName.Name)
+	r.Recorder.Event(instance, "Normal", "ProcessOK", msg)
+	return ctrl.Result{}, nil
+}
+
+func (r *KubeletConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	b := ctrl.NewControllerManagedBy(mgr).
+		For(&mcov1.KubeletConfig{})
+	return b.Owns(&corev1.ConfigMap{}).
+		Complete(r)
+}

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -104,6 +104,8 @@ type NUMAResourcesOperatorReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.2/pkg/reconcile
 func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
+	klog.V(3).InfoS("Starting NUMAResourcesOperator reconcile loop", "object", req.NamespacedName)
+	defer klog.V(3).InfoS("Finish NUMAResourcesOperator reconcile loop", "object", req.NamespacedName)
 
 	instance := &nropv1alpha1.NUMAResourcesOperator{}
 	err := r.Get(context.TODO(), req.NamespacedName, instance)

--- a/controllers/reconcile_configmap.go
+++ b/controllers/reconcile_configmap.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
+	rtemanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte"
+
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	"github.com/openshift-kni/numaresources-operator/pkg/apply"
+	cfgstate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/cfg"
+	rtestate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/rte"
+	rteconfig "github.com/openshift-kni/numaresources-operator/rte/pkg/config"
+	"github.com/openshift-kni/numaresources-operator/rte/pkg/sysinfo"
+)
+
+const (
+	ConfigDataField = "config.yaml"
+)
+
+type configMapHelper struct {
+	cli       client.Client
+	scm       *runtime.Scheme
+	instance  *nropv1alpha1.NUMAResourcesOperator
+	namespace string
+}
+
+func (cmh *configMapHelper) reconcileConfigMap(ctx context.Context, kcKey client.ObjectKey) (*corev1.ConfigMap, error) {
+	mcoKc := &mcov1.KubeletConfig{}
+	if err := cmh.cli.Get(ctx, kcKey, mcoKc); err != nil {
+		return nil, err
+	}
+
+	kubeletConfig, err := mcoKubeletConfToKubeletConf(mcoKc)
+	if err != nil {
+		return nil, err
+	}
+
+	mcps, err := getNodeGroupsMCPs(ctx, cmh.cli, cmh.instance.Spec.NodeGroups)
+	if err != nil {
+		return nil, err
+	}
+
+	mcp, err := findMCPForKubeletConfig(mcps, mcoKc)
+	if err != nil {
+		return nil, err
+	}
+
+	generatedName := rtestate.GetComponentName(cmh.instance.Name, mcp.Name)
+	return cmh.syncConfigMap(ctx, kubeletConfig, generatedName)
+}
+
+func (cmh *configMapHelper) syncConfigMap(ctx context.Context, kubeletConfig *kubeletconfigv1beta1.KubeletConfiguration, name string) (*corev1.ConfigMap, error) {
+	rendered, err := renderRTEConfig(cmh.namespace, name, kubeletConfig)
+	if err != nil {
+		klog.ErrorS(err, "rendering config", "namespace", cmh.namespace, "name", name)
+		return nil, err
+	}
+
+	cfgManifests := cfgstate.Manifests{
+		Config: rendered,
+	}
+	existing := cfgstate.FromClient(context.TODO(), cmh.cli, cmh.namespace, name)
+	for _, objState := range existing.State(cfgManifests) {
+		if err := controllerutil.SetControllerReference(cmh.instance, objState.Desired, cmh.scm); err != nil {
+			return nil, errors.Wrapf(err, "Failed to set controller reference to %s %s", objState.Desired.GetNamespace(), objState.Desired.GetName())
+		}
+		if _, err := apply.ApplyObject(context.TODO(), cmh.cli, objState); err != nil {
+			return nil, errors.Wrapf(err, "could not create %s", objState.Desired.GetObjectKind().GroupVersionKind().String())
+		}
+	}
+	return rendered, nil
+}
+
+func findMCPForKubeletConfig(mcps []*machineconfigv1.MachineConfigPool, mcoKc *mcov1.KubeletConfig) (*machineconfigv1.MachineConfigPool, error) {
+	for _, mcp := range mcps {
+		if mcoKc.Spec.MachineConfigPoolSelector == nil {
+			continue
+		}
+
+		selector, err := metav1.LabelSelectorAsSelector(mcoKc.Spec.MachineConfigPoolSelector)
+		if err != nil {
+			return nil, err
+		}
+
+		if selector.Matches(labels.Set(mcp.Labels)) {
+			return mcp, nil
+		}
+	}
+	return nil, fmt.Errorf("no match")
+}
+
+func mcoKubeletConfToKubeletConf(mcoKc *mcov1.KubeletConfig) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
+	kc := &kubeletconfigv1beta1.KubeletConfiguration{}
+	err := json.Unmarshal(mcoKc.Spec.KubeletConfig.Raw, kc)
+	return kc, err
+}
+
+func renderRTEConfig(namespace, name string, klConfig *kubeletconfigv1beta1.KubeletConfiguration) (*corev1.ConfigMap, error) {
+	conf := rteconfig.Config{
+		Resources: sysinfo.Config{
+			ReservedCPUs: klConfig.ReservedSystemCPUs,
+		},
+		TopologyManagerPolicy: klConfig.TopologyManagerPolicy,
+		TopologyManagerScope:  klConfig.TopologyManagerScope,
+	}
+	data, err := yaml.Marshal(conf)
+	if err != nil {
+		return nil, err
+	}
+	return rtemanifests.CreateConfigMap(namespace, name, string(data)), nil
+}

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,10 @@ module github.com/openshift-kni/numaresources-operator
 go 1.17
 
 require (
+	github.com/ghodss/yaml v1.0.0
 	github.com/jaypipes/ghw v0.8.1-0.20210609141030-acb1a36eaf89
 	github.com/jaypipes/pcidb v0.6.0
-	github.com/k8stopologyawareschedwg/deployer v0.1.1-0.20211125100117-0db4e7348151
+	github.com/k8stopologyawareschedwg/deployer v0.1.1-0.20211130112610-10523aefd5ab
 	github.com/k8stopologyawareschedwg/resource-topology-exporter v0.3.2-0.20211125091854-91f2c3309819
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.14.0
@@ -52,7 +53,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-logr/logr v0.4.0 // indirect
 	github.com/go-logr/zapr v0.4.0 // indirect
 	github.com/go-ole/go-ole v1.2.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -752,8 +752,8 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/julz/importas v0.0.0-20210419104244-841f0c0fe66d/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
-github.com/k8stopologyawareschedwg/deployer v0.1.1-0.20211125100117-0db4e7348151 h1:wTEGlBTU8aSCwlAoF6Zoycc9t24T2PsgFBBs8pwoCr0=
-github.com/k8stopologyawareschedwg/deployer v0.1.1-0.20211125100117-0db4e7348151/go.mod h1:rAX9pFSJRzDN7Cymk4DaGzaxx9JrG08MwR6rxzy+BLM=
+github.com/k8stopologyawareschedwg/deployer v0.1.1-0.20211130112610-10523aefd5ab h1:TnH7+7GlBCRGpUM6GRLNC/TzPUELrXUJ5kzWMPYJLFE=
+github.com/k8stopologyawareschedwg/deployer v0.1.1-0.20211130112610-10523aefd5ab/go.mod h1:rAX9pFSJRzDN7Cymk4DaGzaxx9JrG08MwR6rxzy+BLM=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.8/go.mod h1:zRoCNg6LjSQewUwnpORw1VT9mP0rGNQlYy4WYaGWvHo=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.12 h1:NhXbOjO1st8hIcVpegr3zw/AGG12vs3z//tCDDcfPpE=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.12/go.mod h1:AkACMQGiTgCt0lQw3m7TTU8PLH9lYKNK5e9DqFf5VuM=

--- a/main.go
+++ b/main.go
@@ -187,6 +187,16 @@ func main() {
 		klog.ErrorS(err, "unable to create controller", "controller", "NUMAResourcesOperator")
 		os.Exit(1)
 	}
+	if err = (&controllers.KubeletConfigReconciler{
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Recorder:  mgr.GetEventRecorderFor("kubeletconfig-controller"),
+		Namespace: namespace,
+	}).SetupWithManager(mgr); err != nil {
+		klog.ErrorS(err, "unable to create controller", "controller", "KubeletConfig")
+		os.Exit(1)
+	}
+
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/pkg/objectstate/cfg/cfg.go
+++ b/pkg/objectstate/cfg/cfg.go
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ */
+
+package cfg
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift-kni/numaresources-operator/pkg/objectstate"
+	"github.com/openshift-kni/numaresources-operator/pkg/objectstate/compare"
+	"github.com/openshift-kni/numaresources-operator/pkg/objectstate/merge"
+)
+
+type Manifests struct {
+	Config *corev1.ConfigMap
+}
+
+type ExistingManifests struct {
+	Existing    Manifests
+	ConfigError error
+}
+
+func (em ExistingManifests) State(mf Manifests) []objectstate.ObjectState {
+	return []objectstate.ObjectState{
+		{
+			Existing: em.Existing.Config,
+			Error:    em.ConfigError,
+			Desired:  mf.Config.DeepCopy(),
+			Compare:  compare.Object,
+			Merge:    merge.ObjectForUpdate,
+		},
+	}
+}
+
+func FromClient(ctx context.Context, cli client.Client, namespace, name string) ExistingManifests {
+	ret := ExistingManifests{}
+	key := client.ObjectKey{
+		Name:      name,
+		Namespace: namespace,
+	}
+	config := corev1.ConfigMap{}
+	if ret.ConfigError = cli.Get(ctx, key, &config); ret.ConfigError == nil {
+		ret.Existing.Config = &config
+	}
+	return ret
+}

--- a/rte/pkg/config/config.go
+++ b/rte/pkg/config/config.go
@@ -26,10 +26,10 @@ import (
 )
 
 type Config struct {
-	ExcludeList           map[string][]string
-	Resources             sysinfo.Config
-	TopologyManagerPolicy string
-	TopologyManagerScope  string
+	ExcludeList           map[string][]string `json:"excludeList,omitempty"`
+	Resources             sysinfo.Config      `json:"resources,omitempty"`
+	TopologyManagerPolicy string              `json:"topologyManagerPolicy,omitempty"`
+	TopologyManagerScope  string              `json:"topologyManagerScope,omitempty"`
 }
 
 func ReadConfig(configPath string) (Config, error) {

--- a/vendor/github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte/rte.go
+++ b/vendor/github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte/rte.go
@@ -32,6 +32,10 @@ import (
 	"github.com/k8stopologyawareschedwg/deployer/pkg/tlog"
 )
 
+const (
+	configDataField = "config.yaml"
+)
+
 type Manifests struct {
 	ServiceAccount     *corev1.ServiceAccount
 	Role               *rbacv1.Role
@@ -107,12 +111,13 @@ func (mf Manifests) Update(options UpdateOptions) Manifests {
 	manifests.UpdateClusterRoleBinding(ret.ClusterRoleBinding, mf.ServiceAccount.Name, mf.ServiceAccount.Namespace)
 
 	ret.DaemonSet.Spec.Template.Spec.ServiceAccountName = mf.ServiceAccount.Name
+
+	rteConfigMapName := ""
+	if ret.ConfigMap != nil {
+		rteConfigMapName = manifests.RTEConfigMapName
+	}
 	manifests.UpdateResourceTopologyExporterDaemonSet(
-		ret.DaemonSet,
-		ret.ConfigMap,
-		options.PullIfNotPresent,
-		options.NodeSelector,
-	)
+		ret.DaemonSet, rteConfigMapName, options.PullIfNotPresent, options.NodeSelector)
 
 	if mf.plat == platform.OpenShift {
 		manifests.UpdateMachineConfig(ret.MachineConfig, options.Name, options.MachineConfigPoolSelector)
@@ -120,12 +125,12 @@ func (mf Manifests) Update(options UpdateOptions) Manifests {
 	}
 
 	if len(options.ConfigData) > 0 {
-		ret.ConfigMap = createConfigMap(ret.DaemonSet.Name, ret.DaemonSet.Namespace, options.ConfigData)
+		ret.ConfigMap = CreateConfigMap(ret.DaemonSet.Namespace, ret.DaemonSet.Name, options.ConfigData)
 	}
 	return ret
 }
 
-func createConfigMap(name string, namespace string, configData string) *corev1.ConfigMap {
+func CreateConfigMap(namespace, name, configData string) *corev1.ConfigMap {
 	cm := &corev1.ConfigMap{
 		// TODO: why is this needed?
 		TypeMeta: metav1.TypeMeta{
@@ -137,7 +142,7 @@ func createConfigMap(name string, namespace string, configData string) *corev1.C
 			Namespace: namespace,
 		},
 		Data: map[string]string{
-			"config.yaml": configData,
+			configDataField: configData,
 		},
 	}
 	return cm

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -190,7 +190,7 @@ github.com/josharian/intern
 # github.com/json-iterator/go v1.1.11
 ## explicit; go 1.12
 github.com/json-iterator/go
-# github.com/k8stopologyawareschedwg/deployer v0.1.1-0.20211125100117-0db4e7348151
+# github.com/k8stopologyawareschedwg/deployer v0.1.1-0.20211130112610-10523aefd5ab
 ## explicit; go 1.16
 github.com/k8stopologyawareschedwg/deployer/pkg/assets/rte
 github.com/k8stopologyawareschedwg/deployer/pkg/clientutil


### PR DESCRIPTION
- [X] Cover letter (this message)
- [X] Add configmap mount into daemonset
- [ ] Test coverage
- [ ] Handle config change in RTE

revamp how we handle the configuration of the RTE.
We need to supply to the RTE a configuration file to tell it:
1. details about the TM configuration, which it cannot figure out otherwise (policy, scope...)
2. parameters needed by the `sysinfo` package, which it cannot determine from the system because they depend on the kubelet configuration.
    
The second set is going to be phased out when OCP exposed the latest changes in the podresources API, but the first set will always be needed. So we will need some form of configuration management anyway.
    
So the operator will translate the information from the Kubeletconfig object, if available, to the RTE config.yaml and make it available as configmap.
    
Most important design decisions:
a. always translate as much configuration as possible, since it's cheap once we have access to the relevant kubeconfig. This for example include always reporting `reservedCPUs`, even when the RTE will no longer need this information (podresources' GetAllocatable available). RTE will just ignore the fields it doesn't need anymore
b. build the configuration only on OpenShift; on Kubernetes, we can just mount the kubelet config on the RTE pod and let it figure out.
c. on the other hand, always mount the configMap, marking it `optional`, so we will not need platform-dependent changes on the DaemonSet.
    
Summary: always try to mount the configMap from the RTE daemonset, ignore errors if not available, create it only on OCP translating as much as possible (greedily).
    
In order to process the kubeletconfig, we introduced a new controller.
The new controller will watch the kubeletconfigs and reconcile the relevant configmaps.
We add a new controller to not overload the existing controller, and because, per above design decisions, we can nicely split the responsabilities and make the two reconciliation loops (almost) completely independent: the numaresources main controller will deploy the bigger part of the stack; the kubeletconfig controller will provide configuration, if needed and possible.
(xref: "One controller per custom resource definition" from https://sdk.operatorframework.io/docs/best-practices/best-practices/)
 
Open issues:
- We need to trigger the kubeletconfig processing somehow when we create the manifests the first time.
A possible approach is to is to make sure to run our own kubeletconfig reconciliation loop runs before to create the daemonsets, because this way the daemonset has a very high chance to start up picking the correct configuration right from the start.
We can either process the kubeletconfig explicitely or trigger a reconciliation.
- RTEs do not pick up  ConfigMaps updates automatically yet.