### PR TITLE
e2e: wait for MCP resources

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+)
+
+func GetNodeGroupsMCPs(ctx context.Context, cli client.Client, nodeGroups []nropv1alpha1.NodeGroup) ([]*machineconfigv1.MachineConfigPool, error) {
+	mcps := &machineconfigv1.MachineConfigPoolList{}
+	if err := cli.List(ctx, mcps); err != nil {
+		return nil, err
+	}
+
+	var result []*machineconfigv1.MachineConfigPool
+	for _, nodeGroup := range nodeGroups {
+		found := false
+
+		// handled by validation
+		if nodeGroup.MachineConfigPoolSelector == nil {
+			continue
+		}
+
+		for i := range mcps.Items {
+			mcp := &mcps.Items[i]
+
+			selector, err := metav1.LabelSelectorAsSelector(nodeGroup.MachineConfigPoolSelector)
+			// handled by validation
+			if err != nil {
+				klog.Errorf("bad node group machine config pool selector %q", nodeGroup.MachineConfigPoolSelector.String())
+				continue
+			}
+
+			mcpLabels := labels.Set(mcp.Labels)
+			if selector.Matches(mcpLabels) {
+				found = true
+				result = append(result, mcp)
+			}
+		}
+
+		if !found {
+			return nil, fmt.Errorf("failed to find MachineConfigPool for the node group with the selector %q", nodeGroup.MachineConfigPoolSelector.String())
+		}
+	}
+
+	return result, nil
+}

--- a/controllers/kubeletconfig_controller.go
+++ b/controllers/kubeletconfig_controller.go
@@ -120,7 +120,7 @@ func (r *KubeletConfigReconciler) reconcileConfigMap(ctx context.Context, instan
 		return nil, err
 	}
 
-	mcps, err := getNodeGroupsMCPs(ctx, r.Client, instance.Spec.NodeGroups)
+	mcps, err := GetNodeGroupsMCPs(ctx, r.Client, instance.Spec.NodeGroups)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -189,7 +189,9 @@ func (r *NUMAResourcesOperatorReconciler) reconcileResource(ctx context.Context,
 			return ctrl.Result{}, status.ConditionDegraded, errors.Wrapf(err, "failed to sync machine configs")
 		}
 
-		if !isMachineConfigPoolsUpdated(instance, mcps) {
+		// MCO need to update SELinux context and other stuff, and need to trigger a reboot.
+		// It can take a while.
+		if allMCPsUpdated := r.syncMachineConfigPoolsStatuses(instance, mcps); !allMCPsUpdated {
 			// the Machine Config Pool still did not apply the machine config, wait for one minute
 			return ctrl.Result{RequeueAfter: numaResourcesRetryPeriod}, status.ConditionProgressing, nil
 		}
@@ -246,6 +248,24 @@ func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context
 	}
 
 	return nil
+}
+
+func (r *NUMAResourcesOperatorReconciler) syncMachineConfigPoolsStatuses(instance *nropv1alpha1.NUMAResourcesOperator, mcps []*machineconfigv1.MachineConfigPool) bool {
+	allMCPsUpdated := true
+	instance.Status.MachineConfigPools = []nropv1alpha1.MachineConfigPool{}
+	for _, mcp := range mcps {
+		// update MCP conditions under the NRO
+		instance.Status.MachineConfigPools = append(instance.Status.MachineConfigPools, nropv1alpha1.MachineConfigPool{
+			Name:       mcp.Name,
+			Conditions: mcp.Status.Conditions,
+		})
+
+		if !isMachineConfigPoolUpdated(instance.Name, mcp) {
+			allMCPsUpdated = false
+			break
+		}
+	}
+	return allMCPsUpdated
 }
 
 func (r *NUMAResourcesOperatorReconciler) syncNUMAResourcesOperatorResources(ctx context.Context, instance *nropv1alpha1.NUMAResourcesOperator, mcps []*machineconfigv1.MachineConfigPool) ([]nropv1alpha1.NamespacedName, error) {
@@ -418,28 +438,19 @@ func getNodeGroupsMCPs(ctx context.Context, cli client.Client, nodeGroups []nrop
 	return result, nil
 }
 
-func isMachineConfigPoolsUpdated(instance *nropv1alpha1.NUMAResourcesOperator, mcps []*machineconfigv1.MachineConfigPool) bool {
-	instance.Status.MachineConfigPools = []nropv1alpha1.MachineConfigPool{}
-	for _, mcp := range mcps {
-		// update MCP conditions under the NRO
-		instance.Status.MachineConfigPools = append(instance.Status.MachineConfigPools, nropv1alpha1.MachineConfigPool{
-			Name:       mcp.Name,
-			Conditions: mcp.Status.Conditions,
-		})
-
-		mcName := rte.GetMachineConfigName(instance.Name, mcp.Name)
-		existing := false
-		for _, s := range mcp.Status.Configuration.Source {
-			if s.Name == mcName {
-				existing = true
-				break
-			}
+func isMachineConfigPoolUpdated(instanceName string, mcp *machineconfigv1.MachineConfigPool) bool {
+	mcName := rte.GetMachineConfigName(instanceName, mcp.Name)
+	existing := false
+	for _, s := range mcp.Status.Configuration.Source {
+		if s.Name == mcName {
+			existing = true
+			break
 		}
+	}
 
-		// the Machine Config Pool still did not apply the machine config wait for one minute
-		if !existing || machineconfigv1.IsMachineConfigPoolConditionFalse(mcp.Status.Conditions, machineconfigv1.MachineConfigPoolUpdated) {
-			return false
-		}
+	// the Machine Config Pool still did not apply the machine config wait for one minute
+	if !existing || machineconfigv1.IsMachineConfigPoolConditionFalse(mcp.Status.Conditions, machineconfigv1.MachineConfigPoolUpdated) {
+		return false
 	}
 
 	return true

--- a/test/e2e/basic_install/install.go
+++ b/test/e2e/basic_install/install.go
@@ -43,7 +43,8 @@ var _ = ginkgo.Describe("[BasicInstall] Installation", func() {
 	ginkgo.BeforeEach(func() {
 		if !initialized {
 			gomega.Expect(e2eclient.ClientsEnabled).To(gomega.BeTrue(), "failed to create runtime-controller client")
-			nroObj = objects.TestNRO()
+			// since we are getting an existing object, we don't need the real labels here
+			nroObj = objects.TestNRO(map[string]string{})
 
 		}
 		initialized = true

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -19,19 +19,36 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	e2eclient "github.com/openshift-kni/numaresources-operator/test/e2e/utils/clients"
-	"github.com/openshift-kni/numaresources-operator/test/e2e/utils/objects"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	"github.com/openshift-kni/numaresources-operator/controllers"
 	_ "github.com/openshift-kni/numaresources-operator/test/e2e/basic_install"
 	_ "github.com/openshift-kni/numaresources-operator/test/e2e/rte"
+	e2eclient "github.com/openshift-kni/numaresources-operator/test/e2e/utils/clients"
+	"github.com/openshift-kni/numaresources-operator/test/e2e/utils/objects"
+)
+
+const (
+	envVarMCPUpdateTimeout   = "NROP_E2E_MCP_UPDATE_TIMEOUT"
+	envVarMCPUpdateInterval  = "NROP_E2E_MCP_UPDATE_INTERVAL"
+	envVarMCPSkipWaitCleanup = "NROP_E2E_MCP_SKIP_WAIT_CLEANUP" // for prow CI
+)
+
+const (
+	defaultMCPUpdateTimeout  = 30 * time.Minute
+	defaultMCPUpdateInterval = 30 * time.Second
 )
 
 func TestE2E(t *testing.T) {
@@ -53,6 +70,12 @@ var _ = BeforeSuite(func() {
 	By(fmt.Sprintf("creating the NRO object: %s", nroObj.Name))
 	err = e2eclient.Client.Create(context.TODO(), nroObj)
 	Expect(err).NotTo(HaveOccurred())
+
+	if clusterPlatform == platform.OpenShift {
+		timeout := getMCPUpdateValueFromEnv(envVarMCPUpdateTimeout, defaultMCPUpdateTimeout)
+		interval := getMCPUpdateValueFromEnv(envVarMCPUpdateInterval, defaultMCPUpdateInterval)
+		waitAllMCPsUpdate(timeout, interval, nroObj.Name, nil)
+	}
 })
 
 var _ = AfterSuite(func() {
@@ -68,4 +91,62 @@ var _ = AfterSuite(func() {
 	if err := e2eclient.Client.Delete(context.TODO(), nroObj); err != nil && !errors.IsNotFound(err) {
 		klog.Warningf("failed to delete the numaresourcesoperators %q", nroObj.Name)
 	}
+
+	if clusterPlatform == platform.OpenShift {
+		timeout := getMCPUpdateValueFromEnv(envVarMCPUpdateTimeout, defaultMCPUpdateTimeout)
+		interval := getMCPUpdateValueFromEnv(envVarMCPUpdateInterval, defaultMCPUpdateInterval)
+		if _, found := os.LookupEnv(envVarMCPSkipWaitCleanup); found {
+			klog.Warning("NOT WAITING for MCP resources to be cleaned, as requested by env var")
+			return
+		}
+		waitAllMCPsUpdate(timeout, interval, nroObj.Name, nodeGroups)
+	}
 })
+
+func waitAllMCPsUpdate(timeout, interval time.Duration, nroName string, nodeGroups []nropv1alpha1.NodeGroup) {
+	Eventually(func() bool {
+		if len(nodeGroups) == 0 {
+			nodeGroups = getNodeGroupsFromNRO(nroName)
+		}
+
+		mcps, err := controllers.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nodeGroups)
+		if err != nil {
+			klog.Warningf("failed to get the MCPs resources: %v", err)
+			return false
+		}
+
+		allMCPsUpdate := true
+		for _, mcp := range mcps {
+			if !controllers.IsMachineConfigPoolUpdated(nroName, mcp) {
+				klog.Warningf("MCP %q not update yet", mcp.Name)
+				allMCPsUpdate = false
+			}
+		}
+
+		if allMCPsUpdate {
+			klog.Infof("all MCPs updated!")
+		}
+		return allMCPsUpdate
+	}, timeout, interval).Should(BeTrue(), "MCPs not updated")
+
+}
+
+func getNodeGroupsFromNRO(nroName string) []nropv1alpha1.NodeGroup {
+	updatedNROObj := &nropv1alpha1.NUMAResourcesOperator{}
+	key := client.ObjectKey{
+		Name: nroName,
+	}
+	err := e2eclient.Client.Get(context.TODO(), key, updatedNROObj)
+	Expect(err).NotTo(HaveOccurred())
+	return updatedNROObj.Spec.NodeGroups
+}
+
+func getMCPUpdateValueFromEnv(envVar string, fallback time.Duration) time.Duration {
+	val, ok := os.LookupEnv(envVar)
+	if !ok {
+		return fallback
+	}
+	timeout, err := time.ParseDuration(val)
+	Expect(err).NotTo(HaveOccurred())
+	return timeout
+}

--- a/test/e2e/utils/objects/objects.go
+++ b/test/e2e/utils/objects/objects.go
@@ -24,7 +24,7 @@ import (
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
 
-func TestNRO() *nropv1alpha1.NUMAResourcesOperator {
+func TestNRO(matchLabels map[string]string) *nropv1alpha1.NUMAResourcesOperator {
 	return &nropv1alpha1.NUMAResourcesOperator{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "NUMAResourcesOperator",
@@ -38,7 +38,7 @@ func TestNRO() *nropv1alpha1.NUMAResourcesOperator {
 			NodeGroups: []nropv1alpha1.NodeGroup{
 				{
 					MachineConfigPoolSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"test": "test"},
+						MatchLabels: matchLabels,
 					},
 				},
 			},


### PR DESCRIPTION
we need to wait longer and explicitely for MCPs to be updated on OCP; otherwise the test is misleading - and prone to false
negatives.

The behaviour of the wait is controlled by env variables, to allow tuning without code changes.

This PR includes some refactoring - code movement - to allow to reuse the same code we have in the controllers.