### PR TITLE
E2E bootstrap scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,12 @@ test-unit: envtest
 test-e2e: binary-e2e binary-rte-e2e
 	./bin/e2e.test -ginkgo.v
 
+# a specific target for running e2e tests under the KNI's CI
+# this assumes to be running on a vanilla OCP cluster
+.PHONY: test-e2e-kni
+test-e2e-kni: build-e2e
+	hack/run-e2e-kni.sh
+
 ##@ Build
 
 binary:
@@ -247,3 +253,15 @@ catalog-push: ## Push a catalog image.
 .PHONY: deps-update
 deps-update:
 	go mod tidy && go mod vendor
+
+.PHONY: label-custom-kubelet
+label-custom-kubelet:
+	hack/label-custom-kubelet.sh
+
+.PHONY: kube-update
+kube-update: label-custom-kubelet
+	hack/kube-update.sh
+
+.PHONY: wait-for-mcp
+wait-for-mcp:
+	hack/wait-for-mcp.sh

--- a/hack/kube-update.sh
+++ b/hack/kube-update.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -eux
+
+# expect oc to be in PATH by default
+OC_TOOL="${OC_TOOL:-oc}"
+
+echo "Updating Kubelet with necessary configuration for RTE deployment"
+cat << EOF | oc apply -f -
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: tm-enabled
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      custom-kubelet: enabled
+  kubeletConfig:
+    cpuManagerPolicy: "static"
+    cpuManagerReconcilePeriod: "5s"
+    reservedSystemCPUs: "0,1"
+    memoryManagerPolicy: "Static"
+    systemReserved: {"memory" :"512Mi"}
+    kubeReserved: {"memory" :"512Mi"}
+    evictionHard: {"memory.available": "100Mi"}
+    reservedMemory: [{"numaNode": 0, "limits": {"memory": "1124Mi"}}]
+    topologyManagerPolicy: "single-numa-node"
+EOF

--- a/hack/label-custom-kubelet.sh
+++ b/hack/label-custom-kubelet.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# expect oc to be in PATH by default
+OC_TOOL="${OC_TOOL:-oc}"
+
+# Label worker MCP
+echo "[INFO]: Labeling worker MCP with custom-kubelet"
+mcp=$(${OC_TOOL} get mcp --selector='pools.operator.machineconfiguration.openshift.io/worker=' -o name)
+
+${OC_TOOL} label --overwrite "$mcp" custom-kubelet=enabled

--- a/hack/run-e2e-kni.sh
+++ b/hack/run-e2e-kni.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -xue
+
+# expect oc to be in PATH by default
+OC_TOOL="${OC_TOOL:-oc}"
+
+BASE_DIR="$(dirname "$(realpath "$0")")"
+PROJECT_DIR="${BASE_DIR}"/..
+
+export E2E_NAMESPACE_NAME="${E2E_NAMESPACE_NAME:-numaresources-operator-e2e}"
+export E2E_TOPOLOGY_MANAGER_POLICY="${E2E_TOPOLOGY_MANAGER_POLICY:-SingleNUMANodeContainerLevel}"
+export KUBECONFIG="${KUBECONFIG}"
+
+make -C "${PROJECT_DIR}" kube-update
+make -C "${PROJECT_DIR}" wait-for-mcp
+echo "Kubelet configured properly"
+
+"${BASE_DIR}"/setup-e2e.sh
+
+make -C "${PROJECT_DIR}" test-e2e

--- a/hack/setup-e2e.sh
+++ b/hack/setup-e2e.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -xue
+
+# expect oc to be in PATH by default
+OC_TOOL="${OC_TOOL:-oc}"
+
+E2E_NAMESPACE_NAME="${E2E_NAMESPACE_NAME:-numaresources-operator-e2e}"
+
+function create_ns() {
+echo "Create $E2E_NAMESPACE_NAME namespace"
+  cat << EOF | $OC_TOOL apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "$E2E_NAMESPACE_NAME"
+EOF
+}
+
+create_ns

--- a/hack/wait-for-mcp.sh
+++ b/hack/wait-for-mcp.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -e
+
+# expect oc to be in PATH by default
+OC_TOOL="${OC_TOOL:-oc}"
+
+success=0
+iterations=0
+sleep_time=10
+max_iterations=180 # results in 30 minute timeout
+
+# Let's give the operator some time to do its work before we unpause the MCP (see below)
+echo "[INFO] Waiting a bit for letting the operator do its work"
+sleep 30
+
+until [[ $success -eq 1 ]] || [[ $iterations -eq $max_iterations ]]
+do
+
+  echo "[INFO] Checking if MCP picked up the custom Kubelet configuration"
+  mc=$("$OC_TOOL" get mcp worker -o jsonpath='{.spec.configuration.source[?(@.name=="99-worker-generated-kubelet")]}')
+  # No output means that the new Kubelet config wasn't picked by MCO yet
+  if [ -z "$mc" ]
+  then
+    iterations=$((iterations + 1))
+    iterations_left=$((max_iterations - iterations))
+    echo "[INFO] Custom Kubelet configuration not picked up yet. $iterations_left retries left."
+    sleep $sleep_time
+    continue
+  fi
+
+  echo "[INFO] Checking if MCP is updated"
+  if ! ${OC_TOOL} wait mcp/worker --for condition=Updated --timeout 1s &> /dev/null
+  then
+    iterations=$((iterations + 1))
+    iterations_left=$((max_iterations - iterations))
+    if [[ $iterations_left != 0  ]]; then
+      echo "[WARN] MCP not updated yet, retrying in $sleep_time sec, $iterations_left retries left"
+      sleep $sleep_time
+    fi
+  else
+    success=1
+  fi
+
+done
+
+if [[ $success -eq 0 ]]; then
+  echo "[ERROR] MCP update failed, giving up."
+  exit 1
+fi
+
+echo "[INFO] MCP update successful."


### PR DESCRIPTION
Add scrips for e2e tests bootstrap
Couple of scripts that will bootstrap the environment so we'll be able to run e2e in it:
1. `run-e2e-kni.sh` - This is the main script that fires all the others. Any environment variable that is relevant for the e2e tests should be added here.
2. `kube-update.sh` - Creates a kubeletconfig resource with necessary configuration for RTE/NFD deployment.
3. `label-custom-kubelet.sh` - Labels MCP with a unique label that kubeletconfig resource (from 2) will look for in the machineConfigPoolSelector field.
4. `wait-for-mcp` - Waits for MCP to apply the new MC changes.
5. `setup-e2e.sh` - Setups a namespace where all tests components should be deployed in.