### PR TITLE
e2e: create kubeletconfig resource

### DIFF
--- a/test/utils/objects/objects.go
+++ b/test/utils/objects/objects.go
@@ -17,7 +17,14 @@ limitations under the License.
 package objects
 
 import (
+	"encoding/json"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 
 	e2etestenv "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/testenv"
 	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
@@ -64,5 +71,53 @@ func TestMCP() *machineconfigv1.MachineConfigPool {
 				MatchLabels: map[string]string{"node-role.kubernetes.io/worker": ""},
 			},
 		},
+	}
+}
+
+func TestKC(matchLabels map[string]string) (*machineconfigv1.KubeletConfig, error) {
+	data, err := json.Marshal(getKubeletConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	return &machineconfigv1.KubeletConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KubeletConfig",
+			APIVersion: machineconfigv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "kc-test",
+			Labels: map[string]string{"test": "test"},
+		},
+		Spec: machineconfigv1.KubeletConfigSpec{
+			KubeletConfig: &runtime.RawExtension{
+				Raw: data,
+			},
+			MachineConfigPoolSelector: &metav1.LabelSelector{
+				MatchLabels: matchLabels,
+			},
+		},
+	}, nil
+}
+
+func getKubeletConfig() *kubeletconfigv1beta1.KubeletConfiguration {
+	cpuManagerReconcilePeriod, _ := time.ParseDuration("5s")
+	return &kubeletconfigv1beta1.KubeletConfiguration{
+		CPUManagerPolicy:          "static",
+		CPUManagerReconcilePeriod: metav1.Duration{Duration: cpuManagerReconcilePeriod},
+		ReservedSystemCPUs:        "0,1",
+		MemoryManagerPolicy:       "Static",
+		SystemReserved:            map[string]string{"memory": "512Mi"},
+		KubeReserved:              map[string]string{"memory": "512Mi"},
+		EvictionHard:              map[string]string{"memory.available": "100Mi"},
+		ReservedMemory: []kubeletconfigv1beta1.MemoryReservation{
+			{
+				NumaNode: 0,
+				Limits: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse("1124Mi"),
+				},
+			},
+		},
+		TopologyManagerPolicy: "single-numa-node",
 	}
 }


### PR DESCRIPTION
During the e2e test initialization we should create a kubeletconfig object that will apply all the necessary configuration for a proper functionality of RTE

Signed-off-by: Talor Itzhak <titzhak@redhat.com>