### PR TITLE
RTE: Consume config changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
 test-unit: envtest
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./controllers/... ./pkg/...
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./controllers/... ./pkg/... ./rte/pkg/...
 
 test-e2e: build-e2e-all
 	hack/run-test-e2e.sh

--- a/pkg/flagcodec/flagcodec.go
+++ b/pkg/flagcodec/flagcodec.go
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ */
+
+// flagcodec allows to manipulate foreign command lines following the
+// standard golang conventions. It offeres two-way processing aka
+// parsing/marshalling of flags. It is different from the other, well
+// established packages (pflag...) because it aims to manipulate command
+// lines in general, not this program command line.
+
+package flagcodec
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	FlagToggle = iota
+	FlagOption
+)
+
+type Val struct {
+	Kind int
+	Data string
+}
+
+type Flags struct {
+	argv0 string
+	args  map[string]Val
+}
+
+// ParseArgvKeyValue parses a clean (trimmed) argv whose components are
+// either toggles or key=value pairs. IOW, this is a restricted and easier
+// to parse flavour of argv on which option and value are guaranteed to
+// be in the same item.
+// IOW, we expect
+// "--opt=foo"
+// AND NOT
+// "--opt", "foo"
+func ParseArgvKeyValue(argv []string) *Flags {
+	if len(argv) == 0 {
+		return nil
+	}
+	// argv[0] is always expected to be the command name
+	ret := &Flags{
+		argv0: argv[0],
+		args:  make(map[string]Val),
+	}
+	if len(argv) < 1 {
+		return ret
+	}
+	ret.argv0 = argv[0]
+	for _, arg := range argv[1:] {
+		fields := strings.SplitN(arg, "=", 2)
+		if len(fields) == 1 {
+			ret.SetToggle(fields[0])
+			continue
+		}
+		ret.SetOption(fields[0], fields[1])
+	}
+	return ret
+}
+
+func (fl *Flags) SetToggle(name string) {
+	fl.args[name] = Val{
+		Kind: FlagToggle,
+	}
+}
+
+func (fl *Flags) SetOption(name, data string) {
+	fl.args[name] = Val{
+		Kind: FlagOption,
+		Data: data,
+	}
+}
+
+func (fl *Flags) Argv() []string {
+	var argv []string
+	for name, val := range fl.args {
+		argv = append(argv, toString(name, val))
+	}
+	sort.Strings(argv)
+	return append([]string{fl.argv0}, argv...)
+}
+
+func toString(name string, val Val) string {
+	if val.Kind == FlagToggle {
+		return name
+	}
+	return fmt.Sprintf("%s=%s", name, val.Data)
+}

--- a/pkg/flagcodec/flagcodec_test.go
+++ b/pkg/flagcodec/flagcodec_test.go
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ */
+
+package flagcodec
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseStringRoundTrip(t *testing.T) {
+	type testCase struct {
+		name     string
+		argv     []string
+		expected []string
+	}
+
+	testCases := []testCase{
+		{
+			name: "nil argv",
+		},
+		{
+			name: "empty args",
+			argv: []string{},
+		},
+		{
+			name: "no args",
+			argv: []string{
+				"/bin/true",
+			},
+			expected: []string{
+				"/bin/true",
+			},
+		},
+		{
+			name: "simple",
+			argv: []string{
+				"/bin/resource-topology-exporter",
+				"--sleep-interval=10s",
+				"--sysfs=/host-sys",
+				"--kubelet-state-dir=/host-var/lib/kubelet",
+				"--podresources-socket=unix:///host-var/lib/kubelet/pod-resources/kubelet.sock",
+			},
+			expected: []string{
+				"/bin/resource-topology-exporter",
+				"--kubelet-state-dir=/host-var/lib/kubelet",
+				"--podresources-socket=unix:///host-var/lib/kubelet/pod-resources/kubelet.sock",
+				"--sleep-interval=10s",
+				"--sysfs=/host-sys",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fl := ParseArgvKeyValue(tc.argv)
+			if tc.argv == nil || len(tc.argv) == 0 {
+				if fl != nil {
+					t.Errorf("expected nil result with nil args")
+				}
+				// else the test is passed!
+				return
+			}
+
+			got := fl.Argv()
+			if !reflect.DeepEqual(tc.expected, got) {
+				t.Errorf("expected %v got %v", tc.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/objectstate/rte/rte.go
+++ b/pkg/objectstate/rte/rte.go
@@ -33,6 +33,7 @@ import (
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
 	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	"github.com/openshift-kni/numaresources-operator/pkg/flagcodec"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectstate"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectstate/compare"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectstate/merge"
@@ -311,6 +312,15 @@ func UpdateDaemonSetUserImageSettings(ds *appsv1.DaemonSet, userImageSpec, built
 	klog.V(3).InfoS("Exporter image", "reason", "builtin", "pullSpec", builtinImageSpec, "pullPolicy", builtinPullPolicy)
 	// if we run with operator-as-operand, we know we NEED this.
 	UpdateDaemonSetRunAsIDs(ds)
+
+	// TODO: we know this is in `Command`, but we should actually check
+	fl := flagcodec.ParseArgvKeyValue(cnt.Command)
+	if fl == nil {
+		klog.Warningf("Cannot modify the command line %v", cnt.Command)
+		return
+	}
+	fl.SetToggle("--exit-on-conf-change")
+	cnt.Command = fl.Argv()
 }
 
 // UpdateDaemonSetRunAsIDs bump the ds container privileges to 0/0.

--- a/rte/pkg/config/watcher.go
+++ b/rte/pkg/config/watcher.go
@@ -1,0 +1,92 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"github.com/fsnotify/fsnotify"
+
+	"k8s.io/klog/v2"
+)
+
+type Watcher struct {
+	watcher    *fsnotify.Watcher
+	configPath string
+	stopChan   chan struct{}
+	callback   func() error
+}
+
+func NewWatcher(configPath string, callback func() error) (*Watcher, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		klog.Warningf("config watch: failed to create the fsnotify watcher: %v", err)
+		return nil, err
+	}
+
+	err = watcher.Add(configPath)
+	if err != nil {
+		klog.Warningf("config watch: failed to watch configuration file %q: %v", configPath, err)
+		return nil, err
+	}
+	klog.Infof("config watch: added %q", configPath)
+
+	return &Watcher{
+		watcher:    watcher,
+		configPath: configPath,
+		callback:   callback,
+		stopChan:   make(chan struct{}),
+	}, nil
+}
+
+func (cw *Watcher) Close() {
+	cw.watcher.Close()
+}
+
+func (cw *Watcher) Stop() {
+	cw.stopChan <- struct{}{}
+}
+
+// WaitUntilChanges wait until it notices the first change of the config file.
+// It nevers rearm itself, so it fires at most once.
+// Make sure this run on a separate (not main) goroutine: see https://github.com/fsnotify/fsnotify#faq
+func (cw *Watcher) WaitUntilChanges() {
+	for {
+		select {
+		case <-cw.stopChan:
+			return
+
+		case event := <-cw.watcher.Events:
+			klog.V(2).Infof("config watch: fsnotify event from %q: %v", event.Name, event.Op)
+			if filterEvent(event) {
+				err := cw.callback()
+				if err != nil {
+					klog.Warning("config watch: callback failed for %q: %v", cw.configPath, err)
+				}
+				// we would need to rearm the watch, which we don't yet. So exit.
+				return
+			}
+
+		case err := <-cw.watcher.Errors:
+			// and yes, keep going
+			klog.Warningf("config watch: fsnotify error: %v", err)
+		}
+	}
+}
+
+func filterEvent(event fsnotify.Event) bool {
+	if (event.Op & fsnotify.Write) == fsnotify.Write {
+		return true
+	}
+	return (event.Op & fsnotify.Remove) == fsnotify.Remove
+}

--- a/rte/pkg/config/watcher_test.go
+++ b/rte/pkg/config/watcher_test.go
@@ -1,0 +1,98 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+func TestWatchRewrite(t *testing.T) {
+	initialPath, err := writeTempFile("initial content")
+	if err != nil {
+		t.Fatalf("cannot set initial content: %v", err)
+	}
+	modifiedPath, err := writeTempFile("modified content")
+	if err != nil {
+		t.Fatalf("cannot set modified content: %v", err)
+	}
+
+	changeChan := make(chan bool)
+	cw, err := NewWatcher(initialPath, func() error {
+		changeChan <- true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("cannot watch %q: %v", initialPath, err)
+	}
+	go cw.WaitUntilChanges()
+
+	err = os.Rename(modifiedPath, initialPath)
+	if err != nil {
+		t.Fatalf("rename %q -> %q failed: %v", modifiedPath, initialPath, err)
+	}
+	klog.Infof("%q -> %q", modifiedPath, initialPath)
+
+	changed := <-changeChan
+	if !changed {
+		t.Fatalf("failed to detect change (rename)")
+	}
+}
+
+func TestWatchWritesInPlace(t *testing.T) {
+	f, err := os.CreateTemp("", "testwatchconf")
+	if err != nil {
+		t.Fatalf("CreateTemp failed: %v", err)
+	}
+	defer os.Remove(f.Name()) // clean up
+
+	changeChan := make(chan bool)
+	cw, err := NewWatcher(f.Name(), func() error {
+		changeChan <- true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("cannot watch %q: %v", f.Name(), err)
+	}
+	go cw.WaitUntilChanges()
+
+	if _, err := f.Write([]byte("content")); err != nil {
+		t.Fatalf("Write %q failed: %v", f.Name(), err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("Close %q failed: %v", f.Name(), err)
+	}
+
+	changed := <-changeChan
+	if !changed {
+		t.Fatalf("failed to detect change (write)")
+	}
+}
+
+func writeTempFile(content string) (string, error) {
+	f, err := os.CreateTemp("", "testwatchconf")
+	if err != nil {
+		return "", err
+	}
+	if _, err := f.Write([]byte(content)); err != nil {
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		return "", err
+	}
+	return f.Name(), nil
+}


### PR DESCRIPTION
Add facilities to react to config file changes in turn generated by changes of the `kubeletconfig` objects, which are already being handled by the kubeletconfig controller.