### PR TITLE
build: implement the `version` flag in both exporter and manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,11 +118,17 @@ test-e2e: build-e2e-all
 
 ##@ Build
 
-binary:
-	go build -o bin/manager main.go
+binary: build-tools
+	go build \
+		-o bin/manager \
+		-ldflags "-s -w -X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/git-semver)" \
+		main.go
 
-binary-rte:
-	go build -o bin/exporter rte/main.go
+binary-rte: build-tools
+	go build \
+		-o bin/exporter \
+		-ldflags "-s -w -X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/git-semver)" \
+		rte/main.go
 
 binary-e2e-rte:
 	go test -c -v -o bin/e2e-rte.test ./test/e2e/rte
@@ -270,3 +276,13 @@ catalog-push: ## Push a catalog image.
 .PHONY: deps-update
 deps-update:
 	go mod tidy && go mod vendor
+
+
+# Build tools:
+#
+#
+.PHONY: build-tools
+build-tools: bin/git-semver
+
+bin/git-semver:
+	@go build -o bin/git-semver vendor/github.com/mdomke/git-semver/main.go

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/jaypipes/pcidb v0.6.0
 	github.com/k8stopologyawareschedwg/deployer v0.1.1-0.20211213080518-881e130aa39a
 	github.com/k8stopologyawareschedwg/resource-topology-exporter v0.3.3-0.20211213120214-84b219b93f5b
+	github.com/mdomke/git-semver v1.0.0
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.14.0
 	github.com/openshift/api v0.0.0-20210924154557-a4f696157341

--- a/go.sum
+++ b/go.sum
@@ -852,6 +852,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/mbilski/exhaustivestruct v1.2.0/go.mod h1:OeTBVxQWoEmB2J2JCHmXWPJ0aksxSUOUy+nvtVEfzXc=
+github.com/mdomke/git-semver v1.0.0 h1:cg/a+bI/D2EtPWlx4pKSUKz9G9bTOHEBdF2EjbV0b4s=
+github.com/mdomke/git-semver v1.0.0/go.mod h1:fNw8giSaJDzhF/Gvxe7JSZJVDlkRR+/a8y1b3g6SGZ8=
 github.com/mgechev/dots v0.0.0-20190921121421-c36f7dcfbb81/go.mod h1:KQ7+USdGKfpPjXk4Ga+5XxQM4Lm4e3gAogrreFAYpOg=
 github.com/mgechev/revive v1.1.1/go.mod h1:PKqk4L74K6wVNwY2b6fr+9Qqr/3hIsHVfZCJdbvozrY=
 github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2/go.mod h1:g4cOPxcjV0oFq3qwpjSA30LReKD8AoIfwAY9VvG35NY=

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -19,4 +19,7 @@ limitations under the License.
 // This package imports things required by build scripts, to force `go mod` to see them as dependencies
 package tools
 
-import _ "k8s.io/code-generator"
+import (
+	_ "github.com/mdomke/git-semver"
+	_ "k8s.io/code-generator"
+)

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ import (
 	"github.com/openshift-kni/numaresources-operator/controllers"
 	"github.com/openshift-kni/numaresources-operator/pkg/images"
 	rtestate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/rte"
+	"github.com/openshift-kni/numaresources-operator/pkg/version"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -79,6 +80,7 @@ func main() {
 	var renderMode bool
 	var renderNamespace string
 	var renderImage string
+	var showVersion bool
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -89,12 +91,18 @@ func main() {
 	flag.BoolVar(&renderMode, "render", false, "outputs the rendered manifests, then exits")
 	flag.StringVar(&renderNamespace, "render-namespace", defaultNamespace, "outputs the manifests rendered using the given namespace")
 	flag.StringVar(&renderImage, "render-image", defaultImage, "outputs the manifests rendered using the given image")
+	flag.BoolVar(&showVersion, "version", false, "outputs the version and exit")
 
 	opts := zap.Options{
 		Development: true,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	if showVersion {
+		fmt.Println(version.ProgramName(), version.Get())
+		os.Exit(0)
+	}
 
 	// if it is unknown, it's fine
 	userPlatform, _ := platform.FromString(platformName)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,9 +1,12 @@
 /*
-Copyright 2021 The Kubernetes Authors.
-Licensed under the Apache License, version 2.0 (the "License");
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,9 +16,12 @@ limitations under the License.
 
 package version
 
+import (
+	"os"
+	"path/filepath"
+)
+
 const (
-	// ProgramName is the canonical name of this program
-	ProgramName             = "resource-topology-exporter"
 	undefinedVersion string = "undefined"
 )
 
@@ -30,4 +36,11 @@ func Get() string {
 // Undefined returns if version is at it's default value
 func Undefined() bool {
 	return version == undefinedVersion
+}
+
+func ProgramName() string {
+	if len(os.Args) == 0 {
+		return "undefined"
+	}
+	return filepath.Base(os.Args[0])
 }

--- a/rte/main.go
+++ b/rte/main.go
@@ -28,7 +28,8 @@ import (
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/prometheus"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcemonitor"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcetopologyexporter"
-	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/version"
+
+	"github.com/openshift-kni/numaresources-operator/pkg/version"
 
 	"github.com/openshift-kni/numaresources-operator/rte/pkg/config"
 	"github.com/openshift-kni/numaresources-operator/rte/pkg/podrescompat"
@@ -54,7 +55,7 @@ func main() {
 	}
 
 	if parsedArgs.Version {
-		fmt.Println(version.ProgramName, version.Get())
+		fmt.Println(version.ProgramName(), version.Get())
 		os.Exit(0)
 	}
 
@@ -107,7 +108,7 @@ func parseArgs(args ...string) (ProgArgs, error) {
 	var sysResourceMapping string
 
 	var configPath string
-	flags := flag.NewFlagSet(version.ProgramName, flag.ExitOnError)
+	flags := flag.NewFlagSet(version.ProgramName(), flag.ExitOnError)
 
 	klog.InitFlags(flags)
 

--- a/vendor/github.com/mdomke/git-semver/.gitignore
+++ b/vendor/github.com/mdomke/git-semver/.gitignore
@@ -1,0 +1,14 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+/git-semver

--- a/vendor/github.com/mdomke/git-semver/LICENSE
+++ b/vendor/github.com/mdomke/git-semver/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Martin Domke
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/mdomke/git-semver/README.md
+++ b/vendor/github.com/mdomke/git-semver/README.md
@@ -1,0 +1,73 @@
+# Semantic Versioning with git tags
+
+Software should be versioned in order to be able to identify a certain
+feature set or to know when a specific bug has been fixed. It is a good
+practice to use [Sementic Versioning](https://semver.org/) (SemVer) in
+order to attach a meaning to a version number or the change thereof.
+
+[git](https://git-scm.com/) allows you to conveniently reference a certain
+state of your code through the usage of tags. Tags can have an arbitrary
+identifier, so that it seems a naturaly choice of using them for versioning.
+
+## Version tags
+
+A semantic version consists of three dot-separated parts `<major>.<minor>.<patch>`
+and this should be the name that you give to a tag. Optionally you can prepend
+the letter `v` if your language specific tooling requires it. It is also possible
+to attach a pre-release identifier to a version e.g. for a release candidate. This
+identifier is separated with hyphen from the core version component. A valid version
+tag would be, e.g. `1.2.3`, `v2.3.0`, `1.1.0-rc3`.
+
+```sh
+$ git tag v2.0.0-rc1
+```
+
+So for a tagged commit we would know which version to assign to our software, but
+which version should we use for not tagged commits? We can use `git describe` to
+get a unique identifier based on the last tagged commit.
+
+```sh
+$ git describe --tags
+3.5.1-22-gbaf822dd5
+```
+
+This is the 22nd commit after the tag `3.5.1` with the abbreviated commit hash `gbaf822dd5`.
+Sadly this identifier has two drawbacks.
+
+1. It's not compliant to SemVer, because there are multiple hyphens after the core version.
+   See the [BNF specifiction](https://github.com/semver/semver/blob/master/semver.md#backusnaur-form-grammar-for-valid-semver-versions)
+
+2. It doesn't allow proper sorting of versions, because the pre-release identifier would
+   make the version smaller than the tagged version, even though it has several commits build
+   on top of that version.
+
+## git-semver
+
+`git-semver` parses the output of `git describe` and derives a proper SemVer compliant
+version from it. E.g.:
+
+```
+3.5.1-22-gbaf822dd5 -> 3.5.2-dev22+gbaf822dd5
+4.2.0-rc3-5-fcf2c8f -> 4.2.0-rc4.dev5-fcf2c8f
+```
+
+It will attach a pre-release tag of the form `devN`, where `N` is the number of commits
+since the last commit, and the commit hash as build-metadata. Additionally the patch level
+component will be incremented in case of a pre-release-version. If the last tag itself
+contains a pre-release-identifier of the form `(alpha|beta|rc)\d+`, that identifier will
+be incremnted instead of the patch-level.
+
+If you want to add a prefix to the derived version, you can use the `-prefix`-flag like so
+
+```sh
+$ git-semver -prefix v
+v3.5.2-dev22+gbaf822dd5
+```
+
+## Installation
+
+Currently `git-semver` can be installed with `go get`
+
+```sh
+$ go get gopkg.in/mdomke/git-semver.v1
+```

--- a/vendor/github.com/mdomke/git-semver/main.go
+++ b/vendor/github.com/mdomke/git-semver/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/mdomke/git-semver/version"
+)
+
+var prefix = flag.String("prefix", "", "the version prefix (default: none)")
+
+func main() {
+	flag.Parse()
+	v, err := version.Derive()
+	if err != nil {
+		fmt.Fprint(os.Stderr, err)
+		os.Exit(1)
+	}
+	v.Prefix = *prefix
+	fmt.Println(v)
+}

--- a/vendor/github.com/mdomke/git-semver/version/version.go
+++ b/vendor/github.com/mdomke/git-semver/version/version.go
@@ -1,0 +1,157 @@
+package version
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Prefix is the valid version prefix
+const Prefix string = "v"
+
+// Version holds the parsed components of git describe
+type Version struct {
+	Prefix     string
+	Major      int
+	Minor      int
+	Patch      int
+	PreRelease string
+	Commits    int
+	Hash       string
+}
+
+func (v Version) String() string {
+	var suffix string
+	if v.Commits != 0 {
+		if v.PreRelease == "" {
+			v.Patch++
+			suffix = fmt.Sprintf("dev%d", v.Commits)
+		} else {
+			suffix = fmt.Sprintf("%s.dev%d", nextPreRelease(v.PreRelease), v.Commits)
+		}
+	} else {
+		suffix = v.PreRelease
+	}
+	if v.Hash != "" {
+		suffix += "+" + v.Hash
+	}
+	version := fmt.Sprintf("%s%d.%d.%d", v.Prefix, v.Major, v.Minor, v.Patch)
+	if suffix != "" {
+		version += "-" + suffix
+	}
+	return version
+}
+
+func nextPreRelease(r string) string {
+	re, err := regexp.Compile(`(alpha|beta|rc)(\d+)`)
+	if err != nil {
+		return r
+	}
+	match := re.FindStringSubmatch(r)
+	if match == nil {
+		return r
+	}
+	prefix := match[1]
+	var n int
+	n, err = strconv.Atoi(match[2])
+	if err != nil {
+		return r
+	}
+	n++
+	return fmt.Sprintf("%s%d", prefix, n)
+}
+
+func gitDescribe() string {
+	cmd := exec.Command("git", "describe", "--tags")
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Sprintf("0.0.0-%s-", gitCommitCount())
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func gitCommitCount() string {
+	cmd := exec.Command("git", "rev-list", "--count", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return "0"
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func parseVersion(s string, v *Version) error {
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return fmt.Errorf("git version tag must contain 3 components: X.Y.Z: Got %s", s)
+	}
+	var err error
+	v.Major, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return fmt.Errorf("Failed to parse major version: %v", err)
+	}
+	v.Minor, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return fmt.Errorf("Failed to parse minor version: %v", err)
+	}
+	v.Patch, err = strconv.Atoi(parts[2])
+	if err != nil {
+		return fmt.Errorf("Failed to parse patch version: %v", err)
+	}
+	return nil
+}
+
+func parse(s string, v *Version) (err error) {
+	var version string
+	if strings.HasPrefix(s, Prefix) {
+		v.Prefix = Prefix
+		s = strings.TrimPrefix(s, Prefix)
+	}
+	if strings.Contains(s, "-") {
+		parts := strings.Split(s, "-")
+
+		var commits string
+		switch len(parts) {
+		case 2:
+			v.PreRelease = parts[1]
+		case 3:
+			commits = parts[1]
+			v.Hash = parts[2]
+		case 4:
+			v.PreRelease = parts[1]
+			commits = parts[2]
+			v.Hash = parts[3]
+		default:
+			return fmt.Errorf("Invalid git version must be of format X.Y.Z(-<pre>)?(-n-<hash>)?: Got %s", s)
+		}
+
+		version = parts[0]
+		if commits != "" {
+			v.Commits, err = strconv.Atoi(commits)
+			if err != nil {
+				return fmt.Errorf("Failed to parse commit count from %s: %v", s, err)
+			}
+		}
+	} else {
+		version = s
+	}
+	err = parseVersion(version, v)
+	return err
+}
+
+// Derive calculates a semantic version from the output of git describe.
+// If the latest commit is not tagged, the version will have a pre-release-suffix
+// appended to it (e.g.: 1.2.3-dev3+fcf2c8f). The suffix has the format dev<n>+<hash>,
+// whereas n is the number of commits since the last tag and hash is the commit hash
+// of the latest commit. Derive will also increment the patch-level version component
+// in case it detects that the current version is a pre-release.
+// If the last tag has itself a pre-release-suffix of the form (alpha|beta|rc)\d+ and the
+// last commit is not tagged, Derive will increment the version of the pre-release
+// instead of the patch-level version.
+func Derive() (Version, error) {
+	v := Version{}
+	s := gitDescribe()
+	err := parse(s, &v)
+	return v, err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -224,7 +224,6 @@ github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcetopolo
 github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/sysinfo
 github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/topologypolicy
 github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/utils
-github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/version
 github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/rte
 github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/topology_updater
 github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/client

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -241,6 +241,10 @@ github.com/mailru/easyjson/jwriter
 # github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
 ## explicit; go 1.9
 github.com/matttproud/golang_protobuf_extensions/pbutil
+# github.com/mdomke/git-semver v1.0.0
+## explicit
+github.com/mdomke/git-semver
+github.com/mdomke/git-semver/version
 # github.com/mitchellh/go-homedir v1.1.0
 ## explicit
 github.com/mitchellh/go-homedir


### PR DESCRIPTION
Implement local package version, feed with the semantic version automatically generated by (vendored) `git-semver`, and add flags to both the manager and the exporter to report it.