### PR TITLE
gh actions: rename the e2e lane

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ defaults:
     shell: bash
 
 jobs:
-  e2e-basic-install:
+  e2e:
     runs-on: ubuntu-20.04
     env:
       built_image: "numaresources-operator:ci" # Arbitrary name


### PR DESCRIPTION
The e2e lane is now running the full suite, so
rename it accordingly. No changes in behaviour.

Signed-off-by: Francesco Romani <fromani@redhat.com>