### PR TITLE
nro controller: generate the machine config label if it impossible to get labels from the machine config pool

### DIFF
--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -238,8 +238,13 @@ func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context
 	// create MC objects first
 	for _, objState := range existing.MachineConfigsState(r.RTEManifests, instance, mcps) {
 		if err := controllerutil.SetControllerReference(instance, objState.Desired, r.Scheme); err != nil {
-			return errors.Wrapf(err, "Failed to set controller reference to %s %s", objState.Desired.GetNamespace(), objState.Desired.GetName())
+			return errors.Wrapf(err, "failed to set controller reference to %s %s", objState.Desired.GetNamespace(), objState.Desired.GetName())
 		}
+
+		if err := validateMachineConfigLabels(objState.Desired, mcps); err != nil {
+			return errors.Wrapf(err, "machine conig %q labels validation failed", objState.Desired.GetName())
+		}
+
 		_, err := apply.ApplyObject(ctx, r.Client, objState)
 		if err != nil {
 			return errors.Wrapf(err, "could not apply (%s) %s/%s", objState.Desired.GetObjectKind().GroupVersionKind(), objState.Desired.GetNamespace(), objState.Desired.GetName())
@@ -413,4 +418,32 @@ func IsMachineConfigPoolUpdated(instanceName string, mcp *machineconfigv1.Machin
 	}
 
 	return true
+}
+
+func validateMachineConfigLabels(mc client.Object, mcps []*machineconfigv1.MachineConfigPool) error {
+	mcLabels := mc.GetLabels()
+	v, ok := mcLabels[rtestate.MachineConfigLabelKey]
+	// the machine config does not have generated label, meaning the machine config pool has the matchLabels under
+	// the machine config selector, no need to validate
+	if !ok {
+		return nil
+	}
+
+	for _, mcp := range mcps {
+		if v != mcp.Name {
+			continue
+		}
+
+		mcLabels := labels.Set(mcLabels)
+		mcSelector, err := metav1.LabelSelectorAsSelector(mcp.Spec.MachineConfigSelector)
+		if err != nil {
+			return fmt.Errorf("failed to represent machine config pool %q machine config selector as selector: %w", mcp.Name, err)
+		}
+
+		if !mcSelector.Matches(mcLabels) {
+			return fmt.Errorf("machine config %q labels does not match the machine config pool %q machine config selector", mc.GetName(), mcp.Name)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Provide a backup plan when the targeted machine config pool does not have a machine config
selector with matchLabels field. In the above case, we will generate the label and drop a
warning message under the log.

It should be important for machine config pools that target more than one machine config
label. For example, our worker-cnf machine config pool definition looks, like this:
```
...
  machineConfigSelector:
    matchExpressions:
      - key: machineconfiguration.openshift.io/role
        operator: In
        values: [worker,worker-cnf]
...
```

It is important to say that the code also validates if the generated labels matched by
MachineConfigPool machine config selector, if it not matches the NRO will have
degraded state until the user will update the machine config pool or NRO object with
correct data.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>