### PR TITLE
nro controller: use predicates for all resources

### DIFF
--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -327,9 +327,9 @@ func (r *NUMAResourcesOperatorReconciler) SetupWithManager(mgr ctrl.Manager) err
 			Owns(&machineconfigv1.MachineConfig{}, builder.WithPredicates(p))
 	}
 	return b.Owns(&apiextensionv1.CustomResourceDefinition{}).
-		Owns(&corev1.ServiceAccount{}).
-		Owns(&rbacv1.RoleBinding{}).
-		Owns(&rbacv1.Role{}).
+		Owns(&corev1.ServiceAccount{}, builder.WithPredicates(p)).
+		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(p)).
+		Owns(&rbacv1.Role{}, builder.WithPredicates(p)).
 		Owns(&appsv1.DaemonSet{}, builder.WithPredicates(p)).
 		Watches(
 			&source.Kind{Type: &machineconfigv1.MachineConfigPool{}},


### PR DESCRIPTION
Our apply logic compares the whole object and also update the whole object
including metadata and status that can be a reason for additional reconciliation
loops. Instead of improving the comparison and updating logic that will make
the code more complex, we can just filter events for objects that did not
have any change under spec or labels.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>