### PR TITLE
add controller to deploy the scheduler plugin

### DIFF
--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -230,6 +230,7 @@ spec:
               containers:
               - args:
                 - --leader-elect
+                - --enable-scheduler
                 command:
                 - /bin/numaresources-operator
                 env:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,6 +29,7 @@ spec:
         - /bin/numaresources-operator
         args:
         - --leader-elect
+        - --enable-scheduler
         image: controller:latest
         name: manager
         securityContext:

--- a/controllers/numaresourcesscheduler_controller.go
+++ b/controllers/numaresourcesscheduler_controller.go
@@ -50,6 +50,11 @@ type NUMAResourcesSchedulerReconciler struct {
 	ImageSpec          string
 }
 
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=*
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=*
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=*
+//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=*
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=*
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesschedulers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesschedulers/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesschedulers/finalizers,verbs=update

--- a/controllers/numaresourcesscheduler_controller.go
+++ b/controllers/numaresourcesscheduler_controller.go
@@ -18,19 +18,36 @@ package controllers
 
 import (
 	"context"
+	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	nodetopologyv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	"github.com/pkg/errors"
+
+	nrsv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	"github.com/openshift-kni/numaresources-operator/pkg/apply"
+	schedmanifests "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/manifests/sched"
+	schedstate "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/objectstate/sched"
+	"github.com/openshift-kni/numaresources-operator/pkg/objectstate/sched"
+	"github.com/openshift-kni/numaresources-operator/pkg/status"
 )
 
 // NUMAResourcesSchedulerReconciler reconciles a NUMAResourcesScheduler object
 type NUMAResourcesSchedulerReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme             *runtime.Scheme
+	SchedulerManifests schedmanifests.Manifests
+	Namespace          string
+	ImageSpec          string
 }
 
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesschedulers,verbs=get;list;watch;create;update;patch;delete
@@ -47,16 +64,110 @@ type NUMAResourcesSchedulerReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.2/pkg/reconcile
 func (r *NUMAResourcesSchedulerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
+	_ = context.Background()
+	klog.V(3).InfoS("Starting NUMAResourcesScheduler reconcile loop", "object", req.NamespacedName)
+	defer klog.V(3).InfoS("Finish NUMAResourcesScheduler reconcile loop", "object", req.NamespacedName)
 
-	// your logic here
+	instance := &nrsv1alpha1.NUMAResourcesScheduler{}
+	err := r.Get(context.TODO(), req.NamespacedName, instance)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			return ctrl.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return ctrl.Result{}, err
+	}
 
-	return ctrl.Result{}, nil
+	result, condition, err := r.reconcileResource(ctx, instance)
+	if condition != "" {
+		// TODO: use proper reason
+		reason, message := condition, messageFromError(err)
+		if err := r.updateStatus(ctx, r.Client, instance, condition, reason, message); err != nil {
+			klog.InfoS("Failed to update numaresourcesscheduler status", "Desired condition", condition, "error", err)
+		}
+	}
+	return result, err
+
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NUMAResourcesSchedulerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&nodetopologyv1alpha1.NUMAResourcesScheduler{}).
+		For(&nrsv1alpha1.NUMAResourcesScheduler{}).
 		Complete(r)
+}
+
+func (r *NUMAResourcesSchedulerReconciler) reconcileResource(ctx context.Context, instance *nrsv1alpha1.NUMAResourcesScheduler) (reconcile.Result, string, error) {
+	klog.Info("SchedulerSync start")
+
+	deploymentInfo, err := r.syncNUMASchedulerResources(ctx, instance)
+	if err != nil {
+		return ctrl.Result{}, status.ConditionDegraded, errors.Wrapf(err, "FailedSchedulerSync")
+	}
+
+	instance.Status.Deployment = nrsv1alpha1.NamespacedName{}
+	ok, err := isDeploymentRunning(ctx, r.Client, deploymentInfo)
+	if err != nil {
+		return ctrl.Result{}, status.ConditionDegraded, err
+	}
+	if !ok {
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, status.ConditionProgressing, nil
+	}
+
+	instance.Status.Deployment = deploymentInfo
+
+	return ctrl.Result{}, status.ConditionAvailable, nil
+
+}
+
+func isDeploymentRunning(ctx context.Context, c client.Client, key nrsv1alpha1.NamespacedName) (bool, error) {
+	dp := &appsv1.Deployment{}
+	if err := c.Get(ctx, client.ObjectKey(key), dp); err != nil {
+		return false, err
+	}
+
+	for _, cond := range dp.Status.Conditions {
+		if cond.Type == appsv1.DeploymentAvailable {
+			return cond.Status == corev1.ConditionTrue, nil
+		}
+	}
+	return false, nil
+}
+
+func (r *NUMAResourcesSchedulerReconciler) syncNUMASchedulerResources(ctx context.Context, instance *nrsv1alpha1.NUMAResourcesScheduler) (nrsv1alpha1.NamespacedName, error) {
+	sched.UpdateDeploymentImageSettings(r.SchedulerManifests.Deployment, instance.Spec.SchedulerImage)
+	sched.UpdateDeploymentConfigMapSettings(r.SchedulerManifests.Deployment, r.SchedulerManifests.ConfigMap.Name)
+
+	var deploymentNName nrsv1alpha1.NamespacedName
+	existing := schedstate.FromClient(ctx, r.Client, r.SchedulerManifests)
+	for _, objState := range existing.State(r.SchedulerManifests) {
+		if err := controllerutil.SetControllerReference(instance, objState.Desired, r.Scheme); err != nil {
+			return deploymentNName, errors.Wrapf(err, "Failed to set controller reference to %s %s", objState.Desired.GetNamespace(), objState.Desired.GetName())
+		}
+		obj, err := apply.ApplyObject(ctx, r.Client, objState)
+		if err != nil {
+			return deploymentNName, errors.Wrapf(err, "could not apply (%s) %s/%s", objState.Desired.GetObjectKind().GroupVersionKind(), objState.Desired.GetNamespace(), objState.Desired.GetName())
+		}
+
+		if nname, ok := sched.DeploymentNamespacedNameFromObject(obj); ok {
+			deploymentNName = nname
+		}
+	}
+	return deploymentNName, nil
+}
+
+func (r *NUMAResourcesSchedulerReconciler) updateStatus(ctx context.Context, cli client.Client, sched *nrsv1alpha1.NUMAResourcesScheduler, condition string, reason string, message string) error {
+	conditions := status.NewConditions(condition, reason, message)
+	if apiequality.Semantic.DeepEqual(conditions, sched.Status.Conditions) {
+		return nil
+	}
+	sched.Status.Conditions = status.NewConditions(condition, reason, message)
+
+	if err := cli.Status().Update(ctx, sched); err != nil {
+		return errors.Wrapf(err, "could not update status for object %s", client.ObjectKeyFromObject(sched))
+	}
+	return nil
 }

--- a/pkg/objectstate/sched/sched.go
+++ b/pkg/objectstate/sched/sched.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sched
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nrsv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+)
+
+const SchedulerConfigMapVolumeName = "etckubernetes"
+
+func UpdateDeploymentImageSettings(dp *appsv1.Deployment, userImageSpec string) {
+	// There is only a single container
+	cnt := &dp.Spec.Template.Spec.Containers[0]
+	cnt.Image = userImageSpec
+	klog.V(3).InfoS("Exporter image", "reason", "user-provided", "pullSpec", userImageSpec)
+}
+
+func UpdateDeploymentConfigMapSettings(dp *appsv1.Deployment, cmName string) {
+	spec := &dp.Spec.Template.Spec // shortcut
+	spec.Volumes[0] = newSchedConfigVolume(SchedulerConfigMapVolumeName, cmName)
+}
+
+func DeploymentNamespacedNameFromObject(obj client.Object) (nrsv1alpha1.NamespacedName, bool) {
+	res := nrsv1alpha1.NamespacedName{
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}
+	_, ok := obj.(*appsv1.Deployment)
+	return res, ok
+}
+
+func newSchedConfigVolume(schedVolumeConfigName, configMapName string) corev1.Volume {
+	return corev1.Volume{
+		Name: schedVolumeConfigName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: configMapName,
+				},
+			},
+		},
+	}
+}

--- a/test/e2e/sched/sched.go
+++ b/test/e2e/sched/sched.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sched
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	"github.com/openshift-kni/numaresources-operator/pkg/status"
+	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
+	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
+)
+
+var _ = Describe("[Scheduler] install", func() {
+	var initialized bool
+
+	BeforeEach(func() {
+		if !initialized {
+			Expect(e2eclient.ClientsEnabled).To(BeTrue(), "failed to create runtime-controller client")
+
+		}
+		initialized = true
+	})
+
+	Context("with a running cluster with all the components", func() {
+		It("should perform the scheduler deployment and verify the condition is reported as available", func() {
+			var err error
+			nroSchedObj := objects.TestNROScheduler()
+
+			By(fmt.Sprintf("creating the NRO Scheduler object: %s", nroSchedObj.Name))
+			err = e2eclient.Client.Create(context.TODO(), nroSchedObj)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroSchedObj), nroSchedObj)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("checking that the condition Available=true")
+			Eventually(func() bool {
+				updatedNROObj := &nropv1alpha1.NUMAResourcesScheduler{}
+				err := e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroSchedObj), updatedNROObj)
+				if err != nil {
+					klog.Warningf("failed to get the RTE resource: %v", err)
+					return false
+				}
+
+				cond := status.FindCondition(updatedNROObj.Status.Conditions, status.ConditionAvailable)
+				if cond == nil {
+					klog.Warningf("missing conditions in %v", updatedNROObj)
+					return false
+				}
+
+				klog.Infof("condition: %v", cond)
+
+				return cond.Status == metav1.ConditionTrue
+			}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "RTE condition did not become available")
+		})
+	})
+})

--- a/test/e2e/sched/test_suite_sched_test.go
+++ b/test/e2e/sched/test_suite_sched_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sched
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestScheduler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Scheduler")
+}

--- a/test/utils/objects/objects.go
+++ b/test/utils/objects/objects.go
@@ -30,6 +30,21 @@ import (
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
 
+func TestNROScheduler() *nropv1alpha1.NUMAResourcesScheduler {
+	return &nropv1alpha1.NUMAResourcesScheduler{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "NUMAResourcesScheduler",
+			APIVersion: nropv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-topo-aware-scheduler",
+		},
+		Spec: nropv1alpha1.NUMAResourcesSchedulerSpec{
+			SchedulerImage: "quay.io/openshift-kni/scheduler-plugins:4.10-snapshot",
+		},
+	}
+}
+
 func TestNRO(matchLabels map[string]string) *nropv1alpha1.NUMAResourcesOperator {
 	return &nropv1alpha1.NUMAResourcesOperator{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
This controller is supposed to replace the role of SSOP in our TAS solution until SSOP will catch up with the necessary changes for our needs.

The purpose of this controller is to be able to deploy a secondary scheduler (with a given image) with all the required components.