### PR TITLE
gh actions: push bundle to openshift-kni org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           image: ${{ steps.bundle-build-image.outputs.image }}
           tags: ${{ steps.bundle-build-image.outputs.tags }}
-          registry: quay.io/fromani
+          registry: quay.io/openshift-kni
           username: ${{ secrets.QUAY_IO_USERNAME }}
           password: ${{ secrets.QUAY_IO_ROBOTOKEN }}
 


### PR DESCRIPTION
We had a stale reference for the bundle repo.

Signed-off-by: Francesco Romani <fromani@redhat.com>