### PR TITLE
Improve E2E coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,10 +138,13 @@ binary-e2e-rte:
 	go test -c -v -o bin/e2e-rte.test ./test/e2e/rte
 
 binary-e2e-install:
-	go test -v -c -o bin/e2e-install.test ./test/e2e/install
+	go test -v -c -o bin/e2e-install.test ./test/e2e/install && go test -v -c -o bin/e2e-sched-install.test ./test/e2e/sched/install
 
 binary-e2e-uninstall:
-	go test -v -c -o bin/e2e-uninstall.test ./test/e2e/uninstall
+	go test -v -c -o bin/e2e-uninstall.test ./test/e2e/uninstall && go test -v -c -o bin/e2e-sched-uninstall.test ./test/e2e/sched/uninstall
+
+binary-e2e-sched:
+	go test -c -v -o bin/e2e-sched.test ./test/e2e/sched
 
 binary-all: binary binary-rte
 
@@ -155,7 +158,7 @@ build-e2e-install: fmt vet binary-e2e-install
 
 build-e2e-uninstall: fmt vet binary-e2e-uninstall
 
-build-e2e-all: fmt vet binary-e2e-install binary-e2e-rte binary-e2e-uninstall
+build-e2e-all: fmt vet binary-e2e-install binary-e2e-rte binary-e2e-sched binary-e2e-uninstall
 
 build-all: generate fmt vet binary binary-rte
 

--- a/hack/run-test-e2e.sh
+++ b/hack/run-test-e2e.sh
@@ -2,6 +2,31 @@
 
 source hack/common.sh
 
+ENABLE_SCHED_TESTS="${ENABLE_SCHED_TESTS:-false}"
+
+function test_sched() {
+  # Make sure that we always properly clean the environment
+  trap '{ echo "Running NROScheduler uninstall test suite"; ${BIN_DIR}/e2e-sched-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.reportFile=/tmp/artifacts/sched-uninstall; }' EXIT SIGINT SIGTERM SIGSTOP
+
+  # Run install test suite
+  echo "Running NROScheduler install test suite"
+  ${BIN_DIR}/e2e-sched-install.test ${NO_COLOR} --ginkgo.v --ginkgo.failFast --ginkgo.reportFile=/tmp/artifacts/sched-install
+
+  # The install failed, no taste to continue
+  if [ $? -ne 0 ]; then
+      echo "Failed to install NROScheduler"
+      exit 1
+  fi
+
+  echo "Running Functional Tests: ${GINKGO_SUITS}"
+  # -v: print out the text and location for each spec before running it and flush output to stdout in realtime
+  # -r: run suites recursively
+  # --failFast: ginkgo will stop the suite right after the first spec failure
+  # --flakeAttempts: rerun the test if it fails
+  # -requireSuite: fail if tests are not executed because of missing suite
+  ${BIN_DIR}/e2e-sched.test ${NO_COLOR} --ginkgo.v --ginkgo.failFast --ginkgo.flakeAttempts=2 --ginkgo.reportFile=/tmp/artifacts/e2e-sched
+}
+
 NO_COLOR=""
 if ! which tput &> /dev/null 2>&1 || [[ $(tput -T$TERM colors) -lt 8 ]]; then
   echo "Terminal does not seem to support colored output, disabling it"
@@ -30,3 +55,8 @@ export E2E_TOPOLOGY_MANAGER_POLICY="${E2E_TOPOLOGY_MANAGER_POLICY:-SingleNUMANod
 # --flakeAttempts: rerun the test if it fails
 # -requireSuite: fail if tests are not executed because of missing suite
 ${BIN_DIR}/e2e-rte.test ${NO_COLOR} --ginkgo.v --ginkgo.failFast --ginkgo.flakeAttempts=2 --ginkgo.reportFile=/tmp/artifacts/e2e --ginkgo.skip='\[Disruptive\]|\[StateDirectories\]'
+
+
+if [ "$ENABLE_SCHED_TESTS" = true ]; then
+  test_sched
+fi

--- a/test/e2e/sched/install/install.go
+++ b/test/e2e/sched/install/install.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package install
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	"github.com/openshift-kni/numaresources-operator/pkg/status"
+	schedutils "github.com/openshift-kni/numaresources-operator/test/e2e/sched/utils"
+	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
+	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
+)
+
+var _ = Describe("[Scheduler] install", func() {
+	Context("with a running cluster with all the components", func() {
+		It("should perform the scheduler deployment and verify the condition is reported as available", func() {
+			var err error
+			nroSchedObj := objects.TestNROScheduler()
+
+			By(fmt.Sprintf("creating the NRO Scheduler object: %s", nroSchedObj.Name))
+			err = e2eclient.Client.Create(context.TODO(), nroSchedObj)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroSchedObj), nroSchedObj)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("checking that the condition Available=true")
+			Eventually(func() bool {
+				updatedNROObj := &nropv1alpha1.NUMAResourcesScheduler{}
+				err := e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroSchedObj), updatedNROObj)
+				if err != nil {
+					klog.Warningf("failed to get the RTE resource: %v", err)
+					return false
+				}
+
+				cond := status.FindCondition(updatedNROObj.Status.Conditions, status.ConditionAvailable)
+				if cond == nil {
+					klog.Warningf("missing conditions in %v", updatedNROObj)
+					return false
+				}
+
+				klog.Infof("condition: %v", cond)
+
+				return cond.Status == metav1.ConditionTrue
+			}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "RTE condition did not become available")
+
+			err = e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroSchedObj), nroSchedObj)
+			Expect(err).NotTo(HaveOccurred())
+
+			deploy, err := schedutils.GetDeploymentByOwnerReference(nroSchedObj.UID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deploy.Status.ReadyReplicas).To(BeIdenticalTo(int32(1)))
+		})
+	})
+})

--- a/test/e2e/sched/install/test_suite_install_test.go
+++ b/test/e2e/sched/install/test_suite_install_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package install
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
+)
+
+func TestInstall(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Install")
+}
+
+var _ = BeforeSuite(func() {
+	By("Creating all test resources")
+	Expect(e2eclient.ClientsEnabled).To(BeTrue(), "failed to create runtime-controller client")
+})

--- a/test/e2e/sched/uninstall/test_suite_uninstall_test.go
+++ b/test/e2e/sched/uninstall/test_suite_uninstall_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package uninstall
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
+)
+
+func TestInstall(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Install")
+}
+
+var _ = BeforeSuite(func() {
+	By("Creating all test resources")
+	Expect(e2eclient.ClientsEnabled).To(BeTrue(), "failed to create runtime-controller client")
+})

--- a/test/e2e/sched/uninstall/uninstall.go
+++ b/test/e2e/sched/uninstall/uninstall.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package uninstall
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/manifests/sched"
+	"github.com/openshift-kni/numaresources-operator/test/e2e/sched/utils"
+	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
+	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
+)
+
+var _ = Describe("[Scheduler] uninstall", func() {
+	Context("with a running cluster with all the components", func() {
+		It("should delete all components after NROScheduler deletion", func() {
+			By("deleting the NROScheduler object")
+			nroSchedObj := objects.TestNROScheduler()
+
+			// failed to get the NROScheduler object, nothing else we can do
+			if err := e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroSchedObj), nroSchedObj); err != nil {
+				if !errors.IsNotFound(err) {
+					klog.Warningf("failed to get the NUMA resource scheduler %q: %w", nroSchedObj.Name, err)
+				}
+				return
+			}
+
+			deploy, err := utils.GetDeploymentByOwnerReference(nroSchedObj.GetUID())
+			Expect(err).ToNot(HaveOccurred())
+
+			err = e2eclient.Client.Delete(context.TODO(), nroSchedObj)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("checking there are no leftovers")
+			// by taking the ns from the deployment we're avoiding the need to figure out in advanced
+			// at which ns we should look for the resources
+			mf, err := sched.GetManifests(deploy.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() bool {
+				objs := mf.ToObjects()
+				for _, obj := range objs {
+					key := client.ObjectKeyFromObject(obj)
+					if err := e2eclient.Client.Get(context.TODO(), key, obj); !errors.IsNotFound(err) {
+						if err == nil {
+							klog.Warningf("obj %s still exists", key.String())
+						} else {
+							klog.Warningf("obj %s return with error: %v", key.String(), err)
+						}
+						return false
+					}
+				}
+				return true
+			}, 5*time.Minute, 10*time.Second).Should(BeTrue())
+		})
+	})
+})

--- a/test/e2e/sched/utils/deployment.go
+++ b/test/e2e/sched/utils/deployment.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
+)
+
+func GetDeploymentByOwnerReference(uid types.UID) (*v1.Deployment, error) {
+	deployList := &v1.DeploymentList{}
+
+	if err := e2eclient.Client.List(context.TODO(), deployList); err != nil {
+		return nil, fmt.Errorf("failed to get deployment: %w", err)
+	}
+
+	for _, deploy := range deployList.Items {
+		for _, or := range deploy.GetOwnerReferences() {
+			if or.UID == uid {
+				return &deploy, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("failed to get deployment with uid: %s", uid)
+}


### PR DESCRIPTION
We need to control the order of the NUMAResourcesScheduler tests:
1. Install
2. Other tests
3. Uninstall

For that, we need each one of the above to be placed in a separate suite and call the suites in the desired order.
This PR intended to address exactly that.

In addition, the NUMAResourcesScheduler e2e tests are set as an opt-in for the e2e script.
Current behavior stays the same, i.e. NUMAResourcesScheduler e2e tests are not running.