### PR TITLE
read tm scope from conf file

### DIFF
--- a/rte/main.go
+++ b/rte/main.go
@@ -200,6 +200,11 @@ func parseArgs(args ...string) (ProgArgs, error) {
 		pArgs.RTE.TopologyManagerPolicy = conf.TopologyManagerPolicy
 	}
 
+	// overwrite if explicitly mentioned in conf
+	if conf.TopologyManagerScope != "" {
+		pArgs.RTE.TopologyManagerScope = conf.TopologyManagerScope
+	}
+
 	return pArgs, nil
 }
 


### PR DESCRIPTION
In case the topology manager scope is configured in the conf file we should read the value from it instead of the default.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>