### PR TITLE
Add relevant tolerations and annotations

### DIFF
--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -224,6 +224,8 @@ spec:
           strategy: {}
           template:
             metadata:
+              annotations:
+                target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 control-plane: controller-manager
             spec:
@@ -257,9 +259,6 @@ spec:
                   initialDelaySeconds: 5
                   periodSeconds: 10
                 resources:
-                  limits:
-                    cpu: 200m
-                    memory: 100Mi
                   requests:
                     cpu: 100m
                     memory: 20Mi
@@ -269,6 +268,9 @@ spec:
                 runAsNonRoot: true
               serviceAccountName: numaresources-controller-manager
               terminationGracePeriodSeconds: 10
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
       permissions:
       - rules:
         - apiGroups:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,6 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: numaresources-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.bundle.channel.default.v1: alpha
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.12.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -19,11 +19,16 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         control-plane: controller-manager
     spec:
       securityContext:
         runAsNonRoot: true
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
       containers:
       - command:
         - /bin/numaresources-operator


### PR DESCRIPTION
Add workload annotation to make sure our operator will consume only resources specified for control plane containers.
Add tolerations to make sure our operator will continue to run on the non-schedulable master


Signed-off-by: Mario Fernandez <mariofer@redhat.com>