### PR TITLE
Apply make bundle to remove limits

### DIFF
--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -257,9 +257,6 @@ spec:
                   initialDelaySeconds: 5
                   periodSeconds: 10
                 resources:
-                  limits:
-                    cpu: 200m
-                    memory: 100Mi
                   requests:
                     cpu: 100m
                     memory: 20Mi


### PR DESCRIPTION
The operator pod should really not have limits until/unless we have a good rationale and proof the limits will not backfire. 

Apply make bundle to remove limits after https://github.com/openshift-kni/numaresources-operator/pull/71

Signed-off-by: Mario Fernandez <mariofer@redhat.com>