### PR TITLE
doc: fix reserved memory value to be equal to NodeAllocatable

### DIFF
--- a/doc/examples/kubeletconfig.yaml
+++ b/doc/examples/kubeletconfig.yaml
@@ -17,7 +17,7 @@ spec:
     reservedMemory:
       - numaNode: 0
         limits:
-          memory: "100Mi"
+          memory: "1124Mi"
     systemReserved: 
       memory: "512Mi"
     topologyManagerPolicy: "single-numa-node"


### PR DESCRIPTION
The kubelet start fails if the reserved memory is not equal to
NodeAllocatable(system-reserved + kube-reserved + hard eviction threshold).

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>