### PR TITLE
Additional e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,9 @@ test-unit: envtest
 test-e2e: build-e2e-all
 	hack/run-test-e2e.sh
 
+test-install-e2e: build-e2e-all
+	hack/run-test-install-e2e.sh
+
 ##@ Build
 
 binary: build-tools

--- a/hack/run-test-e2e.sh
+++ b/hack/run-test-e2e.sh
@@ -13,7 +13,7 @@ trap '{ echo "Running NRO uninstall test suite"; ${BIN_DIR}/e2e-uninstall.test $
 
 # Run install test suite
 echo "Running NRO install test suite"
-${BIN_DIR}/e2e-install.test ${NO_COLOR} --ginkgo.v --ginkgo.failFast --ginkgo.reportFile=/tmp/artifacts/install
+${BIN_DIR}/e2e-install.test ${NO_COLOR} --ginkgo.v --ginkgo.failFast --ginkgo.reportFile=/tmp/artifacts/install --ginkgo.focus='\[Install\] continuousIntegration'
 
 # The install failed, no taste to continue
 if [ $? -ne 0 ]; then

--- a/hack/run-test-install-e2e.sh
+++ b/hack/run-test-install-e2e.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+source hack/common.sh
+
+NO_COLOR=""
+if ! which tput &> /dev/null 2>&1 || [[ $(tput -T$TERM colors) -lt 8 ]]; then
+  echo "Terminal does not seem to support colored output, disabling it"
+  NO_COLOR="-ginkgo.noColor"
+fi
+
+# Make sure that we always properly clean the environment
+trap '{ echo "Running NRO uninstall test suite"; ${BIN_DIR}/e2e-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.reportFile=/tmp/artifacts/uninstall; }' EXIT SIGINT SIGTERM SIGSTOP
+
+# Run install test suite
+echo "Running NRO install test suite"
+${BIN_DIR}/e2e-install.test ${NO_COLOR} --ginkgo.v --ginkgo.failFast --ginkgo.reportFile=/tmp/artifacts/install --ginkgo.focus='\[Install\] durability'

--- a/test/e2e/install/install.go
+++ b/test/e2e/install/install.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,6 +37,8 @@ import (
 	"github.com/openshift-kni/numaresources-operator/test/utils/machineconfigpools"
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 )
+
+const crdName = "noderesourcetopologies.topology.node.k8s.io"
 
 var _ = Describe("[Install]", func() {
 	var initialized bool
@@ -117,6 +120,14 @@ var _ = Describe("[Install]", func() {
 
 				return cond.Status == metav1.ConditionTrue
 			}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "RTE condition did not become available")
+
+			By("checking the NumaResourceTopology CRD is deployed")
+			crd := &apiextensionv1.CustomResourceDefinition{}
+			key := client.ObjectKey{
+				Name: crdName,
+			}
+			err = e2eclient.Client.Get(context.TODO(), key, crd)
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/test/e2e/install/install.go
+++ b/test/e2e/install/install.go
@@ -24,12 +24,16 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	v1 "k8s.io/api/apps/v1"
 	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte"
 	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 	"github.com/openshift-kni/numaresources-operator/pkg/status"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
@@ -38,7 +42,10 @@ import (
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 )
 
-const crdName = "noderesourcetopologies.topology.node.k8s.io"
+const (
+	crdName      = "noderesourcetopologies.topology.node.k8s.io"
+	newTestImage = "quay.io/openshift-kni/numaresources-operator:v0.1.0"
+)
 
 var _ = Describe("[Install] continuousIntegration", func() {
 	var initialized bool
@@ -52,12 +59,20 @@ var _ = Describe("[Install] continuousIntegration", func() {
 
 	Context("with a running cluster with all the components", func() {
 		It("should perform overall deployment and verify the condition is reported as available", func() {
-			nroObj := overallDeployment()
+			deployedObj := overallDeployment()
+
+			var nname client.ObjectKey
+			for _, obj := range deployedObj {
+				if nroObj, ok := obj.(*nropv1alpha1.NUMAResourcesOperator); ok {
+					nname = client.ObjectKeyFromObject(nroObj)
+				}
+			}
+			Expect(nname.Name).ToNot(BeEmpty())
 
 			By("checking that the condition Available=true")
 			Eventually(func() bool {
 				updatedNROObj := &nropv1alpha1.NUMAResourcesOperator{}
-				err := e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroObj), updatedNROObj)
+				err := e2eclient.Client.Get(context.TODO(), nname, updatedNROObj)
 				if err != nil {
 					klog.Warningf("failed to get the RTE resource: %v", err)
 					return false
@@ -87,7 +102,6 @@ var _ = Describe("[Install] continuousIntegration", func() {
 
 var _ = Describe("[Install] durability", func() {
 	var initialized bool
-	var objForDeletion []client.Object
 
 	BeforeEach(func() {
 		if !initialized {
@@ -100,7 +114,6 @@ var _ = Describe("[Install] durability", func() {
 		It("should do nothing", func() {
 			nroObj := objects.TestNRO(nil)
 			nroObj.Name = "wrong-name"
-			objForDeletion = append(objForDeletion, nroObj)
 
 			err := e2eclient.Client.Create(context.TODO(), nroObj)
 			Expect(err).ToNot(HaveOccurred())
@@ -129,16 +142,103 @@ var _ = Describe("[Install] durability", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
+
+	Context("with a running cluster with all the components and overall deployment", func() {
+		var deployedObj []client.Object
+
+		BeforeEach(func() {
+			deployedObj = overallDeployment()
+		})
+
+		AfterEach(func() {
+			for _, obj := range deployedObj {
+				err := e2eclient.Client.Delete(context.TODO(), obj)
+				if err != nil {
+					Expect(errors.IsNotFound(err)).To(BeTrue(), fmt.Sprintf("unexpected error: %v", err))
+				}
+			}
+		})
+
+		It("should be able to delete NUMAResourceOperator CR and redeploy without polluting cluster state", func() {
+			var nname client.ObjectKey
+			for _, obj := range deployedObj {
+				if nroObj, ok := obj.(*nropv1alpha1.NUMAResourcesOperator); ok {
+					nname = client.ObjectKeyFromObject(nroObj)
+				}
+			}
+			Expect(nname.Name).ToNot(BeEmpty())
+
+			nroObj := &nropv1alpha1.NUMAResourcesOperator{}
+			err := e2eclient.Client.Get(context.TODO(), nname, nroObj)
+			Expect(err).ToNot(HaveOccurred())
+
+			uid := nroObj.GetUID()
+			ds, err := getDaemonSetByOwnerReference(uid)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = e2eclient.Client.Delete(context.TODO(), nroObj)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("checking there are no leftovers")
+			// by taking the ns from the ds we're avoiding the need to figure out in advanced
+			// at which ns we should look for the resources
+			mf, err := rte.GetManifests(configuration.Platform, ds.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() bool {
+				objs := mf.ToObjects()
+				for _, obj := range objs {
+					key := client.ObjectKeyFromObject(obj)
+					if err := e2eclient.Client.Get(context.TODO(), key, obj); !errors.IsNotFound(err) {
+						if err == nil {
+							klog.Warningf("obj %s still exists", key.String())
+						} else {
+							klog.Warningf("obj %s return with error: %v", key.String(), err)
+						}
+						return false
+					}
+				}
+				return true
+			}, 5*time.Minute, 10*time.Second).Should(BeTrue())
+
+			By("redeploy with other parameters")
+			// TODO change to an image which is test dedicated
+			nroObj.Spec.ExporterImage = newTestImage
+			// resourceVersion should not be set on objects to be created
+			nroObj.ResourceVersion = ""
+
+			err = e2eclient.Client.Create(context.TODO(), nroObj)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() bool {
+				updatedNroObj := &nropv1alpha1.NUMAResourcesOperator{}
+				err := e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroObj), updatedNroObj)
+				Expect(err).ToNot(HaveOccurred())
+
+				ds, err := getDaemonSetByOwnerReference(updatedNroObj.GetUID())
+				if err != nil {
+					klog.Warningf("failed to get the RTE DaemonSet: %v", err)
+					return false
+				}
+
+				return ds.Spec.Template.Spec.Containers[0].Image == newTestImage
+			}, 5*time.Minute, 10*time.Second).Should(BeTrue())
+		})
+	})
 })
 
-func overallDeployment() *nropv1alpha1.NUMAResourcesOperator {
+// overallDeployment returns a slice of an objects created by it,
+// so it will be easier to introspect and delete them later.
+func overallDeployment() []client.Object {
 	var matchLabels map[string]string
+	var deployedObj []client.Object
 
 	if configuration.Platform == platform.Kubernetes {
 		mcpObj := objects.TestMCP()
 		By(fmt.Sprintf("creating the machine config pool object: %s", mcpObj.Name))
 		err := e2eclient.Client.Create(context.TODO(), mcpObj)
 		Expect(err).NotTo(HaveOccurred())
+		deployedObj = append(deployedObj, mcpObj)
 		matchLabels = map[string]string{"test": "test"}
 	}
 
@@ -157,10 +257,12 @@ func overallDeployment() *nropv1alpha1.NUMAResourcesOperator {
 	By(fmt.Sprintf("creating the KC object: %s", kcObj.Name))
 	err = e2eclient.Client.Create(context.TODO(), kcObj)
 	Expect(err).NotTo(HaveOccurred())
+	deployedObj = append(deployedObj, kcObj)
 
 	By(fmt.Sprintf("creating the NRO object: %s", nroObj.Name))
 	err = e2eclient.Client.Create(context.TODO(), nroObj)
 	Expect(err).NotTo(HaveOccurred())
+	deployedObj = append(deployedObj, nroObj)
 
 	err = unpause()
 	Expect(err).NotTo(HaveOccurred())
@@ -179,5 +281,22 @@ func overallDeployment() *nropv1alpha1.NUMAResourcesOperator {
 			return updated
 		}, configuration.MachineConfigPoolUpdateTimeout, configuration.MachineConfigPoolUpdateInterval).Should(BeTrue())
 	}
-	return nroObj
+	return deployedObj
+}
+
+func getDaemonSetByOwnerReference(uid types.UID) (*v1.DaemonSet, error) {
+	dsList := &v1.DaemonSetList{}
+
+	if err := e2eclient.Client.List(context.TODO(), dsList); err != nil {
+		return nil, fmt.Errorf("failed to get daemonset: %w", err)
+	}
+
+	for _, ds := range dsList.Items {
+		for _, or := range ds.GetOwnerReferences() {
+			if or.UID == uid {
+				return &ds, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("failed to get daemonset with owner reference uid: %s", uid)
 }


### PR DESCRIPTION
The following E2E were added:
- Verify that ```NumaResourceTopology``` CRD is deployed.
- Check that nothing happens when ```NUMAResourcesOperator``` CR deployed with the wrong name.
- Check that ```NUMAResourceOperator``` CR is deleted, redeploy with different parameters and without polluting cluster state.

These tests are part of the ```[Install]``` labels tests but should run on a separate lane dedicated for them.