### PR TITLE
Makefile: use the most updated tag as default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 4.10.0
+VERSION ?= 4.10-snapshot
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")


### PR DESCRIPTION
When a user is running ```make deploy``` without specifiying any specific option we should deploy the controller with the most updated version.
The most updated version that is getting build (automatically by the CI) is with the 4.10-snapshot tag, hence that should be the default.

Not running with the most updated version out of the box, might lead to gaps between what specified in the manifests (flags, args, etc.) and what the binary in the image actually contains

Signed-off-by: Talor Itzhak <titzhak@redhat.com>