### PR TITLE
tests: kubeletconfig: add tests for events

### DIFF
--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -52,6 +52,10 @@ func NewMachineConfigPool(name string, labels map[string]string, machineConfigSe
 
 func NewKubeletConfig(name string, labels map[string]string, machineConfigSelector *metav1.LabelSelector, kubeletConfig *kubeletconfigv1beta1.KubeletConfiguration) *machineconfigv1.KubeletConfig {
 	data, _ := json.Marshal(kubeletConfig)
+	return NewKubeletConfigWithData(name, labels, machineConfigSelector, data)
+}
+
+func NewKubeletConfigWithData(name string, labels map[string]string, machineConfigSelector *metav1.LabelSelector, data []byte) *machineconfigv1.KubeletConfig {
 	return &machineconfigv1.KubeletConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "KubeletConfig",


### PR DESCRIPTION
Add basic coverage for the events emitted by the kubeletconfig
controller. Being part of the user-visible behaviour, we need
to have at least _some_ test coverage.

Signed-off-by: Francesco Romani <fromani@redhat.com>