### PR TITLE
gh actions: add regex to match longer tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     # Sequence of patterns matched against refs/tags
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-dev[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-pre[0-9]+"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
we want to use longer tags to tag milestones (-dev) and pre-releases (-pre),
while we can keep the existing tag model (e.g. v4.10.0) for
official releases.

Signed-off-by: Francesco Romani <fromani@redhat.com>