### PR TITLE
e2e: start the serial suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,9 @@ binary-e2e-uninstall:
 binary-e2e-sched:
 	go test -c -v -o bin/e2e-sched.test ./test/e2e/sched
 
+binary-e2e-serial:
+	go test -c -v -o bin/e2e-serial.test ./test/e2e/serial
+
 binary-all: binary binary-rte
 
 build: generate fmt vet binary

--- a/controllers/kubeletconfig_controller.go
+++ b/controllers/kubeletconfig_controller.go
@@ -38,15 +38,17 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 
+	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
 	rtemanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte"
 	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 	"github.com/openshift-kni/numaresources-operator/pkg/apply"
+	mcphelpers "github.com/openshift-kni/numaresources-operator/pkg/machineconfigpools"
 	cfgstate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/cfg"
 	rtestate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/rte"
 	rteconfig "github.com/openshift-kni/numaresources-operator/rte/pkg/config"
 	"github.com/openshift-kni/numaresources-operator/rte/pkg/sysinfo"
-	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
-	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
 
 const (
@@ -120,7 +122,7 @@ func (r *KubeletConfigReconciler) reconcileConfigMap(ctx context.Context, instan
 		return nil, err
 	}
 
-	mcps, err := GetNodeGroupsMCPs(ctx, r.Client, instance.Spec.NodeGroups)
+	mcps, err := mcphelpers.GetNodeGroupsMCPs(ctx, r.Client, instance.Spec.NodeGroups)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -53,6 +53,7 @@ import (
 
 	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 	"github.com/openshift-kni/numaresources-operator/pkg/apply"
+	mcphelpers "github.com/openshift-kni/numaresources-operator/pkg/machineconfigpools"
 	apistate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/api"
 	rtestate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/rte"
 	"github.com/openshift-kni/numaresources-operator/pkg/status"
@@ -133,7 +134,7 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 		return r.updateStatus(ctx, instance, status.ConditionDegraded, validation.NodeGroupsError, err.Error())
 	}
 
-	mcps, err := GetNodeGroupsMCPs(ctx, r.Client, instance.Spec.NodeGroups)
+	mcps, err := mcphelpers.GetNodeGroupsMCPs(ctx, r.Client, instance.Spec.NodeGroups)
 	if err != nil {
 		return r.updateStatus(ctx, instance, status.ConditionDegraded, validation.NodeGroupsError, err.Error())
 	}
@@ -271,7 +272,8 @@ func (r *NUMAResourcesOperatorReconciler) syncMachineConfigPoolsStatuses(instanc
 			Conditions: mcp.Status.Conditions,
 		})
 
-		if !IsMachineConfigPoolUpdated(instance.Name, mcp) {
+		mcName := rtestate.GetMachineConfigName(instance.Name, mcp.Name)
+		if !mcphelpers.IsMachineConfigPoolUpdated(mcName, mcp) {
 			allMCPsUpdated = false
 			break
 		}
@@ -452,24 +454,6 @@ func validateUpdateEvent(e *event.UpdateEvent) bool {
 	}
 	if e.ObjectNew == nil {
 		klog.Error("Update event has no new runtime object for update")
-		return false
-	}
-
-	return true
-}
-
-func IsMachineConfigPoolUpdated(instanceName string, mcp *machineconfigv1.MachineConfigPool) bool {
-	mcName := rtestate.GetMachineConfigName(instanceName, mcp.Name)
-	existing := false
-	for _, s := range mcp.Status.Configuration.Source {
-		if s.Name == mcName {
-			existing = true
-			break
-		}
-	}
-
-	// the Machine Config Pool still did not apply the machine config wait for one minute
-	if !existing || machineconfigv1.IsMachineConfigPoolConditionFalse(mcp.Status.Conditions, machineconfigv1.MachineConfigPoolUpdated) {
 		return false
 	}
 

--- a/test/e2e/serial/sched_removal_test.go
+++ b/test/e2e/serial/sched_removal_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serial
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	e2efixture "github.com/openshift-kni/numaresources-operator/test/utils/fixture"
+	"github.com/openshift-kni/numaresources-operator/test/utils/nrosched"
+	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
+	e2ewait "github.com/openshift-kni/numaresources-operator/test/utils/objects/wait"
+)
+
+var _ = Describe("[test_id:47593][serial][disruptive][Scheduler] scheduler removal on a live cluster", func() {
+	var fxt *e2efixture.Fixture
+	var nroSchedObj *nropv1alpha1.NUMAResourcesScheduler
+	var schedulerName string
+
+	BeforeEach(func() {
+		var err error
+		fxt, err = e2efixture.Setup("e2e-test-sched-remove")
+		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
+
+		nroSchedObj = &nropv1alpha1.NUMAResourcesScheduler{}
+		err = fxt.Client.Get(context.TODO(), client.ObjectKey{Name: nrosched.NROSchedObjectName}, nroSchedObj)
+		Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", nrosched.NROSchedObjectName)
+
+		schedulerName = nroSchedObj.Status.SchedulerName
+		Expect(schedulerName).ToNot(BeEmpty(), "cannot autodetect the TAS scheduler name from the cluster")
+
+		nrosched.CheckNROSchedulerAvailable(fxt.Client, nroSchedObj.Name)
+	})
+
+	AfterEach(func() {
+		By(fmt.Sprintf("re-creating the NRO Scheduler object: %s", nroSchedObj.Name))
+
+		nroSched := &nropv1alpha1.NUMAResourcesScheduler{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "NUMAResourcesScheduler",
+				APIVersion: nropv1alpha1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nroSchedObj.Name,
+			},
+			Spec: nroSchedObj.Spec,
+		}
+
+		err := fxt.Client.Create(context.TODO(), nroSched)
+		Expect(err).NotTo(HaveOccurred())
+
+		nrosched.CheckNROSchedulerAvailable(fxt.Client, nroSchedObj.Name)
+
+		err = e2efixture.Teardown(fxt)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	When("removing the topology aware scheduler from a live cluster", func() {
+		It("should keep existing workloads running", func() {
+			var err error
+
+			dp := createDeploymentSync(fxt, "testdp", schedulerName)
+
+			By(fmt.Sprintf("deleting the NRO Scheduler object: %s", nroSchedObj.Name))
+			err = fxt.Client.Delete(context.TODO(), nroSchedObj)
+			Expect(err).ToNot(HaveOccurred())
+
+			maxStep := 3
+			for step := 0; step < maxStep; step++ {
+				time.Sleep(10 * time.Second)
+
+				By(fmt.Sprintf("ensuring the deployment %q keep being ready %d/%d", dp.Name, step, maxStep))
+
+				updatedDp := &appsv1.Deployment{}
+				err = fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(dp), updatedDp)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(e2ewait.IsDeploymentComplete(dp, &updatedDp.Status)).To(BeTrue(), "deployment %q become unready", dp.Name)
+			}
+		})
+
+		It("should keep new scheduled workloads pending", func() {
+			var err error
+
+			By(fmt.Sprintf("deleting the NRO Scheduler object: %s", nroSchedObj.Name))
+			err = fxt.Client.Delete(context.TODO(), nroSchedObj)
+			Expect(err).ToNot(HaveOccurred())
+
+			dp := createDeploymentSync(fxt, "testdp", schedulerName)
+
+			maxStep := 3
+			for step := 0; step < maxStep; step++ {
+				time.Sleep(10 * time.Second)
+
+				By(fmt.Sprintf("ensuring the deployment %q keep being ready %d/%d", dp.Name, step, maxStep))
+
+				updatedDp := &appsv1.Deployment{}
+				err = fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(dp), updatedDp)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(e2ewait.IsDeploymentComplete(dp, &updatedDp.Status)).To(BeFalse(), "deployment %q become ready", dp.Name)
+			}
+		})
+	})
+})
+
+func createDeploymentSync(fxt *e2efixture.Fixture, name, schedulerName string) *appsv1.Deployment {
+	var err error
+	var replicas int32 = 2
+
+	podLabels := map[string]string{
+		"test": "test-dp",
+	}
+	nodeSelector := map[string]string{}
+	dp := objects.NewTestDeployment(replicas, podLabels, nodeSelector, fxt.Namespace.Name, name, objects.PauseImage, []string{objects.PauseCommand}, []string{})
+	dp.Spec.Template.Spec.SchedulerName = schedulerName
+
+	By(fmt.Sprintf("creating a test deployment %q", name))
+	err = fxt.Client.Create(context.TODO(), dp)
+	Expect(err).ToNot(HaveOccurred())
+
+	By(fmt.Sprintf("waiting for the test deployment %q to be complete and ready", name))
+	err = e2ewait.ForDeploymentComplete(fxt.Client, dp, 1*time.Second, 30*time.Second)
+	Expect(err).ToNot(HaveOccurred())
+	return dp
+}

--- a/test/e2e/serial/test_suite_serial_test.go
+++ b/test/e2e/serial/test_suite_serial_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serial
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// This suite holds the e2e tests which span across components,
+// e.g. involve both the behaviour of RTE and the scheduler.
+// These tests are almost always disruptive, meaning they significantly
+// alter the cluster state and need a very specific cluster state (which
+// is each test responsability to setup and cleanup).
+// Hence we call this suite serial, implying each test should run alone
+// and indisturbed on the cluster. No concurrency at all is possible,
+// each test "owns" the cluster - but again, must leave no leftovers.
+
+func TestSerial(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Serial")
+}

--- a/test/e2e/serial/workload_placement_test.go
+++ b/test/e2e/serial/workload_placement_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serial
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nrtv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	e2efixture "github.com/openshift-kni/numaresources-operator/test/utils/fixture"
+	e2enrt "github.com/openshift-kni/numaresources-operator/test/utils/noderesourcetopologies"
+	"github.com/openshift-kni/numaresources-operator/test/utils/nrosched"
+	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
+	e2ewait "github.com/openshift-kni/numaresources-operator/test/utils/objects/wait"
+)
+
+var _ = Describe("[serial][disruptive][Scheduler] workload placement", func() {
+	var fxt *e2efixture.Fixture
+	var nroSchedObj *nropv1alpha1.NUMAResourcesScheduler
+	var schedulerName string
+	var nrtList nrtv1alpha1.NodeResourceTopologyList
+	var nrts []nrtv1alpha1.NodeResourceTopology
+
+	BeforeEach(func() {
+		var err error
+		fxt, err = e2efixture.Setup("e2e-test-workload-placement")
+		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
+
+		nroSchedObj = &nropv1alpha1.NUMAResourcesScheduler{}
+		err = fxt.Client.Get(context.TODO(), client.ObjectKey{Name: nrosched.NROSchedObjectName}, nroSchedObj)
+		Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", nrosched.NROSchedObjectName)
+
+		schedulerName = nroSchedObj.Status.SchedulerName
+		Expect(schedulerName).ToNot(BeEmpty(), "cannot autodetect the TAS scheduler name from the cluster")
+
+		err = fxt.Client.List(context.TODO(), &nrtList)
+		Expect(err).ToNot(HaveOccurred())
+
+		tmPolicy := nrtv1alpha1.SingleNUMANodeContainerLevel
+		nrts = e2enrt.FilterTopologyManagerPolicy(nrtList.Items, tmPolicy)
+		if len(nrts) == 0 {
+			Skip(fmt.Sprintf("cannot find NRT with policy %q", string(tmPolicy)))
+		}
+
+		// Note that this test, being part of "serial", expects NO OTHER POD being scheduled
+		// in between, so we consider this information current and valid when the It()s run.
+	})
+
+	AfterEach(func() {
+		err := e2efixture.Teardown(fxt)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("cluster with multiple worker nodes suitable", func() {
+		It("[test_id:47575] should make a pod land on a node with enough resources on a specific NUMA zone", func() {
+			requiredRes := corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("3"),
+				corev1.ResourceMemory: resource.MustParse("384Mi"),
+			}
+			pod := objects.NewTestPodPause(fxt.Namespace.Name, "testpod")
+			pod.Spec.SchedulerName = schedulerName
+			pod.Spec.Containers[0].Resources.Limits = requiredRes
+
+			By("checking the cluster can run the test workload")
+			testNRTs := e2enrt.FilterAnyZoneMatchingResources(nrts, requiredRes)
+			if len(testNRTs) < 2 {
+				Skip(fmt.Sprintf("not enough nodes which can run pod (%#v) on a single NUMA zone: found %d", requiredRes, len(testNRTs)))
+			}
+
+			By("finding the candidate node list")
+			candidateNodeNames := e2enrt.AccumulateNames(testNRTs)
+			candidateNodeNamesList := candidateNodeNames.List()
+
+			By("running the test pod")
+			err := fxt.Client.Create(context.TODO(), pod)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for the pod to be scheduled")
+			updatedPod, err := e2ewait.ForPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodRunning, 2*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+
+			By(fmt.Sprintf("checking the pod landed on a candidate node %q vs %v", updatedPod.Spec.NodeName, candidateNodeNamesList))
+			Expect(updatedPod.Spec.NodeName).To(BeElementOf(candidateNodeNamesList),
+				"node landed on %q instead of on %v", updatedPod.Spec.NodeName, candidateNodeNamesList)
+
+			By(fmt.Sprintf("checking the pod was scheduled with the topology aware scheduler %q", schedulerName))
+			schedOK, err := nrosched.CheckPODWasScheduledWith(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, schedulerName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, schedulerName)
+
+			By(fmt.Sprintf("checking the resources are accounted as expected on %q", updatedPod.Spec.NodeName))
+			nrtListPostCreate, err := e2enrt.GetUpdated(fxt.Client, nrtList, 1*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+
+			nrtInitial, err := e2enrt.FindFromList(nrtList.Items, updatedPod.Spec.NodeName)
+			Expect(err).ToNot(HaveOccurred())
+			nrtPostCreate, err := e2enrt.FindFromList(nrtListPostCreate.Items, updatedPod.Spec.NodeName)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = e2enrt.CheckZoneConsumedResourcesAtLeast(*nrtInitial, *nrtPostCreate, requiredRes)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("deleting the test pod")
+			err = fxt.Client.Delete(context.TODO(), updatedPod)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("checking the test pod is removed")
+			err = e2ewait.ForPodDeleted(fxt.Client, updatedPod.Namespace, updatedPod.Name, 3*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+
+			// the NRT updaters MAY be slow to react for a number of reasons including factors out of our control
+			// (kubelet, runtime). This is a known behaviour. We can only tolerate some delay in reporting on pod removal.
+			Eventually(func() bool {
+				By(fmt.Sprintf("checking the resources are restored as expected on %q", updatedPod.Spec.NodeName))
+
+				nrtListPostDelete, err := e2enrt.GetUpdated(fxt.Client, nrtListPostCreate, 1*time.Minute)
+				Expect(err).ToNot(HaveOccurred())
+
+				nrtPostDelete, err := e2enrt.FindFromList(nrtListPostDelete.Items, updatedPod.Spec.NodeName)
+				Expect(err).ToNot(HaveOccurred())
+
+				ok, err := e2enrt.CheckEqualAvailableResources(*nrtInitial, *nrtPostDelete)
+				Expect(err).ToNot(HaveOccurred())
+				return ok
+			}, time.Minute, time.Second*5).Should(BeTrue(), "resources not restored on %q", updatedPod.Spec.NodeName)
+		})
+	})
+})

--- a/test/e2e/uninstall/uninstall.go
+++ b/test/e2e/uninstall/uninstall.go
@@ -26,14 +26,17 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
-	"github.com/openshift-kni/numaresources-operator/controllers"
+
+	mcphelpers "github.com/openshift-kni/numaresources-operator/pkg/machineconfigpools"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectstate/rte"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
+
 	"github.com/openshift-kni/numaresources-operator/test/utils/configuration"
 	"github.com/openshift-kni/numaresources-operator/test/utils/machineconfigpools"
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
-	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
 
 var _ = Describe("[Uninstall]", func() {
@@ -91,7 +94,7 @@ var _ = Describe("[Uninstall]", func() {
 
 			if configuration.Platform == platform.OpenShift {
 				Eventually(func() bool {
-					mcps, err := controllers.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nroObj.Spec.NodeGroups)
+					mcps, err := mcphelpers.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nroObj.Spec.NodeGroups)
 					if err != nil {
 						klog.Warningf("failed to get machine config pools: %w", err)
 						return false

--- a/test/utils/clients/clients.go
+++ b/test/utils/clients/clients.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
+	nrtv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
 	numaresourcesoperatorv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -54,6 +55,10 @@ func init() {
 	}
 
 	if err := apiextensionsv1beta1.AddToScheme(scheme.Scheme); err != nil {
+		klog.Exit(err.Error())
+	}
+
+	if err := nrtv1alpha1.AddToScheme(scheme.Scheme); err != nil {
 		klog.Exit(err.Error())
 	}
 

--- a/test/utils/fixture/fixture.go
+++ b/test/utils/fixture/fixture.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fixture
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Fixture struct {
+	// Client defines the API client to run CRUD operations, that will be used for testing
+	Client client.Client
+	// K8sClient defines k8s client to run subresource operations, for example you should use it to get pod logs
+	K8sClient *kubernetes.Clientset
+	Namespace corev1.Namespace
+}
+
+func Setup(baseName string) (*Fixture, error) {
+	if !e2eclient.ClientsEnabled {
+		return nil, fmt.Errorf("clients not enabled")
+	}
+	ns, err := setupNamespace(e2eclient.Client, baseName)
+	if err != nil {
+		klog.Errorf("cannot setup namespace %q: %v", baseName, err)
+		return nil, err
+	}
+	By(fmt.Sprintf("set up the test namespace %q", ns.Name))
+	return &Fixture{
+		Client:    e2eclient.Client,
+		K8sClient: e2eclient.K8sClient,
+		Namespace: ns,
+	}, nil
+}
+
+func Teardown(ft *Fixture) error {
+	By(fmt.Sprintf("tearing down the test namespace %q", ft.Namespace.Name))
+	err := teardownNamespace(ft.Client, ft.Namespace)
+	if err != nil {
+		klog.Errorf("cannot teardown namespace %q: %s", ft.Namespace.Name, err)
+	}
+	return err
+}
+
+func setupNamespace(cli client.Client, baseName string) (corev1.Namespace, error) {
+	// intentionally avoid GenerateName like the k8s e2e framework does
+	ns := v1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Namespace",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: RandomName(baseName),
+		},
+	}
+
+	err := cli.Create(context.TODO(), &ns)
+	if err != nil {
+		return ns, err
+	}
+
+	// again we do like the k8s e2e framework does and we try to be robust
+	var updatedNs corev1.Namespace
+	err = wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
+		err := cli.Get(context.TODO(), client.ObjectKeyFromObject(&ns), &updatedNs)
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+	return updatedNs, err
+}
+
+func teardownNamespace(cli client.Client, ns corev1.Namespace) error {
+	err := cli.Delete(context.TODO(), &ns)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+
+	var updatedNs corev1.Namespace
+	return wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
+		err := cli.Get(context.TODO(), client.ObjectKeyFromObject(&ns), &updatedNs)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	})
+}
+
+func RandomName(baseName string) string {
+	return fmt.Sprintf("%s-%s", baseName, strconv.Itoa(rand.Intn(10000)))
+}

--- a/test/utils/machineconfigpools/machineconfigpools.go
+++ b/test/utils/machineconfigpools/machineconfigpools.go
@@ -21,19 +21,19 @@ import (
 	"fmt"
 
 	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
-	"github.com/openshift-kni/numaresources-operator/controllers"
+	mcphelpers "github.com/openshift-kni/numaresources-operator/pkg/machineconfigpools"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
 )
 
 // IsMachineConfigPoolsUpdated checks if all related to NUMAResourceOperator CR machines config pools have updated status
 func IsMachineConfigPoolsUpdated(nro *nropv1alpha1.NUMAResourcesOperator) (bool, error) {
-	mcps, err := controllers.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nro.Spec.NodeGroups)
+	mcps, err := mcphelpers.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nro.Spec.NodeGroups)
 	if err != nil {
 		return false, err
 	}
 
 	for _, mcp := range mcps {
-		if !controllers.IsMachineConfigPoolUpdated(nro.Name, mcp) {
+		if !mcphelpers.IsMachineConfigPoolUpdated(nro.Name, mcp) {
 			return false, nil
 		}
 	}
@@ -42,7 +42,7 @@ func IsMachineConfigPoolsUpdated(nro *nropv1alpha1.NUMAResourcesOperator) (bool,
 }
 
 func PauseMCPs(nodeGroups []nropv1alpha1.NodeGroup) (func() error, error) {
-	mcps, err := controllers.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nodeGroups)
+	mcps, err := mcphelpers.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nodeGroups)
 	if err != nil {
 		return nil, err
 	}

--- a/test/utils/noderesourcetopologies/noderesourcetopologies.go
+++ b/test/utils/noderesourcetopologies/noderesourcetopologies.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package noderesourcetopologies
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nrtv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+)
+
+func GetUpdated(cli client.Client, ref nrtv1alpha1.NodeResourceTopologyList, timeout time.Duration) (nrtv1alpha1.NodeResourceTopologyList, error) {
+	var updatedNrtList nrtv1alpha1.NodeResourceTopologyList
+	err := wait.Poll(1*time.Second, timeout, func() (bool, error) {
+		err := cli.List(context.TODO(), &updatedNrtList)
+		if err != nil {
+			klog.Errorf("cannot get the NRT List: %v", err)
+			return false, err
+		}
+		klog.Infof("NRT List current ResourceVersion %s reference %s", updatedNrtList.ListMeta.ResourceVersion, ref.ListMeta.ResourceVersion)
+		return (updatedNrtList.ListMeta.ResourceVersion != ref.ListMeta.ResourceVersion), nil
+	})
+	return updatedNrtList, err
+}
+
+func CheckEqualAvailableResources(nrtInitial, nrtUpdated nrtv1alpha1.NodeResourceTopology) (bool, error) {
+	for idx := 0; idx < len(nrtInitial.Zones); idx++ {
+		zoneInitial := &nrtInitial.Zones[idx] // shortcut
+		zoneUpdated, err := findZoneByName(nrtUpdated, zoneInitial.Name)
+		if err != nil {
+			klog.Errorf("missing updated zone %q: %v", zoneInitial.Name, err)
+			return false, err
+		}
+		ok, what, err := checkEqualResourcesInfo(nrtInitial.Name, zoneInitial.Name, zoneInitial.Resources, zoneUpdated.Resources)
+		if err != nil {
+			klog.Errorf("error checking zone %q: %v", zoneInitial.Name, err)
+			return false, err
+		}
+		if !ok {
+			klog.Infof("node %q zone %q resource %q is different", nrtInitial.Name, zoneInitial.Name, what)
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func CheckZoneConsumedResourcesAtLeast(nrtInitial, nrtUpdated nrtv1alpha1.NodeResourceTopology, required corev1.ResourceList) (string, error) {
+	for idx := 0; idx < len(nrtInitial.Zones); idx++ {
+		zoneInitial := &nrtInitial.Zones[idx] // shortcut
+		zoneUpdated, err := findZoneByName(nrtUpdated, zoneInitial.Name)
+		if err != nil {
+			klog.Errorf("missing updated zone %q: %v", zoneInitial.Name, err)
+			return "", err
+		}
+		ok, err := checkConsumedResourcesAtLeast(zoneInitial.Resources, zoneUpdated.Resources, required)
+		if err != nil {
+			klog.Errorf("error checking zone %q: %v", zoneInitial.Name, err)
+			return "", err
+		}
+		if ok {
+			klog.Infof("match for zone %q", zoneInitial.Name)
+			return zoneInitial.Name, nil
+		}
+	}
+	return "", nil
+}
+
+func checkEqualResourcesInfo(nodeName, zoneName string, resourcesInitial, resourcesUpdated []nrtv1alpha1.ResourceInfo) (bool, string, error) {
+	for _, res := range resourcesInitial {
+		initialQty := res.Available
+		updatedQty, ok := findResourceAvailableByName(resourcesUpdated, res.Name)
+		if !ok {
+			return false, res.Name, fmt.Errorf("resource %q not found in the updated set", res.Name)
+		}
+		if initialQty.Cmp(updatedQty) != 0 {
+			klog.Infof("node %q zone %q resource %q initial=%v updated=%v", nodeName, zoneName, res.Name, initialQty, updatedQty)
+			return false, res.Name, nil
+		}
+	}
+	return true, "", nil
+}
+
+func checkConsumedResourcesAtLeast(resourcesInitial, resourcesUpdated []nrtv1alpha1.ResourceInfo, required corev1.ResourceList) (bool, error) {
+	for resName, resQty := range required {
+		initialQty, ok := findResourceAvailableByName(resourcesInitial, string(resName))
+		if !ok {
+			return false, fmt.Errorf("resource %q not found in the initial set", string(resName))
+		}
+		updatedQty, ok := findResourceAvailableByName(resourcesUpdated, string(resName))
+		if !ok {
+			return false, fmt.Errorf("resource %q not found in the updated set", string(resName))
+		}
+		expectedQty := initialQty.DeepCopy()
+		expectedQty.Sub(resQty)
+		ret := updatedQty.Cmp(expectedQty)
+		if ret > 0 {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func ResourcesFromGuaranteedPod(pod corev1.Pod) corev1.ResourceList {
+	res := make(corev1.ResourceList)
+	for idx := 0; idx < len(pod.Spec.Containers); idx++ {
+		cnt := &pod.Spec.Containers[idx] // shortcut
+		for resName, resQty := range cnt.Resources.Limits {
+			qty := res[resName]
+			qty.Add(resQty)
+			res[resName] = qty
+		}
+	}
+	return res
+}
+
+func AccumulateNames(nrts []nrtv1alpha1.NodeResourceTopology) sets.String {
+	nodeNames := sets.NewString()
+	for _, nrt := range nrts {
+		nodeNames.Insert(nrt.Name)
+	}
+	return nodeNames
+}
+
+func FilterTopologyManagerPolicy(nrts []nrtv1alpha1.NodeResourceTopology, tmPolicy nrtv1alpha1.TopologyManagerPolicy) []nrtv1alpha1.NodeResourceTopology {
+	ret := []nrtv1alpha1.NodeResourceTopology{}
+	for _, nrt := range nrts {
+		if !contains(nrt.TopologyPolicies, string(tmPolicy)) {
+			klog.Warningf("SKIP: node %q doesn't support topology manager policy %q", nrt.Name, string(tmPolicy))
+			continue
+		}
+		klog.Infof("ADD : node %q supports topology manager policy %q", nrt.Name, string(tmPolicy))
+		ret = append(ret, nrt)
+	}
+	return ret
+}
+
+func FilterAnyZoneMatchingResources(nrts []nrtv1alpha1.NodeResourceTopology, requests corev1.ResourceList) []nrtv1alpha1.NodeResourceTopology {
+	ret := []nrtv1alpha1.NodeResourceTopology{}
+	for _, nrt := range nrts {
+		matches := 0
+		for _, zone := range nrt.Zones {
+			if !zoneResourcesMatchesRequest(zone.Resources, requests) {
+				continue
+			}
+			klog.Infof(" ----> node %q zone %q provides at least %#v", nrt.Name, zone.Name, requests)
+			matches++
+		}
+		if matches == 0 {
+			klog.Warningf("SKIP: node %q can't provide %#v", nrt.Name, requests)
+			continue
+		}
+		klog.Infof("ADD : node %q provides at least %#v", nrt.Name, requests)
+		ret = append(ret, nrt)
+	}
+	return ret
+}
+
+func FindFromList(nrts []nrtv1alpha1.NodeResourceTopology, name string) (*nrtv1alpha1.NodeResourceTopology, error) {
+	for idx := 0; idx < len(nrts); idx++ {
+		if nrts[idx].Name == name {
+			return &nrts[idx], nil
+		}
+	}
+	return nil, fmt.Errorf("failed to find NRT for %q", name)
+}
+
+func findZoneByName(nrt nrtv1alpha1.NodeResourceTopology, zoneName string) (*nrtv1alpha1.Zone, error) {
+	for idx := 0; idx < len(nrt.Zones); idx++ {
+		if nrt.Zones[idx].Name == zoneName {
+			return &nrt.Zones[idx], nil
+		}
+	}
+	return nil, fmt.Errorf("cannot find zone %q", zoneName)
+}
+
+func zoneResourcesMatchesRequest(resources []nrtv1alpha1.ResourceInfo, requests corev1.ResourceList) bool {
+	for resName, resQty := range requests {
+		zoneQty, ok := findResourceAvailableByName(resources, string(resName))
+		if !ok {
+			return false
+		}
+		if zoneQty.Cmp(resQty) < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func findResourceAvailableByName(resources []nrtv1alpha1.ResourceInfo, name string) (resource.Quantity, bool) {
+	for _, resource := range resources {
+		if resource.Name != name {
+			continue
+		}
+		return resource.Available, true
+	}
+	return *resource.NewQuantity(0, resource.DecimalSI), false
+}
+
+func contains(items []string, st string) bool {
+	for _, item := range items {
+		if item == st {
+			return true
+		}
+	}
+	return false
+}

--- a/test/utils/nrosched/nrosched.go
+++ b/test/utils/nrosched/nrosched.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -36,7 +37,32 @@ const (
 	// TODO: fetch this from NRO scheduler status
 	NROSchedulerName   = "topo-aware-scheduler"
 	NROSchedObjectName = "numaresourcesscheduler"
+
+	ReasonScheduled = "Scheduled"
 )
+
+func CheckPODWasScheduledWith(k8sCli *kubernetes.Clientset, podNamespace, podName, schedulerName string) (bool, error) {
+	By(fmt.Sprintf("checking events for pod %s/%s", podNamespace, podName))
+	opts := metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("involvedObject.name=%s", podName),
+		TypeMeta:      metav1.TypeMeta{Kind: "Pod"},
+	}
+	events, err := k8sCli.CoreV1().Events(podNamespace).List(context.TODO(), opts)
+	if err != nil {
+		klog.ErrorS(err, "cannot get events for pod %s/%s", podNamespace, podName)
+		return false, err
+	}
+	for _, item := range events.Items {
+		klog.Infof("checking event: [%s: %s]", item.ReportingController, item.Reason)
+		// TODO: is this check robust enough?
+		if item.Reason == ReasonScheduled && item.ReportingController == schedulerName {
+			klog.Infof("-> found relevant scheduling event for pod %s/%s", podNamespace, podName)
+			return true, nil
+		}
+	}
+	klog.Warningf("Failed to find relevant scheduling event for pod %s/%s", podNamespace, podName)
+	return false, nil
+}
 
 func CheckNROSchedulerAvailable(cli client.Client, nroSchedName string) *nropv1alpha1.NUMAResourcesScheduler {
 	nroSchedObj := &nropv1alpha1.NUMAResourcesScheduler{}

--- a/test/utils/nrosched/nrosched.go
+++ b/test/utils/nrosched/nrosched.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nrosched
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	"github.com/openshift-kni/numaresources-operator/pkg/status"
+)
+
+const (
+	// TODO: fetch this from NRO scheduler status
+	NROSchedulerName   = "topo-aware-scheduler"
+	NROSchedObjectName = "numaresourcesscheduler"
+)
+
+func CheckNROSchedulerAvailable(cli client.Client, nroSchedName string) *nropv1alpha1.NUMAResourcesScheduler {
+	nroSchedObj := &nropv1alpha1.NUMAResourcesScheduler{}
+	Eventually(func() bool {
+		By(fmt.Sprintf("checking %q for the condition Available=true", nroSchedName))
+
+		err := cli.Get(context.TODO(), client.ObjectKey{Name: NROSchedObjectName}, nroSchedObj)
+		if err != nil {
+			klog.Warningf("failed to get the scheduler resource: %v", err)
+			return false
+		}
+
+		cond := status.FindCondition(nroSchedObj.Status.Conditions, status.ConditionAvailable)
+		if cond == nil {
+			klog.Warningf("missing conditions in %v", nroSchedObj)
+			return false
+		}
+
+		klog.Infof("condition: %v", cond)
+
+		return cond.Status == metav1.ConditionTrue
+	}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "Scheduler condition did not become available")
+	return nroSchedObj
+}

--- a/test/utils/objects/consts.go
+++ b/test/utils/objects/consts.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objects
+
+const (
+	PauseImage   = "gcr.io/google_containers/pause-amd64:3.0"
+	PauseCommand = "/pause"
+)

--- a/test/utils/objects/deployment.go
+++ b/test/utils/objects/deployment.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objects
+
+import (
+	"context"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewTestDeployment(replicas int32, podLabels map[string]string, nodeSelector map[string]string, namespace, name, image string, command, args []string) *appsv1.Deployment {
+	var zero int64
+	dp := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: podLabels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+				},
+				Spec: corev1.PodSpec{
+					TerminationGracePeriodSeconds: &zero,
+					Containers: []corev1.Container{
+						{
+							Name:    name + "-cnt",
+							Image:   image,
+							Command: command,
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyAlways,
+				},
+			},
+		},
+	}
+	if nodeSelector != nil {
+		dp.Spec.Template.Spec.NodeSelector = nodeSelector
+	}
+	return dp
+}
+
+func WaitForDeploymentComplete(cli client.Client, dp *appsv1.Deployment, pollInterval, pollTimeout time.Duration) error {
+	return wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+		updatedDp := &appsv1.Deployment{}
+		err := cli.Get(context.TODO(), client.ObjectKeyFromObject(dp), updatedDp)
+		if err != nil {
+			// TODO: log
+			return false, err
+		}
+
+		if !IsDeploymentComplete(dp, &updatedDp.Status) {
+			// TODO: log
+			return false, nil
+		}
+
+		return true, nil
+	})
+}
+
+func AreDeploymentReplicasAvailable(newStatus *appsv1.DeploymentStatus, replicas int32) bool {
+	return newStatus.UpdatedReplicas == replicas &&
+		newStatus.Replicas == replicas &&
+		newStatus.AvailableReplicas == replicas
+}
+
+func IsDeploymentComplete(dp *appsv1.Deployment, newStatus *appsv1.DeploymentStatus) bool {
+	return AreDeploymentReplicasAvailable(newStatus, *(dp.Spec.Replicas)) &&
+		newStatus.ObservedGeneration >= dp.Generation
+}

--- a/test/utils/objects/deployment.go
+++ b/test/utils/objects/deployment.go
@@ -17,15 +17,9 @@ limitations under the License.
 package objects
 
 import (
-	"context"
-	"time"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func NewTestDeployment(replicas int32, podLabels map[string]string, nodeSelector map[string]string, namespace, name, image string, command, args []string) *appsv1.Deployment {
@@ -62,33 +56,4 @@ func NewTestDeployment(replicas int32, podLabels map[string]string, nodeSelector
 		dp.Spec.Template.Spec.NodeSelector = nodeSelector
 	}
 	return dp
-}
-
-func WaitForDeploymentComplete(cli client.Client, dp *appsv1.Deployment, pollInterval, pollTimeout time.Duration) error {
-	return wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
-		updatedDp := &appsv1.Deployment{}
-		err := cli.Get(context.TODO(), client.ObjectKeyFromObject(dp), updatedDp)
-		if err != nil {
-			// TODO: log
-			return false, err
-		}
-
-		if !IsDeploymentComplete(dp, &updatedDp.Status) {
-			// TODO: log
-			return false, nil
-		}
-
-		return true, nil
-	})
-}
-
-func AreDeploymentReplicasAvailable(newStatus *appsv1.DeploymentStatus, replicas int32) bool {
-	return newStatus.UpdatedReplicas == replicas &&
-		newStatus.Replicas == replicas &&
-		newStatus.AvailableReplicas == replicas
-}
-
-func IsDeploymentComplete(dp *appsv1.Deployment, newStatus *appsv1.DeploymentStatus) bool {
-	return AreDeploymentReplicasAvailable(newStatus, *(dp.Spec.Replicas)) &&
-		newStatus.ObservedGeneration >= dp.Generation
 }

--- a/test/utils/objects/pod.go
+++ b/test/utils/objects/pod.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objects
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewTestPodPause(namespace, name string) *corev1.Pod {
+	var zero int64
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			TerminationGracePeriodSeconds: &zero,
+			Containers: []corev1.Container{
+				{
+					Name:    name + "-cnt",
+					Image:   PauseImage,
+					Command: []string{PauseCommand},
+				},
+			},
+		},
+	}
+}

--- a/test/utils/objects/wait/deployment.go
+++ b/test/utils/objects/wait/deployment.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wait
+
+import (
+	"context"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ForDeploymentComplete(cli client.Client, dp *appsv1.Deployment, pollInterval, pollTimeout time.Duration) error {
+	return wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+		updatedDp := &appsv1.Deployment{}
+		key := client.ObjectKeyFromObject(dp)
+		err := cli.Get(context.TODO(), key, updatedDp)
+		if err != nil {
+			klog.Warningf("failed to get the deployment %#v: %v", key, err)
+			return false, err
+		}
+
+		if !IsDeploymentComplete(dp, &updatedDp.Status) {
+			klog.Warningf("deployment %#v not yet complete", key)
+			return false, nil
+		}
+
+		klog.Infof("deployment %#v not yet complete", key)
+		return true, nil
+	})
+}
+
+func AreDeploymentReplicasAvailable(newStatus *appsv1.DeploymentStatus, replicas int32) bool {
+	return newStatus.UpdatedReplicas == replicas &&
+		newStatus.Replicas == replicas &&
+		newStatus.AvailableReplicas == replicas
+}
+
+func IsDeploymentComplete(dp *appsv1.Deployment, newStatus *appsv1.DeploymentStatus) bool {
+	return AreDeploymentReplicasAvailable(newStatus, *(dp.Spec.Replicas)) &&
+		newStatus.ObservedGeneration >= dp.Generation
+}

--- a/test/utils/objects/wait/pod.go
+++ b/test/utils/objects/wait/pod.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wait
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ForPodPhase(cli client.Client, podNamespace, podName string, phase corev1.PodPhase, timeout time.Duration) (*corev1.Pod, error) {
+	updatedPod := &corev1.Pod{}
+	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		key := types.NamespacedName{Name: podName, Namespace: podNamespace}
+		if err := cli.Get(context.TODO(), key, updatedPod); err != nil {
+			klog.Warningf("failed to get the pod %#v: %v", key, err)
+			return false, nil
+		}
+
+		if updatedPod.Status.Phase == phase {
+			klog.Infof("pod %#v reached phase %s", key, string(phase))
+			return true, nil
+		}
+
+		klog.Infof("pod %#v phase %s desired %s", key, string(updatedPod.Status.Phase), string(phase))
+		return false, nil
+	})
+	return updatedPod, err
+}
+
+func ForPodDeleted(cli client.Client, podNamespace, podName string, timeout time.Duration) error {
+	return wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		pod := &corev1.Pod{}
+		key := types.NamespacedName{Name: podName, Namespace: podNamespace}
+		err := cli.Get(context.TODO(), key, pod)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				klog.Infof("pod %#v is gone", key)
+				return true, nil
+			}
+			klog.Warningf("failed to get the pod %#v: %v", key, err)
+			return false, err
+		}
+		klog.Infof("pod %#v still present", key)
+		return false, err
+	})
+}


### PR DESCRIPTION
The "serial" lane will have e2e tests which check the whole scheduler + RTE solution, thus aiming to validate
the real e2e, cluster level solution and not just the individual components.

For this reason, each test need to change the cluster state, even though is responsability of each test to clean up everything.

Hence, each test is potentially disruptive and must run in complete isolation with respect any other cluster activity, not just any other test.

Mimicing(ish) what k8s upstream does, we collect these tests in a "sefial" suite, to be called in a strictly serial and exclusive
(as in mutual exclusion) way. 
The latter has to be addressed using proper cluster and test runner configuration, hence it is out of scope for this PR.