### PR TITLE
sched: report the scheduler name in the status

### DIFF
--- a/api/numaresourcesoperator/v1alpha1/numaresourcesscheduler_types.go
+++ b/api/numaresourcesoperator/v1alpha1/numaresourcesscheduler_types.go
@@ -27,7 +27,8 @@ type NUMAResourcesSchedulerSpec struct {
 
 // NUMAResourcesSchedulerStatus defines the observed state of NUMAResourcesScheduler
 type NUMAResourcesSchedulerStatus struct {
-	Deployment NamespacedName `json:"deployment,omitempty"`
+	Deployment    NamespacedName `json:"deployment,omitempty"`
+	SchedulerName string         `json:"schedulerName,omitempty"`
 	// Conditions show the current state of the NUMAResourcesOperator Operator
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }

--- a/bundle/manifests/nodetopology.openshift.io_numaresourcesschedulers.yaml
+++ b/bundle/manifests/nodetopology.openshift.io_numaresourcesschedulers.yaml
@@ -126,6 +126,8 @@ spec:
                   namespace:
                     type: string
                 type: object
+              schedulerName:
+                type: string
             type: object
         type: object
     served: true

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesschedulers.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesschedulers.yaml
@@ -128,6 +128,8 @@ spec:
                   namespace:
                     type: string
                 type: object
+              schedulerName:
+                type: string
             type: object
         type: object
     served: true


### PR DESCRIPTION
Expose the scheduler name in the NUMAResourcesScheduler Status.
This makes easier for any workload, including e2e tests, to
consume the scheduler.

Workload wishing to be scheduled using the Topology/NUMA aware
scheduler need to be using the same name.

Signed-off-by: Francesco Romani <fromani@redhat.com>