### PR TITLE
Verify TAS deployed properly with default values

### DIFF
--- a/test/e2e/sched/install/install_test.go
+++ b/test/e2e/sched/install/install_test.go
@@ -32,12 +32,15 @@ import (
 	"github.com/openshift-kni/numaresources-operator/pkg/status"
 	schedutils "github.com/openshift-kni/numaresources-operator/test/e2e/sched/utils"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
+	"github.com/openshift-kni/numaresources-operator/test/utils/crds"
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 )
 
+const crdName = "numaresourcesschedulers.nodetopology.openshift.io"
+
 var _ = Describe("[Scheduler] install", func() {
 	Context("with a running cluster with all the components", func() {
-		It("should perform the scheduler deployment and verify the condition is reported as available", func() {
+		It("[test_id: 47574] should perform the scheduler deployment and verify the condition is reported as available", func() {
 			var err error
 			nroSchedObj := objects.TestNROScheduler()
 
@@ -71,9 +74,14 @@ var _ = Describe("[Scheduler] install", func() {
 			err = e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroSchedObj), nroSchedObj)
 			Expect(err).NotTo(HaveOccurred())
 
+			By("checking the NumaResourcesScheduler Deployment is correctly deployed")
 			deploy, err := schedutils.GetDeploymentByOwnerReference(nroSchedObj.UID)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(deploy.Status.ReadyReplicas).To(BeIdenticalTo(int32(1)))
+
+			By("checking the NumaResourcesScheduler CRD is deployed")
+			_, err = crds.GetByName(e2eclient.Client, crdName)
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/test/utils/crds/crds.go
+++ b/test/utils/crds/crds.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crds
+
+import (
+	"context"
+
+	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	CrdNRTName = "noderesourcetopologies.topology.node.k8s.io"
+	CrdNROName = "numaresourcesoperators.nodetopology.openshift.io"
+)
+
+func GetByName(aclient client.Client, crdName string) (*apiextensionv1.CustomResourceDefinition, error) {
+	crd := &apiextensionv1.CustomResourceDefinition{}
+	key := client.ObjectKey{
+		Name: crdName,
+	}
+	err := aclient.Get(context.TODO(), key, crd)
+	return crd, err
+}


### PR DESCRIPTION
Improve verification of deployed resources when NRO use default values.
We need to check if all the resources has been properly deployed. 
There are multiple resources to check but we are going to start checking Deployments, DemonSets And CRDs 