### PR TITLE
e2e: add serial lane skeleton and infrastructure

### DIFF
--- a/test/utils/nrosched/nrosched.go
+++ b/test/utils/nrosched/nrosched.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -36,7 +37,32 @@ const (
 	// TODO: fetch this from NRO scheduler status
 	NROSchedulerName   = "topo-aware-scheduler"
 	NROSchedObjectName = "numaresourcesscheduler"
+
+	ReasonScheduled = "Scheduled"
 )
+
+func CheckPODWasScheduledWith(k8sCli *kubernetes.Clientset, podNamespace, podName, schedulerName string) (bool, error) {
+	By(fmt.Sprintf("checking events for pod %s/%s", podNamespace, podName))
+	opts := metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("involvedObject.name=%s", podName),
+		TypeMeta:      metav1.TypeMeta{Kind: "Pod"},
+	}
+	events, err := k8sCli.CoreV1().Events(podNamespace).List(context.TODO(), opts)
+	if err != nil {
+		klog.ErrorS(err, "cannot get events for pod %s/%s", podNamespace, podName)
+		return false, err
+	}
+	for _, item := range events.Items {
+		klog.Infof("checking event: [%s: %s]", item.ReportingController, item.Reason)
+		// TODO: is this check robust enough?
+		if item.Reason == ReasonScheduled && item.ReportingController == schedulerName {
+			klog.Infof("-> found relevant scheduling event for pod %s/%s", podNamespace, podName)
+			return true, nil
+		}
+	}
+	klog.Warningf("Failed to find relevant scheduling event for pod %s/%s", podNamespace, podName)
+	return false, nil
+}
 
 func CheckNROSchedulerAvailable(cli client.Client, nroSchedName string) *nropv1alpha1.NUMAResourcesScheduler {
 	nroSchedObj := &nropv1alpha1.NUMAResourcesScheduler{}

--- a/test/utils/objects/deployment.go
+++ b/test/utils/objects/deployment.go
@@ -17,15 +17,9 @@ limitations under the License.
 package objects
 
 import (
-	"context"
-	"time"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func NewTestDeployment(replicas int32, podLabels map[string]string, nodeSelector map[string]string, namespace, name, image string, command, args []string) *appsv1.Deployment {
@@ -62,33 +56,4 @@ func NewTestDeployment(replicas int32, podLabels map[string]string, nodeSelector
 		dp.Spec.Template.Spec.NodeSelector = nodeSelector
 	}
 	return dp
-}
-
-func WaitForDeploymentComplete(cli client.Client, dp *appsv1.Deployment, pollInterval, pollTimeout time.Duration) error {
-	return wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
-		updatedDp := &appsv1.Deployment{}
-		err := cli.Get(context.TODO(), client.ObjectKeyFromObject(dp), updatedDp)
-		if err != nil {
-			// TODO: log
-			return false, err
-		}
-
-		if !IsDeploymentComplete(dp, &updatedDp.Status) {
-			// TODO: log
-			return false, nil
-		}
-
-		return true, nil
-	})
-}
-
-func AreDeploymentReplicasAvailable(newStatus *appsv1.DeploymentStatus, replicas int32) bool {
-	return newStatus.UpdatedReplicas == replicas &&
-		newStatus.Replicas == replicas &&
-		newStatus.AvailableReplicas == replicas
-}
-
-func IsDeploymentComplete(dp *appsv1.Deployment, newStatus *appsv1.DeploymentStatus) bool {
-	return AreDeploymentReplicasAvailable(newStatus, *(dp.Spec.Replicas)) &&
-		newStatus.ObservedGeneration >= dp.Generation
 }

--- a/test/utils/objects/pod.go
+++ b/test/utils/objects/pod.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objects
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewTestPodPause(namespace, name string) *corev1.Pod {
+	var zero int64
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			TerminationGracePeriodSeconds: &zero,
+			Containers: []corev1.Container{
+				{
+					Name:    name + "-cnt",
+					Image:   PauseImage,
+					Command: []string{PauseCommand},
+				},
+			},
+		},
+	}
+}

--- a/test/utils/objects/wait/deployment.go
+++ b/test/utils/objects/wait/deployment.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wait
+
+import (
+	"context"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ForDeploymentComplete(cli client.Client, dp *appsv1.Deployment, pollInterval, pollTimeout time.Duration) error {
+	return wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+		updatedDp := &appsv1.Deployment{}
+		key := client.ObjectKeyFromObject(dp)
+		err := cli.Get(context.TODO(), key, updatedDp)
+		if err != nil {
+			klog.Warningf("failed to get the deployment %#v: %v", key, err)
+			return false, err
+		}
+
+		if !IsDeploymentComplete(dp, &updatedDp.Status) {
+			klog.Warningf("deployment %#v not yet complete", key)
+			return false, nil
+		}
+
+		klog.Infof("deployment %#v not yet complete", key)
+		return true, nil
+	})
+}
+
+func AreDeploymentReplicasAvailable(newStatus *appsv1.DeploymentStatus, replicas int32) bool {
+	return newStatus.UpdatedReplicas == replicas &&
+		newStatus.Replicas == replicas &&
+		newStatus.AvailableReplicas == replicas
+}
+
+func IsDeploymentComplete(dp *appsv1.Deployment, newStatus *appsv1.DeploymentStatus) bool {
+	return AreDeploymentReplicasAvailable(newStatus, *(dp.Spec.Replicas)) &&
+		newStatus.ObservedGeneration >= dp.Generation
+}

--- a/test/utils/objects/wait/pod.go
+++ b/test/utils/objects/wait/pod.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wait
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ForPodPhase(cli client.Client, podNamespace, podName string, phase corev1.PodPhase, timeout time.Duration) (*corev1.Pod, error) {
+	updatedPod := &corev1.Pod{}
+	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		key := types.NamespacedName{Name: podName, Namespace: podNamespace}
+		if err := cli.Get(context.TODO(), key, updatedPod); err != nil {
+			klog.Warningf("failed to get the pod %#v: %v", key, err)
+			return false, nil
+		}
+
+		if updatedPod.Status.Phase == phase {
+			klog.Infof("pod %#v reached phase %s", key, string(phase))
+			return true, nil
+		}
+
+		klog.Infof("pod %#v phase %s desired %s", key, string(updatedPod.Status.Phase), string(phase))
+		return false, nil
+	})
+	return updatedPod, err
+}
+
+func ForPodDeleted(cli client.Client, podNamespace, podName string, timeout time.Duration) error {
+	return wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		pod := &corev1.Pod{}
+		key := types.NamespacedName{Name: podName, Namespace: podNamespace}
+		err := cli.Get(context.TODO(), key, pod)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				klog.Infof("pod %#v is gone", key)
+				return true, nil
+			}
+			klog.Warningf("failed to get the pod %#v: %v", key, err)
+			return false, err
+		}
+		klog.Infof("pod %#v still present", key)
+		return false, err
+	})
+}


### PR DESCRIPTION
Spin off from #95: bootstrap the serial lane and add all the utilities which we know we need, because we will use them in #95, but are likely helpful in other related PRs like #100