### PR TITLE
e2e: introduce NO_TEARDOWN option

### DIFF
--- a/hack/run-test-e2e.sh
+++ b/hack/run-test-e2e.sh
@@ -3,10 +3,11 @@
 source hack/common.sh
 
 ENABLE_SCHED_TESTS="${ENABLE_SCHED_TESTS:-false}"
+NO_TEARDOWN="${NO_TEARDOWN:-false}"
 
 function test_sched() {
   # Make sure that we always properly clean the environment
-  trap '{ echo "Running NROScheduler uninstall test suite"; ${BIN_DIR}/e2e-sched-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.reportFile=/tmp/artifacts/sched-uninstall; }' EXIT SIGINT SIGTERM SIGSTOP
+  trap '{ if [ ${NO_TEARDOWN} = false ]; then echo "Running NROScheduler uninstall test suite"; ${BIN_DIR}/e2e-sched-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.reportFile=/tmp/artifacts/sched-uninstall; fi }' EXIT SIGINT SIGTERM SIGSTOP
 
   # Run install test suite
   echo "Running NROScheduler install test suite"
@@ -34,7 +35,7 @@ if ! which tput &> /dev/null 2>&1 || [[ $(tput -T$TERM colors) -lt 8 ]]; then
 fi
 
 # Make sure that we always properly clean the environment
-trap '{ echo "Running NRO uninstall test suite"; ${BIN_DIR}/e2e-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.reportFile=/tmp/artifacts/uninstall; }' EXIT SIGINT SIGTERM SIGSTOP
+trap '{ if [ ${NO_TEARDOWN} = false ]; then echo "Running NRO uninstall test suite"; ${BIN_DIR}/e2e-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.reportFile=/tmp/artifacts/uninstall; fi }' EXIT SIGINT SIGTERM SIGSTOP
 
 # Run install test suite
 echo "Running NRO install test suite"


### PR DESCRIPTION
In order to explain the motivation of this PR let's define the following terms:
Clean state: The cluster state, **before** any MC changes and/or TAS components were applied.
Dirty state: The cluster state, **after** any/all MC changes and/or TAS components were applied.

In the ususal test cases, we would always want the cluster to be at clean state, after the test run.
But there are special cases, like local tests and GH action tests, that we would like to keep the cluster in dirty state so we could perform various investigation, exporting logs, events, etc.

For that, we'll introduce the NO_TEARDOWN option, that will allow us to keep the cluster in dirty state after test run.
This is totaly optional and keep the current behavior intact.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>