### PR TITLE
numaresourcesscheduler: configurable scheduler name

### DIFF
--- a/api/numaresourcesoperator/v1alpha1/numaresourcesscheduler_types.go
+++ b/api/numaresourcesoperator/v1alpha1/numaresourcesscheduler_types.go
@@ -23,6 +23,7 @@ import (
 // NUMAResourcesSchedulerSpec defines the desired state of NUMAResourcesScheduler
 type NUMAResourcesSchedulerSpec struct {
 	SchedulerImage string `json:"imageSpec"`
+	SchedulerName  string `json:"schedulerName,omitempty"`
 }
 
 // NUMAResourcesSchedulerStatus defines the observed state of NUMAResourcesScheduler

--- a/bundle/manifests/nodetopology.openshift.io_numaresourcesschedulers.yaml
+++ b/bundle/manifests/nodetopology.openshift.io_numaresourcesschedulers.yaml
@@ -39,6 +39,8 @@ spec:
             properties:
               imageSpec:
                 type: string
+              schedulerName:
+                type: string
             required:
             - imageSpec
             type: object

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesschedulers.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesschedulers.yaml
@@ -41,6 +41,8 @@ spec:
             properties:
               imageSpec:
                 type: string
+              schedulerName:
+                type: string
             required:
             - imageSpec
             type: object

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -33,7 +33,7 @@ func NewNUMAResourcesOperator(name string, labelSelectors []*metav1.LabelSelecto
 	}
 }
 
-func NewNUMAResourcesScheduler(name, imageSpec string) *nrov1alpha1.NUMAResourcesScheduler {
+func NewNUMAResourcesScheduler(name, imageSpec, schedulerName string) *nrov1alpha1.NUMAResourcesScheduler {
 	return &nrov1alpha1.NUMAResourcesScheduler{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "NUMAResourcesScheduler",
@@ -44,6 +44,7 @@ func NewNUMAResourcesScheduler(name, imageSpec string) *nrov1alpha1.NUMAResource
 		},
 		Spec: nrov1alpha1.NUMAResourcesSchedulerSpec{
 			SchedulerImage: imageSpec,
+			SchedulerName:  schedulerName,
 		},
 	}
 }


### PR DESCRIPTION
This PR contains the necessary changes in the ```NUMAResourceScheduler``` CR and controller in order for the user to be able to configure the ```SchedulerName``` field.

PR contains both implementation and unit tests.

E2E tests will be added on a separate PR later on since there is a lot of activity in this area atm and there is no point with stepping each other toes.  