### PR TITLE
gh actions: opt in the kind e2e flow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,6 +54,7 @@ jobs:
         IMG=${built_image} KUSTOMIZE_DEPLOY_DIR="config/kind-ci/" make deploy
 
     - name: E2E Tests
+      if: "contains(github.event.head_commit.message, '[ci-run-e2e-kind]')"
       run: |
         export KUBECONFIG=${HOME}/.kube/config
         make test-e2e


### PR DESCRIPTION
We always considered the kind e2e flow a extra sanity check
and a tier-2 platform because this operator has -and will have-
a number of unavoidable OCP dependencies.

Since the kind e2e lane is flaking recently and no good
resolution is in sight, we make the kind e2e-lane opt in.

We totally want to keep deploying on kind, and we still
recommend to test also on kind.

gh docs references:
https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push

inspired by:
https://github.com/veggiemonk/skip-commit/issues/5

Signed-off-by: Francesco Romani <fromani@redhat.com>