### PR TITLE
E2E serial infra foundations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,9 @@ binary-e2e-uninstall:
 binary-e2e-sched:
 	go test -c -v -o bin/e2e-sched.test ./test/e2e/sched
 
+binary-e2e-serial:
+	go test -c -v -o bin/e2e-serial.test ./test/e2e/serial
+
 binary-all: binary binary-rte
 
 build: generate fmt vet binary

--- a/test/e2e/serial/test_suite_serial_test.go
+++ b/test/e2e/serial/test_suite_serial_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serial
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// This suite holds the e2e tests which span across components,
+// e.g. involve both the behaviour of RTE and the scheduler.
+// These tests are almost always disruptive, meaning they significantly
+// alter the cluster state and need a very specific cluster state (which
+// is each test responsability to setup and cleanup).
+// Hence we call this suite serial, implying each test should run alone
+// and indisturbed on the cluster. No concurrency at all is possible,
+// each test "owns" the cluster - but again, must leave no leftovers.
+
+func TestSerial(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Serial")
+}

--- a/test/utils/fixture/fixture.go
+++ b/test/utils/fixture/fixture.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fixture
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Fixture struct {
+	// Client defines the API client to run CRUD operations, that will be used for testing
+	Client client.Client
+	// K8sClient defines k8s client to run subresource operations, for example you should use it to get pod logs
+	K8sClient *kubernetes.Clientset
+	Namespace corev1.Namespace
+}
+
+func Setup(baseName string) (*Fixture, error) {
+	if !e2eclient.ClientsEnabled {
+		return nil, fmt.Errorf("clients not enabled")
+	}
+	ns, err := setupNamespace(e2eclient.Client, baseName)
+	if err != nil {
+		klog.Errorf("cannot setup namespace %q: %v", baseName, err)
+		return nil, err
+	}
+	By(fmt.Sprintf("set up the test namespace %q", ns.Name))
+	return &Fixture{
+		Client:    e2eclient.Client,
+		K8sClient: e2eclient.K8sClient,
+		Namespace: ns,
+	}, nil
+}
+
+func Teardown(ft *Fixture) error {
+	By(fmt.Sprintf("tearing down the test namespace %q", ft.Namespace.Name))
+	err := teardownNamespace(ft.Client, ft.Namespace)
+	if err != nil {
+		klog.Errorf("cannot teardown namespace %q: %s", ft.Namespace.Name, err)
+	}
+	return err
+}
+
+func setupNamespace(cli client.Client, baseName string) (corev1.Namespace, error) {
+	// intentionally avoid GenerateName like the k8s e2e framework does
+	ns := v1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Namespace",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: RandomName(baseName),
+		},
+	}
+
+	err := cli.Create(context.TODO(), &ns)
+	if err != nil {
+		return ns, err
+	}
+
+	// again we do like the k8s e2e framework does and we try to be robust
+	var updatedNs corev1.Namespace
+	err = wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
+		err := cli.Get(context.TODO(), client.ObjectKeyFromObject(&ns), &updatedNs)
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+	return updatedNs, err
+}
+
+func teardownNamespace(cli client.Client, ns corev1.Namespace) error {
+	err := cli.Delete(context.TODO(), &ns)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+
+	var updatedNs corev1.Namespace
+	return wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
+		err := cli.Get(context.TODO(), client.ObjectKeyFromObject(&ns), &updatedNs)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	})
+}
+
+func RandomName(baseName string) string {
+	return fmt.Sprintf("%s-%s", baseName, strconv.Itoa(rand.Intn(10000)))
+}

--- a/test/utils/nrosched/nrosched.go
+++ b/test/utils/nrosched/nrosched.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nrosched
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	"github.com/openshift-kni/numaresources-operator/pkg/status"
+)
+
+const (
+	// TODO: fetch this from NRO scheduler status
+	NROSchedulerName   = "topo-aware-scheduler"
+	NROSchedObjectName = "numaresourcesscheduler"
+)
+
+func CheckNROSchedulerAvailable(cli client.Client, nroSchedName string) *nropv1alpha1.NUMAResourcesScheduler {
+	nroSchedObj := &nropv1alpha1.NUMAResourcesScheduler{}
+	Eventually(func() bool {
+		By(fmt.Sprintf("checking %q for the condition Available=true", nroSchedName))
+
+		err := cli.Get(context.TODO(), client.ObjectKey{Name: NROSchedObjectName}, nroSchedObj)
+		if err != nil {
+			klog.Warningf("failed to get the scheduler resource: %v", err)
+			return false
+		}
+
+		cond := status.FindCondition(nroSchedObj.Status.Conditions, status.ConditionAvailable)
+		if cond == nil {
+			klog.Warningf("missing conditions in %v", nroSchedObj)
+			return false
+		}
+
+		klog.Infof("condition: %v", cond)
+
+		return cond.Status == metav1.ConditionTrue
+	}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "Scheduler condition did not become available")
+	return nroSchedObj
+}

--- a/test/utils/objects/consts.go
+++ b/test/utils/objects/consts.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objects
+
+const (
+	PauseImage   = "gcr.io/google_containers/pause-amd64:3.0"
+	PauseCommand = "/pause"
+)

--- a/test/utils/objects/deployment.go
+++ b/test/utils/objects/deployment.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objects
+
+import (
+	"context"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewTestDeployment(replicas int32, podLabels map[string]string, nodeSelector map[string]string, namespace, name, image string, command, args []string) *appsv1.Deployment {
+	var zero int64
+	dp := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: podLabels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+				},
+				Spec: corev1.PodSpec{
+					TerminationGracePeriodSeconds: &zero,
+					Containers: []corev1.Container{
+						{
+							Name:    name + "-cnt",
+							Image:   image,
+							Command: command,
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyAlways,
+				},
+			},
+		},
+	}
+	if nodeSelector != nil {
+		dp.Spec.Template.Spec.NodeSelector = nodeSelector
+	}
+	return dp
+}
+
+func WaitForDeploymentComplete(cli client.Client, dp *appsv1.Deployment, pollInterval, pollTimeout time.Duration) error {
+	return wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+		updatedDp := &appsv1.Deployment{}
+		err := cli.Get(context.TODO(), client.ObjectKeyFromObject(dp), updatedDp)
+		if err != nil {
+			// TODO: log
+			return false, err
+		}
+
+		if !IsDeploymentComplete(dp, &updatedDp.Status) {
+			// TODO: log
+			return false, nil
+		}
+
+		return true, nil
+	})
+}
+
+func AreDeploymentReplicasAvailable(newStatus *appsv1.DeploymentStatus, replicas int32) bool {
+	return newStatus.UpdatedReplicas == replicas &&
+		newStatus.Replicas == replicas &&
+		newStatus.AvailableReplicas == replicas
+}
+
+func IsDeploymentComplete(dp *appsv1.Deployment, newStatus *appsv1.DeploymentStatus) bool {
+	return AreDeploymentReplicasAvailable(newStatus, *(dp.Spec.Replicas)) &&
+		newStatus.ObservedGeneration >= dp.Generation
+}


### PR DESCRIPTION
Spinoff from #95: bootstrap the serial lane and add all the utilities which we know we need, because we will use them in #95, but are likely helpful in other related PRs like #100

Spinoff of the spinoff to troubleshoot the unexpcted CI failures