### PR TITLE
pkg: controllers: move MCP code in its own package

### DIFF
--- a/controllers/kubeletconfig_controller.go
+++ b/controllers/kubeletconfig_controller.go
@@ -38,15 +38,17 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 
+	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
 	rtemanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte"
 	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 	"github.com/openshift-kni/numaresources-operator/pkg/apply"
+	mcphelpers "github.com/openshift-kni/numaresources-operator/pkg/machineconfigpools"
 	cfgstate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/cfg"
 	rtestate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/rte"
 	rteconfig "github.com/openshift-kni/numaresources-operator/rte/pkg/config"
 	"github.com/openshift-kni/numaresources-operator/rte/pkg/sysinfo"
-	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
-	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
 
 const (
@@ -120,7 +122,7 @@ func (r *KubeletConfigReconciler) reconcileConfigMap(ctx context.Context, instan
 		return nil, err
 	}
 
-	mcps, err := GetNodeGroupsMCPs(ctx, r.Client, instance.Spec.NodeGroups)
+	mcps, err := mcphelpers.GetNodeGroupsMCPs(ctx, r.Client, instance.Spec.NodeGroups)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/uninstall/uninstall.go
+++ b/test/e2e/uninstall/uninstall.go
@@ -26,14 +26,17 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
-	"github.com/openshift-kni/numaresources-operator/controllers"
+
+	mcphelpers "github.com/openshift-kni/numaresources-operator/pkg/machineconfigpools"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectstate/rte"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
+
 	"github.com/openshift-kni/numaresources-operator/test/utils/configuration"
 	"github.com/openshift-kni/numaresources-operator/test/utils/machineconfigpools"
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
-	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
 
 var _ = Describe("[Uninstall]", func() {
@@ -91,7 +94,7 @@ var _ = Describe("[Uninstall]", func() {
 
 			if configuration.Platform == platform.OpenShift {
 				Eventually(func() bool {
-					mcps, err := controllers.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nroObj.Spec.NodeGroups)
+					mcps, err := mcphelpers.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nroObj.Spec.NodeGroups)
 					if err != nil {
 						klog.Warningf("failed to get machine config pools: %w", err)
 						return false

--- a/test/utils/machineconfigpools/machineconfigpools.go
+++ b/test/utils/machineconfigpools/machineconfigpools.go
@@ -21,19 +21,19 @@ import (
 	"fmt"
 
 	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
-	"github.com/openshift-kni/numaresources-operator/controllers"
+	mcphelpers "github.com/openshift-kni/numaresources-operator/pkg/machineconfigpools"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
 )
 
 // IsMachineConfigPoolsUpdated checks if all related to NUMAResourceOperator CR machines config pools have updated status
 func IsMachineConfigPoolsUpdated(nro *nropv1alpha1.NUMAResourcesOperator) (bool, error) {
-	mcps, err := controllers.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nro.Spec.NodeGroups)
+	mcps, err := mcphelpers.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nro.Spec.NodeGroups)
 	if err != nil {
 		return false, err
 	}
 
 	for _, mcp := range mcps {
-		if !controllers.IsMachineConfigPoolUpdated(nro.Name, mcp) {
+		if !mcphelpers.IsMachineConfigPoolUpdated(nro.Name, mcp) {
 			return false, nil
 		}
 	}
@@ -42,7 +42,7 @@ func IsMachineConfigPoolsUpdated(nro *nropv1alpha1.NUMAResourcesOperator) (bool,
 }
 
 func PauseMCPs(nodeGroups []nropv1alpha1.NodeGroup) (func() error, error) {
-	mcps, err := controllers.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nodeGroups)
+	mcps, err := mcphelpers.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nodeGroups)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Extract MCP utilities from the controllers to its own package,
so the test code doesn't depend on the controllers anymore.

Signed-off-by: Francesco Romani <fromani@redhat.com>