### PR TITLE
extract machineconfigpools utilities from the controller package

### DIFF
--- a/controllers/kubeletconfig_controller.go
+++ b/controllers/kubeletconfig_controller.go
@@ -1,5 +1,5 @@
 /*
-
+Copyright 2021.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/kubeletconfig_controller.go
+++ b/controllers/kubeletconfig_controller.go
@@ -45,7 +45,6 @@ import (
 	rtestate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/rte"
 	rteconfig "github.com/openshift-kni/numaresources-operator/rte/pkg/config"
 	"github.com/openshift-kni/numaresources-operator/rte/pkg/sysinfo"
-	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
 
@@ -159,7 +158,7 @@ func (r *KubeletConfigReconciler) syncConfigMap(ctx context.Context, instance *n
 	return rendered, nil
 }
 
-func findMCPForKubeletConfig(mcps []*machineconfigv1.MachineConfigPool, mcoKc *mcov1.KubeletConfig) (*machineconfigv1.MachineConfigPool, error) {
+func findMCPForKubeletConfig(mcps []*mcov1.MachineConfigPool, mcoKc *mcov1.KubeletConfig) (*mcov1.MachineConfigPool, error) {
 	if mcoKc.Spec.MachineConfigPoolSelector == nil {
 		return nil, fmt.Errorf("no MCP selector for kubeletconfig %s", mcoKc.Name)
 

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -53,6 +53,7 @@ import (
 
 	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 	"github.com/openshift-kni/numaresources-operator/pkg/apply"
+	"github.com/openshift-kni/numaresources-operator/pkg/machineconfigpools"
 	apistate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/api"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectstate/loglevel"
 	rtestate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/rte"
@@ -134,7 +135,7 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 		return r.updateStatus(ctx, instance, status.ConditionDegraded, validation.NodeGroupsError, err.Error())
 	}
 
-	mcps, err := GetNodeGroupsMCPs(ctx, r.Client, instance.Spec.NodeGroups)
+	mcps, err := machineconfigpools.GetNodeGroupsMCPs(ctx, r.Client, instance.Spec.NodeGroups)
 	if err != nil {
 		return r.updateStatus(ctx, instance, status.ConditionDegraded, validation.NodeGroupsError, err.Error())
 	}

--- a/pkg/machineconfigpools/machineconfigpools.go
+++ b/pkg/machineconfigpools/machineconfigpools.go
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package machineconfigpools
 
 import (
 	"context"
 	"fmt"
 
-	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
@@ -29,13 +29,13 @@ import (
 	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 )
 
-func GetNodeGroupsMCPs(ctx context.Context, cli client.Client, nodeGroups []nropv1alpha1.NodeGroup) ([]*machineconfigv1.MachineConfigPool, error) {
-	mcps := &machineconfigv1.MachineConfigPoolList{}
+func GetNodeGroupsMCPs(ctx context.Context, cli client.Client, nodeGroups []nropv1alpha1.NodeGroup) ([]*mcov1.MachineConfigPool, error) {
+	mcps := &mcov1.MachineConfigPoolList{}
 	if err := cli.List(ctx, mcps); err != nil {
 		return nil, err
 	}
 
-	var result []*machineconfigv1.MachineConfigPool
+	var result []*mcov1.MachineConfigPool
 	for _, nodeGroup := range nodeGroups {
 		found := false
 
@@ -67,4 +67,23 @@ func GetNodeGroupsMCPs(ctx context.Context, cli client.Client, nodeGroups []nrop
 	}
 
 	return result, nil
+}
+
+func FindMCPBySelector(mcps []*mcov1.MachineConfigPool, sel *metav1.LabelSelector) (*mcov1.MachineConfigPool, error) {
+	if sel == nil {
+		return nil, fmt.Errorf("no MCP selector for selector %v", sel)
+
+	}
+
+	selector, err := metav1.LabelSelectorAsSelector(sel)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, mcp := range mcps {
+		if selector.Matches(labels.Set(mcp.Labels)) {
+			return mcp, nil
+		}
+	}
+	return nil, fmt.Errorf("cannot find MCP related to the selector %v", sel)
 }

--- a/test/e2e/uninstall/uninstall.go
+++ b/test/e2e/uninstall/uninstall.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
-	"github.com/openshift-kni/numaresources-operator/controllers"
+	nropmcp "github.com/openshift-kni/numaresources-operator/pkg/machineconfigpools"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectstate/rte"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
 	"github.com/openshift-kni/numaresources-operator/test/utils/configuration"
@@ -91,7 +91,7 @@ var _ = Describe("[Uninstall]", func() {
 
 			if configuration.Platform == platform.OpenShift {
 				Eventually(func() bool {
-					mcps, err := controllers.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nroObj.Spec.NodeGroups)
+					mcps, err := nropmcp.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nroObj.Spec.NodeGroups)
 					if err != nil {
 						klog.Warningf("failed to get machine config pools: %w", err)
 						return false

--- a/test/utils/machineconfigpools/machineconfigpools.go
+++ b/test/utils/machineconfigpools/machineconfigpools.go
@@ -22,12 +22,13 @@ import (
 
 	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 	"github.com/openshift-kni/numaresources-operator/controllers"
+	nropmcp "github.com/openshift-kni/numaresources-operator/pkg/machineconfigpools"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
 )
 
 // IsMachineConfigPoolsUpdated checks if all related to NUMAResourceOperator CR machines config pools have updated status
 func IsMachineConfigPoolsUpdated(nro *nropv1alpha1.NUMAResourcesOperator) (bool, error) {
-	mcps, err := controllers.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nro.Spec.NodeGroups)
+	mcps, err := nropmcp.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nro.Spec.NodeGroups)
 	if err != nil {
 		return false, err
 	}
@@ -42,7 +43,7 @@ func IsMachineConfigPoolsUpdated(nro *nropv1alpha1.NUMAResourcesOperator) (bool,
 }
 
 func PauseMCPs(nodeGroups []nropv1alpha1.NodeGroup) (func() error, error) {
-	mcps, err := controllers.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nodeGroups)
+	mcps, err := nropmcp.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nodeGroups)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Create a new package to resolve MCPs by the selector and/or by the NodeGroups configuration, extracting the code
from the controllers package with no intended changes in behaviour.
