### PR TITLE
e2e: padder package

### DIFF
--- a/test/utils/padder/padder.go
+++ b/test/utils/padder/padder.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package padder
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nrtv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+	"github.com/openshift-kni/numaresources-operator/test/utils/fixture"
+	nrtutil "github.com/openshift-kni/numaresources-operator/test/utils/noderesourcetopologies"
+	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
+	"github.com/openshift-kni/numaresources-operator/test/utils/objects/wait"
+)
+
+// This package allows to control the amount of available allocationTarget under the nodes.
+// it's doing that by "padding" the nodes with guaranteed pods until node reaches the desired amount of available allocationTarget.
+//
+// Usage example:
+// pad := New(client, "test-ns")
+// pad.Nodes(2).UntilAvailableIsResource(corev1.ResourceCPU, "3").UntilAvailableIsResource(corev1.ResourceMemory, "100Mi").Pad()
+// or
+// rl := corev1.ResourceList {
+//		corev1.ResourceCPU: "10",
+//		corev1.ResourceMemory: "100Mi"
+//	}
+// pad.Nodes(2).UntilAvailableIsResourceList(rl).Pad()
+
+const PadderLabel = "nrop-test-pad-pod"
+
+type Padder struct {
+	// Client defines the API client to run CRUD operations, that will be used for testing
+	Client    client.Client
+	namespace string
+	*padRequest
+}
+
+type padRequest struct {
+	nNodes           int
+	allocationTarget corev1.ResourceList
+}
+
+// New return new padder object
+// ns is where padding pods will get deployed
+func New(cli client.Client, ns string) (*Padder, error) {
+	return &Padder{
+		Client:     cli,
+		namespace:  ns,
+		padRequest: &padRequest{allocationTarget: make(corev1.ResourceList)},
+	}, nil
+}
+
+// Nodes number of nodes to pad
+func (p *Padder) Nodes(n int) *Padder {
+	p.padRequest.nNodes = n
+	return p
+}
+
+// UntilAvailableIsResource will pad pods into nodes until reach the desired available allocationTarget
+func (p *Padder) UntilAvailableIsResource(resName corev1.ResourceName, quantity string) *Padder {
+	quan := resource.MustParse(quantity)
+	p.allocationTarget[resName] = quan
+	return p
+}
+
+// UntilAvailableIsResourceList is like UntilAvailableIsResource but with a complete ResourceList as a parameter
+func (p *Padder) UntilAvailableIsResourceList(resources corev1.ResourceList) *Padder {
+	p.allocationTarget = resources
+	return p
+}
+
+// Pad will create pad pods in order to align the nodes
+// with the requested amount of available allocationTarget
+func (p *Padder) Pad() error {
+	if p.nNodes == 0 {
+		klog.Warningf("no nodes for padding were found. please specify at least one node")
+		return nil
+	}
+
+	nrtList, err := nrtutil.GetUpdated(p.Client, nrtv1alpha1.NodeResourceTopologyList{}, time.Second*10)
+	if err != nil {
+		return err
+	}
+
+	singleNumaNrt := filterSingleNumaNodePolicyNrts(nrtList.Items)
+
+	for i := 0; i < len(singleNumaNrt) && p.nNodes > 0; i++ {
+		nrt := singleNumaNrt[i]
+		nodePadded := false
+		for _, zone := range nrt.Zones {
+			// check that zone has at least the amount of allocationTarget that needed
+			if nrtutil.ZoneResourcesMatchesRequest(zone.Resources, p.allocationTarget) {
+				availResList := nrtutil.AvailableFromZone(zone)
+				diffList, err := diffAvailableToExpected(availResList, p.allocationTarget)
+				if err != nil {
+					return err
+				}
+
+				// create a pod that asks for exact amount of allocationTarget as the diff
+				// in order to reach to desired amount of available allocationTarget in the node
+				padPod := objects.NewTestPodPause(p.namespace, fixture.RandomName("padder"))
+
+				// label the pod with a pad label, so it will be easier to identify later
+				labelPod(padPod, map[string]string{PadderLabel: ""})
+
+				padPod.Spec.Containers[0].Resources.Limits = diffList
+				padPod.Spec.Containers[0].Resources.Requests = diffList
+
+				// place the pod on the selected node
+				//padPod.Spec.NodeSelector = map[string]string{nodes.LabelHostname: nrt.Name}
+				padPod.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": nrt.Name}
+				if err := p.Client.Create(context.TODO(), padPod); err != nil {
+					return err
+				}
+				if _, err = wait.ForPodPhase(p.Client, p.namespace, padPod.Name, corev1.PodRunning, time.Minute); err != nil {
+					return err
+				}
+				klog.InfoS("created pod", "pod", fmt.Sprintf("%s/%s", padPod.Namespace, padPod.Name), "node", nrt.Name)
+				nodePadded = true
+			} else {
+				klog.Warningf("node: %q zone: %q, doesn't have enough available allocationTarget", nrt.Name, zone.Name)
+			}
+		}
+		if nodePadded {
+			p.nNodes--
+		}
+	}
+	return nil
+}
+
+// Clean can be called after test finished
+// in order to clean all the padding pod in an easier way
+func (p *Padder) Clean() error {
+	pod := &corev1.Pod{}
+	opts := []client.DeleteAllOfOption{
+		client.InNamespace(p.namespace),
+		client.MatchingLabels{PadderLabel: ""},
+		client.GracePeriodSeconds(5),
+	}
+	err := p.Client.DeleteAllOf(context.TODO(), pod, opts...)
+	if errors.IsNotFound(err) {
+		err = nil
+	}
+	return err
+}
+
+// return a resourceList of differences between the available and expected amount of resources
+// it will return an error if requested allocationTarget are more than available
+func diffAvailableToExpected(availableResLst corev1.ResourceList, expectedResLst corev1.ResourceList) (corev1.ResourceList, error) {
+	// this list will be requested by the pad pod
+	// in order to align the nodes resources with the expectedResLst
+	resourceList := corev1.ResourceList{}
+
+	for n, q1 := range availableResLst {
+		if q2, ok := expectedResLst[n]; ok {
+			// resource exist in expected list
+			// calc the diff
+			q1.Sub(q2)
+			if q1.Sign() == -1 {
+				return resourceList, fmt.Errorf("expected resource: %s=%v is higher than available: %s=%v", n, q2.String(), n, q1.String())
+			}
+			resourceList[n] = q1
+		} else {
+			// resource does not exist in the expected list,
+			// hence we don't expect any changes on that specific resource
+			resourceList[n] = resource.MustParse("0")
+		}
+	}
+
+	return resourceList, nil
+}
+
+func labelPod(pod *corev1.Pod, labelMap map[string]string) {
+	if pod.Labels == nil {
+		pod.Labels = labelMap
+		return
+	}
+	for k, v := range labelMap {
+		pod.Labels[k] = v
+	}
+}
+
+func filterSingleNumaNodePolicyNrts(list []nrtv1alpha1.NodeResourceTopology) []nrtv1alpha1.NodeResourceTopology {
+	singleNUMANodeContainerLevelNrts := nrtutil.FilterTopologyManagerPolicy(list, nrtv1alpha1.SingleNUMANodeContainerLevel)
+	singleNUMANodePodLevelNrts := nrtutil.FilterTopologyManagerPolicy(list, nrtv1alpha1.SingleNUMANodePodLevel)
+
+	var singleNumaNrt []nrtv1alpha1.NodeResourceTopology
+	singleNumaNrt = append(singleNumaNrt, singleNUMANodeContainerLevelNrts...)
+	singleNumaNrt = append(singleNumaNrt, singleNUMANodePodLevelNrts...)
+	return singleNumaNrt
+}


### PR DESCRIPTION
The padder package allows controlling the number of available resources under the nodes.
It's doing that by padding the nodes with idle pods, until the node reaches the desired amount of available resources.

This package comes very handy on cases when we need specific prerequisites to be apply on nodes,
wrt the amount of available resources they have prior to the test run.

Usage example:
```
pad := New(client, test-ns)
pad.Nodes(2).UntilAvailableReach(corev1.ResourceCPU, 3).UntilAvailableReach(corev1.ResourceMemory, 100Mi).Pad()
```
or
```
rl := corev1.ResourceList {
corev1.ResourceCPU: 10,
corev1.ResourceMemory: 100Mi
}
pad.Nodes(2).UntilAvailableReachWithResourceList(rl).Pad()
```

In an ideal situation, this package would deserve some unit tests, but unit tests are complex to implement here, and anyway we can trust that if there is a bug in the package, the test that is using it won't pass.
 