### PR TITLE
makefile: change default VERSION parameter value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 4.10.0
+VERSION ?= 4.10.999-snapshot
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
     capabilities: Basic Install
     operators.operatorframework.io/builder: operator-sdk-v1.12.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: numaresources-operator.v4.10.0
+  name: numaresources-operator.v4.10.999-snapshot
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -251,7 +251,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/openshift-kni/numaresources-operator:4.10.0
+                image: quay.io/openshift-kni/numaresources-operator:4.10.999-snapshot
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -334,4 +334,4 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  version: 4.10.0
+  version: 4.10.999-snapshot

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/openshift-kni/numaresources-operator
-  newTag: 4.10.0
+  newTag: 4.10.999-snapshot


### PR DESCRIPTION
We want, by default, to always use the most updated version existed.
This is new value is a valid semantic version tag that pushed to quay for every new image that gets created.

Also see: https://github.com/openshift/release/pull/25141

Signed-off-by: Talor Itzhak <titzhak@redhat.com>