### PR TITLE
improve verify-generated.sh error message

### DIFF
--- a/hack/verify-generated.sh
+++ b/hack/verify-generated.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [[ -n "$(git status --untracked-files=no --porcelain .)" ]]; then
-        echo "uncommitted generated files. run 'make generate' and commit results."
+        echo "uncommitted generated files. run 'make generate bundle manifests' and commit results."
         echo "$(git status --untracked-files=no --porcelain .)"
         exit 1
 fi


### PR DESCRIPTION
When the verify-generated return with error, it tells the user to run \'make generate\' and commit results.
There are times when it's not enough and the user need to run other make targets.

This new message aims to resolve that.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>