### PR TITLE
Revert "gh actions: opt in the kind e2e flow"

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,7 +55,6 @@ jobs:
         IMG=${built_image} KUSTOMIZE_DEPLOY_DIR="config/kind-ci/" make deploy
 
     - name: E2E Tests
-      if: "contains(github.event.head_commit.message, '[ci-run-e2e-kind]')"
       run: |
         export KUBECONFIG=${HOME}/.kube/config
         NO_TEARDOWN=true make test-e2e


### PR DESCRIPTION
This reverts commit 629a7a0f4bbe2870bcd50f79eb05f30a0b0653bf.

this reverted commit not needed anymore due to following reasons:
1. It doesn't seem to work.
2. The original problem it intended to solve, already addressed at: https://github.com/openshift-kni/numaresources-operator/pull/98