### PR TITLE
makefile: fix make deploy target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 	kubectl apply -f $(CRD_MACHINE_CONFIG_POOL_URL)
 	kubectl apply -f $(CRD_KUBELET_CONFIG_URL)
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build $(KUSTOMIZE_DEPLOY_DIR)
+	$(KUSTOMIZE) build $(KUSTOMIZE_DEPLOY_DIR) | kubectl apply -f -
 
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build $(KUSTOMIZE_DEPLOY_DIR) | kubectl delete -f -


### PR DESCRIPTION
We should actually apply the manifests that got built by Kustomize and not just output them to the console

Regression caused by: https://github.com/openshift-kni/numaresources-operator/pull/98

Signed-off-by: Talor Itzhak <titzhak@redhat.com>
