### PR TITLE
flagcodec: preserve the order of args

### DIFF
--- a/pkg/flagcodec/flagcodec.go
+++ b/pkg/flagcodec/flagcodec.go
@@ -24,7 +24,6 @@ package flagcodec
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 )
 
@@ -41,6 +40,7 @@ type Val struct {
 type Flags struct {
 	command string
 	args    map[string]Val
+	keys    []string
 }
 
 func ParseArgvKeyValue(args []string) *Flags {
@@ -71,13 +71,21 @@ func ParseArgvKeyValueWithCommand(command string, args []string) *Flags {
 	return ret
 }
 
+func (fl *Flags) recordFlag(name string) {
+	if _, ok := fl.args[name]; !ok {
+		fl.keys = append(fl.keys, name)
+	}
+}
+
 func (fl *Flags) SetToggle(name string) {
+	fl.recordFlag(name)
 	fl.args[name] = Val{
 		Kind: FlagToggle,
 	}
 }
 
 func (fl *Flags) SetOption(name, data string) {
+	fl.recordFlag(name)
 	fl.args[name] = Val{
 		Kind: FlagOption,
 		Data: data,
@@ -90,10 +98,9 @@ func (fl *Flags) Command() string {
 
 func (fl *Flags) Args() []string {
 	var args []string
-	for name, val := range fl.args {
-		args = append(args, toString(name, val))
+	for _, name := range fl.keys {
+		args = append(args, toString(name, fl.args[name]))
 	}
-	sort.Strings(args)
 	return args
 }
 


### PR DESCRIPTION
Up until now, `flagcodec` was reordering the args
before rendering them.
This is not always correct, because it's relatively common
for command line argument to have some ordering requirements.

A key example is the subcommands: some options for a command
may make sense for the global context, while some other options
are subcommand-specific.

flagcodec doesn't aim (yet) to cover all the cases, but this is
simple to fix: instead of force a sorting, just record the order
on which the flags are parsed, and reuse it when rendering.
The end result is still a valid command line, the implementation
is not more complex and the behaviour is more correct.

Signed-off-by: Francesco Romani <fromani@redhat.com>