### PR TITLE
manifests: set executable under the command stanza

### DIFF
--- a/pkg/numaresourcesscheduler/manifests/yaml/deployment.yaml
+++ b/pkg/numaresourcesscheduler/manifests/yaml/deployment.yaml
@@ -30,8 +30,9 @@ spec:
             requests:
               cpu: "100m"
               memory: "500Mi"
-          args:
+          command:
             - /bin/kube-scheduler
+          args:
             - --config=/etc/kubernetes/config.yaml
           volumeMounts:
             - mountPath: "/etc/kubernetes"


### PR DESCRIPTION
According to the line we took at: https://github.com/k8stopologyawareschedwg/deployer/pull/79
We should also have the same here.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>