### PR TITLE
e2e: stabilize and enable numaresourcesscheduler test-suite

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,8 +65,8 @@ jobs:
         mkdir -p ${LOG_DIR}
         for pod in $(kubectl get pods -n $E2E_NAMESPACE_NAME --no-headers=true -o custom-columns=NAME:.metadata.name) 
         do 
-          oc logs $pod -n $E2E_NAMESPACE_NAME > ${LOG_DIR}/${pod}.log
-          oc describe $pod -n $E2E_NAMESPACE_NAME > ${LOG_DIR}/${pod}.describe.log
+          oc logs $pod -n $E2E_NAMESPACE_NAME --all-containers=true > ${LOG_DIR}/${pod}.log
+          oc describe pod $pod -n $E2E_NAMESPACE_NAME > ${LOG_DIR}/${pod}.describe.log
         done
 
     - name: Archive E2E Tests logs

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ test-unit: envtest
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./controllers/... ./pkg/... ./rte/pkg/...
 
 test-e2e: build-e2e-all
-	hack/run-test-e2e.sh
+	ENABLE_SCHED_TESTS=true hack/run-test-e2e.sh
 
 test-install-e2e: build-e2e-all
 	hack/run-test-install-e2e.sh

--- a/hack/run-test-e2e.sh
+++ b/hack/run-test-e2e.sh
@@ -6,9 +6,6 @@ ENABLE_SCHED_TESTS="${ENABLE_SCHED_TESTS:-false}"
 NO_TEARDOWN="${NO_TEARDOWN:-false}"
 
 function test_sched() {
-  # Make sure that we always properly clean the environment
-  trap '{ if [ ${NO_TEARDOWN} = false ]; then echo "Running NROScheduler uninstall test suite"; ${BIN_DIR}/e2e-sched-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.reportFile=/tmp/artifacts/sched-uninstall; fi }' EXIT SIGINT SIGTERM SIGSTOP
-
   # Run install test suite
   echo "Running NROScheduler install test suite"
   ${BIN_DIR}/e2e-sched-install.test ${NO_COLOR} --ginkgo.v --ginkgo.failFast --ginkgo.reportFile=/tmp/artifacts/sched-install
@@ -35,7 +32,14 @@ if ! which tput &> /dev/null 2>&1 || [[ $(tput -T$TERM colors) -lt 8 ]]; then
 fi
 
 # Make sure that we always properly clean the environment
-trap '{ if [ ${NO_TEARDOWN} = false ]; then echo "Running NRO uninstall test suite"; ${BIN_DIR}/e2e-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.reportFile=/tmp/artifacts/uninstall; fi }' EXIT SIGINT SIGTERM SIGSTOP
+trap '{ if [ "${NO_TEARDOWN}" = false ]; then
+          if [ "${ENABLE_SCHED_TESTS}" = true ]; then
+             echo "Running NROScheduler uninstall test suite";
+             ${BIN_DIR}/e2e-sched-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.reportFile=/tmp/artifacts/sched-uninstall;
+          fi
+          echo "Running NRO uninstall test suite";
+          ${BIN_DIR}/e2e-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.reportFile=/tmp/artifacts/uninstall;
+        fi }' EXIT SIGINT SIGTERM SIGSTOP
 
 # Run install test suite
 echo "Running NRO install test suite"

--- a/test/e2e/sched/install/install_test.go
+++ b/test/e2e/sched/install/install_test.go
@@ -37,8 +37,6 @@ import (
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 )
 
-const crdName = "numaresourcesschedulers.nodetopology.openshift.io"
-
 var _ = Describe("[Scheduler] install", func() {
 	Context("with a running cluster with all the components", func() {
 		It("[test_id: 47574] should perform the scheduler deployment and verify the condition is reported as available", func() {
@@ -107,7 +105,7 @@ var _ = Describe("[Scheduler] install", func() {
 			}
 
 			By("checking the NumaResourcesScheduler CRD is deployed")
-			_, err = crds.GetByName(e2eclient.Client, crdName)
+			_, err = crds.GetByName(e2eclient.Client, crds.CrdNROSName)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/test/utils/clients/clients.go
+++ b/test/utils/clients/clients.go
@@ -32,7 +32,7 @@ import (
 	nrtv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
 	numaresourcesoperatorv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 var (
@@ -54,7 +54,7 @@ func init() {
 		klog.Exit(err.Error())
 	}
 
-	if err := apiextensionsv1beta1.AddToScheme(scheme.Scheme); err != nil {
+	if err := apiextensionsv1.AddToScheme(scheme.Scheme); err != nil {
 		klog.Exit(err.Error())
 	}
 

--- a/test/utils/crds/crds.go
+++ b/test/utils/crds/crds.go
@@ -21,8 +21,9 @@ import (
 )
 
 const (
-	CrdNRTName = "noderesourcetopologies.topology.node.k8s.io"
-	CrdNROName = "numaresourcesoperators.nodetopology.openshift.io"
+	CrdNRTName  = "noderesourcetopologies.topology.node.k8s.io"
+	CrdNROName  = "numaresourcesoperators.nodetopology.openshift.io"
+	CrdNROSName = "numaresourcesschedulers.nodetopology.openshift.io"
 )
 
 func GetByName(aclient client.Client, crdName string) (*apiextensionv1.CustomResourceDefinition, error) {


### PR DESCRIPTION
When the numaresourcesscheduler was implemented initially, we thought it was going to stay with us for a very short time.
This assumption turned out to be wrong, so it's worth enabling the e2e tests for numaresourcesscheduler by default in order to avoid future regression.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>