### PR TITLE
rte: exit on config changes if the file exists

### DIFF
--- a/rte/pkg/config/config.go
+++ b/rte/pkg/config/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	TopologyManagerScope  string              `json:"topologyManagerScope,omitempty"`
 }
 
-func ReadConfig(configPath string) (Config, error) {
+func ReadConfig(configPath string) (Config, bool, error) {
 	conf := Config{}
 	// TODO modernize using os.ReadFile
 	data, err := ioutil.ReadFile(configPath)
@@ -40,10 +40,10 @@ func ReadConfig(configPath string) (Config, error) {
 		// config is optional
 		if errors.Is(err, os.ErrNotExist) {
 			klog.Warningf("Info: couldn't find configuration in %q", configPath)
-			return conf, nil
+			return conf, false, nil
 		}
-		return conf, err
+		return conf, false, err
 	}
 	err = yaml.Unmarshal(data, &conf)
-	return conf, err
+	return conf, true, err
 }

--- a/rte/pkg/config/config_test.go
+++ b/rte/pkg/config/config_test.go
@@ -21,9 +21,12 @@ import (
 )
 
 func TestReadNonExistent(t *testing.T) {
-	cfg, err := ReadConfig("/does/not/exist")
+	cfg, ok, err := ReadConfig("/does/not/exist")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Errorf("unexpected config reported present")
 	}
 	if cfg.ExcludeList != nil || !cfg.Resources.IsEmpty() || cfg.TopologyManagerPolicy != "" {
 		t.Errorf("unexpected data: %#v", cfg)
@@ -31,7 +34,10 @@ func TestReadNonExistent(t *testing.T) {
 }
 
 func TestReadMalformed(t *testing.T) {
-	_, err := ReadConfig("/etc/services")
+	_, ok, err := ReadConfig("/etc/services")
+	if !ok {
+		t.Errorf("unexpected config reported missing")
+	}
 	if err == nil {
 		t.Errorf("unexpected success reading unrelated data")
 	}
@@ -51,9 +57,12 @@ func TestReadValidData(t *testing.T) {
 	if err := tmpfile.Close(); err != nil {
 		t.Errorf("closing the tempfile: %v", err)
 	}
-	cfg, err := ReadConfig(tmpfile.Name())
+	cfg, ok, err := ReadConfig(tmpfile.Name())
 	if err != nil {
 		t.Errorf("unexpected error reading back the config: %v", err)
+	}
+	if !ok {
+		t.Errorf("unexpected config reported missing")
 	}
 	if cfg.TopologyManagerPolicy != "restricted" {
 		t.Errorf("unexpected values: %#v", cfg)


### PR DESCRIPTION
the `--exit-on-config-changes` should make the RTE process fail
only if the config file which should be monitored actually exists.
Otherwise the behaviour is ill-defined to begin with.

Signed-off-by: Francesco Romani <fromani@redhat.com>