### PR TITLE
e2e: use CI-provided test images

### DIFF
--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -38,12 +38,9 @@ import (
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
 	"github.com/openshift-kni/numaresources-operator/test/utils/configuration"
 	"github.com/openshift-kni/numaresources-operator/test/utils/crds"
+	e2eimages "github.com/openshift-kni/numaresources-operator/test/utils/images"
 	"github.com/openshift-kni/numaresources-operator/test/utils/machineconfigpools"
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
-)
-
-const (
-	newTestImage = "quay.io/openshift-kni/numaresources-operator:v0.1.0"
 )
 
 var _ = Describe("[Install] continuousIntegration", func() {
@@ -235,7 +232,7 @@ var _ = Describe("[Install] durability", func() {
 
 			By("redeploy with other parameters")
 			// TODO change to an image which is test dedicated
-			nroObj.Spec.ExporterImage = newTestImage
+			nroObj.Spec.ExporterImage = e2eimages.RTETestImageCI
 			// resourceVersion should not be set on objects to be created
 			nroObj.ResourceVersion = ""
 
@@ -253,7 +250,7 @@ var _ = Describe("[Install] durability", func() {
 					return false
 				}
 
-				return ds.Spec.Template.Spec.Containers[0].Image == newTestImage
+				return ds.Spec.Template.Spec.Containers[0].Image == e2eimages.RTETestImageCI
 			}, 5*time.Minute, 10*time.Second).Should(BeTrue())
 		})
 	})

--- a/test/e2e/sched/sched_test.go
+++ b/test/e2e/sched/sched_test.go
@@ -28,10 +28,9 @@ import (
 
 	schedutils "github.com/openshift-kni/numaresources-operator/test/e2e/sched/utils"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
+	e2eimages "github.com/openshift-kni/numaresources-operator/test/utils/images"
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 )
-
-const newTestImage = "quay.io/openshift-kni/scheduler-plugins:test-ci"
 
 var _ = Describe("[Scheduler] imageReplacement", func() {
 	var initialized bool
@@ -50,7 +49,7 @@ var _ = Describe("[Scheduler] imageReplacement", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			uid := nroSchedObj.GetUID()
-			nroSchedObj.Spec.SchedulerImage = newTestImage
+			nroSchedObj.Spec.SchedulerImage = e2eimages.SchedTestImageCI
 
 			err = e2eclient.Client.Update(context.TODO(), nroSchedObj)
 			Expect(err).ToNot(HaveOccurred())
@@ -67,7 +66,7 @@ var _ = Describe("[Scheduler] imageReplacement", func() {
 					return false
 				}
 
-				return deploy.Spec.Template.Spec.Containers[0].Image == newTestImage
+				return deploy.Spec.Template.Spec.Containers[0].Image == e2eimages.SchedTestImageCI
 			}, time.Minute, time.Second*10).Should(BeTrue())
 		})
 	})

--- a/test/utils/images/consts.go
+++ b/test/utils/images/consts.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package images
+
+const (
+	RTETestImageCI   = "quay.io/openshift-kni/resource-topology-exporter:test-ci"
+	SchedTestImageCI = "quay.io/openshift-kni/scheduler-plugins:test-ci"
+)


### PR DESCRIPTION
Use CI test images, built by prow, in all the relevant tests
which want to use test images.
Previously, we used different (and now obsolete) images only because
the e2e tests predated the prow config.
Nowadays prow builds the test images for this specific task.

Signed-off-by: Francesco Romani <fromani@redhat.com>