### PR TITLE
e2e: numacell dp: configurable device count

### DIFF
--- a/test/deviceplugin/cmd/numacell/main.go
+++ b/test/deviceplugin/cmd/numacell/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/jaypipes/ghw/pkg/topology"
 	"github.com/kubevirt/device-plugin-manager/pkg/dpm"
 
+	"github.com/openshift-kni/numaresources-operator/test/deviceplugin/pkg/numacell/api"
 	"github.com/openshift-kni/numaresources-operator/test/deviceplugin/pkg/numacell/manifests"
 	"github.com/openshift-kni/numaresources-operator/test/deviceplugin/pkg/numacell/plugin"
 )
@@ -69,8 +70,10 @@ func render(w io.Writer) int {
 func main() {
 	var renderManifest bool
 	var sysfsPath string
+	var deviceCount int
 	flag.BoolVar(&renderManifest, "render", false, "render daemonset manifest and exit")
 	flag.StringVar(&sysfsPath, "sysfs", "/sys", "mount path of sysfs")
+	flag.IntVar(&deviceCount, "devices", api.NUMACellDefaultDeviceCount, "amount of devices to expose (will not be decremented anyway)")
 	flag.Parse()
 
 	if renderManifest {
@@ -87,6 +90,6 @@ func main() {
 
 	klog.Infof("hardware detected:\n%s", summarize(topoInfo))
 
-	manager := dpm.NewManager(plugin.NewNUMACellLister(topoInfo))
+	manager := dpm.NewManager(plugin.NewNUMACellLister(topoInfo, deviceCount))
 	manager.Run()
 }

--- a/test/deviceplugin/pkg/numacell/api/numacell.go
+++ b/test/deviceplugin/pkg/numacell/api/numacell.go
@@ -28,6 +28,8 @@ const (
 	NUMACellResourceNamespace = "kni.node"
 
 	NUMACellEnvironVarName = "KNI_NODE_CELL_ID"
+
+	NUMACellDefaultDeviceCount = 15
 )
 
 func MakeResourceName(numacellid int) corev1.ResourceName {

--- a/test/deviceplugin/pkg/numacell/manifests/manifests.go
+++ b/test/deviceplugin/pkg/numacell/manifests/manifests.go
@@ -153,6 +153,7 @@ func DaemonSet(nodeSelector map[string]string, namespace, name, saName, image st
 								"-alsologtostderr",
 								"-v", "3",
 							},
+							ImagePullPolicy: corev1.PullAlways,
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: &true_,
 							},


### PR DESCRIPTION
In order to avoid possible races with the scheduler,
we add an option to configure more fake numacell devices
rather than just 1. We keep producing an infinite amount of them.

Signed-off-by: Francesco Romani <fromani@redhat.com>