### PR TITLE
e2e: install: wait for objects to be deleted

### DIFF
--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -19,6 +19,7 @@ package install
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -31,6 +32,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte"
@@ -62,12 +65,7 @@ var _ = Describe("[Install] continuousIntegration", func() {
 	Context("with a running cluster with all the components", func() {
 		It("[test_id: 47574] should perform overall deployment and verify the condition is reported as available", func() {
 			deployedObj := overallDeployment()
-			var nname client.ObjectKey
-			for _, obj := range deployedObj {
-				if nroObj, ok := obj.(*nropv1alpha1.NUMAResourcesOperator); ok {
-					nname = client.ObjectKeyFromObject(nroObj)
-				}
-			}
+			nname := client.ObjectKeyFromObject(deployedObj.nroObj)
 			Expect(nname.Name).ToNot(BeEmpty())
 
 			By("checking that the condition Available=true")
@@ -103,7 +101,6 @@ var _ = Describe("[Install] continuousIntegration", func() {
 			const DSCheckTimeout = 1 * time.Minute
 			const DSCheckPollingPeriod = 5 * time.Second
 			Eventually(func() bool {
-
 				ds, err := getDaemonSetByOwnerReference(updatedNROObj.UID)
 				if err != nil {
 					klog.Warningf("unable to get Daemonset  %v", err)
@@ -173,31 +170,25 @@ var _ = Describe("[Install] durability", func() {
 				return cond.Status == metav1.ConditionTrue
 			}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "NUMAResourcesOperator condition did not become degraded")
 
-			err = e2eclient.Client.Delete(context.TODO(), nroObj)
-			Expect(err).ToNot(HaveOccurred())
+			deleteNROPSync(e2eclient.Client, nroObj)
 		})
 	})
 
 	Context("with a running cluster with all the components and overall deployment", func() {
-		var deployedObj []client.Object
+		var deployedObj nroDeployment
 
 		BeforeEach(func() {
 			deployedObj = overallDeployment()
 		})
 
 		AfterEach(func() {
-			for _, obj := range deployedObj {
-				err := e2eclient.Client.Delete(context.TODO(), obj)
-				if err != nil {
-					Expect(errors.IsNotFound(err)).To(BeTrue(), fmt.Sprintf("unexpected error: %v", err))
-				}
-			}
+			teardownDeployment(deployedObj, 5*time.Minute)
 		})
 
 		It("[test_id: 47587] should restart RTE DaemonSet when image is updated in NUMAResourcesOperator", func() {
 
 			By("wait for DaemonSet to be ready")
-			nname := getNRONamespacedNameFromDeployedObjects(deployedObj)
+			nname := client.ObjectKeyFromObject(deployedObj.nroObj)
 			Expect(nname.Name).NotTo(BeEmpty())
 
 			nroObj := &nropv1alpha1.NUMAResourcesOperator{}
@@ -254,7 +245,7 @@ var _ = Describe("[Install] durability", func() {
 		})
 
 		It("should be able to delete NUMAResourceOperator CR and redeploy without polluting cluster state", func() {
-			nname := getNRONamespacedNameFromDeployedObjects(deployedObj)
+			nname := client.ObjectKeyFromObject(deployedObj.nroObj)
 			Expect(nname.Name).NotTo(BeEmpty())
 
 			nroObj := &nropv1alpha1.NUMAResourcesOperator{}
@@ -270,8 +261,7 @@ var _ = Describe("[Install] durability", func() {
 				return err
 			}, 5*time.Minute, 10*time.Second).Should(BeNil())
 
-			err = e2eclient.Client.Delete(context.TODO(), nroObj)
-			Expect(err).ToNot(HaveOccurred())
+			deleteNROPSync(e2eclient.Client, nroObj)
 
 			By("checking there are no leftovers")
 			// by taking the ns from the ds we're avoiding the need to figure out in advanced
@@ -299,6 +289,7 @@ var _ = Describe("[Install] durability", func() {
 			// TODO change to an image which is test dedicated
 			nroObj.Spec.ExporterImage = e2eimages.RTETestImageCI
 			// resourceVersion should not be set on objects to be created
+			// TODO: don't reuse existing objects
 			nroObj.ResourceVersion = ""
 
 			err = e2eclient.Client.Create(context.TODO(), nroObj)
@@ -342,18 +333,24 @@ func findContainerByName(daemonset appsv1.DaemonSet, containerName string) (*cor
 	return nil, fmt.Errorf("container %q not found in %s/%s", containerName, daemonset.Namespace, daemonset.Name)
 }
 
-// overallDeployment returns a slice of an objects created by it,
+type nroDeployment struct {
+	mcpObj *machineconfigv1.MachineConfigPool
+	kcObj  *machineconfigv1.KubeletConfig
+	nroObj *nropv1alpha1.NUMAResourcesOperator
+}
+
+// overallDeployment returns a struct containing all the deployed objects,
 // so it will be easier to introspect and delete them later.
-func overallDeployment() []client.Object {
+func overallDeployment() nroDeployment {
 	var matchLabels map[string]string
-	var deployedObj []client.Object
+	var deployedObj nroDeployment
 
 	if configuration.Platform == platform.Kubernetes {
 		mcpObj := objects.TestMCP()
 		By(fmt.Sprintf("creating the machine config pool object: %s", mcpObj.Name))
 		err := e2eclient.Client.Create(context.TODO(), mcpObj)
 		Expect(err).NotTo(HaveOccurred())
-		deployedObj = append(deployedObj, mcpObj)
+		deployedObj.mcpObj = mcpObj
 		matchLabels = map[string]string{"test": "test"}
 	}
 
@@ -372,12 +369,12 @@ func overallDeployment() []client.Object {
 	By(fmt.Sprintf("creating the KC object: %s", kcObj.Name))
 	err = e2eclient.Client.Create(context.TODO(), kcObj)
 	Expect(err).NotTo(HaveOccurred())
-	deployedObj = append(deployedObj, kcObj)
+	deployedObj.kcObj = kcObj
 
 	By(fmt.Sprintf("creating the NRO object: %s", nroObj.Name))
 	err = e2eclient.Client.Create(context.TODO(), nroObj)
 	Expect(err).NotTo(HaveOccurred())
-	deployedObj = append(deployedObj, nroObj)
+	deployedObj.nroObj = nroObj
 
 	Eventually(
 		unpause,
@@ -402,6 +399,57 @@ func overallDeployment() []client.Object {
 	return deployedObj
 }
 
+// TODO: what if timeout < period?
+func teardownDeployment(nrod nroDeployment, timeout time.Duration) {
+	var wg sync.WaitGroup
+	if nrod.mcpObj != nil {
+		err := e2eclient.Client.Delete(context.TODO(), nrod.mcpObj)
+		Expect(err).ToNot(HaveOccurred())
+
+		wg.Add(1)
+		go func(mcpObj *machineconfigv1.MachineConfigPool) {
+			defer GinkgoRecover()
+			defer wg.Done()
+			klog.Infof("waiting for MCP %q to be gone", mcpObj.Name)
+			err := e2ewait.ForMachineConfigPoolDeleted(e2eclient.Client, mcpObj, 10*time.Second, timeout)
+			Expect(err).ToNot(HaveOccurred(), "MCP %q failed to be deleted", mcpObj.Name)
+		}(nrod.mcpObj)
+	}
+
+	var err error
+	err = e2eclient.Client.Delete(context.TODO(), nrod.kcObj)
+	Expect(err).ToNot(HaveOccurred())
+	wg.Add(1)
+	go func(kcObj *machineconfigv1.KubeletConfig) {
+		defer GinkgoRecover()
+		defer wg.Done()
+		klog.Infof("waiting for KC %q to be gone", kcObj.Name)
+		err := e2ewait.ForKubeletConfigDeleted(e2eclient.Client, kcObj, 10*time.Second, timeout)
+		Expect(err).ToNot(HaveOccurred(), "KC %q failed to be deleted", kcObj.Name)
+	}(nrod.kcObj)
+
+	err = e2eclient.Client.Delete(context.TODO(), nrod.nroObj)
+	Expect(err).ToNot(HaveOccurred())
+	wg.Add(1)
+	go func(nropObj *nropv1alpha1.NUMAResourcesOperator) {
+		defer GinkgoRecover()
+		defer wg.Done()
+		klog.Infof("waiting for NROP %q to be gone", nropObj.Name)
+		err := e2ewait.ForNUMAResourcesOperatorDeleted(e2eclient.Client, nropObj, 10*time.Second, timeout)
+		Expect(err).ToNot(HaveOccurred(), "NROP %q failed to be deleted", nropObj.Name)
+	}(nrod.nroObj)
+
+	wg.Wait()
+}
+
+func deleteNROPSync(cli client.Client, nropObj *nropv1alpha1.NUMAResourcesOperator) {
+	var err error
+	err = cli.Delete(context.TODO(), nropObj)
+	Expect(err).ToNot(HaveOccurred())
+	err = e2ewait.ForNUMAResourcesOperatorDeleted(cli, nropObj, 10*time.Second, 2*time.Minute)
+	Expect(err).ToNot(HaveOccurred(), "NROP %q failed to be deleted", nropObj.Name)
+}
+
 func getDaemonSetByOwnerReference(uid types.UID) (*appsv1.DaemonSet, error) {
 	dsList := &appsv1.DaemonSetList{}
 
@@ -417,13 +465,4 @@ func getDaemonSetByOwnerReference(uid types.UID) (*appsv1.DaemonSet, error) {
 		}
 	}
 	return nil, fmt.Errorf("failed to get daemonset with owner reference uid: %s", uid)
-}
-
-func getNRONamespacedNameFromDeployedObjects(deployedObjects []client.Object) types.NamespacedName {
-	for _, obj := range deployedObjects {
-		if nroObj, ok := obj.(*nropv1alpha1.NUMAResourcesOperator); ok {
-			return client.ObjectKeyFromObject(nroObj)
-		}
-	}
-	return types.NamespacedName{}
 }

--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -379,8 +379,11 @@ func overallDeployment() []client.Object {
 	Expect(err).NotTo(HaveOccurred())
 	deployedObj = append(deployedObj, nroObj)
 
-	err = unpause()
-	Expect(err).NotTo(HaveOccurred())
+	Eventually(
+		unpause,
+		configuration.MachineConfigPoolUpdateTimeout,
+		configuration.MachineConfigPoolUpdateInterval,
+	).ShouldNot(HaveOccurred())
 
 	err = e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroObj), nroObj)
 	Expect(err).NotTo(HaveOccurred())

--- a/test/utils/machineconfigpools/machineconfigpools.go
+++ b/test/utils/machineconfigpools/machineconfigpools.go
@@ -59,6 +59,10 @@ func PauseMCPs(nodeGroups []nropv1alpha1.NodeGroup) (func() error, error) {
 	}
 
 	unpause := func() error {
+		mcps, err := nropmcp.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nodeGroups)
+		if err != nil {
+			return err
+		}
 		for i := range mcps {
 			mcps[i].Spec.Paused = false
 			err = e2eclient.Client.Update(context.TODO(), mcps[i])

--- a/test/utils/objects/wait/errors.go
+++ b/test/utils/objects/wait/errors.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wait
+
+import (
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func deletionStatusFromError(kind string, key client.ObjectKey, err error) (bool, error) {
+	if err == nil {
+		klog.Infof("%s %#v still present", kind, key)
+		return false, nil
+	}
+	if apierrors.IsNotFound(err) {
+		klog.Infof("%s %#v is gone", kind, key)
+		return true, nil
+	}
+	klog.Warningf("failed to get the %s %#v: %v", kind, key, err)
+	return false, err
+}

--- a/test/utils/objects/wait/machineconfig.go
+++ b/test/utils/objects/wait/machineconfig.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wait
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+)
+
+func ForMachineConfigPoolDeleted(cli client.Client, mcp *machineconfigv1.MachineConfigPool, pollInterval, pollTimeout time.Duration) error {
+	err := wait.Poll(pollInterval, pollTimeout, func() (bool, error) {
+		updatedMcp := machineconfigv1.MachineConfigPool{}
+		key := client.ObjectKeyFromObject(mcp)
+		err := cli.Get(context.TODO(), key, &updatedMcp)
+		return deletionStatusFromError("MachineConfigPool", key, err)
+	})
+	return err
+}
+
+func ForKubeletConfigDeleted(cli client.Client, kc *machineconfigv1.KubeletConfig, pollInterval, pollTimeout time.Duration) error {
+	err := wait.Poll(pollInterval, pollTimeout, func() (bool, error) {
+		updatedKc := machineconfigv1.KubeletConfig{}
+		key := client.ObjectKeyFromObject(kc)
+		err := cli.Get(context.TODO(), key, &updatedKc)
+		return deletionStatusFromError("KubeletConfig", key, err)
+	})
+	return err
+}

--- a/test/utils/objects/wait/numaresources.go
+++ b/test/utils/objects/wait/numaresources.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wait
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+)
+
+func ForNUMAResourcesOperatorDeleted(cli client.Client, nrop *nropv1alpha1.NUMAResourcesOperator, pollInterval, pollTimeout time.Duration) error {
+	err := wait.Poll(pollInterval, pollTimeout, func() (bool, error) {
+		updatedNrop := nropv1alpha1.NUMAResourcesOperator{}
+		key := client.ObjectKeyFromObject(nrop)
+		err := cli.Get(context.TODO(), key, &updatedNrop)
+		return deletionStatusFromError("NUMAResourcesOperator", key, err)
+	})
+	return err
+}

--- a/test/utils/objects/wait/pod.go
+++ b/test/utils/objects/wait/pod.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
@@ -54,15 +53,6 @@ func ForPodDeleted(cli client.Client, podNamespace, podName string, timeout time
 		pod := &corev1.Pod{}
 		key := types.NamespacedName{Name: podName, Namespace: podNamespace}
 		err := cli.Get(context.TODO(), key, pod)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				klog.Infof("pod %#v is gone", key)
-				return true, nil
-			}
-			klog.Warningf("failed to get the pod %#v: %v", key, err)
-			return false, err
-		}
-		klog.Infof("pod %#v still present", key)
-		return false, err
+		return deletionStatusFromError("Pod", key, err)
 	})
 }


### PR DESCRIPTION
the install suite was flaking with errors similar to
```
Message: "object is being deleted: kubeletconfigs.machineconfiguration.openshift.io \"kc-test\" already exists",
```

This is because the test code was not waiting for the object
to be deleted from the cluster, but it was rather going along
if the deletion *request* was succesfully accepted by the system.

It's more correct to wait for objects to be deleted before to
keep going with the tests, so we do it in this patch, adding
the necessary utilities to enable this flow.

Signed-off-by: Francesco Romani <fromani@redhat.com>