### PR TITLE
vendor: bump k8swg/rte to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jaypipes/pcidb v0.6.0
 	github.com/k8stopologyawareschedwg/deployer v0.3.0
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.12
-	github.com/k8stopologyawareschedwg/resource-topology-exporter v0.4.1
+	github.com/k8stopologyawareschedwg/resource-topology-exporter v0.4.2-0.20220206104702-bb95c4d402dc
 	github.com/kubevirt/device-plugin-manager v1.18.8
 	github.com/mdomke/git-semver v1.0.0
 	github.com/onsi/ginkgo v1.16.4
@@ -19,7 +19,6 @@ require (
 	github.com/openshift/machine-config-operator v0.0.1-0.20211105081319-76d6155c1dab
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985
 	google.golang.org/grpc v1.38.0
 	k8s.io/api v0.22.3
 	k8s.io/apiextensions-apiserver v0.22.3
@@ -112,6 +111,7 @@ require (
 	go.uber.org/zap v1.18.1 // indirect
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a // indirect
 	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985 // indirect
 	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602 // indirect
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect

--- a/go.sum
+++ b/go.sum
@@ -761,8 +761,8 @@ github.com/k8stopologyawareschedwg/deployer v0.3.0/go.mod h1:rAX9pFSJRzDN7Cymk4D
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.8/go.mod h1:zRoCNg6LjSQewUwnpORw1VT9mP0rGNQlYy4WYaGWvHo=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.12 h1:NhXbOjO1st8hIcVpegr3zw/AGG12vs3z//tCDDcfPpE=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.12/go.mod h1:AkACMQGiTgCt0lQw3m7TTU8PLH9lYKNK5e9DqFf5VuM=
-github.com/k8stopologyawareschedwg/resource-topology-exporter v0.4.1 h1:tmKbRfTMnWZ1Dz6sdk33jQaXGBGZ+CLA03vz9CvJVEE=
-github.com/k8stopologyawareschedwg/resource-topology-exporter v0.4.1/go.mod h1:+ZguzA8pEV14UKTlIBB3tKSSkhayg0MPZrRC6E67Nfw=
+github.com/k8stopologyawareschedwg/resource-topology-exporter v0.4.2-0.20220206104702-bb95c4d402dc h1:+HlWN21IF0p/L8y3zzBF/ogFvrcqMG0tJ3kR4QJO6R0=
+github.com/k8stopologyawareschedwg/resource-topology-exporter v0.4.2-0.20220206104702-bb95c4d402dc/go.mod h1:+ZguzA8pEV14UKTlIBB3tKSSkhayg0MPZrRC6E67Nfw=
 github.com/karrick/godirwalk v1.7.5/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/topology_updater/topology_updater.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/topology_updater/topology_updater.go
@@ -154,8 +154,8 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 			if len(initialAllocRes) == 0 || len(finalAllocRes) == 0 {
 				ginkgo.Fail(fmt.Sprintf("failed to find available resources from node topology initial=%v final=%v", initialAllocRes, finalAllocRes))
 			}
-			zoneName, resName, cmp, ok := e2enodetopology.CmpAvailableResources(initialAllocRes, finalAllocRes)
-			framework.Logf("zone=%q resource=%q cmp=%v ok=%v", zoneName, resName, cmp, ok)
+			zoneName, cmp, ok := e2enodetopology.CmpAvailableCPUs(initialAllocRes, finalAllocRes)
+			framework.Logf("zone=%q resource=%q cmp=%v ok=%v", zoneName, v1.ResourceCPU, cmp, ok)
 			if !ok {
 				ginkgo.Fail(fmt.Sprintf("failed to compare available resources from node topology initial=%v final=%v", initialAllocRes, finalAllocRes))
 			}

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/nodetopology/nodetopology.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/nodetopology/nodetopology.go
@@ -180,3 +180,27 @@ func CmpResourceList(expected, got v1.ResourceList) (string, int, bool) {
 	}
 	return "", 0, true
 }
+
+func CmpAvailableCPUs(expected, got map[string]v1.ResourceList) (string, int, bool) {
+	if len(got) != len(expected) {
+		framework.Logf("-> expected=%v (len=%d) got=%v (len=%d)", expected, len(expected), got, len(got))
+		return "", 0, false
+	}
+
+	for expZoneName, expResList := range expected {
+		gotResList, ok := got[expZoneName]
+		if !ok {
+			return expZoneName, 0, false
+		}
+		if _, ok := expResList[v1.ResourceCPU]; !ok {
+			return expZoneName, 0, false
+		}
+
+		if _, ok := gotResList[v1.ResourceCPU]; !ok {
+			return expZoneName, 0, false
+		}
+		quan := gotResList[v1.ResourceCPU]
+		return "", quan.Cmp(expResList[v1.ResourceCPU]), true
+	}
+	return "", 0, true
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -216,7 +216,7 @@ github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned/scheme
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned/typed/topology/v1alpha1
-# github.com/k8stopologyawareschedwg/resource-topology-exporter v0.4.1
+# github.com/k8stopologyawareschedwg/resource-topology-exporter v0.4.2-0.20220206104702-bb95c4d402dc
 ## explicit; go 1.16
 github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/k8shelpers
 github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/kubeconf


### PR DESCRIPTION
Latest version contains fixes for some flaky tests we had.
Maybe it is better to create a new tag and only then update the dependencies.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>