### PR TITLE
e2e: fix master node affinity test

### DIFF
--- a/test/e2e/sched/install/install_test.go
+++ b/test/e2e/sched/install/install_test.go
@@ -99,10 +99,11 @@ var _ = Describe("[Scheduler] install", func() {
 
 			nodeList, err := schedutils.ListMasterNodes(e2eclient.Client)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(nodeList).ToNot(BeEmpty())
 
 			nodeNames := schedutils.GetNodeNames(nodeList)
 			for _, pod := range podList {
-				Expect(pod.Spec.NodeName).To(BeElementOf(nodeNames))
+				Expect(pod.Spec.NodeName).To(BeElementOf(nodeNames), "pod: %q landed on node: %q, which is not part of the master nodes group: %v", pod.Name, pod.Spec.NodeName, nodeNames)
 			}
 
 			By("checking the NumaResourcesScheduler CRD is deployed")

--- a/test/e2e/sched/utils/node.go
+++ b/test/e2e/sched/utils/node.go
@@ -22,17 +22,30 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+	"github.com/openshift-kni/numaresources-operator/test/utils/configuration"
+)
+
+const (
+	// LabelMasterRole contains the key for the role label
+	LabelMasterRole = "node-role.kubernetes.io/master"
+
+	// LabelControlPlane contains the key for the control-plane role label
+	LabelControlPlane = "node-role.kubernetes.io/control-plane"
 )
 
 func ListMasterNodes(aclient client.Client) ([]corev1.Node, error) {
-
 	nodeList := &corev1.NodeList{}
 	labels := metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			"node-role.kubernetes.io/control-plane": "",
-			"node-role.kubernetes.io/master":        "",
+			LabelMasterRole: "",
 		},
 	}
+	if configuration.Platform == platform.Kubernetes {
+		labels.MatchLabels[LabelControlPlane] = ""
+	}
+
 	selNodes, err := metav1.LabelSelectorAsSelector(&labels)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When running in an OCP environment, the label "node-role.kubernetes.io/control-plane" doesn't exist for the master nodes.
We shall add this label only when running in a K8S environment