### PR TITLE
e2e: serial: test multi-container placement

### DIFF
--- a/test/e2e/serial/workload_placement_test.go
+++ b/test/e2e/serial/workload_placement_test.go
@@ -26,7 +26,6 @@ import (
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	nrtv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
@@ -36,6 +35,8 @@ import (
 	"github.com/openshift-kni/numaresources-operator/test/utils/nrosched"
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 	e2ewait "github.com/openshift-kni/numaresources-operator/test/utils/objects/wait"
+
+	nrtv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
 
 	numacellapi "github.com/openshift-kni/numaresources-operator/test/deviceplugin/pkg/numacell/api"
 )
@@ -68,12 +69,12 @@ var _ = Describe("[serial][disruptive][scheduler] workload placement", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	// note we hardcode the values we need here and when we pad node.
+	// This is ugly, but automatically computing the values is not straightforward
+	// and will we want to start lean and mean.
+
 	Context("cluster with at least a worker node suitable", func() {
 		It("[placement][case:1] should keep the pod pending if not enough resources available, then schedule when resources are freed", func() {
-			// note we hardcode the values we need here and when we pad node.
-			// This is ugly, but automatically computing the values is not straightforward
-			// and will we want to start lean and mean.
-
 			// make sure this is > 1 and LESS than required Res!
 			unsuitableFreeRes := corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("2"),
@@ -238,6 +239,180 @@ var _ = Describe("[serial][disruptive][scheduler] workload placement", func() {
 			schedOK, err := nrosched.CheckPODWasScheduledWith(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, schedulerName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, schedulerName)
+		})
+	})
+
+	Context("cluster with multiple worker nodes suitable", func() {
+		It("[placement][test_id:47575] should make a pod with two gu containers land on a node with enough resources on a specific NUMA zone, each container on a different zone", func() {
+			hostsRequired := 2
+
+			pod := objects.NewTestPodPause(fxt.Namespace.Name, "testpod")
+			pod.Spec.SchedulerName = schedulerName
+			pod.Spec.NodeSelector = map[string]string{
+				multiNUMALabel: "2",
+			}
+			pod.Spec.Containers = append(pod.Spec.Containers, pod.Spec.Containers[0])
+			pod.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("6"),
+				corev1.ResourceMemory: resource.MustParse("6Gi"),
+			}
+			pod.Spec.Containers[1].Resources.Limits = corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("12"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			}
+			requiredRes := e2enrt.ResourcesFromGuaranteedPod(*pod)
+
+			// make sure the sum is equal to the sum of the requirement of the test pod,
+			// so the *node* total free resources are equal between the target node and
+			// the unsuitable nodes
+			unsuitableFreeRes := []corev1.ResourceList{
+				{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				{
+					corev1.ResourceCPU:    resource.MustParse("16"),
+					corev1.ResourceMemory: resource.MustParse("12Gi"),
+				},
+			}
+
+			// TODO: we need AT LEAST 2 (so 4, 8 is fine...) but we hardcode the padding logic to keep the test simple,
+			// so we can't support ATM zones > 2. HW with zones > 2 is rare anyway, so not to big of a deal now.
+			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", 2))
+			nrtCandidates := e2enrt.FilterZoneCountEqual(nrts, 2)
+			if len(nrtCandidates) < hostsRequired {
+				Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates)))
+			}
+			By("filtering available nodes with allocatable resources on each NUMA zone that can match request")
+			nrtCandidates = e2enrt.FilterAnyZoneMatchingResources(nrtCandidates, requiredRes)
+			if len(nrtCandidates) < hostsRequired {
+				Skip(fmt.Sprintf("not enough nodes with NUMA zones each of them can match requests: found %d", len(nrtCandidates)))
+			}
+
+			candidateNodeNames := e2enrt.AccumulateNames(nrtCandidates)
+			// nodes we have now are all equal for our purposes. Pick one at random
+			// TODO: make sure we can control this randomness using ginkgo seed or any other way
+			targetNodeName, ok := candidateNodeNames.PopAny()
+			Expect(ok).To(BeTrue(), "cannot select a target node among %#v", candidateNodeNames.List())
+			unsuitableNodeNames := candidateNodeNames.List()
+
+			By(fmt.Sprintf("selecting target node %q and unsuitable nodes %#v (random pick)", targetNodeName, unsuitableNodeNames))
+
+			By(fmt.Sprintf("preparing target node %q to fit the test case", targetNodeName))
+			// first, let's make sure that ONLY the required res can fit in either zone on the target node
+			nrtInfo, err := e2enrt.FindFromList(nrtList.Items, targetNodeName)
+			Expect(err).ToNot(HaveOccurred(), "missing NRT info for %q", targetNodeName)
+
+			// if we get this far we can now depend on the fact that len(nrt.Zones) == len(pod.Spec.Containers) == 2
+			var paddingPods []*corev1.Pod
+
+			for idx := 0; idx < 2; idx++ {
+				zone := nrtInfo.Zones[idx]
+				cnt := pod.Spec.Containers[1-idx] // switch requirements intentionally - both couplings are legit anyway
+
+				By(fmt.Sprintf("padding node %q zone %q to fit only %s", nrtInfo.Name, zone.Name, e2enrt.ResourceListToString(cnt.Resources.Limits)))
+				padPod, err := makePaddingPod(fxt.Namespace.Name, "target", zone, cnt.Resources.Limits)
+				Expect(err).ToNot(HaveOccurred())
+
+				padPod, err = pinPodTo(padPod, nrtInfo.Name, zone.Name)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = fxt.Client.Create(context.TODO(), padPod)
+				Expect(err).ToNot(HaveOccurred())
+				paddingPods = append(paddingPods, padPod)
+			}
+
+			// still working under the assumption that len(nrt.Zones) == len(pod.Spec.Containers) == 2
+			for nodeIdx, unsuitableNodeName := range unsuitableNodeNames {
+				nrtInfo, err := e2enrt.FindFromList(nrtList.Items, unsuitableNodeName)
+				Expect(err).ToNot(HaveOccurred(), "missing NRT info for %q", unsuitableNodeName)
+
+				for zoneIdx, zone := range nrtInfo.Zones {
+					padRes := unsuitableFreeRes[zoneIdx]
+
+					name := fmt.Sprintf("unsuitable%d", nodeIdx)
+					By(fmt.Sprintf("saturating node %q -> %q zone %q to fit only %s", nrtInfo.Name, name, zone.Name, e2enrt.ResourceListToString(padRes)))
+					padPod, err := makePaddingPod(fxt.Namespace.Name, name, zone, padRes)
+					Expect(err).ToNot(HaveOccurred())
+
+					padPod, err = pinPodTo(padPod, nrtInfo.Name, zone.Name)
+					Expect(err).ToNot(HaveOccurred())
+
+					err = fxt.Client.Create(context.TODO(), padPod)
+					Expect(err).ToNot(HaveOccurred())
+					paddingPods = append(paddingPods, padPod)
+				}
+			}
+
+			By("waiting for ALL padding pods to go running - or fail")
+			failedPods := e2ewait.ForPodListAllRunning(fxt.Client, paddingPods)
+			for _, failedPod := range failedPods {
+				// ignore errors intentionally
+				_ = objects.LogEventsForPod(fxt.K8sClient, failedPod.Namespace, failedPod.Name)
+			}
+			Expect(failedPods).To(BeEmpty())
+
+			// TODO: smarter cooldown
+			time.Sleep(18 * time.Second)
+			dumpNRTForNode(fxt.Client, targetNodeName)
+
+			By("checking the resource allocation as the test starts")
+			nrtListInitial, err := e2enrt.GetUpdated(fxt.Client, nrtList, 1*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("running the test pod")
+			err = fxt.Client.Create(context.TODO(), pod)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for the pod to be scheduled")
+			updatedPod, err := e2ewait.ForPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodRunning, 2*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+
+			By(fmt.Sprintf("checking the pod landed on the target node %q vs %q", updatedPod.Spec.NodeName, targetNodeName))
+			Expect(updatedPod.Spec.NodeName).To(Equal(targetNodeName),
+				"node landed on %q instead of on %v", updatedPod.Spec.NodeName, targetNodeName)
+
+			By(fmt.Sprintf("checking the pod was scheduled with the topology aware scheduler %q", schedulerName))
+			schedOK, err := nrosched.CheckPODWasScheduledWith(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, schedulerName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, schedulerName)
+
+			By(fmt.Sprintf("checking the resources are accounted as expected on %q", updatedPod.Spec.NodeName))
+			nrtListPostCreate, err := e2enrt.GetUpdated(fxt.Client, nrtList, 1*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+
+			nrtInitial, err := e2enrt.FindFromList(nrtListInitial.Items, updatedPod.Spec.NodeName)
+			Expect(err).ToNot(HaveOccurred())
+			nrtPostCreate, err := e2enrt.FindFromList(nrtListPostCreate.Items, updatedPod.Spec.NodeName)
+			Expect(err).ToNot(HaveOccurred())
+
+			// TODO: this is only partially correct. We should check with NUMA zone granularity (not with NODE granularity)
+			_, err = e2enrt.CheckZoneConsumedResourcesAtLeast(*nrtInitial, *nrtPostCreate, requiredRes)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("deleting the test pod")
+			err = fxt.Client.Delete(context.TODO(), updatedPod)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("checking the test pod is removed")
+			err = e2ewait.ForPodDeleted(fxt.Client, updatedPod.Namespace, updatedPod.Name, 3*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+
+			// the NRT updaters MAY be slow to react for a number of reasons including factors out of our control
+			// (kubelet, runtime). This is a known behaviour. We can only tolerate some delay in reporting on pod removal.
+			Eventually(func() bool {
+				By(fmt.Sprintf("checking the resources are restored as expected on %q", updatedPod.Spec.NodeName))
+
+				nrtListPostDelete, err := e2enrt.GetUpdated(fxt.Client, nrtListPostCreate, 1*time.Minute)
+				Expect(err).ToNot(HaveOccurred())
+
+				nrtPostDelete, err := e2enrt.FindFromList(nrtListPostDelete.Items, updatedPod.Spec.NodeName)
+				Expect(err).ToNot(HaveOccurred())
+
+				ok, err := e2enrt.CheckEqualAvailableResources(*nrtInitial, *nrtPostDelete)
+				Expect(err).ToNot(HaveOccurred())
+				return ok
+			}, time.Minute, time.Second*5).Should(BeTrue(), "resources not restored on %q", updatedPod.Spec.NodeName)
 		})
 	})
 })


### PR DESCRIPTION
Add e2e test to verify the behaviour of the NUMA aware scheduler by creating a testcase which is expected to foul the default,
NUMA-unaware scheduler. 

We expect to run on a cluster with two or more machines each of which has two NUMA zones. We don't actually support
more than two zones because the resource allocation numbers are hardcoded, not computed on the fly. Given how rare machines with more than 2 NUMA zones, that should not be a problem anytime soon.

We use a guaranteed pod with two containers; we set the required resources such as the total amount of requested resources is available on both the two workers but one of them only has all resources on one NUMA per container.

IOW:
- 2+ nodes have all the required resources availaible at *node* level
- exactly 1 node have all the required resources available at *NUMA
  zone* level.

Hence we expect here the NUMA-aware scheduler to pick the only right spot every time, at the first try.