### PR TITLE
e2e: wait for MCP UPDATED status

### DIFF
--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -440,6 +440,17 @@ func teardownDeployment(nrod nroDeployment, timeout time.Duration) {
 	}(nrod.nroObj)
 
 	wg.Wait()
+
+	if configuration.Platform == platform.OpenShift {
+		Eventually(func() bool {
+			updated, err := machineconfigpools.IsMachineConfigPoolsUpdatedAfterDeletion(nrod.nroObj)
+			if err != nil {
+				klog.Errorf("failed to retrieve information about machine config pools: %w", err)
+				return false
+			}
+			return updated
+		}, configuration.MachineConfigPoolUpdateTimeout, configuration.MachineConfigPoolUpdateInterval).Should(BeTrue())
+	}
 }
 
 func deleteNROPSync(cli client.Client, nropObj *nropv1alpha1.NUMAResourcesOperator) {

--- a/test/utils/machineconfigpools/machineconfigpools.go
+++ b/test/utils/machineconfigpools/machineconfigpools.go
@@ -42,6 +42,23 @@ func IsMachineConfigPoolsUpdated(nro *nropv1alpha1.NUMAResourcesOperator) (bool,
 	return true, nil
 }
 
+// IsMachineConfigPoolsUpdatedAfterDeletion checks if all related to NUMAResourceOperator CR machines config pools have updated status
+// after MachineConfig deletion
+func IsMachineConfigPoolsUpdatedAfterDeletion(nro *nropv1alpha1.NUMAResourcesOperator) (bool, error) {
+	mcps, err := nropmcp.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nro.Spec.NodeGroups)
+	if err != nil {
+		return false, err
+	}
+
+	for _, mcp := range mcps {
+		if !controllers.IsMachineConfigPoolUpdatedAfterDeletion(nro.Name, mcp) {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
 func PauseMCPs(nodeGroups []nropv1alpha1.NodeGroup) (func() error, error) {
 	mcps, err := nropmcp.GetNodeGroupsMCPs(context.TODO(), e2eclient.Client, nodeGroups)
 	if err != nil {


### PR DESCRIPTION
After a teardown of the environment at the end of each test, we should wait for all mcps` ```UPDATED``` status to be ``True`` , in order to avoid conflicts before applying new MachineConfig data on the next tests.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>