### PR TITLE
e2e: serial: implement test id 47594

### DIFF
--- a/test/e2e/serial/workload_placement_test.go
+++ b/test/e2e/serial/workload_placement_test.go
@@ -27,23 +27,29 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/util/taints"
 
+	nrtv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+	numacellapi "github.com/openshift-kni/numaresources-operator/test/deviceplugin/pkg/numacell/api"
 	schedutils "github.com/openshift-kni/numaresources-operator/test/e2e/sched/utils"
 	e2efixture "github.com/openshift-kni/numaresources-operator/test/utils/fixture"
 	e2enrt "github.com/openshift-kni/numaresources-operator/test/utils/noderesourcetopologies"
+	e2enodes "github.com/openshift-kni/numaresources-operator/test/utils/nodes"
 	"github.com/openshift-kni/numaresources-operator/test/utils/nrosched"
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 	e2ewait "github.com/openshift-kni/numaresources-operator/test/utils/objects/wait"
-
-	nrtv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
-
-	numacellapi "github.com/openshift-kni/numaresources-operator/test/deviceplugin/pkg/numacell/api"
+	e2epadder "github.com/openshift-kni/numaresources-operator/test/utils/padder"
 )
+
+const testKey = "testkey"
 
 var _ = Describe("[serial][disruptive][scheduler] workload placement", func() {
 	var fxt *e2efixture.Fixture
+	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha1.NodeResourceTopologyList
 	var nrts []nrtv1alpha1.NodeResourceTopology
 
@@ -51,6 +57,9 @@ var _ = Describe("[serial][disruptive][scheduler] workload placement", func() {
 		var err error
 		fxt, err = e2efixture.Setup("e2e-test-workload-placement")
 		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
+
+		padder, err = e2epadder.New(fxt.Client, fxt.Namespace.Name)
+		Expect(err).ToNot(HaveOccurred())
 
 		err = fxt.Client.List(context.TODO(), &nrtList)
 		Expect(err).ToNot(HaveOccurred())
@@ -66,7 +75,9 @@ var _ = Describe("[serial][disruptive][scheduler] workload placement", func() {
 	})
 
 	AfterEach(func() {
-		err := e2efixture.Teardown(fxt)
+		err := padder.Clean()
+		Expect(err).NotTo(HaveOccurred())
+		err = e2efixture.Teardown(fxt)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -547,6 +558,163 @@ var _ = Describe("[serial][disruptive][scheduler] workload placement", func() {
 			}
 		})
 	})
+
+	When("cluster has two feasible nodes with taint but only one has the requested resources on a single NUMA zone", func() {
+		timeout := 5 * time.Minute
+		BeforeEach(func() {
+			numOfNodeToBePadded := len(nrts) - 1
+
+			rl := corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("3"),
+				corev1.ResourceMemory: resource.MustParse("8G"),
+			}
+			By("padding the nodes before test start")
+			err := padder.Nodes(numOfNodeToBePadded).UntilAvailableIsResourceList(rl).Pad(timeout)
+			Expect(err).ToNot(HaveOccurred())
+
+			nodes, err := e2enodes.GetWorkerNodes(fxt.Client)
+			Expect(err).ToNot(HaveOccurred())
+
+			t, _, err := taints.ParseTaints([]string{testTaint()})
+			Expect(err).ToNot(HaveOccurred())
+
+			for i := range nodes {
+				node := &nodes[i]
+				updatedNode, updated, err := taints.AddOrUpdateTaint(node, &t[0])
+				Expect(err).ToNot(HaveOccurred())
+				if updated {
+					node = updatedNode
+					klog.Infof("adding taint: %q to node: %q", t[0].String(), node.Name)
+					err = fxt.Client.Update(context.TODO(), node)
+					Expect(err).ToNot(HaveOccurred())
+				}
+			}
+		})
+
+		AfterEach(func() {
+			nodes, err := e2enodes.GetWorkerNodes(fxt.Client)
+			Expect(err).ToNot(HaveOccurred())
+
+			t, _, err := taints.ParseTaints([]string{testTaint()})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("removing taints from the nodes")
+			for i := range nodes {
+				node := &nodes[i]
+				updatedNode, updated, err := taints.RemoveTaint(node, &t[0])
+				Expect(err).ToNot(HaveOccurred())
+				if updated {
+					node = updatedNode
+					klog.Infof("removing taint: %q from node: %q", t[0].String(), node.Name)
+					err = fxt.Client.Update(context.TODO(), node)
+					Expect(err).ToNot(HaveOccurred())
+				}
+			}
+
+			By("unpadding the nodes after test finish")
+			err = padder.Clean()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("[test_id:47594] should make a pod with a toleration land on a node with enough resources on a specific NUMA zone", func() {
+			hostsRequired := 2
+			paddedNodes := padder.GetPaddedNodes()
+			paddedNodesSet := sets.NewString(paddedNodes...)
+
+			nrtInitialList, err := e2enrt.GetUpdated(fxt.Client, nrtv1alpha1.NodeResourceTopologyList{}, time.Second*10)
+			Expect(err).ToNot(HaveOccurred())
+
+			// so we can't support ATM zones > 2. HW with zones > 2 is rare anyway, so not to big of a deal now.
+			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", 2))
+			nrtCandidates := e2enrt.FilterZoneCountEqual(nrtInitialList.Items, 2)
+			if len(nrtCandidates) < hostsRequired {
+				Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates)))
+			}
+
+			singleNUMAPolicyNrts := e2enrt.FilterByPolicies(nrtInitialList.Items, []nrtv1alpha1.TopologyManagerPolicy{nrtv1alpha1.SingleNUMANodePodLevel, nrtv1alpha1.SingleNUMANodeContainerLevel})
+			nodesNameSet := e2enrt.AccumulateNames(singleNUMAPolicyNrts)
+
+			// the only node which was not padded is the targetedNode
+			// since we know exactly how the test setup looks like we expect only targeted node here
+			targetNodeNameSet := nodesNameSet.Difference(paddedNodesSet)
+			Expect(targetNodeNameSet.Len()).To(Equal(1))
+
+			targetNodeName, ok := targetNodeNameSet.PopAny()
+			Expect(ok).To(BeTrue())
+
+			testPod := objects.NewTestPodPause(fxt.Namespace.Name, "testpod")
+			pSpec := &testPod.Spec
+			if pSpec.Tolerations == nil {
+				pSpec.Tolerations = []corev1.Toleration{}
+			}
+			pSpec.Tolerations = append(pSpec.Tolerations, testToleration()...)
+
+			testPod.Spec.SchedulerName = schedulerName
+			cnt := &testPod.Spec.Containers[0]
+			requiredRes := corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("100Mi"),
+			}
+			cnt.Resources.Requests = requiredRes
+			cnt.Resources.Limits = requiredRes
+
+			err = fxt.Client.Create(context.TODO(), testPod)
+			Expect(err).ToNot(HaveOccurred())
+
+			updatedPod, err := e2ewait.ForPodPhase(fxt.Client, testPod.Namespace, testPod.Name, corev1.PodRunning, timeout)
+			Expect(err).ToNot(HaveOccurred())
+
+			By(fmt.Sprintf("checking the pod landed on the target node %q vs %q", updatedPod.Spec.NodeName, targetNodeName))
+			Expect(updatedPod.Spec.NodeName).To(Equal(targetNodeName),
+				"node landed on %q instead of on %v", updatedPod.Spec.NodeName, targetNodeName)
+
+			By(fmt.Sprintf("checking the pod was scheduled with the topology aware scheduler %q", schedulerName))
+			schedOK, err := nrosched.CheckPODWasScheduledWith(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, schedulerName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, schedulerName)
+
+			nrtPostCreateList, err := e2enrt.GetUpdated(fxt.Client, nrtInitialList, time.Second*10)
+			Expect(err).ToNot(HaveOccurred())
+
+			rl := e2enrt.ResourcesFromGuaranteedPod(*updatedPod)
+
+			nrtInitial, err := e2enrt.FindFromList(nrtInitialList.Items, updatedPod.Spec.NodeName)
+			Expect(err).ToNot(HaveOccurred())
+
+			nrtPostCreate, err := e2enrt.FindFromList(nrtPostCreateList.Items, updatedPod.Spec.NodeName)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = e2enrt.CheckZoneConsumedResourcesAtLeast(*nrtInitial, *nrtPostCreate, rl)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("deleting the test pod")
+			if err := fxt.Client.Delete(context.TODO(), updatedPod); err != nil {
+				if !errors.IsNotFound(err) {
+					Expect(err).ToNot(HaveOccurred())
+				}
+			}
+
+			By("checking the test pod is removed")
+			err = e2ewait.ForPodDeleted(fxt.Client, updatedPod.Namespace, testPod.Name, 3*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+
+			// the NRT updaters MAY be slow to react for a number of reasons including factors out of our control
+			// (kubelet, runtime). This is a known behaviour. We can only tolerate some delay in reporting on pod removal.
+			Eventually(func() bool {
+				By(fmt.Sprintf("checking the resources are restored as expected on %q", updatedPod.Spec.NodeName))
+
+				nrtListPostDelete, err := e2enrt.GetUpdated(fxt.Client, nrtPostCreateList, 1*time.Minute)
+				Expect(err).ToNot(HaveOccurred())
+
+				nrtPostDelete, err := e2enrt.FindFromList(nrtListPostDelete.Items, updatedPod.Spec.NodeName)
+				Expect(err).ToNot(HaveOccurred())
+
+				ok, err := e2enrt.CheckEqualAvailableResources(*nrtInitial, *nrtPostDelete)
+				Expect(err).ToNot(HaveOccurred())
+				return ok
+			}, time.Minute, time.Second*5).Should(BeTrue(), "resources not restored on %q", updatedPod.Spec.NodeName)
+		})
+	})
 })
 
 func makePaddingPod(namespace, nodeName string, zone nrtv1alpha1.Zone, podReqs corev1.ResourceList) (*corev1.Pod, error) {
@@ -587,4 +755,18 @@ func dumpNRTForNode(cli client.Client, nodeName string) {
 	data, err := yaml.Marshal(nrt)
 	Expect(err).ToNot(HaveOccurred())
 	klog.Infof("NRT for node %q:\n%s", nodeName, data)
+}
+
+func testTaint() string {
+	return fmt.Sprintf("%s:%s", testKey, corev1.TaintEffectNoSchedule)
+}
+
+func testToleration() []corev1.Toleration {
+	return []corev1.Toleration{
+		{
+			Key:      testKey,
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	}
 }

--- a/test/utils/noderesourcetopologies/noderesourcetopologies.go
+++ b/test/utils/noderesourcetopologies/noderesourcetopologies.go
@@ -256,6 +256,15 @@ func ZoneResourcesMatchesRequest(resources []nrtv1alpha1.ResourceInfo, requests 
 	return true
 }
 
+func FilterByPolicies(list []nrtv1alpha1.NodeResourceTopology, policies []nrtv1alpha1.TopologyManagerPolicy) []nrtv1alpha1.NodeResourceTopology {
+	var filteredNrts []nrtv1alpha1.NodeResourceTopology
+	for _, policy := range policies {
+		nrts := FilterTopologyManagerPolicy(list, policy)
+		filteredNrts = append(filteredNrts, nrts...)
+	}
+	return filteredNrts
+}
+
 func findZoneByName(nrt nrtv1alpha1.NodeResourceTopology, zoneName string) (*nrtv1alpha1.Zone, error) {
 	for idx := 0; idx < len(nrt.Zones); idx++ {
 		if nrt.Zones[idx].Name == zoneName {

--- a/test/utils/nodes/nodes.go
+++ b/test/utils/nodes/nodes.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodes
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil"
+)
+
+func GetWorkerNodes(cli client.Client) ([]corev1.Node, error) {
+	nodes := &corev1.NodeList{}
+	selector, err := labels.Parse(fmt.Sprintf("%s/%s=", clientutil.LabelRole, clientutil.RoleWorker))
+	if err != nil {
+		return nil, err
+	}
+
+	err = cli.List(context.TODO(), nodes, &client.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, err
+	}
+
+	return nodes.Items, nil
+}

--- a/test/utils/padder/padder.go
+++ b/test/utils/padder/padder.go
@@ -108,7 +108,7 @@ func (p *Padder) Pad(timeout time.Duration) error {
 		return err
 	}
 
-	singleNumaNrt := filterSingleNumaNodePolicyNrts(nrtList.Items)
+	singleNumaNrt := nrtutil.FilterByPolicies(nrtList.Items, []nrtv1alpha1.TopologyManagerPolicy{nrtv1alpha1.SingleNUMANodePodLevel, nrtv1alpha1.SingleNUMANodeContainerLevel})
 	if p.nNodes > len(singleNumaNrt) {
 		return fmt.Errorf("not enough nodes were found for padding. requested: %d, got: %d", p.nNodes, len(singleNumaNrt))
 	}
@@ -277,16 +277,6 @@ func labelPod(pod *corev1.Pod, labelMap map[string]string) {
 	for k, v := range labelMap {
 		pod.Labels[k] = v
 	}
-}
-
-func filterSingleNumaNodePolicyNrts(list []nrtv1alpha1.NodeResourceTopology) []nrtv1alpha1.NodeResourceTopology {
-	singleNUMANodeContainerLevelNrts := nrtutil.FilterTopologyManagerPolicy(list, nrtv1alpha1.SingleNUMANodeContainerLevel)
-	singleNUMANodePodLevelNrts := nrtutil.FilterTopologyManagerPolicy(list, nrtv1alpha1.SingleNUMANodePodLevel)
-
-	var singleNumaNrt []nrtv1alpha1.NodeResourceTopology
-	singleNumaNrt = append(singleNumaNrt, singleNUMANodeContainerLevelNrts...)
-	singleNumaNrt = append(singleNumaNrt, singleNUMANodePodLevelNrts...)
-	return singleNumaNrt
 }
 
 func isZoneMeetAllocationTarget(zone nrtv1alpha1.Zone, target corev1.ResourceList) bool {


### PR DESCRIPTION
The test creates a guaranteed pod with toleration.
The cluster has two feasible nodes with taint matching the toleration of the workload, but only one of them has all the requested resources on a single NUMA.
The test verifies the pod land on the correct node, otherwise, it failed

depend on #116 