### PR TITLE
[release-4.10] bundle: examples: update CR examples

### DIFF
--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -8,20 +8,28 @@ metadata:
           "apiVersion": "nodetopology.openshift.io/v1alpha1",
           "kind": "NUMAResourcesOperator",
           "metadata": {
-            "name": "numaresourcesoperator-sample"
+            "name": "numaresourcesoperator"
           },
           "spec": {
-            "foo": "bar"
+            "nodeGroups": [
+              {
+                "machineConfigPoolSelector": {
+                  "matchLabels": {
+                    "pools.operator.machineconfiguration.openshift.io/worker": ""
+                  }
+                }
+              }
+            ]
           }
         },
         {
           "apiVersion": "nodetopology.openshift.io/v1alpha1",
           "kind": "NUMAResourcesScheduler",
           "metadata": {
-            "name": "numaresourcesscheduler-sample"
+            "name": "numaresourcesscheduler"
           },
           "spec": {
-            "foo": "bar"
+            "imageSpec": "quay.io/openshift-kni/scheduler-plugins:4.10-snapshot"
           }
         }
       ]

--- a/config/samples/nodetopology_v1alpha1_numaresourcesoperator.yaml
+++ b/config/samples/nodetopology_v1alpha1_numaresourcesoperator.yaml
@@ -1,7 +1,9 @@
 apiVersion: nodetopology.openshift.io/v1alpha1
 kind: NUMAResourcesOperator
 metadata:
-  name: numaresourcesoperator-sample
+  name: numaresourcesoperator
 spec:
-  # Add fields here
-  foo: bar
+  nodeGroups:
+  - machineConfigPoolSelector:
+      matchLabels:
+        pools.operator.machineconfiguration.openshift.io/worker: ""

--- a/config/samples/nodetopology_v1alpha1_numaresourcesscheduler.yaml
+++ b/config/samples/nodetopology_v1alpha1_numaresourcesscheduler.yaml
@@ -1,7 +1,6 @@
 apiVersion: nodetopology.openshift.io/v1alpha1
 kind: NUMAResourcesScheduler
 metadata:
-  name: numaresourcesscheduler-sample
+  name: numaresourcesscheduler
 spec:
-  # Add fields here
-  foo: bar
+  imageSpec: "quay.io/openshift-kni/scheduler-plugins:4.10-snapshot"


### PR DESCRIPTION
copy data from doc/examples, which still is our authoritative source.
manual cherry-pick of https://github.com/openshift-kni/numaresources-operator/pull/151

Signed-off-by: Francesco Romani <fromani@redhat.com>