### PR TITLE
csv: declare minimum kubernetes version

### DIFF
--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -382,6 +382,7 @@ spec:
   - email: fromani@redhat.com
     name: fromani
   maturity: alpha
+  minKubeVersion: 1.23.0
   provider:
     name: Red Hat
   version: 4.11.999-snapshot

--- a/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
@@ -92,6 +92,7 @@ spec:
   - email: fromani@redhat.com
     name: fromani
   maturity: alpha
+  minKubeVersion: 1.23.0
   provider:
     name: Red Hat
   version: 4.11.0


### PR DESCRIPTION
We need k8s >= 1.23 because of the podresources API.