### PR TITLE
e2e-workload: Workload requests guaranteed pod resources available on one node but not on a single numa

### DIFF
--- a/test/e2e/sched/utils/daemonset.go
+++ b/test/e2e/sched/utils/daemonset.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ListPodsByDaemonset(cli client.Client, ds appsv1.DaemonSet) ([]corev1.Pod, error) {
+	podList := &corev1.PodList{}
+	sel, err := metav1.LabelSelectorAsSelector(ds.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+
+	err = cli.List(context.TODO(), podList, &client.ListOptions{LabelSelector: sel})
+	if err != nil {
+		return nil, err
+	}
+
+	return podList.Items, nil
+}

--- a/test/e2e/serial/workload_placement_test.go
+++ b/test/e2e/serial/workload_placement_test.go
@@ -576,6 +576,151 @@ var _ = Describe("[serial][disruptive][scheduler] workload placement", func() {
 		})
 	})
 
+	Context("with no suitable node", func() {
+		var requiredRes corev1.ResourceList
+		BeforeEach(func() {
+			requiredNUMAZones := 2
+			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", requiredNUMAZones))
+			nrtCandidates := e2enrt.FilterZoneCountEqual(nrts, requiredNUMAZones)
+
+			neededNodes := 1
+			if len(nrtCandidates) < neededNodes {
+				Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d, needed %d", len(nrtCandidates), neededNodes))
+			}
+
+			nrtCandidateNames := e2enrt.AccumulateNames(nrtCandidates)
+
+			//TODO: we should calculate requiredRes from NUMA zones in cluster nodes instead.
+			requiredRes = corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
+			}
+
+			By("Padding selected node")
+			// TODO This should be calculated as 3/4 of requiredRes
+			paddingRes := corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("3"),
+				corev1.ResourceMemory: resource.MustParse("3Gi"),
+			}
+
+			var paddingPods []*corev1.Pod
+			for _, nodeName := range nrtCandidateNames.List() {
+
+				nrtInfo, err := e2enrt.FindFromList(nrtCandidates, nodeName)
+				Expect(err).NotTo(HaveOccurred(), "missing NRT info for %q", nodeName)
+
+				for idx, zone := range nrtInfo.Zones {
+					podName := fmt.Sprintf("padding%s-%d", nodeName, idx)
+					padPod, err := makePaddingPod(fxt.Namespace.Name, podName, zone, paddingRes)
+					Expect(err).NotTo(HaveOccurred(), "unable to create padding pod %q on zone", podName, zone.Name)
+
+					padPod, err = pinPodTo(padPod, nodeName, zone.Name)
+					Expect(err).NotTo(HaveOccurred(), "unable to pin pod %q to zone", podName, zone.Name)
+
+					err = fxt.Client.Create(context.TODO(), padPod)
+					Expect(err).NotTo(HaveOccurred(), "unable to create pod %q on zone", podName, zone.Name)
+
+					paddingPods = append(paddingPods, padPod)
+				}
+			}
+
+			failedPods := e2ewait.ForPodListAllRunning(fxt.Client, paddingPods)
+			for _, failedPod := range failedPods {
+				_ = objects.LogEventsForPod(fxt.K8sClient, failedPod.Namespace, failedPod.Name)
+			}
+			Expect(failedPods).To(BeEmpty(), "some padding pods have failed to run")
+		})
+
+		It("[test_id:47617] workload requests guaranteed pod resources available on one node but not on a single numa", func() {
+
+			By("Scheduling the testing pod")
+			pod := objects.NewTestPodPause(fxt.Namespace.Name, "testPod")
+			pod.Spec.SchedulerName = schedulerName
+			pod.Spec.Containers[0].Resources.Limits = requiredRes
+
+			err := fxt.Client.Create(context.TODO(), pod)
+			Expect(err).NotTo(HaveOccurred(), "unable to create pod %q", pod.Name)
+
+			err = e2ewait.WhileInPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodPending, 10*time.Second, 3)
+			if err != nil {
+				_ = objects.LogEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
+			}
+			Expect(err).ToNot(HaveOccurred())
+
+			By(fmt.Sprintf("checking the pod was scheduled with the topology aware scheduler %q", schedulerName))
+			schedOK, err := nrosched.CheckPODWasScheduledWith(fxt.K8sClient, pod.Namespace, pod.Name, schedulerName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", pod.Namespace, pod.Name, schedulerName)
+		})
+
+		It("a deployment with a guaranteed pod resources available on one node but not on a single numa", func() {
+
+			By("Scheduling the testing deployment")
+			deploymentName := "test-dp"
+			var replicas int32 = 1
+
+			podLabels := map[string]string{
+				"test": "test-dp",
+			}
+			nodeSelector := map[string]string{}
+			deployment := objects.NewTestDeployment(replicas, podLabels, nodeSelector, fxt.Namespace.Name, deploymentName, objects.PauseImage, []string{objects.PauseCommand}, []string{})
+			deployment.Spec.Template.Spec.SchedulerName = schedulerName
+			deployment.Spec.Template.Spec.Containers[0].Resources.Limits = requiredRes
+
+			err := fxt.Client.Create(context.TODO(), deployment)
+			Expect(err).NotTo(HaveOccurred(), "unable to create deployment %q", deployment.Name)
+
+			By("waiting for deployment to be completed")
+			dpRunningTimeout := 1 * time.Minute
+			dpRunningPollInterval := 10 * time.Second
+			err = e2ewait.ForDeploymentComplete(fxt.Client, deployment, dpRunningPollInterval, dpRunningTimeout)
+			Expect(err).To(HaveOccurred(), "Deployment %q not up&running after %v", deployment.Name, dpRunningTimeout)
+
+			By(fmt.Sprintf("checking deployment pods have been scheduled with the topology aware scheduler %q ", schedulerName))
+			pods, err := schedutils.ListPodsByDeployment(fxt.Client, *deployment)
+			Expect(err).NotTo(HaveOccurred(), "Unable to get pods from Deployment %q:  %v", deployment.Name, err)
+
+			for _, pod := range pods {
+				schedOK, err := nrosched.CheckPODWasScheduledWith(fxt.K8sClient, pod.Namespace, pod.Name, schedulerName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", pod.Namespace, pod.Name, schedulerName)
+			}
+		})
+
+		It("a daemonset with a guaranteed pod resources available on one node but not on a single numa", func() {
+
+			By("Scheduling the testing daemonset")
+			dsName := "test-ds"
+
+			podLabels := map[string]string{
+				"test": "test-dp",
+			}
+			nodeSelector := map[string]string{}
+			ds := objects.NewTestDaemonset(podLabels, nodeSelector, fxt.Namespace.Name, dsName, objects.PauseImage, []string{objects.PauseCommand}, []string{})
+			ds.Spec.Template.Spec.SchedulerName = schedulerName
+			ds.Spec.Template.Spec.Containers[0].Resources.Limits = requiredRes
+
+			err := fxt.Client.Create(context.TODO(), ds)
+			Expect(err).NotTo(HaveOccurred(), "unable to create deployment %q", ds.Name)
+
+			By("waiting for daemonset to be ready")
+			dsRunningPollInterval := 10 * time.Second
+			dsRunningTimeout := 1 * time.Minute
+			ds, err = e2ewait.ForDaemonSetReady(fxt.Client, ds, dsRunningPollInterval, dsRunningTimeout)
+			Expect(err).To(HaveOccurred(), "Daemonset %q not up&running after %v", ds.Name, dsRunningTimeout)
+
+			By(fmt.Sprintf("checking daemonset pods have been scheduled with the topology aware scheduler %q ", schedulerName))
+			pods, err := schedutils.ListPodsByDaemonset(fxt.Client, *ds)
+			Expect(err).To(HaveOccurred(), "Unable to get pods from daemonset %q:  %v", ds.Name, err)
+
+			for _, pod := range pods {
+				schedOK, err := nrosched.CheckPODWasScheduledWith(fxt.K8sClient, pod.Namespace, pod.Name, schedulerName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", pod.Namespace, pod.Name, schedulerName)
+			}
+		})
+	})
+
 	When("cluster has two feasible nodes with taint but only one has the requested resources on a single NUMA zone", func() {
 		timeout := 5 * time.Minute
 		BeforeEach(func() {

--- a/test/utils/objects/daemonset.go
+++ b/test/utils/objects/daemonset.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objects
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewTestDaemonset(podLabels map[string]string, nodeSelector map[string]string, namespace, name, image string, command, args []string) *appsv1.DaemonSet {
+	var zero int64
+	podSpec := corev1.PodSpec{
+		TerminationGracePeriodSeconds: &zero,
+		Containers: []corev1.Container{
+			{
+				Name:    name + "-cnt",
+				Image:   image,
+				Command: command,
+			},
+		},
+		RestartPolicy: corev1.RestartPolicyAlways,
+	}
+	ds := NewTestDaemonsetWithPodSpec(podLabels, nodeSelector, namespace, name, podSpec)
+	if nodeSelector != nil {
+		ds.Spec.Template.Spec.NodeSelector = nodeSelector
+	}
+	return ds
+}
+
+func NewTestDaemonsetWithPodSpec(podLabels map[string]string, nodeSelector map[string]string, namespace, name string, podSpec corev1.PodSpec) *appsv1.DaemonSet {
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: podLabels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+				},
+				Spec: podSpec,
+			},
+		},
+	}
+	if nodeSelector != nil {
+		ds.Spec.Template.Spec.NodeSelector = nodeSelector
+	}
+	return ds
+}


### PR DESCRIPTION
Ensure that there is at least one node with guaranteed resources available but cannot be scheduled in a single numa zone.

Signed-off-by: Mario Fernandez <mariofer@redhat.com>