### PR TITLE
e2e: serial: revamp the runner script

### DIFF
--- a/Dockerfile.openshift.tests
+++ b/Dockerfile.openshift.tests
@@ -1,3 +1,4 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 COPY e2e-*.test /usr/local/bin/
-ENTRYPOINT ["/bin/bash"]
+COPY run-e2e-serial.sh /usr/local/bin
+ENTRYPOINT ["/usr/local/bin/run-e2e-serial.sh"]

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -8,5 +8,6 @@ RUN make build-e2e-all
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/e2e*.test /usr/local/bin
+COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/run-e2e-serial.sh /usr/local/bin
 USER 65532:65532
-ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/usr/local/bin/run-e2e-serial.sh"]

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,12 @@ binary-e2e-sched:
 binary-e2e-serial:
 	go test -c -v -o bin/e2e-serial.test ./test/e2e/serial
 
-binary-e2e-all: binary-e2e-install binary-e2e-rte binary-e2e-sched binary-e2e-uninstall binary-e2e-serial
+binary-e2e-all: binary-e2e-install binary-e2e-rte binary-e2e-sched binary-e2e-uninstall binary-e2e-serial runner-e2e-serial
+
+runner-e2e-serial:
+	@grep -v 'source hack/common.sh' hack/run-test-e2e-serial.sh | \
+		env BIN_DIR=/usr/local/bin envsubst > bin/run-e2e-serial.sh && \
+		chmod 0755 bin/run-e2e-serial.sh
 
 build: generate fmt vet binary
 

--- a/hack/run-test-e2e-serial.sh
+++ b/hack/run-test-e2e-serial.sh
@@ -2,6 +2,20 @@
 
 source hack/common.sh
 
+# we expect the lane to run against a already configured cluster
+SETUP="${SETUP:-false}"
+TEARDOWN="${TEARDOWN:-false}"
+RUN_TESTS="${RUN_TESTS:-true}"
+
+# so few arguments is no bother enough for getopt
+for arg in "$@"; do
+	case "${arg}" in
+		--setup) SETUP="true";;
+		--teardown) TEARDOWN="true";;
+		--no-run-tests) RUN_TESTS="false";;
+	esac
+done
+
 NO_COLOR=""
 if ! which tput &> /dev/null 2>&1 || [[ $(tput -T$TERM colors) -lt 8 ]]; then
   echo "Terminal does not seem to support colored output, disabling it"
@@ -12,5 +26,55 @@ if [ -n "${E2E_SERIAL_FOCUS}" ]; then
 	FOCUS="-ginkgo.focus=${E2E_SERIAL_FOCUS}"
 fi
 
-echo "Running Serial, disruptive E2E Tests"
-${BIN_DIR}/e2e-serial.test ${NO_COLOR} --ginkgo.v --ginkgo.failFast --ginkgo.reportFile=/tmp/artifacts/e2e-serial --test.parallel=1 ${FOCUS}
+function setup() {
+	if [[ "${SETUP}" != "true" ]]; then
+		return 0
+	fi
+
+	echo "Running NRO install test suite"
+	${BIN_DIR}/e2e-install.test ${NO_COLOR} --ginkgo.v --ginkgo.failFast --ginkgo.reportFile=/tmp/artifacts/e2e-serial-install --ginkgo.focus='\[Install\] continuousIntegration'
+
+	RC="$?"
+	if [[ "${RC}" != "0" ]]; then
+		return ${RC}
+	fi
+
+	echo "Running NROScheduler install test suite"
+	${BIN_DIR}/e2e-sched-install.test ${NO_COLOR} --ginkgo.v --ginkgo.failFast --ginkgo.reportFile=/tmp/artifacts/e2e-serial-install-sched
+}
+
+function teardown() {
+	if [[ "${TEARDOWN}" != "true" ]]; then
+		return 0
+	fi
+
+	echo "Running NROScheduler uninstall test suite";
+	${BIN_DIR}/e2e-sched-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.reportFile=/tmp/artifacts/e2e-serial-uninstall-sched
+
+	RC="$?"
+	if [[ "${RC}" != "0" ]]; then
+		return ${RC}
+	fi
+
+	echo "Running NRO uninstall test suite";
+	${BIN_DIR}/e2e-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.reportFile=/tmp/artifacts/e2e-serial-uninstall
+}
+
+function runtests() {
+	if [[ "${RUN_TESTS}" != "true" ]]; then
+		echo "running no tests"
+		return 0
+	fi
+	echo "Running Serial, disruptive E2E Tests"
+	${BIN_DIR}/e2e-serial.test ${NO_COLOR} --ginkgo.v --ginkgo.failFast --ginkgo.reportFile=/tmp/artifacts/e2e-serial-run --test.parallel=1 ${FOCUS}
+}
+
+# Make sure that we always properly clean the environment
+trap 'teardown' EXIT SIGINT SIGTERM SIGSTOP
+
+setup
+if [ $? -ne 0 ]; then
+    echo "Failed to install NRO"
+    exit 1
+fi
+runtests


### PR DESCRIPTION
reorganize the e2e serial runner script and make sure
it can be shipped in the tests container image.
This means fixing the paths.

Signed-off-by: Francesco Romani <fromani@redhat.com>