### PR TITLE
doc: example: fix kubeletconfig

### DIFF
--- a/doc/examples/kubeletconfig.yaml
+++ b/doc/examples/kubeletconfig.yaml
@@ -22,3 +22,4 @@ spec:
     systemReserved: 
       memory: "512Mi"
     topologyManagerPolicy: "single-numa-node"
+    topologyManagerScope: "pod"


### PR DESCRIPTION
We only support "TopologyManagerScope"="pod" at this moment,
so fix the example config to suggest that.

Signed-off-by: Francesco Romani <fromani@redhat.com>