### PR TITLE
e2e: install: enable install lane to reuse existing kubeletconfig

### DIFF
--- a/test/utils/objects/objects.go
+++ b/test/utils/objects/objects.go
@@ -162,5 +162,6 @@ func getKubeletConfig() *kubeletconfigv1beta1.KubeletConfiguration {
 			},
 		},
 		TopologyManagerPolicy: "single-numa-node",
+		TopologyManagerScope:  "pod",
 	}
 }


### PR DESCRIPTION
Add an option (env var) to let the install suite avoid to deploy kubeletconfig. This enables CIs to test different environments and configs easily.
Switch the default scope to "pod" - as is the only one we support atm.

Also add minor fixes to improve the debuggability.
