### PR TITLE
e2e: serial: Modify configurable values

### DIFF
--- a/test/e2e/serial/test_suite_serial_test.go
+++ b/test/e2e/serial/test_suite_serial_test.go
@@ -49,7 +49,9 @@ import (
 )
 
 const (
-	multiNUMALabel = "numa.hardware.openshift-kni.io/cell-count"
+	multiNUMALabel    = "numa.hardware.openshift-kni.io/cell-count"
+	nropTestCIImage   = "quay.io/openshift-kni/resource-topology-exporter:test-ci"
+	schedulerTestName = "test-topology-scheduler"
 )
 
 var (

--- a/test/utils/nodes/nodes.go
+++ b/test/utils/nodes/nodes.go
@@ -27,6 +27,12 @@ import (
 	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil"
 )
 
+const (
+	LabelRole   = "node-role.kubernetes.io"
+	RoleWorker  = "worker"
+	RoleMCPTest = "mcp-test"
+)
+
 func GetWorkerNodes(cli client.Client) ([]corev1.Node, error) {
 	nodes := &corev1.NodeList{}
 	selector, err := labels.Parse(fmt.Sprintf("%s/%s=", clientutil.LabelRole, clientutil.RoleWorker))
@@ -40,4 +46,12 @@ func GetWorkerNodes(cli client.Client) ([]corev1.Node, error) {
 	}
 
 	return nodes.Items, nil
+}
+
+func GetLabelRoleWorker() string {
+	return fmt.Sprintf("%s/%s", LabelRole, RoleWorker)
+}
+
+func GetLabelRoleMCPTest() string {
+	return fmt.Sprintf("%s/%s", LabelRole, RoleMCPTest)
 }


### PR DESCRIPTION
The test modifies every configurable value under the ```NUMAResourcesOperator``` and ```NUMAResourcesScheduler``` CR's and checks that the controller applied the configuration as expected.

The test requires MCP changes, hence nodes reboot, and therefore it's label with a special ```[reboot_required]``` label to denote that.
We also add the ```[slow]``` label to denote this test might take more time than usual.



