### PR TITLE
rte: don't use google pause container

### DIFF
--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -314,6 +314,10 @@ func (r *NUMAResourcesOperatorReconciler) syncNUMAResourcesOperatorResources(ctx
 	if err != nil {
 		return daemonSetsNName, err
 	}
+	err = rtestate.UpdateDaemonSetPauseContainerSettings(r.RTEManifests.DaemonSet)
+	if err != nil {
+		return daemonSetsNName, err
+	}
 	if err = loglevel.UpdatePodSpec(&r.RTEManifests.DaemonSet.Spec.Template.Spec, instance.Spec.LogLevel); err != nil {
 		return daemonSetsNName, err
 	}

--- a/main.go
+++ b/main.go
@@ -314,6 +314,7 @@ func renderRTEManifests(rteManifests rtemanifests.Manifests, namespace string, i
 		Namespace: namespace,
 	})
 	_ = rtestate.UpdateDaemonSetUserImageSettings(mf.DaemonSet, "", imageSpec, images.NullPolicy)
+	_ = rtestate.UpdateDaemonSetPauseContainerSettings(mf.DaemonSet)
 	return mf
 }
 

--- a/pkg/objectstate/rte/rte.go
+++ b/pkg/objectstate/rte/rte.go
@@ -317,6 +317,24 @@ func DaemonSetNamespacedNameFromObject(obj client.Object) (nropv1alpha1.Namespac
 	return res, ok
 }
 
+func UpdateDaemonSetPauseContainerSettings(ds *appsv1.DaemonSet) error {
+	// TODO: better match by name than assume container#0 is RTE proper (not minion)
+	rteCnt := &ds.Spec.Template.Spec.Containers[0]
+	// TODO: better match by name than assume container#1 is the RTE minion
+	cnt := &ds.Spec.Template.Spec.Containers[1]
+	cnt.Image = rteCnt.Image
+	cnt.ImagePullPolicy = rteCnt.ImagePullPolicy
+	cnt.Command = []string{
+		"/bin/sh",
+		"-c",
+		"--",
+	}
+	cnt.Args = []string{
+		"while true; do sleep 30s; done",
+	}
+	return nil
+}
+
 func UpdateDaemonSetUserImageSettings(ds *appsv1.DaemonSet, userImageSpec, builtinImageSpec string, builtinPullPolicy corev1.PullPolicy) error {
 	// TODO: better match by name than assume container#0 is RTE proper (not minion)
 	cnt := &ds.Spec.Template.Spec.Containers[0]


### PR DESCRIPTION
u/s RTE wants to use the google pause container for the
shared pool container. We need to minimize the container image,
so we replace it reusing the same RTE image with a different
entry point.

Since we require anyway the RTE image to be based on a ubi-minimal
(or equivalent) image, and since the shared-pool-container
does not need to reap pids but just to sleep forever peacefully,
we can use just the simplest sleep command.

Signed-off-by: Francesco Romani <fromani@redhat.com>