### PR TITLE
e2e: make tests pod's image configurable

### DIFF
--- a/test/utils/images/images.go
+++ b/test/utils/images/images.go
@@ -16,13 +16,11 @@ limitations under the License.
 
 package images
 
-const (
-	RTETestImageCI   = "quay.io/openshift-kni/resource-topology-exporter:test-ci"
-	SchedTestImageCI = "quay.io/openshift-kni/scheduler-plugins:test-ci"
+import "os"
 
-	// NEVER EVER USE THIS OUTSIDE CI or (early) DEVELOPMENT ENVIRONMENTS
-	NUMACellDevicePluginTestImageCI = "quay.io/openshift-kni/numacell-device-plugin:test-ci"
-
-	//the default image used for test pods
-	PauseImage = "gcr.io/google_containers/pause-amd64:3.0"
-)
+func GetPauseImage() string {
+	if pullSpec, ok := os.LookupEnv("E2E_PAUSE_IMAGE_URL"); ok {
+		return pullSpec
+	}
+	return PauseImage
+}

--- a/test/utils/objects/pod.go
+++ b/test/utils/objects/pod.go
@@ -24,6 +24,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+
+	"github.com/openshift-kni/numaresources-operator/test/utils/images"
 )
 
 func NewTestPodPause(namespace, name string) *corev1.Pod {
@@ -38,7 +40,7 @@ func NewTestPodPause(namespace, name string) *corev1.Pod {
 			Containers: []corev1.Container{
 				{
 					Name:    name + "-cnt",
-					Image:   PauseImage,
+					Image:   images.GetPauseImage(),
 					Command: []string{PauseCommand},
 				},
 			},


### PR DESCRIPTION
Running the tests on disconnected environments might lead to pod crash while pulling images from external registries.

Keep using Pause image as the default test image and allow configuring the image via an environment variable TEST_IMAGE.