### PR TITLE
[release-4.10][manual] hack: dockerfile: add pause entrypoint

### DIFF
--- a/Dockerfile.openshift.tests
+++ b/Dockerfile.openshift.tests
@@ -2,4 +2,5 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 COPY e2e-nrop-*.test /usr/local/bin/
 COPY run-e2e-nrop-serial.sh /usr/local/bin
 COPY numacell /bin
+COPY pause /
 ENTRYPOINT ["/usr/local/bin/run-e2e-nrop-serial.sh"]

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -11,5 +11,6 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/e2e-nrop*.test /usr/local/bin
 COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/run-e2e-nrop-serial.sh /usr/local/bin
 COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/numacell /bin
+COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/pause /
 USER 65532:65532
 ENTRYPOINT ["/usr/local/bin/run-e2e-nrop-serial.sh"]

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ binary-e2e-sched:
 binary-e2e-serial:
 	go test -c -v -o bin/e2e-nrop-serial.test ./test/e2e/serial
 
-binary-e2e-all: binary-e2e-install binary-e2e-rte binary-e2e-sched binary-e2e-uninstall binary-e2e-serial runner-e2e-serial
+binary-e2e-all: binary-e2e-install binary-e2e-rte binary-e2e-sched binary-e2e-uninstall binary-e2e-serial runner-e2e-serial build-pause
 
 runner-e2e-serial:
 	hack/render-e2e-runner.sh
@@ -185,6 +185,9 @@ build-e2e-install: fmt vet binary-e2e-install
 build-e2e-uninstall: fmt vet binary-e2e-uninstall
 
 build-e2e-all: fmt vet binary-e2e-all
+
+build-pause:
+	install -m 755 hack/pause bin/
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go

--- a/hack/pause
+++ b/hack/pause
@@ -1,0 +1,4 @@
+#!/bin/sh
+while true; do
+	sleep 30s
+done


### PR DESCRIPTION
Add a simplified version of pause entrypoint in the same
location of the google pause image. This is expected to
make the tests image fully compatible with the google pause image.

Signed-off-by: Francesco Romani <fromani@redhat.com>