### PR TITLE
e2e:serial: use a lowercase letters in pod name

### DIFF
--- a/test/e2e/serial/workload_placement_test.go
+++ b/test/e2e/serial/workload_placement_test.go
@@ -519,7 +519,7 @@ var _ = Describe("[serial][disruptive][scheduler] workload placement", func() {
 		It("[test_id:48713] a guaranteed pod with one container should be scheduled into one NUMA zone", func() {
 
 			By("Scheduling the testing pod")
-			pod := objects.NewTestPodPause(fxt.Namespace.Name, "testPod")
+			pod := objects.NewTestPodPause(fxt.Namespace.Name, "testpod")
 			pod.Spec.SchedulerName = schedulerName
 			pod.Spec.Containers[0].Resources.Limits = requiredRes
 


### PR DESCRIPTION
Pod name must be consist of the following letters only: ```'[a-z0-9]'```
The serial test is falling without this change.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>