### PR TITLE
e2e:serial: schedule guaranteed pod in selective way

### DIFF
--- a/test/e2e/serial/workload_placement_test.go
+++ b/test/e2e/serial/workload_placement_test.go
@@ -1037,6 +1037,82 @@ var _ = Describe("[serial][disruptive][scheduler] workload placement", func() {
 				return ok
 			}, time.Minute, time.Second*5).Should(BeTrue(), "resources not restored on %q", updatedPod.Spec.NodeName)
 		})
+
+		It("[test_id:47584] should be able to schedule guarnteed pod in selective way", func() {
+			nrtList := nrtv1alpha1.NodeResourceTopologyList{}
+			nrtListInitial, err := e2enrt.GetUpdated(fxt.Client, nrtList, time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+
+			workers, err := e2enodes.GetWorkerNodes(fxt.Client)
+			Expect(err).ToNot(HaveOccurred())
+
+			// TODO choose randomly
+			targetedNodeName := workers[0].Name
+
+			nrtInitial, err := e2enrt.FindFromList(nrtListInitial.Items, targetedNodeName)
+			Expect(err).ToNot(HaveOccurred())
+
+			testPod := objects.NewTestPodPause(fxt.Namespace.Name, "testpod")
+			pSpec := &testPod.Spec
+
+			By(fmt.Sprintf("explicitly mentioning which we want pod to land on node %q", targetedNodeName))
+			pSpec.NodeName = targetedNodeName
+
+			By("setting a fake schedule name under the pod to make sure pod not scheduled by any scheduler")
+			noneExistingSchedulerName := "foo"
+			testPod.Spec.SchedulerName = noneExistingSchedulerName
+
+			cnt := &testPod.Spec.Containers[0]
+			requiredRes := corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("100Mi"),
+			}
+			cnt.Resources.Requests = requiredRes
+			cnt.Resources.Limits = requiredRes
+
+			By(fmt.Sprintf("creating pod %s/%s", testPod.Namespace, testPod.Name))
+			err = fxt.Client.Create(context.TODO(), testPod)
+			Expect(err).ToNot(HaveOccurred())
+
+			updatedPod, err := e2ewait.ForPodPhase(fxt.Client, testPod.Namespace, testPod.Name, corev1.PodRunning, timeout)
+			Expect(err).ToNot(HaveOccurred())
+
+			By(fmt.Sprintf("checking the pod landed on the target node %q vs %q", updatedPod.Spec.NodeName, targetedNodeName))
+			Expect(updatedPod.Spec.NodeName).To(Equal(targetedNodeName),
+				"node landed on %q instead of on %v", updatedPod.Spec.NodeName, targetedNodeName)
+
+			nrtListPostPodCreate, err := e2enrt.GetUpdated(fxt.Client, nrtListInitial, time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+
+			nrtPostPodCreate, err := e2enrt.FindFromList(nrtListPostPodCreate.Items, updatedPod.Spec.NodeName)
+			Expect(err).ToNot(HaveOccurred())
+
+			rl := e2ereslist.FromGuaranteedPod(*updatedPod)
+			By(fmt.Sprintf("checking NRT for target node %q updated correctly", targetedNodeName))
+			// TODO: this is only partially correct. We should check with NUMA zone granularity (not with NODE granularity)
+			_, err = e2enrt.CheckZoneConsumedResourcesAtLeast(*nrtInitial, *nrtPostPodCreate, rl)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("deleting the pod")
+			err = fxt.Client.Delete(context.TODO(), updatedPod)
+			Expect(err).ToNot(HaveOccurred())
+
+			// the NRT updaters MAY be slow to react for a number of reasons including factors out of our control
+			// (kubelet, runtime). This is a known behaviour. We can only tolerate some delay in reporting on pod removal.
+			Eventually(func() bool {
+				By(fmt.Sprintf("checking the resources are restored as expected on %q", targetedNodeName))
+
+				nrtListPostPodDelete, err := e2enrt.GetUpdated(fxt.Client, nrtListPostPodCreate, 1*time.Minute)
+				Expect(err).ToNot(HaveOccurred())
+
+				nrtPostDelete, err := e2enrt.FindFromList(nrtListPostPodDelete.Items, targetedNodeName)
+				Expect(err).ToNot(HaveOccurred())
+
+				ok, err := e2enrt.CheckEqualAvailableResources(*nrtInitial, *nrtPostDelete)
+				Expect(err).ToNot(HaveOccurred())
+				return ok
+			}, time.Minute, time.Second*5).Should(BeTrue(), "resources not restored on %q", targetedNodeName)
+		})
 	})
 })
 


### PR DESCRIPTION
The test creates a pod, pin it selectively using the nodeName stanza and makes sure that NRT objects are updating respectivley

Signed-off-by: Talor Itzhak <titzhak@redhat.com>