### PR TITLE
e2e: serial: split tests form workload_placement_test.go - take 4

### DIFF
--- a/test/e2e/serial/workload_placement_test.go
+++ b/test/e2e/serial/workload_placement_test.go
@@ -18,7 +18,6 @@ package serial
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -92,128 +91,6 @@ var _ = Describe("[serial][disruptive][scheduler] workload placement", func() {
 	// This is ugly, but automatically computing the values is not straightforward
 	// and will we want to start lean and mean.
 
-	Context("cluster with node/s having two numa zones, and there are enough resources on one node but not in any numa zone when trying to schedule a deployment with burstable pods", func() {
-		var nrtCandidates []nrtv1alpha1.NodeResourceTopology
-		var targetNodeName string
-		var targetNodeNRTInitial *nrtv1alpha1.NodeResourceTopology
-		var deployment *appsv1.Deployment
-
-		BeforeEach(func() {
-			const requiredNUMAZones = 2
-			By(fmt.Sprintf("filtering available nodes with %d NUMA zones", requiredNUMAZones))
-			nrtCandidates = e2enrt.FilterZoneCountEqual(nrts, requiredNUMAZones)
-
-			const neededNodes = 1
-			if len(nrtCandidates) < neededNodes {
-				Skip(fmt.Sprintf("not enough nodes with at least %d NUMA Zones: found %d, needed %d", requiredNUMAZones, len(nrtCandidates), neededNodes))
-			}
-
-			nrtCandidateNames := e2enrt.AccumulateNames(nrtCandidates)
-
-			var ok bool
-			targetNodeName, ok = nrtCandidateNames.PopAny()
-			Expect(ok).To(BeTrue(), "cannot select a node among %#v", nrtCandidateNames.List())
-			By(fmt.Sprintf("selecting node to schedule the pod: %q", targetNodeName))
-
-			var err error
-			targetNodeNRTInitial, err = e2enrt.FindFromList(nrtCandidates, targetNodeName)
-			Expect(err).NotTo(HaveOccurred())
-
-			//get maximum zone CPU and Memory to be sure it wont fit on any zone
-			maxResources := corev1.ResourceList{
-				corev1.ResourceCPU:    maxResourceType(*targetNodeNRTInitial, corev1.ResourceCPU),
-				corev1.ResourceMemory: maxResourceType(*targetNodeNRTInitial, corev1.ResourceMemory),
-			}
-
-			// add a mim ammount of resources just in case all the zones
-			// are equal so the pod wont fit on any of them
-			excessRes := corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("100M"),
-			}
-			reqResources := maxResources.DeepCopy()
-
-			reqCpu := reqResources[corev1.ResourceCPU]
-			reqCpu.Add(excessRes[corev1.ResourceCPU])
-			reqResources[corev1.ResourceCPU] = reqCpu
-
-			reqMem := reqResources[corev1.ResourceMemory]
-			reqMem.Add(excessRes[corev1.ResourceMemory])
-			reqResources[corev1.ResourceMemory] = reqMem
-
-			By("Padding all other candidate nodes")
-			var paddingPods []*corev1.Pod
-			for _, nodeName := range nrtCandidateNames.List() {
-				node := &corev1.Node{}
-				nodeKey := client.ObjectKey{Name: nodeName}
-				err := fxt.Client.Get(context.TODO(), nodeKey, node)
-				Expect(err).NotTo(HaveOccurred())
-
-				// Padding all the other nodes until only maxResources is free
-				// remember reqResources = maxReources + excessResources
-				// so we ensure out pod will not be scheduled on any other node.
-				padPod, err := makeNodePaddingPod(fxt.Namespace.Name, *node, maxResources)
-				if errors.Is(err, e2enrt.ErrNotEnoughResources) {
-					klog.Infof("Node %q has not enough resources without padding", nodeName)
-					continue
-				}
-				Expect(err).NotTo(HaveOccurred())
-
-				pinnedPadPod, err := pinPodToNode(padPod, nodeName)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = fxt.Client.Create(context.TODO(), pinnedPadPod)
-				Expect(err).NotTo(HaveOccurred())
-
-				paddingPods = append(paddingPods, pinnedPadPod)
-			}
-
-			// Wait for all the padding pods to be up&running
-			failedPods := e2ewait.ForPodListAllRunning(fxt.Client, paddingPods)
-			for _, failedPod := range failedPods {
-				_ = objects.LogEventsForPod(fxt.K8sClient, failedPod.Namespace, failedPod.Name)
-			}
-			Expect(failedPods).To(BeEmpty())
-
-			By("create a deployment with one burstable pod")
-			deploymentName := "test-dp"
-			var replicas int32 = 1
-
-			podLabels := map[string]string{
-				"test": "test-dp",
-			}
-			nodeSelector := map[string]string{}
-			deployment = objects.NewTestDeployment(replicas, podLabels, nodeSelector, fxt.Namespace.Name, deploymentName, objects.PauseImage, []string{objects.PauseCommand}, []string{})
-			deployment.Spec.Template.Spec.SchedulerName = schedulerName
-			// make it burstable
-			deployment.Spec.Template.Spec.Containers[0].Resources.Requests = reqResources
-
-			err = fxt.Client.Create(context.TODO(), deployment)
-			Expect(err).NotTo(HaveOccurred(), "unable to create deployment %q", deployment.Name)
-
-			By("waiting for deployment to be up&running")
-			dpRunningTimeout := 1 * time.Minute
-			dpRunningPollInterval := 10 * time.Second
-			err = e2ewait.ForDeploymentComplete(fxt.Client, deployment, dpRunningPollInterval, dpRunningTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Deployment %q not up&running after %v", deployment.Name, dpRunningTimeout)
-		})
-		It("[test_id:47618][tier2] should be properly scheduled with no changes in NRTs", func() {
-			By(fmt.Sprintf("checking deployment pods have been scheduled with the topology aware scheduler %q and in the proper node %q", schedulerName, targetNodeName))
-			pods, err := schedutils.ListPodsByDeployment(fxt.Client, *deployment)
-			Expect(err).NotTo(HaveOccurred(), "Unable to get pods from Deployment %q:  %v", deployment.Name, err)
-			for _, pod := range pods {
-				Expect(pod.Spec.NodeName).To(Equal(targetNodeName))
-				schedOK, err := nrosched.CheckPODWasScheduledWith(fxt.K8sClient, pod.Namespace, pod.Name, schedulerName)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", pod.Namespace, pod.Name, schedulerName)
-			}
-
-			targetNodeNRTCurrent, err := e2enrt.FindFromList(nrtCandidates, targetNodeName)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(e2enrt.CheckEqualAvailableResources(*targetNodeNRTInitial, *targetNodeNRTCurrent)).To(BeTrue())
-		})
-
-	})
 	Context("with at least two nodes suitable", func() {
 		var targetNodeName string
 		var requiredRes corev1.ResourceList
@@ -286,6 +163,7 @@ var _ = Describe("[serial][disruptive][scheduler] workload placement", func() {
 			}
 			Expect(failedPods).To(BeEmpty(), "some padding pods have failed to run")
 		})
+
 		It("[test_id:48713][tier1] a guaranteed pod with one container should be scheduled into one NUMA zone", func() {
 
 			By("Scheduling the testing pod")


### PR DESCRIPTION
Split off test that verifies a burstable pod is properly scheduled and doesn't expect for resources to be accounted in NRT. The test is relevant for both TM policies.