### PR TITLE
e2e: serial: enable TM scope pod for tests in workload_placement_test_go

### DIFF
--- a/test/e2e/serial/workload_placement_test.go
+++ b/test/e2e/serial/workload_placement_test.go
@@ -71,10 +71,15 @@ var _ = Describe("[serial][disruptive][scheduler] workload placement", func() {
 		err = fxt.Client.List(context.TODO(), &nrtList)
 		Expect(err).ToNot(HaveOccurred())
 
-		tmPolicy := nrtv1alpha1.SingleNUMANodeContainerLevel
-		nrts = e2enrt.FilterTopologyManagerPolicy(nrtList.Items, tmPolicy)
+		// we're ok with any TM policy as long as the updater can handle it,
+		// we use this as proxy for "there is valid NRT data for at least X nodes
+		policies := []nrtv1alpha1.TopologyManagerPolicy{
+			nrtv1alpha1.SingleNUMANodeContainerLevel,
+			nrtv1alpha1.SingleNUMANodePodLevel,
+		}
+		nrts = e2enrt.FilterByPolicies(nrtList.Items, policies)
 		if len(nrts) < 2 {
-			Skip(fmt.Sprintf("not enough nodes with policy %q - found %d", string(tmPolicy), len(nrts)))
+			Skip(fmt.Sprintf("not enough nodes with valid policy - found %d", len(nrts)))
 		}
 
 		// Note that this test, being part of "serial", expects NO OTHER POD being scheduled


### PR DESCRIPTION
Tests in `workload_placement_test.go` run only if TM scope is container and skipped if the scope is pod, while they can support both scopes.

Enable tests in workload_placement_test.go to run whether TM policy is container or pod.