### PR TITLE
e2e: serial: make it easier to integrate

### DIFF
--- a/test/e2e/serial/README.md
+++ b/test/e2e/serial/README.md
@@ -18,3 +18,15 @@ IOW, the suite expects to run against a pristine, unloaded cluster to validate i
 
 It is responsability of the tests in this suite to clean up properly and to restore the cluster state as
 they found it before they run.
+
+### configuring using the environment variables
+
+- `E2E_NROP_INSTALL_SKIP_KC` (accepts boolean, e.g. `true`) instructs the suite to NOT deploy the builtin
+  `kubeletconfig`. With this enabled, the suite will expect a `kubeletconfig` already deployed (and consumed)
+  in the cluster against it is running.
+- `E2E_NROP_MCP_UPDATE_TIMEOUT` (accepts a duration, e.g. `5m`) instructs the suite how much time it should
+  wait for the MCP updates to take place before to exit with error.
+- `E2E_NROP_MCP_UPDATE_INTERVAL` (accepts a duration, e.g. `10s`) instructs the suite about how much it should
+  wait between checks for MCP updates.
+- `E2E_NROP_PLATFORM` (accepts a string, e.g. `Kubernetes`, `OpenShift`) instructs the suite to *disable* the
+  autodetection of the platform and force it to the provided value.

--- a/test/e2e/serial/e2e_serial_test.go
+++ b/test/e2e/serial/e2e_serial_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serial
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	_ "github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests"
+)
+
+func TestSerial(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "serial")
+}

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -48,7 +48,7 @@ import (
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
 
-var _ = Describe("[serial][disruptive][slow] configuration management", func() {
+var _ = Describe("[serial][disruptive][slow] numaresources configuration management", func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha1.NodeResourceTopologyList

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package serial
+package tests
 
 import (
 	"context"

--- a/test/e2e/serial/tests/e2e_suite.go
+++ b/test/e2e/serial/tests/e2e_suite.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package serial
+package tests
 
 import (
 	"context"
@@ -22,7 +22,6 @@ import (
 	"math/rand"
 	"os"
 	"sync"
-	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -115,11 +114,6 @@ var _ = AfterSuite(func() {
 	err := e2efixture.Teardown(__fxt)
 	Expect(err).NotTo(HaveOccurred())
 })
-
-func TestSerial(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "serial")
-}
 
 func setupInfra(fxt *e2efixture.Fixture, nodeGroups []nropv1alpha1.NodeGroup, timeout time.Duration) {
 	klog.Infof("e2e infra setup begin")

--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -36,7 +36,7 @@ import (
 	e2ereslist "github.com/openshift-kni/numaresources-operator/test/utils/resourcelist"
 )
 
-var _ = Describe("[serial][disruptive][scheduler] workload placement", func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement", func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha1.NodeResourceTopologyList

--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package serial
+package tests
 
 import (
 	"context"

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -42,7 +42,7 @@ import (
 	e2ereslist "github.com/openshift-kni/numaresources-operator/test/utils/resourcelist"
 )
 
-var _ = Describe("[serial][disruptive][scheduler] workload resource accounting", func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload resource accounting", func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha1.NodeResourceTopologyList

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package serial
+package tests
 
 import (
 	"context"

--- a/test/e2e/serial/tests/sched_removal.go
+++ b/test/e2e/serial/tests/sched_removal.go
@@ -35,7 +35,7 @@ import (
 	e2ewait "github.com/openshift-kni/numaresources-operator/test/utils/objects/wait"
 )
 
-var _ = Describe("[serial][disruptive][scheduler] scheduler removal on a live cluster", func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources scheduler removal on a live cluster", func() {
 	var fxt *e2efixture.Fixture
 
 	BeforeEach(func() {
@@ -103,7 +103,7 @@ var _ = Describe("[serial][disruptive][scheduler] scheduler removal on a live cl
 	})
 })
 
-var _ = Describe("[serial][disruptive][scheduler] scheduler restart on a live cluster", func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources scheduler restart on a live cluster", func() {
 	var fxt *e2efixture.Fixture
 	var nroSchedObj *nropv1alpha1.NUMAResourcesScheduler
 	var schedulerName string

--- a/test/e2e/serial/tests/sched_removal.go
+++ b/test/e2e/serial/tests/sched_removal.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package serial
+package tests
 
 import (
 	"context"

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -39,7 +39,7 @@ import (
 	e2epadder "github.com/openshift-kni/numaresources-operator/test/utils/padder"
 )
 
-var _ = Describe("[serial][disruptive][scheduler] workload overhead", func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhead", func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha1.NodeResourceTopologyList

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package serial
+package tests
 
 import (
 	"context"

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -53,7 +53,7 @@ import (
 
 const testKey = "testkey"
 
-var _ = Describe("[serial][disruptive][scheduler] workload placement", func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement", func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha1.NodeResourceTopologyList

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package serial
+package tests
 
 import (
 	"context"

--- a/test/e2e/serial/tests/workload_placement_nodesel.go
+++ b/test/e2e/serial/tests/workload_placement_nodesel.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var _ = Describe("[serial][disruptive][scheduler] workload placement considering node selector", func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement considering node selector", func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha1.NodeResourceTopologyList

--- a/test/e2e/serial/tests/workload_placement_nodesel.go
+++ b/test/e2e/serial/tests/workload_placement_nodesel.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package serial
+package tests
 
 import (
 	"context"

--- a/test/e2e/serial/tests/workload_placement_taint.go
+++ b/test/e2e/serial/tests/workload_placement_taint.go
@@ -41,7 +41,7 @@ import (
 	e2ereslist "github.com/openshift-kni/numaresources-operator/test/utils/resourcelist"
 )
 
-var _ = Describe("[serial][disruptive][scheduler] workload placement", func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement considering taints", func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha1.NodeResourceTopologyList

--- a/test/e2e/serial/tests/workload_placement_taint.go
+++ b/test/e2e/serial/tests/workload_placement_taint.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package serial
+package tests
 
 import (
 	"context"

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -48,7 +48,7 @@ type paddingInfo struct {
 
 type setupPaddingFunc func(fxt *e2efixture.Fixture, nrtList nrtv1alpha1.NodeResourceTopologyList, padInfo paddingInfo) []*corev1.Pod
 
-var _ = Describe("[serial][disruptive][scheduler] workload placement considering TM policy", func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement considering TM policy", func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha1.NodeResourceTopologyList
 

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package serial
+package tests
 
 import (
 	"context"

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -36,7 +36,7 @@ import (
 	e2epadder "github.com/openshift-kni/numaresources-operator/test/utils/padder"
 )
 
-var _ = Describe("[serial][disruptive][scheduler] workload unschedulable", func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload unschedulable", func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha1.NodeResourceTopologyList

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package serial
+package tests
 
 import (
 	"context"

--- a/test/utils/configuration/configuration.go
+++ b/test/utils/configuration/configuration.go
@@ -19,6 +19,7 @@ package configuration
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
@@ -28,6 +29,7 @@ import (
 const (
 	envVarMCPUpdateTimeout  = "NROP_E2E_MCP_UPDATE_TIMEOUT"
 	envVarMCPUpdateInterval = "NROP_E2E_MCP_UPDATE_INTERVAL"
+	envVarPlatform          = "NROP_E2E_PLATFORM"
 )
 
 const (
@@ -56,8 +58,25 @@ func init() {
 
 	Platform, err = detect.Detect()
 	if err != nil {
+		Platform = getPlatformFromEnv(envVarPlatform)
+	}
+	if Platform == platform.Unknown {
 		panic(fmt.Errorf("failed to detect a platform: %w", err))
 	}
+}
+
+func getPlatformFromEnv(envVar string) platform.Platform {
+	val, ok := os.LookupEnv(envVar)
+	if !ok {
+		return platform.Unknown
+	}
+	switch strings.ToLower(val) {
+	case "kubernetes":
+		return platform.Kubernetes
+	case "openshift":
+		return platform.OpenShift
+	}
+	return platform.Unknown
 }
 
 func getMachineConfigPoolUpdateValueFromEnv(envVar string, fallback time.Duration) (time.Duration, error) {

--- a/test/utils/configuration/configuration.go
+++ b/test/utils/configuration/configuration.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/klog/v2"
+
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform/detect"
 )
@@ -61,7 +63,8 @@ func init() {
 		Platform = getPlatformFromEnv(envVarPlatform)
 	}
 	if Platform == platform.Unknown {
-		panic(fmt.Errorf("failed to detect a platform: %w", err))
+		Platform = platform.OpenShift
+		klog.Infof("forced to %q: failed to detect a platform: %w", Platform, err)
 	}
 }
 

--- a/test/utils/configuration/configuration.go
+++ b/test/utils/configuration/configuration.go
@@ -29,9 +29,9 @@ import (
 )
 
 const (
-	envVarMCPUpdateTimeout  = "NROP_E2E_MCP_UPDATE_TIMEOUT"
-	envVarMCPUpdateInterval = "NROP_E2E_MCP_UPDATE_INTERVAL"
-	envVarPlatform          = "NROP_E2E_PLATFORM"
+	envVarMCPUpdateTimeout  = "E2E_NROP_MCP_UPDATE_TIMEOUT"
+	envVarMCPUpdateInterval = "E2E_NROP_MCP_UPDATE_INTERVAL"
+	envVarPlatform          = "E2E_NROP_PLATFORM"
 )
 
 const (


### PR DESCRIPTION
The previous reorganization of the e2e tests was
made into the attempt to follow more closely the
go conventions, adding the `_test` suffix for source
files containing test code.

This worked well but made hard to import the testsuite
into external projects (cnf-tests).
Trying to import the existing suite leads to
```
no non-test files found
```
which is not good.

Hence we do another reorganization for the serial suite
only, moving the actual test definition into a utility
package.

No expected change in behaviour for the NROP testsuite
proper (nor test image).

Signed-off-by: Francesco Romani <fromani@redhat.com>