### PR TITLE
e2e: serial: move away Before/AfterSuite

### DIFF
--- a/test/e2e/serial/e2e_serial_test.go
+++ b/test/e2e/serial/e2e_serial_test.go
@@ -22,8 +22,12 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	_ "github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests"
+	serialtests "github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests"
 )
+
+var _ = BeforeSuite(serialtests.BeforeSuiteHelper)
+
+var _ = AfterSuite(serialtests.AfterSuiteHelper)
 
 func TestSerial(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/test/e2e/serial/tests/e2e_suite.go
+++ b/test/e2e/serial/tests/e2e_suite.go
@@ -72,7 +72,7 @@ var (
 var __fxt *e2efixture.Fixture
 var __nrtList nrtv1alpha1.NodeResourceTopologyList
 
-var _ = BeforeSuite(func() {
+func BeforeSuiteHelper() {
 	// this must be the very first thing
 	rand.Seed(time.Now().UnixNano())
 
@@ -101,9 +101,9 @@ var _ = BeforeSuite(func() {
 	setupInfra(__fxt, nroOperObj.Spec.NodeGroups, 3*time.Minute)
 
 	labelNodes(__fxt.Client, __nrtList)
-})
+}
 
-var _ = AfterSuite(func() {
+func AfterSuiteHelper() {
 	if _, ok := os.LookupEnv("E2E_INFRA_NO_TEARDOWN"); ok {
 		return
 	}
@@ -113,7 +113,7 @@ var _ = AfterSuite(func() {
 	// numacell daemonset automatically cleaned up when we remove the namespace
 	err := e2efixture.Teardown(__fxt)
 	Expect(err).NotTo(HaveOccurred())
-})
+}
 
 func setupInfra(fxt *e2efixture.Fixture, nodeGroups []nropv1alpha1.NodeGroup, timeout time.Duration) {
 	klog.Infof("e2e infra setup begin")


### PR DESCRIPTION
the `serial/tests` subpackage should include the actual
logic to be run in the ginkgo `Before/AfterSuite` helpers,
but not the hooks themselves, to make it possible to
integrate with other suites (e.g. cnf-tests) which may
have their `Before/AfterSuite` already.

Signed-off-by: Francesco Romani <fromani@redhat.com>