### PR TITLE
WIP: sched: better interoperability with the noderesourcefit plugin

### DIFF
--- a/pkg/numaresourcesscheduler/manifests/yaml/configmap.nrt.yaml
+++ b/pkg/numaresourcesscheduler/manifests/yaml/configmap.nrt.yaml
@@ -13,8 +13,21 @@ data:
       - schedulerName: topo-aware-scheduler
         plugins:
           filter:
+            disabled:
+              - name: '*'
             enabled:
+              - name: NodeUnschedulable
+              - name: NodeName
+              - name: TaintToleration
+              - name: NodePorts
               - name: NodeResourceTopologyMatch
+              - name: NodeResourcesFit
+              - name: VolumeRestrictions
+              - name: NodeVolumeLimits
+              - name: VolumeBinding
+              - name: VolumeZone
+              - name: PodTopologySpread
+              - name: InterPodAffinity
           score:
             enabled:
               - name: NodeResourceTopologyMatch


### PR DESCRIPTION
Since the enabling of memory resource alignment, we started to observe misscheduling due to the fact that the NRT filter plugin allows nodes which the builtin noderesources fit plugin rejects for lack of memory.

This PR reorganizes the code to remove this misbehaviour, and to make these conditions easier to be troubleshooted in the future.