### PR TITLE
fix and unconditionally enable the workload placement by tm scope tests

### DIFF
--- a/test/e2e/serial/tests/e2e_suite.go
+++ b/test/e2e/serial/tests/e2e_suite.go
@@ -29,7 +29,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -46,11 +45,6 @@ import (
 	"github.com/openshift-kni/numaresources-operator/test/utils/nrosched"
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 	e2ewait "github.com/openshift-kni/numaresources-operator/test/utils/objects/wait"
-)
-
-const (
-	OCPBaseLoadMemory = "4608Mi" // estimate; OCP 4.10
-	OCPBaseLoadCores  = "2"      // estimate; OCP 4.10 actually roughly 1.3 cores, but let's take HT pairs
 )
 
 const (
@@ -212,15 +206,4 @@ func unlabelNodes(cli client.Client, nrtList nrtv1alpha1.NodeResourceTopologyLis
 		err = cli.Update(context.TODO(), &node)
 		Expect(err).ToNot(HaveOccurred())
 	}
-}
-
-func applyBaseload(res corev1.ResourceList) corev1.ResourceList {
-	adjustedCPU := res.Cpu()
-	adjustedCPU.Add(resource.MustParse(OCPBaseLoadCores))
-	res[corev1.ResourceCPU] = *adjustedCPU
-
-	adjustedMemory := res.Memory()
-	adjustedMemory.Add(resource.MustParse(OCPBaseLoadMemory))
-	res[corev1.ResourceMemory] = *adjustedMemory
-	return res
 }

--- a/test/e2e/serial/tests/e2e_suite.go
+++ b/test/e2e/serial/tests/e2e_suite.go
@@ -29,6 +29,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,6 +46,11 @@ import (
 	"github.com/openshift-kni/numaresources-operator/test/utils/nrosched"
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 	e2ewait "github.com/openshift-kni/numaresources-operator/test/utils/objects/wait"
+)
+
+const (
+	OCPBaseLoadMemory = "4608Mi" // estimate; OCP 4.10
+	OCPBaseLoadCores  = "2"      // estimate; OCP 4.10 actually roughly 1.3 cores, but let's take HT pairs
 )
 
 const (
@@ -206,4 +212,15 @@ func unlabelNodes(cli client.Client, nrtList nrtv1alpha1.NodeResourceTopologyLis
 		err = cli.Update(context.TODO(), &node)
 		Expect(err).ToNot(HaveOccurred())
 	}
+}
+
+func applyBaseload(res corev1.ResourceList) corev1.ResourceList {
+	adjustedCPU := res.Cpu()
+	adjustedCPU.Add(resource.MustParse(OCPBaseLoadCores))
+	res[corev1.ResourceCPU] = *adjustedCPU
+
+	adjustedMemory := res.Memory()
+	adjustedMemory.Add(resource.MustParse(OCPBaseLoadMemory))
+	res[corev1.ResourceMemory] = *adjustedMemory
+	return res
 }

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -76,8 +76,6 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 	DescribeTable("[placement] cluster with multiple worker nodes suitable",
 		func(tmPolicy nrtv1alpha1.TopologyManagerPolicy, setupPadding setupPaddingFunc, podRes, unsuitableFreeRes []corev1.ResourceList) {
 
-			skipUnlessEnvVar("E2E_SERIAL_STAGING", "FIXME: NRT filter clashes with the noderesources fit plugin")
-
 			hostsRequired := 2
 
 			nrts := e2enrt.FilterTopologyManagerPolicy(nrtList.Items, tmPolicy)

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -33,6 +33,7 @@ import (
 	nrtv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
 	e2efixture "github.com/openshift-kni/numaresources-operator/test/utils/fixture"
 	e2enrt "github.com/openshift-kni/numaresources-operator/test/utils/noderesourcetopologies"
+	"github.com/openshift-kni/numaresources-operator/test/utils/nodes"
 	"github.com/openshift-kni/numaresources-operator/test/utils/nrosched"
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 	e2ewait "github.com/openshift-kni/numaresources-operator/test/utils/objects/wait"
@@ -269,6 +270,10 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 })
 
 func setupPaddingPodLevel(fxt *e2efixture.Fixture, nrtList nrtv1alpha1.NodeResourceTopologyList, padInfo paddingInfo) []*corev1.Pod {
+	baseload, err := nodes.GetLoad(fxt.K8sClient, padInfo.targetNodeName)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "missing node load info for %q", padInfo.targetNodeName)
+	By(fmt.Sprintf("computed base load: %s", baseload))
+
 	By(fmt.Sprintf("preparing target node %q to fit the test case", padInfo.targetNodeName))
 	// first, let's make sure that ONLY the required res can fit in either zone on the target node
 	nrtInfo, err := e2enrt.FindFromList(nrtList.Items, padInfo.targetNodeName)
@@ -300,7 +305,7 @@ func setupPaddingPodLevel(fxt *e2efixture.Fixture, nrtList nrtv1alpha1.NodeResou
 
 	podTotRes := e2ereslist.FromGuaranteedPod(*padInfo.pod)
 	By(fmt.Sprintf("testpod resource requests (vanilla): %s", e2ereslist.ToString(podTotRes)))
-	podTotRes = applyBaseload(podTotRes)
+	podTotRes = baseload.Apply(podTotRes)
 	By(fmt.Sprintf("testpod resource requests (adjusted): %s", e2ereslist.ToString(podTotRes)))
 
 	zone = nrtInfo.Zones[1]
@@ -320,6 +325,10 @@ func setupPaddingPodLevel(fxt *e2efixture.Fixture, nrtList nrtv1alpha1.NodeResou
 }
 
 func setupPaddingContainerLevel(fxt *e2efixture.Fixture, nrtList nrtv1alpha1.NodeResourceTopologyList, padInfo paddingInfo) []*corev1.Pod {
+	baseload, err := nodes.GetLoad(fxt.K8sClient, padInfo.targetNodeName)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "missing node load info for %q", padInfo.targetNodeName)
+	By(fmt.Sprintf("computed base load: %s", baseload))
+
 	By(fmt.Sprintf("preparing target node %q to fit the test case", padInfo.targetNodeName))
 	// first, let's make sure that ONLY the required res can fit in either zone on the target node
 	nrtInfo, err := e2enrt.FindFromList(nrtList.Items, padInfo.targetNodeName)
@@ -334,6 +343,8 @@ func setupPaddingContainerLevel(fxt *e2efixture.Fixture, nrtList nrtv1alpha1.Nod
 		numaIdx := idx % 2
 		zone := nrtInfo.Zones[numaIdx]
 		cnt := padInfo.pod.Spec.Containers[idx] // TODO: reverse
+
+		// TODO: apply baseload
 
 		By(fmt.Sprintf("padding node %q zone %q to fit only %s", nrtInfo.Name, zone.Name, e2ereslist.ToString(cnt.Resources.Limits)))
 		padPod, err := makePaddingPod(fxt.Namespace.Name, "target", zone, cnt.Resources.Limits)
@@ -359,13 +370,17 @@ func setupPaddingForUnsuitableNodes(offset int, fxt *e2efixture.Fixture, nrtList
 		nrtInfo, err := e2enrt.FindFromList(nrtList.Items, unsuitableNodeName)
 		ExpectWithOffset(offset, err).ToNot(HaveOccurred(), "missing NRT info for %q", unsuitableNodeName)
 
+		baseload, err := nodes.GetLoad(fxt.K8sClient, unsuitableNodeName)
+		ExpectWithOffset(offset, err).ToNot(HaveOccurred(), "missing node load info for %q", unsuitableNodeName)
+		By(fmt.Sprintf("computed base load: %s", baseload))
+
 		for zoneIdx, zone := range nrtInfo.Zones {
 			padRes := padInfo.unsuitableFreeRes[zoneIdx]
 			name := fmt.Sprintf("unsuitable%d", nodeIdx)
 
 			By(fmt.Sprintf("saturating node %q -> %q zone %q to fit only (vanilla) %s", nrtInfo.Name, name, zone.Name, e2ereslist.ToString(padRes)))
 			if zoneIdx == 0 { // any random zone is actually fine
-				padRes = applyBaseload(padRes)
+				padRes = baseload.Apply(padRes)
 				By(fmt.Sprintf("saturating node %q -> %q zone %q to fit only (adjusted) %s", nrtInfo.Name, name, zone.Name, e2ereslist.ToString(padRes)))
 			}
 

--- a/test/utils/nodes/baseload.go
+++ b/test/utils/nodes/baseload.go
@@ -1,0 +1,100 @@
+/*
+
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodes
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// we don't use corev1.ResourceList because we need values for CPU and Memory
+// so we can just use a struct at this point
+type Load struct {
+	Name   string
+	CPU    resource.Quantity
+	Memory resource.Quantity
+}
+
+func GetLoad(k8sCli *kubernetes.Clientset, nodeName string) (Load, error) {
+	nl := Load{
+		Name: nodeName,
+	}
+	pods, err := k8sCli.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	if err != nil {
+		return nl, err
+	}
+
+	cpu := &resource.Quantity{}
+	mem := &resource.Quantity{}
+
+	for _, pod := range pods.Items {
+		// TODO: we assume a steady state - aka we ignore InitContainers
+		for _, cnt := range pod.Spec.Containers {
+			for resName, resQty := range cnt.Resources.Requests {
+				switch resName {
+				case corev1.ResourceCPU:
+					cpu.Add(resQty)
+				case corev1.ResourceMemory:
+					mem.Add(resQty)
+				}
+			}
+		}
+	}
+	// get full cpus, and always take even number of CPUs
+	cpuMillis, _ := cpu.AsInt64()
+	// we round the CPU consumption as expressed in millicores (not entire cores)
+	// in order to (try to) avoid bugs related to integer division
+	// int64(2900 / 1000) -> 2 -> roundUp(2, 2) -> 2 (correct, but unexpected!)
+	// OTOH
+	// roundUp(2900, 2000) -> 4000 -> 4000/1000 -> 4 (intended behaviour)
+	// TODO: we can use some testing of the test utilities here (!)
+	cpuAmount := roundUp(cpuMillis, 2000)
+	nl.CPU = *resource.NewQuantity(cpuAmount/1000, resource.DecimalSI)
+
+	mem.RoundUp(resource.Giga)
+	nl.Memory = *mem
+	return nl, nil
+}
+
+func (nl Load) String() string {
+	return fmt.Sprintf("load for node %q: CPU=%s Memory=%s", nl.Name, nl.CPU.String(), nl.Memory.String())
+}
+
+// Apply adjust the given ResourceList with the current node load, mutating
+// the parameter in place and also returning the updated value.
+func (nl Load) Apply(res corev1.ResourceList) corev1.ResourceList {
+	adjustedCPU := res.Cpu()
+	adjustedCPU.Add(nl.CPU)
+	res[corev1.ResourceCPU] = *adjustedCPU
+
+	adjustedMemory := res.Memory()
+	adjustedMemory.Add(nl.Memory)
+	res[corev1.ResourceMemory] = *adjustedMemory
+	return res
+}
+
+func roundUp(num, multiple int64) int64 {
+	return ((num + multiple - 1) / multiple) * multiple
+}


### PR DESCRIPTION
the interaction between the noderesourcetopology and the noderesource filter plugins highlighted quite few complications.

by design, NRT objects do NOT account for non-esclusive resources; this mean burstable pods do take node resources, but these are not reflected into NRT available fields. This is unfortunate, but due to the fact that non-esclusive resources are not pinned to a NUMA zone, hence are difficult to track and account.

This means the NRT and the noderesource plugin have a different perspective about the available resources.
Note the kubelet has the same picture as the noderesource plugin (bar network delays) hence - noderesource can cause a node to be filtered out "unexpectedly" - just disabling noderesource (debatable) can lead to pod rejections for `OutOfCpu` or `OutOfMemory` errors, postponing but not solving the issue.

All the above means that tests which want to saturate a node must take the burstable pod into account and not assume eviction will solve all the problems, which is what we do in this PR by adding (estimate of) node base load and using these values when doing the node padding.

Additionally, to improve the troubleshooting experience, we can and should improve the scheduling configuration, but that's
being handled in different PRs (e.g. https://github.com/openshift-kni/numaresources-operator/pull/220 )