### PR TITLE
e2e: skip with call stack offset

### DIFF
--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -757,7 +757,7 @@ func skipUnlessEnvVar(envVar, message string) {
 	if isEnvTrue(envVar) {
 		return
 	}
-	Skip(message)
+	Skip(message, 1)
 }
 
 func isEnvTrue(envVar string) bool {


### PR DESCRIPTION
When the test calls outputed by the Skip function, it points to the code location where its caller is located which is ```skipUnlessEnvVar``` function (i.e. ```.../github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests/workload_placement.go:760```)

We less care about the ```skipUnlessEnvVar``` function and more about it's caller which is the actual test code.
Let's add caller skip in order to get more useful code location.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>