### PR TITLE
serial: add baseload to maxResources before padding

### DIFF
--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -545,19 +545,20 @@ func makePaddingPod(namespace, nodeName string, zone nrtv1alpha1.Zone, podReqs c
 	return padPod, nil
 }
 
-func makeNodePaddingPod(namespace string, node corev1.Node, podReqs corev1.ResourceList) (*corev1.Pod, error) {
-	klog.Infof("want to have node %q with allocatable: %s", node.Name, e2ereslist.ToString(podReqs))
+// need to be adjusted to be smart enough to distinguish TM scope and pad the node accordingly, but a pod with only one container cannot be used for padding a node with multiple numas
+// func makeNodePaddingPod(namespace string, node corev1.Node, podReqs corev1.ResourceList) (*corev1.Pod, error) {
+// 	klog.Infof("want to have node %q with allocatable: %s", node.Name, e2ereslist.ToString(podReqs))
 
-	paddingReqs, err := e2enrt.SaturateNodeUntilLeft(node, podReqs)
-	if err != nil {
-		return nil, err
-	}
+// 	paddingReqs, err := e2enrt.SaturateNodeUntilLeft(node, podReqs)
+// 	if err != nil {
+// 		return nil, err
+// 	}
 
-	klog.Infof("padding resource to saturate %q: %s", node.Name, e2ereslist.ToString(paddingReqs))
+// 	klog.Infof("padding resource to saturate %q: %s", node.Name, e2ereslist.ToString(paddingReqs))
 
-	padPod := newPaddingPod(node.Name, "", namespace, paddingReqs)
-	return padPod, nil
-}
+// 	padPod := newPaddingPod(node.Name, "", namespace, paddingReqs)
+// 	return padPod, nil
+// }
 
 func newPaddingPod(nodeName, zoneName, namespace string, resourceReqs corev1.ResourceList) *corev1.Pod {
 	var zero int64
@@ -737,8 +738,24 @@ func matchLogLevelToKlog(cnt *corev1.Container, level operatorv1.LogLevel) (bool
 	return found, val.Data == kLvl.String()
 }
 
-func maxResourceType(nrtInfo nrtv1alpha1.NodeResourceTopology, resName corev1.ResourceName) resource.Quantity {
-	var max resource.Quantity
+// func maxResourceType(nrtInfo nrtv1alpha1.NodeResourceTopology, resName corev1.ResourceName) resource.Quantity {
+// 	var max resource.Quantity
+
+// 	for _, zone := range nrtInfo.Zones {
+// 		zoneQty, ok := e2enrt.FindResourceAvailableByName(zone.Resources, resName.String())
+// 		if !ok {
+// 			continue
+// 		}
+
+// 		if zoneQty.Cmp(max) == 1 {
+// 			max = zoneQty
+// 		}
+// 	}
+// 	return max.DeepCopy()
+// }
+
+func availableResourceType(nrtInfo nrtv1alpha1.NodeResourceTopology, resName corev1.ResourceName) resource.Quantity {
+	var res resource.Quantity
 
 	for _, zone := range nrtInfo.Zones {
 		zoneQty, ok := e2enrt.FindResourceAvailableByName(zone.Resources, resName.String())
@@ -746,11 +763,9 @@ func maxResourceType(nrtInfo nrtv1alpha1.NodeResourceTopology, resName corev1.Re
 			continue
 		}
 
-		if zoneQty.Cmp(max) > 1 {
-			max = zoneQty
-		}
+		res.Add(zoneQty)
 	}
-	return max.DeepCopy()
+	return res.DeepCopy()
 }
 
 func skipUnlessEnvVar(envVar, message string) {

--- a/vendor/k8s.io/kubernetes/pkg/api/v1/resource/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/v1/resource/helpers.go
@@ -1,0 +1,296 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+// PodRequestsAndLimits returns a dictionary of all defined resources summed up for all
+// containers of the pod. If PodOverhead feature is enabled, pod overhead is added to the
+// total container resource requests and to the total container limits which have a
+// non-zero quantity.
+func PodRequestsAndLimits(pod *v1.Pod) (reqs, limits v1.ResourceList) {
+	return PodRequestsAndLimitsReuse(pod, nil, nil)
+}
+
+// PodRequestsAndLimitsReuse returns a dictionary of all defined resources summed up for all
+// containers of the pod. If PodOverhead feature is enabled, pod overhead is added to the
+// total container resource requests and to the total container limits which have a
+// non-zero quantity. The caller may avoid allocations of resource lists by passing
+// a requests and limits list to the function, which will be cleared before use.
+func PodRequestsAndLimitsReuse(pod *v1.Pod, reuseReqs, reuseLimits v1.ResourceList) (reqs, limits v1.ResourceList) {
+	// attempt to reuse the maps if passed, or allocate otherwise
+	reqs, limits = reuseOrClearResourceList(reuseReqs), reuseOrClearResourceList(reuseLimits)
+
+	for _, container := range pod.Spec.Containers {
+		addResourceList(reqs, container.Resources.Requests)
+		addResourceList(limits, container.Resources.Limits)
+	}
+	// init containers define the minimum of any resource
+	for _, container := range pod.Spec.InitContainers {
+		maxResourceList(reqs, container.Resources.Requests)
+		maxResourceList(limits, container.Resources.Limits)
+	}
+
+	// if PodOverhead feature is supported, add overhead for running a pod
+	// to the sum of requests and to non-zero limits:
+	if pod.Spec.Overhead != nil && utilfeature.DefaultFeatureGate.Enabled(features.PodOverhead) {
+		addResourceList(reqs, pod.Spec.Overhead)
+
+		for name, quantity := range pod.Spec.Overhead {
+			if value, ok := limits[name]; ok && !value.IsZero() {
+				value.Add(quantity)
+				limits[name] = value
+			}
+		}
+	}
+
+	return
+}
+
+// reuseOrClearResourceList is a helper for avoiding excessive allocations of
+// resource lists within the inner loop of resource calculations.
+func reuseOrClearResourceList(reuse v1.ResourceList) v1.ResourceList {
+	if reuse == nil {
+		return make(v1.ResourceList, 4)
+	}
+	for k := range reuse {
+		delete(reuse, k)
+	}
+	return reuse
+}
+
+// addResourceList adds the resources in newList to list.
+func addResourceList(list, newList v1.ResourceList) {
+	for name, quantity := range newList {
+		if value, ok := list[name]; !ok {
+			list[name] = quantity.DeepCopy()
+		} else {
+			value.Add(quantity)
+			list[name] = value
+		}
+	}
+}
+
+// maxResourceList sets list to the greater of list/newList for every resource in newList
+func maxResourceList(list, newList v1.ResourceList) {
+	for name, quantity := range newList {
+		if value, ok := list[name]; !ok || quantity.Cmp(value) > 0 {
+			list[name] = quantity.DeepCopy()
+		}
+	}
+}
+
+// GetResourceRequestQuantity finds and returns the request quantity for a specific resource.
+func GetResourceRequestQuantity(pod *v1.Pod, resourceName v1.ResourceName) resource.Quantity {
+	requestQuantity := resource.Quantity{}
+
+	switch resourceName {
+	case v1.ResourceCPU:
+		requestQuantity = resource.Quantity{Format: resource.DecimalSI}
+	case v1.ResourceMemory, v1.ResourceStorage, v1.ResourceEphemeralStorage:
+		requestQuantity = resource.Quantity{Format: resource.BinarySI}
+	default:
+		requestQuantity = resource.Quantity{Format: resource.DecimalSI}
+	}
+
+	if resourceName == v1.ResourceEphemeralStorage && !utilfeature.DefaultFeatureGate.Enabled(features.LocalStorageCapacityIsolation) {
+		// if the local storage capacity isolation feature gate is disabled, pods request 0 disk
+		return requestQuantity
+	}
+
+	for _, container := range pod.Spec.Containers {
+		if rQuantity, ok := container.Resources.Requests[resourceName]; ok {
+			requestQuantity.Add(rQuantity)
+		}
+	}
+
+	for _, container := range pod.Spec.InitContainers {
+		if rQuantity, ok := container.Resources.Requests[resourceName]; ok {
+			if requestQuantity.Cmp(rQuantity) < 0 {
+				requestQuantity = rQuantity.DeepCopy()
+			}
+		}
+	}
+
+	// if PodOverhead feature is supported, add overhead for running a pod
+	// to the total requests if the resource total is non-zero
+	if pod.Spec.Overhead != nil && utilfeature.DefaultFeatureGate.Enabled(features.PodOverhead) {
+		if podOverhead, ok := pod.Spec.Overhead[resourceName]; ok && !requestQuantity.IsZero() {
+			requestQuantity.Add(podOverhead)
+		}
+	}
+
+	return requestQuantity
+}
+
+// GetResourceRequest finds and returns the request value for a specific resource.
+func GetResourceRequest(pod *v1.Pod, resource v1.ResourceName) int64 {
+	if resource == v1.ResourcePods {
+		return 1
+	}
+
+	requestQuantity := GetResourceRequestQuantity(pod, resource)
+
+	if resource == v1.ResourceCPU {
+		return requestQuantity.MilliValue()
+	}
+
+	return requestQuantity.Value()
+}
+
+// ExtractResourceValueByContainerName extracts the value of a resource
+// by providing container name
+func ExtractResourceValueByContainerName(fs *v1.ResourceFieldSelector, pod *v1.Pod, containerName string) (string, error) {
+	container, err := findContainerInPod(pod, containerName)
+	if err != nil {
+		return "", err
+	}
+	return ExtractContainerResourceValue(fs, container)
+}
+
+// ExtractResourceValueByContainerNameAndNodeAllocatable extracts the value of a resource
+// by providing container name and node allocatable
+func ExtractResourceValueByContainerNameAndNodeAllocatable(fs *v1.ResourceFieldSelector, pod *v1.Pod, containerName string, nodeAllocatable v1.ResourceList) (string, error) {
+	realContainer, err := findContainerInPod(pod, containerName)
+	if err != nil {
+		return "", err
+	}
+
+	container := realContainer.DeepCopy()
+
+	MergeContainerResourceLimits(container, nodeAllocatable)
+
+	return ExtractContainerResourceValue(fs, container)
+}
+
+// ExtractContainerResourceValue extracts the value of a resource
+// in an already known container
+func ExtractContainerResourceValue(fs *v1.ResourceFieldSelector, container *v1.Container) (string, error) {
+	divisor := resource.Quantity{}
+	if divisor.Cmp(fs.Divisor) == 0 {
+		divisor = resource.MustParse("1")
+	} else {
+		divisor = fs.Divisor
+	}
+
+	switch fs.Resource {
+	case "limits.cpu":
+		return convertResourceCPUToString(container.Resources.Limits.Cpu(), divisor)
+	case "limits.memory":
+		return convertResourceMemoryToString(container.Resources.Limits.Memory(), divisor)
+	case "limits.ephemeral-storage":
+		return convertResourceEphemeralStorageToString(container.Resources.Limits.StorageEphemeral(), divisor)
+	case "requests.cpu":
+		return convertResourceCPUToString(container.Resources.Requests.Cpu(), divisor)
+	case "requests.memory":
+		return convertResourceMemoryToString(container.Resources.Requests.Memory(), divisor)
+	case "requests.ephemeral-storage":
+		return convertResourceEphemeralStorageToString(container.Resources.Requests.StorageEphemeral(), divisor)
+	}
+	// handle extended standard resources with dynamic names
+	// example: requests.hugepages-<pageSize> or limits.hugepages-<pageSize>
+	if strings.HasPrefix(fs.Resource, "requests.") {
+		resourceName := v1.ResourceName(strings.TrimPrefix(fs.Resource, "requests."))
+		if IsHugePageResourceName(resourceName) {
+			return convertResourceHugePagesToString(container.Resources.Requests.Name(resourceName, resource.BinarySI), divisor)
+		}
+	}
+	if strings.HasPrefix(fs.Resource, "limits.") {
+		resourceName := v1.ResourceName(strings.TrimPrefix(fs.Resource, "limits."))
+		if IsHugePageResourceName(resourceName) {
+			return convertResourceHugePagesToString(container.Resources.Limits.Name(resourceName, resource.BinarySI), divisor)
+		}
+	}
+	return "", fmt.Errorf("unsupported container resource : %v", fs.Resource)
+}
+
+// convertResourceCPUToString converts cpu value to the format of divisor and returns
+// ceiling of the value.
+func convertResourceCPUToString(cpu *resource.Quantity, divisor resource.Quantity) (string, error) {
+	c := int64(math.Ceil(float64(cpu.MilliValue()) / float64(divisor.MilliValue())))
+	return strconv.FormatInt(c, 10), nil
+}
+
+// convertResourceMemoryToString converts memory value to the format of divisor and returns
+// ceiling of the value.
+func convertResourceMemoryToString(memory *resource.Quantity, divisor resource.Quantity) (string, error) {
+	m := int64(math.Ceil(float64(memory.Value()) / float64(divisor.Value())))
+	return strconv.FormatInt(m, 10), nil
+}
+
+// convertResourceHugePagesToString converts hugepages value to the format of divisor and returns
+// ceiling of the value.
+func convertResourceHugePagesToString(hugePages *resource.Quantity, divisor resource.Quantity) (string, error) {
+	m := int64(math.Ceil(float64(hugePages.Value()) / float64(divisor.Value())))
+	return strconv.FormatInt(m, 10), nil
+}
+
+// convertResourceEphemeralStorageToString converts ephemeral storage value to the format of divisor and returns
+// ceiling of the value.
+func convertResourceEphemeralStorageToString(ephemeralStorage *resource.Quantity, divisor resource.Quantity) (string, error) {
+	m := int64(math.Ceil(float64(ephemeralStorage.Value()) / float64(divisor.Value())))
+	return strconv.FormatInt(m, 10), nil
+}
+
+// findContainerInPod finds a container by its name in the provided pod
+func findContainerInPod(pod *v1.Pod, containerName string) (*v1.Container, error) {
+	for _, container := range pod.Spec.Containers {
+		if container.Name == containerName {
+			return &container, nil
+		}
+	}
+	for _, container := range pod.Spec.InitContainers {
+		if container.Name == containerName {
+			return &container, nil
+		}
+	}
+	return nil, fmt.Errorf("container %s not found", containerName)
+}
+
+// MergeContainerResourceLimits checks if a limit is applied for
+// the container, and if not, it sets the limit to the passed resource list.
+func MergeContainerResourceLimits(container *v1.Container,
+	allocatable v1.ResourceList) {
+	if container.Resources.Limits == nil {
+		container.Resources.Limits = make(v1.ResourceList)
+	}
+	// NOTE: we exclude hugepages-* resources because hugepages are never overcommitted.
+	// This means that the container always has a limit specified.
+	for _, resource := range []v1.ResourceName{v1.ResourceCPU, v1.ResourceMemory, v1.ResourceEphemeralStorage} {
+		if quantity, exists := container.Resources.Limits[resource]; !exists || quantity.IsZero() {
+			if cap, exists := allocatable[resource]; exists {
+				container.Resources.Limits[resource] = cap.DeepCopy()
+			}
+		}
+	}
+}
+
+// IsHugePageResourceName returns true if the resource name has the huge page
+// resource prefix.
+func IsHugePageResourceName(name v1.ResourceName) bool {
+	return strings.HasPrefix(string(name), v1.ResourceHugePagesPrefix)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1163,6 +1163,7 @@ k8s.io/kubelet/pkg/apis/stats/v1alpha1
 k8s.io/kubernetes/pkg/api/legacyscheme
 k8s.io/kubernetes/pkg/api/service
 k8s.io/kubernetes/pkg/api/v1/pod
+k8s.io/kubernetes/pkg/api/v1/resource
 k8s.io/kubernetes/pkg/apis/apps
 k8s.io/kubernetes/pkg/apis/autoscaling
 k8s.io/kubernetes/pkg/apis/batch


### PR DESCRIPTION
Creating padding pods without considering the current baseload on the node causes scheduling those pods to fail due to insufficient resources on that node.

Account for the base load in the padding resources to avoid such cases.

Signed-off-by: shereenH <shajmakh@redhat.com>