### PR TITLE
add e2e serial config suite

### DIFF
--- a/test/e2e/serial/config/config.go
+++ b/test/e2e/serial/config/config.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+)
+
+const (
+	MultiNUMALabel    = "numa.hardware.openshift-kni.io/cell-count"
+	NropTestCIImage   = "quay.io/openshift-kni/resource-topology-exporter:test-ci"
+	SchedulerTestName = "test-topology-scheduler"
+)
+
+// This suite holds the e2e tests which span across components,
+// e.g. involve both the behaviour of RTE and the scheduler.
+// These tests are almost always disruptive, meaning they significantly
+// alter the cluster state and need a very specific cluster state (which
+// is each test responsability to setup and cleanup).
+// Hence we call this suite serial, implying each test should run alone
+// and indisturbed on the cluster. No concurrency at all is possible,
+// each test "owns" the cluster - but again, must leave no leftovers.
+
+var Config *E2EConfig
+
+func Setup() {
+	Config = SetupFixture()
+	SetupInfra(Config.Fixture, Config.NROOperObj, Config.NRTList)
+}
+
+func Teardown() {
+	if _, ok := os.LookupEnv("E2E_INFRA_NO_TEARDOWN"); ok {
+		return
+	}
+	TeardownInfra(Config.Fixture, Config.NRTList)
+	// numacell daemonset automatically cleaned up when we remove the namespace
+	TeardownFixture(Config)
+}

--- a/test/e2e/serial/config/fixture.go
+++ b/test/e2e/serial/config/fixture.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+
+	. "github.com/onsi/gomega"
+
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nrtv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	e2efixture "github.com/openshift-kni/numaresources-operator/test/utils/fixture"
+	"github.com/openshift-kni/numaresources-operator/test/utils/nrosched"
+	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
+)
+
+type E2EConfig struct {
+	Fixture       *e2efixture.Fixture
+	NRTList       nrtv1alpha1.NodeResourceTopologyList
+	NROOperObj    *nropv1alpha1.NUMAResourcesOperator
+	NROSchedObj   *nropv1alpha1.NUMAResourcesScheduler
+	SchedulerName string
+}
+
+func SetupFixture() *E2EConfig {
+	var err error
+	var cfg E2EConfig
+
+	cfg.Fixture, err = e2efixture.Setup("e2e-test-infra")
+	Expect(err).ToNot(HaveOccurred(), "unable to setup infra test fixture")
+
+	err = cfg.Fixture.Client.List(context.TODO(), &cfg.NRTList)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = cfg.Fixture.Client.Get(context.TODO(), client.ObjectKey{Name: nrosched.NROSchedObjectName}, cfg.NROSchedObj)
+	Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", nrosched.NROSchedObjectName)
+
+	err = cfg.Fixture.Client.Get(context.TODO(), client.ObjectKey{Name: objects.NROName()}, cfg.NROOperObj)
+	Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", objects.NROName())
+
+	Expect(cfg.NROOperObj.Spec.NodeGroups).ToNot(BeEmpty(), "cannot autodetect the TAS node groups from the cluster")
+
+	cfg.SchedulerName = cfg.NROSchedObj.Status.SchedulerName
+	Expect(cfg.SchedulerName).ToNot(BeEmpty(), "cannot autodetect the TAS scheduler name from the cluster")
+	klog.Infof("scheduler name: %q", cfg.SchedulerName)
+
+	return &cfg
+}
+
+func TeardownFixture(cfg *E2EConfig) {
+	err := e2efixture.Teardown(cfg.Fixture)
+	Expect(err).NotTo(HaveOccurred())
+}

--- a/test/e2e/serial/config/infra.go
+++ b/test/e2e/serial/config/infra.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tests
+package config
 
 import (
 	"context"
@@ -41,77 +41,20 @@ import (
 	numacellmanifests "github.com/openshift-kni/numaresources-operator/test/deviceplugin/pkg/numacell/manifests"
 	e2efixture "github.com/openshift-kni/numaresources-operator/test/utils/fixture"
 	"github.com/openshift-kni/numaresources-operator/test/utils/images"
-	"github.com/openshift-kni/numaresources-operator/test/utils/nrosched"
-	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 	e2ewait "github.com/openshift-kni/numaresources-operator/test/utils/objects/wait"
 )
 
-const (
-	multiNUMALabel    = "numa.hardware.openshift-kni.io/cell-count"
-	nropTestCIImage   = "quay.io/openshift-kni/resource-topology-exporter:test-ci"
-	schedulerTestName = "test-topology-scheduler"
-)
+func SetupInfra(fxt *e2efixture.Fixture, nroOperObj *nropv1alpha1.NUMAResourcesOperator, nrtList nrtv1alpha1.NodeResourceTopologyList) {
+	setupNUMACell(fxt, nroOperObj.Spec.NodeGroups, 3*time.Minute)
 
-var (
-	nroOperObj    *nropv1alpha1.NUMAResourcesOperator
-	nroSchedObj   *nropv1alpha1.NUMAResourcesScheduler
-	schedulerName string
-)
-
-// This suite holds the e2e tests which span across components,
-// e.g. involve both the behaviour of RTE and the scheduler.
-// These tests are almost always disruptive, meaning they significantly
-// alter the cluster state and need a very specific cluster state (which
-// is each test responsability to setup and cleanup).
-// Hence we call this suite serial, implying each test should run alone
-// and indisturbed on the cluster. No concurrency at all is possible,
-// each test "owns" the cluster - but again, must leave no leftovers.
-
-// do not use these outside this *file*
-var __fxt *e2efixture.Fixture
-var __nrtList nrtv1alpha1.NodeResourceTopologyList
-
-func BeforeSuiteHelper() {
-	var err error
-
-	__fxt, err = e2efixture.Setup("e2e-test-infra")
-	Expect(err).ToNot(HaveOccurred(), "unable to setup infra test fixture")
-
-	err = __fxt.Client.List(context.TODO(), &__nrtList)
-	Expect(err).ToNot(HaveOccurred())
-
-	nroSchedObj = &nropv1alpha1.NUMAResourcesScheduler{}
-	err = __fxt.Client.Get(context.TODO(), client.ObjectKey{Name: nrosched.NROSchedObjectName}, nroSchedObj)
-	Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", nrosched.NROSchedObjectName)
-
-	nroOperObj = &nropv1alpha1.NUMAResourcesOperator{}
-	err = __fxt.Client.Get(context.TODO(), client.ObjectKey{Name: objects.NROName()}, nroOperObj)
-	Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", objects.NROName())
-
-	Expect(nroOperObj.Spec.NodeGroups).ToNot(BeEmpty(), "cannot autodetect the TAS node groups from the cluster")
-
-	schedulerName = nroSchedObj.Status.SchedulerName
-	Expect(schedulerName).ToNot(BeEmpty(), "cannot autodetect the TAS scheduler name from the cluster")
-	klog.Infof("scheduler name: %q", schedulerName)
-
-	setupInfra(__fxt, nroOperObj.Spec.NodeGroups, 3*time.Minute)
-
-	labelNodes(__fxt.Client, __nrtList)
+	LabelNodes(fxt.Client, nrtList)
 }
 
-func AfterSuiteHelper() {
-	if _, ok := os.LookupEnv("E2E_INFRA_NO_TEARDOWN"); ok {
-		return
-	}
-
-	unlabelNodes(__fxt.Client, __nrtList)
-
-	// numacell daemonset automatically cleaned up when we remove the namespace
-	err := e2efixture.Teardown(__fxt)
-	Expect(err).NotTo(HaveOccurred())
+func TeardownInfra(fxt *e2efixture.Fixture, nrtList nrtv1alpha1.NodeResourceTopologyList) {
+	UnlabelNodes(fxt.Client, nrtList)
 }
 
-func setupInfra(fxt *e2efixture.Fixture, nodeGroups []nropv1alpha1.NodeGroup, timeout time.Duration) {
+func setupNUMACell(fxt *e2efixture.Fixture, nodeGroups []nropv1alpha1.NodeGroup, timeout time.Duration) {
 	klog.Infof("e2e infra setup begin")
 
 	mcps, err := machineconfigpools.GetNodeGroupsMCPs(context.TODO(), fxt.Client, nodeGroups)
@@ -177,28 +120,28 @@ func getNUMACellDevicePluginPullSpec() string {
 	return images.NUMACellDevicePluginTestImageCI
 }
 
-func labelNodes(cli client.Client, nrtList nrtv1alpha1.NodeResourceTopologyList) {
+func LabelNodes(cli client.Client, nrtList nrtv1alpha1.NodeResourceTopologyList) {
 	for _, nrt := range nrtList.Items {
 		node := corev1.Node{}
 		err := cli.Get(context.TODO(), client.ObjectKey{Name: nrt.Name}, &node)
 		Expect(err).ToNot(HaveOccurred())
 		labelValue := fmt.Sprintf("%d", len(nrt.Zones))
-		node.Labels[multiNUMALabel] = labelValue
+		node.Labels[MultiNUMALabel] = labelValue
 
-		klog.Infof("labeling node %q with %s: %s", nrt.Name, multiNUMALabel, labelValue)
+		klog.Infof("labeling node %q with %s: %s", nrt.Name, MultiNUMALabel, labelValue)
 		err = cli.Update(context.TODO(), &node)
 		Expect(err).ToNot(HaveOccurred())
 	}
 }
 
-func unlabelNodes(cli client.Client, nrtList nrtv1alpha1.NodeResourceTopologyList) {
+func UnlabelNodes(cli client.Client, nrtList nrtv1alpha1.NodeResourceTopologyList) {
 	for _, nrt := range nrtList.Items {
 		node := corev1.Node{}
 		err := cli.Get(context.TODO(), client.ObjectKey{Name: nrt.Name}, &node)
 		Expect(err).ToNot(HaveOccurred())
 
-		klog.Infof("unlabeling node %q removing label %s", nrt.Name, multiNUMALabel)
-		delete(node.Labels, multiNUMALabel)
+		klog.Infof("unlabeling node %q removing label %s", nrt.Name, MultiNUMALabel)
+		delete(node.Labels, MultiNUMALabel)
 		err = cli.Update(context.TODO(), &node)
 		Expect(err).ToNot(HaveOccurred())
 	}

--- a/test/e2e/serial/e2e_serial_test.go
+++ b/test/e2e/serial/e2e_serial_test.go
@@ -18,8 +18,10 @@ package serial
 
 import (
 	"flag"
+	"math/rand"
 	"path"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/reporters"
@@ -52,6 +54,10 @@ func TestSerial(t *testing.T) {
 	RunSpecsWithDefaultAndCustomReporters(t, "NUMAResources serial e2e tests", rr)
 }
 
-var _ = BeforeSuite(serialtests.BeforeSuiteHelper)
+var _ = BeforeSuite(func() {
+	// this must be the very first thing
+	rand.Seed(time.Now().UnixNano())
+	serialtests.BeforeSuiteHelper()
+})
 
 var _ = AfterSuite(serialtests.AfterSuiteHelper)

--- a/test/e2e/serial/e2e_serial_test.go
+++ b/test/e2e/serial/e2e_serial_test.go
@@ -29,7 +29,8 @@ import (
 
 	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 
-	serialtests "github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests"
+	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
+	_ "github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests"
 )
 
 var (
@@ -57,7 +58,7 @@ func TestSerial(t *testing.T) {
 var _ = BeforeSuite(func() {
 	// this must be the very first thing
 	rand.Seed(time.Now().UnixNano())
-	serialtests.BeforeSuiteHelper()
+	serialconfig.Setup()
 })
 
-var _ = AfterSuite(serialtests.AfterSuiteHelper)
+var _ = AfterSuite(serialconfig.Teardown)

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -46,6 +46,8 @@ import (
 	e2epadder "github.com/openshift-kni/numaresources-operator/test/utils/padder"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
+	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 )
 
 var _ = Describe("[serial][disruptive][slow] numaresources configuration management", func() {
@@ -257,11 +259,11 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 				return true, nil
 			}, 10*time.Minute, 30*time.Second).Should(BeTrue())
 
-			By(fmt.Sprintf("modifing the NUMAResourcesOperator ExporterImage filed to %q", nropTestCIImage))
+			By(fmt.Sprintf("modifing the NUMAResourcesOperator ExporterImage filed to %q", serialconfig.NropTestCIImage))
 			err = fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroOperObj), nroOperObj)
 			Expect(err).ToNot(HaveOccurred())
 
-			nroOperObj.Spec.ExporterImage = nropTestCIImage
+			nroOperObj.Spec.ExporterImage = serialconfig.NropTestCIImage
 			err = fxt.Client.Update(context.TODO(), nroOperObj)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -278,13 +280,13 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 				for _, ds := range dss {
 					// RTE container shortcut
 					cnt := ds.Spec.Template.Spec.Containers[0]
-					if cnt.Image != nropTestCIImage {
-						klog.Warningf("container: %q image not updated yet. expected %q actual %q", cnt.Name, nropTestCIImage, cnt.Image)
+					if cnt.Image != serialconfig.NropTestCIImage {
+						klog.Warningf("container: %q image not updated yet. expected %q actual %q", cnt.Name, serialconfig.NropTestCIImage, cnt.Image)
 						return false, nil
 					}
 				}
 				return true, nil
-			}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "failed to update RTE container with image %q", nropTestCIImage)
+			}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "failed to update RTE container with image %q", serialconfig.NropTestCIImage)
 
 			By(fmt.Sprintf("modifing the NUMAResourcesOperator LogLevel filed to %q", operatorv1.Trace))
 			err = fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroOperObj), nroOperObj)
@@ -321,17 +323,17 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 				return true, nil
 			}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "failed to update RTE container with LogLevel %q", operatorv1.Trace)
 
-			By(fmt.Sprintf("modifing the NUMAResourcesScheduler SchedulerName Filed to %q", schedulerTestName))
+			By(fmt.Sprintf("modifing the NUMAResourcesScheduler SchedulerName Filed to %q", serialconfig.SchedulerTestName))
 			err = fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroSchedObj), nroSchedObj)
 			Expect(err).ToNot(HaveOccurred())
 
-			nroSchedObj.Spec.SchedulerName = schedulerTestName
+			nroSchedObj.Spec.SchedulerName = serialconfig.SchedulerTestName
 			err = fxt.Client.Update(context.TODO(), nroSchedObj)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("schedule pod using the new scheduler name")
 			testPod := objects.NewTestPodPause(fxt.Namespace.Name, e2efixture.RandomName("testpod"))
-			testPod.Spec.SchedulerName = schedulerTestName
+			testPod.Spec.SchedulerName = serialconfig.SchedulerTestName
 
 			err = fxt.Client.Create(context.TODO(), testPod)
 			Expect(err).ToNot(HaveOccurred())
@@ -339,9 +341,9 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 			updatedPod, err := e2ewait.ForPodPhase(fxt.Client, testPod.Namespace, testPod.Name, corev1.PodRunning, 5*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 
-			schedOK, err := nrosched.CheckPODWasScheduledWith(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, schedulerTestName)
+			schedOK, err := nrosched.CheckPODWasScheduledWith(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.SchedulerTestName)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, schedulerTestName)
+			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.SchedulerTestName)
 		})
 	})
 })

--- a/test/e2e/serial/tests/e2e_suite.go
+++ b/test/e2e/serial/tests/e2e_suite.go
@@ -19,7 +19,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"os"
 	"sync"
 	"time"
@@ -73,9 +72,6 @@ var __fxt *e2efixture.Fixture
 var __nrtList nrtv1alpha1.NodeResourceTopologyList
 
 func BeforeSuiteHelper() {
-	// this must be the very first thing
-	rand.Seed(time.Now().UnixNano())
-
 	var err error
 
 	__fxt, err = e2efixture.Setup("e2e-test-infra")

--- a/test/e2e/serial/tests/sched_removal.go
+++ b/test/e2e/serial/tests/sched_removal.go
@@ -33,22 +33,26 @@ import (
 	"github.com/openshift-kni/numaresources-operator/test/utils/nrosched"
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 	e2ewait "github.com/openshift-kni/numaresources-operator/test/utils/objects/wait"
+
+	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 )
 
 var _ = Describe("[serial][disruptive][scheduler] numaresources scheduler removal on a live cluster", func() {
 	var fxt *e2efixture.Fixture
 
 	BeforeEach(func() {
+		Expect(serialconfig.Config).ToNot(BeNil())
+
 		var err error
 		fxt, err = e2efixture.Setup("e2e-test-sched-remove")
 		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
 
-		nrosched.CheckNROSchedulerAvailable(fxt.Client, nroSchedObj.Name)
+		nrosched.CheckNROSchedulerAvailable(fxt.Client, serialconfig.Config.NROSchedObj.Name)
 	})
 
 	AfterEach(func() {
-		restoreScheduler(fxt, nroSchedObj)
-		nrosched.CheckNROSchedulerAvailable(fxt.Client, nroSchedObj.Name)
+		restoreScheduler(fxt, serialconfig.Config.NROSchedObj)
+		nrosched.CheckNROSchedulerAvailable(fxt.Client, serialconfig.Config.NROSchedObj.Name)
 
 		err := e2efixture.Teardown(fxt)
 		Expect(err).NotTo(HaveOccurred())
@@ -58,10 +62,10 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources scheduler remova
 		It("[case:1][test_id:47593][tier1] should keep existing workloads running", func() {
 			var err error
 
-			dp := createDeploymentSync(fxt, "testdp", schedulerName)
+			dp := createDeploymentSync(fxt, "testdp", serialconfig.Config.SchedulerName)
 
-			By(fmt.Sprintf("deleting the NRO Scheduler object: %s", nroSchedObj.Name))
-			err = fxt.Client.Delete(context.TODO(), nroSchedObj)
+			By(fmt.Sprintf("deleting the NRO Scheduler object: %s", serialconfig.Config.NROSchedObj.Name))
+			err = fxt.Client.Delete(context.TODO(), serialconfig.Config.NROSchedObj)
 			Expect(err).ToNot(HaveOccurred())
 
 			maxStep := 3
@@ -81,11 +85,11 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources scheduler remova
 		It("[case:2][test_id:49093][tier1] should keep new scheduled workloads pending", func() {
 			var err error
 
-			By(fmt.Sprintf("deleting the NRO Scheduler object: %s", nroSchedObj.Name))
-			err = fxt.Client.Delete(context.TODO(), nroSchedObj)
+			By(fmt.Sprintf("deleting the NRO Scheduler object: %s", serialconfig.Config.NROSchedObj.Name))
+			err = fxt.Client.Delete(context.TODO(), serialconfig.Config.NROSchedObj)
 			Expect(err).ToNot(HaveOccurred())
 
-			dp := createDeployment(fxt, "testdp", schedulerName)
+			dp := createDeployment(fxt, "testdp", serialconfig.Config.SchedulerName)
 
 			maxStep := 3
 			for step := 0; step < maxStep; step++ {

--- a/test/e2e/serial/tests/workload_placement_nodesel.go
+++ b/test/e2e/serial/tests/workload_placement_nodesel.go
@@ -24,6 +24,7 @@ import (
 	nrtv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 	e2efixture "github.com/openshift-kni/numaresources-operator/test/utils/fixture"
 	e2enrt "github.com/openshift-kni/numaresources-operator/test/utils/noderesourcetopologies"
 	"github.com/openshift-kni/numaresources-operator/test/utils/nrosched"
@@ -42,6 +43,8 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 	var nrts []nrtv1alpha1.NodeResourceTopology
 
 	BeforeEach(func() {
+		Expect(serialconfig.Config).ToNot(BeNil())
+
 		var err error
 		fxt, err = e2efixture.Setup("e2e-test-workload-placement-nodesel")
 		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
@@ -178,7 +181,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			By("Scheduling the testing pod")
 			pod := objects.NewTestPodPause(fxt.Namespace.Name, "testPod")
-			pod.Spec.SchedulerName = schedulerName
+			pod.Spec.SchedulerName = serialconfig.Config.SchedulerName
 			pod.Spec.Containers[0].Resources.Limits = requiredRes
 			pod.Spec.NodeSelector = map[string]string{
 				labelName: labelValue,
@@ -195,10 +198,10 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			By("checking the pod has been scheduled in the proper node")
 			Expect(updatedPod.Spec.NodeName).To(Equal(targetNodeName))
 
-			By(fmt.Sprintf("checking the pod was scheduled with the topology aware scheduler %q", schedulerName))
-			schedOK, err := nrosched.CheckPODWasScheduledWith(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, schedulerName)
+			By(fmt.Sprintf("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName))
+			schedOK, err := nrosched.CheckPODWasScheduledWith(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, schedulerName)
+			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 		})
 	})
 })


### PR DESCRIPTION
Move the configuration steps we used to do in the {Before,After}Suite{,Helper} in their own subpackage.

This way, we can keep the current suite behaving like before (bar the necessary mechanical API and import changes) but we
enable better integration with external projects (= cnf-tests)

It goes like this:
cnf-tests want to run the configuration steps in a different suite (configsuite) separated by the test suite proper (e2esuite).

In this model, we will add all the configuration steps in the config suite; in the test suite, we will integrate the tests proper and the minimal configuration support (our own fixture).