### PR TITLE
e2e:serial: modify kubeletconfig while TAS is running

### DIFF
--- a/pkg/kubeletconfig/kubeletconfig.go
+++ b/pkg/kubeletconfig/kubeletconfig.go
@@ -29,3 +29,9 @@ func MCOKubeletConfToKubeletConf(mcoKc *mcov1.KubeletConfig) (*kubeletconfigv1be
 	err := json.Unmarshal(mcoKc.Spec.KubeletConfig.Raw, kc)
 	return kc, err
 }
+
+func KubeletConfToMCKubeletConf(kcObj *kubeletconfigv1beta1.KubeletConfiguration, kcAsMc *mcov1.KubeletConfig) error {
+	rawKc, err := json.Marshal(kcObj)
+	kcAsMc.Spec.KubeletConfig.Raw = rawKc
+	return err
+}


### PR DESCRIPTION
This test ensure that TAS knows how to handle and respond to live kubeletconfig changes while it's already running

Signed-off-by: Talor Itzhak <titzhak@redhat.com>