### PR TITLE
WIP: e2e: sched: install better error reporting

### DIFF
--- a/test/e2e/sched/install/install_test.go
+++ b/test/e2e/sched/install/install_test.go
@@ -23,6 +23,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -35,12 +36,18 @@ import (
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
 	"github.com/openshift-kni/numaresources-operator/test/utils/crds"
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
+	e2ewait "github.com/openshift-kni/numaresources-operator/test/utils/objects/wait"
 )
 
 var _ = Describe("[Scheduler] install", func() {
 	Context("with a running cluster with all the components", func() {
 		It("[test_id:48598][tier2] should perform the scheduler deployment and verify the condition is reported as available", func() {
 			var err error
+
+			By("checking the NumaResourcesScheduler CRD is deployed")
+			_, err = crds.GetByName(e2eclient.Client, crds.CrdNROSName)
+			Expect(err).NotTo(HaveOccurred())
+
 			nroSchedObj := objects.TestNROScheduler()
 
 			By(fmt.Sprintf("creating the NRO Scheduler object: %s", nroSchedObj.Name))
@@ -50,46 +57,60 @@ var _ = Describe("[Scheduler] install", func() {
 			err = e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroSchedObj), nroSchedObj)
 			Expect(err).NotTo(HaveOccurred())
 
+			// if there is a valid object, there MUST be a deployment - perhaps not ready, but still the
+			// deployment object proper must exist
+			schedDp, err := schedutils.GetDeploymentByNROSched(nroSchedObj)
+			Expect(err).NotTo(HaveOccurred())
+
 			By("checking that the condition Available=true")
-			Eventually(func() bool {
+			schedAvailable := false
+			err = wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
 				updatedNROObj := &nropv1alpha1.NUMAResourcesScheduler{}
 				err := e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroSchedObj), updatedNROObj)
 				if err != nil {
 					klog.Warningf("failed to get the NRO Scheduler resource: %v", err)
-					return false
+					return false, err
 				}
 
 				cond := status.FindCondition(updatedNROObj.Status.Conditions, status.ConditionAvailable)
 				if cond == nil {
 					klog.Warningf("missing conditions in %v", updatedNROObj)
-					return false
+					return false, nil
 				}
 
 				klog.Infof("condition: %v", cond)
 
-				return cond.Status == metav1.ConditionTrue
-			}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "NRO Scheduler condition did not become available")
+				schedAvailable = (cond.Status == metav1.ConditionTrue)
+				return schedAvailable, nil
+			})
+			if !schedAvailable {
+				_ = logEventsForPodsInDeployment(schedDp.Namespace, schedDp.Name)
+			}
+			Expect(schedAvailable).Should(BeTrue(), "NRO Scheduler condition did not become available")
 
 			err = e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroSchedObj), nroSchedObj)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("checking the NumaResourcesScheduler Deployment is correctly deployed")
-			const deploymentCheckTimeout = 5 * time.Minute
-			const deploymentCheckPollPeriod = 10 * time.Second
 			deployment := &appsv1.Deployment{}
-			Eventually(func() bool {
-				deployment, err = schedutils.GetDeploymentByOwnerReference(nroSchedObj.UID)
+			schedDpComplete := false
+			err = wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
+				deployment, err = schedutils.GetDeploymentByNROSched(nroSchedObj)
 				if err != nil {
 					klog.Warningf("unable to get deployment by owner reference: %v", err)
-					return false
+					return false, err
 				}
 
-				if deployment.Status.ReadyReplicas != *deployment.Spec.Replicas {
-					klog.Warningf("Invalid number of ready replicas: desired: %d, actual: %d", *deployment.Spec.Replicas, deployment.Status.ReadyReplicas)
-					return false
+				if !e2ewait.IsDeploymentComplete(schedDp, &deployment.Status) {
+					klog.Warningf("Deployment %s/%s not yet complete", deployment.Namespace, deployment.Name)
+					return false, nil
 				}
-				return true
-			}, deploymentCheckTimeout, deploymentCheckPollPeriod).Should(BeTrue(), "Deployment Status not OK")
+				return true, nil
+			})
+			if !schedDpComplete {
+				_ = logEventsForPodsInDeployment(deployment.Namespace, deployment.Name)
+			}
+			Expect(schedDpComplete).To(BeTrue(), "Deployment Status not OK")
 
 			By("Check secondary scheduler pod is scheduled on a control-plane node")
 			podList, err := schedutils.ListPodsByDeployment(e2eclient.Client, *deployment)
@@ -103,10 +124,27 @@ var _ = Describe("[Scheduler] install", func() {
 			for _, pod := range podList {
 				Expect(pod.Spec.NodeName).To(BeElementOf(nodeNames), "pod: %q landed on node: %q, which is not part of the master nodes group: %v", pod.Name, pod.Spec.NodeName, nodeNames)
 			}
-
-			By("checking the NumaResourcesScheduler CRD is deployed")
-			_, err = crds.GetByName(e2eclient.Client, crds.CrdNROSName)
-			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })
+
+func logEventsForPodsInDeployment(dpNamespace, dpName string) error {
+	dp := appsv1.Deployment{}
+	err := e2eclient.Client.Get(context.TODO(), client.ObjectKey{Namespace: dpNamespace, Name: dpName}, &dp)
+	if err != nil {
+		klog.ErrorS(err, "cannot get deployment %s/%s", dpNamespace, dpName)
+		return err
+	}
+
+	// TODO: log events for Deployment
+
+	podList, err := schedutils.ListPodsByDeployment(e2eclient.Client, dp)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	for _, pod := range podList {
+		err = objects.LogEvents(e2eclient.K8sClient, "Pod", pod.Namespace, pod.Name)
+		if err != nil {
+			klog.Warningf("error getting events for pod %s/%s: %v - SKIPPED", pod.Namespace, pod.Name, err)
+		}
+	}
+	return nil
+}

--- a/test/utils/objects/events.go
+++ b/test/utils/objects/events.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objects
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+func LogEvents(k8sCli *kubernetes.Clientset, kind, namespace, name string) error {
+	klog.Infof("checking events for pod %s/%s", namespace, name)
+	opts := metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("involvedObject.name=%s", name),
+		TypeMeta:      metav1.TypeMeta{Kind: kind},
+	}
+	events, err := k8sCli.CoreV1().Events(namespace).List(context.TODO(), opts)
+	if err != nil {
+		klog.ErrorS(err, "cannot get events for %s %s/%s", kind, namespace, name)
+		return err
+	}
+	klog.Infof("begin events for %s/%s", namespace, name)
+	for _, item := range events.Items {
+		klog.Infof("+- event: %s %s: %s %s", item.Type, item.ReportingController, item.Reason, item.Message)
+	}
+	klog.Infof("end events for %s/%s", namespace, name)
+	return nil
+}

--- a/test/utils/objects/pod.go
+++ b/test/utils/objects/pod.go
@@ -17,13 +17,9 @@ limitations under the License.
 package objects
 
 import (
-	"context"
-	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 
 	"github.com/openshift-kni/numaresources-operator/test/utils/images"
 )
@@ -49,20 +45,5 @@ func NewTestPodPause(namespace, name string) *corev1.Pod {
 }
 
 func LogEventsForPod(k8sCli *kubernetes.Clientset, podNamespace, podName string) error {
-	klog.Infof("checking events for pod %s/%s", podNamespace, podName)
-	opts := metav1.ListOptions{
-		FieldSelector: fmt.Sprintf("involvedObject.name=%s", podName),
-		TypeMeta:      metav1.TypeMeta{Kind: "Pod"},
-	}
-	events, err := k8sCli.CoreV1().Events(podNamespace).List(context.TODO(), opts)
-	if err != nil {
-		klog.ErrorS(err, "cannot get events for pod %s/%s", podNamespace, podName)
-		return err
-	}
-	klog.Infof("begin events for %s/%s", podNamespace, podName)
-	for _, item := range events.Items {
-		klog.Infof("+- event: %s %s: %s %s", item.Type, item.ReportingController, item.Reason, item.Message)
-	}
-	klog.Infof("end events for %s/%s", podNamespace, podName)
-	return nil
+	return LogEvents(k8sCli, "Pod", podNamespace, podName)
 }


### PR DESCRIPTION
Improving the error reporting when the test fails,
adding the event dump of the relevant object.
The test proper should be equivalent, but we want
to make the troubleshooting easier.

Signed-off-by: Francesco Romani <fromani@redhat.com>