### PR TITLE
serial: add events reporting for failing pods

### DIFF
--- a/internal/baseload/baseload.go
+++ b/internal/baseload/baseload.go
@@ -81,8 +81,8 @@ func (nl Load) String() string {
 	return fmt.Sprintf("load for node %q: CPU=%s Memory=%s", nl.Name, nl.CPU.String(), nl.Memory.String())
 }
 
-// Apply adjust the given ResourceList with the current node load, mutating
-// the parameter in place and also returning the updated value.
+// Apply adjust the given ResourceList with the current node load by mutating
+// the parameter in place
 func (nl Load) Apply(res corev1.ResourceList) {
 	adjustedCPU := res.Cpu()
 	adjustedCPU.Add(nl.CPU)
@@ -93,8 +93,8 @@ func (nl Load) Apply(res corev1.ResourceList) {
 	res[corev1.ResourceMemory] = *adjustedMemory
 }
 
-// Deduct subtract the current node load from the given ResourceList, mutating
-// the parameter in place and also returning the updated value.
+// Deduct subtract the current node load from the given ResourceList by mutating
+// the parameter in place
 func (nl Load) Deduct(res corev1.ResourceList) {
 	adjustedCPU := res.Cpu()
 	adjustedCPU.Sub(nl.CPU)

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -347,6 +347,9 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 			Expect(err).ToNot(HaveOccurred())
 
 			updatedPod, err := e2ewait.ForPodPhase(fxt.Client, testPod.Namespace, testPod.Name, corev1.PodRunning, 5*time.Minute)
+			if err != nil {
+				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
+			}
 			Expect(err).ToNot(HaveOccurred())
 
 			schedOK, err := nrosched.CheckPODWasScheduledWith(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.SchedulerTestName)
@@ -465,6 +468,9 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 			Expect(err).ToNot(HaveOccurred())
 
 			testPod, err = e2ewait.ForPodPhase(fxt.Client, testPod.Namespace, testPod.Name, corev1.PodRunning, timeout)
+			if err != nil {
+				_ = objects.LogEventsForPod(fxt.K8sClient, testPod.Namespace, testPod.Name)
+			}
 			Expect(err).ToNot(HaveOccurred())
 
 			By(fmt.Sprintf("checking the pod was scheduled with the topology aware scheduler %q", schedulerName))

--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -146,6 +146,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			updatedPod, err := e2ewait.ForPodPhase(fxt.Client, testPod.Namespace, testPod.Name, corev1.PodRunning, timeout)
+			if err != nil {
+				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
+			}
 			Expect(err).ToNot(HaveOccurred())
 
 			By(fmt.Sprintf("checking the pod landed on the target node %q vs %q", updatedPod.Spec.NodeName, targetedNodeName))

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -257,6 +257,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload resourc
 
 			By("waiting for the pod to be scheduled")
 			updatedPod, err := e2ewait.ForPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodRunning, 3*time.Minute)
+			if err != nil {
+				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
+			}
 			Expect(err).ToNot(HaveOccurred())
 
 			By(fmt.Sprintf("checking the pod landed on the target node %q vs %q", updatedPod.Spec.NodeName, targetNodeName))

--- a/test/e2e/serial/tests/sched_removal.go
+++ b/test/e2e/serial/tests/sched_removal.go
@@ -201,9 +201,12 @@ func createDeployment(fxt *e2efixture.Fixture, name, schedulerName string) *apps
 }
 
 func createDeploymentSync(fxt *e2efixture.Fixture, name, schedulerName string) *appsv1.Deployment {
+	dpRunningTimeout := time.Minute
+	dpRunningPollInterval := 10 * time.Second
 	dp := createDeployment(fxt, name, schedulerName)
 	By(fmt.Sprintf("waiting for the test deployment %q to be complete and ready", name))
-	err := e2ewait.ForDeploymentComplete(fxt.Client, dp, 2*time.Second, 30*time.Second)
-	Expect(err).ToNot(HaveOccurred())
+
+	err := e2ewait.ForDeploymentComplete(fxt.Client, dp, dpRunningPollInterval, dpRunningTimeout)
+	Expect(err).ToNot(HaveOccurred(), "Deployment %q is not up & running after %v", dp.Name, dpRunningTimeout)
 	return dp
 }

--- a/test/e2e/serial/tests/workload_placement_nodesel.go
+++ b/test/e2e/serial/tests/workload_placement_nodesel.go
@@ -159,13 +159,13 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				for zidx, zone := range nrtInfo.Zones {
 					podName := fmt.Sprintf("padding%d-%d", nidx, zidx)
 					padPod, err := makePaddingPod(fxt.Namespace.Name, podName, zone, paddingRes)
-					Expect(err).NotTo(HaveOccurred(), "unable to create padding pod %q on zone", podName, zone.Name)
+					Expect(err).NotTo(HaveOccurred(), "unable to create padding pod %q on zone %q", podName, zone.Name)
 
 					padPod, err = pinPodTo(padPod, nodeName, zone.Name)
-					Expect(err).NotTo(HaveOccurred(), "unable to pin pod %q to zone", podName, zone.Name)
+					Expect(err).NotTo(HaveOccurred(), "unable to pin pod %q to zone %q", podName, zone.Name)
 
 					err = fxt.Client.Create(context.TODO(), padPod)
-					Expect(err).NotTo(HaveOccurred(), "unable to create pod %q on zone", podName, zone.Name)
+					Expect(err).NotTo(HaveOccurred(), "unable to create pod %q on zone %q", podName, zone.Name)
 
 					paddingPods = append(paddingPods, padPod)
 				}
@@ -193,6 +193,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			By("waiting for node to be up&running")
 			podRunningTimeout := 1 * time.Minute
 			updatedPod, err := e2ewait.ForPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodRunning, podRunningTimeout)
+			if err != nil {
+				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
+			}
 			Expect(err).NotTo(HaveOccurred(), "Pod %q not up&running after %v", pod.Name, podRunningTimeout)
 
 			By("checking the pod has been scheduled in the proper node")

--- a/test/e2e/serial/tests/workload_placement_taint.go
+++ b/test/e2e/serial/tests/workload_placement_taint.go
@@ -192,6 +192,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			updatedPod, err := e2ewait.ForPodPhase(fxt.Client, testPod.Namespace, testPod.Name, corev1.PodRunning, timeout)
+			if err != nil {
+				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
+			}
 			Expect(err).ToNot(HaveOccurred())
 
 			By(fmt.Sprintf("checking the pod landed on the target node %q vs %q", updatedPod.Spec.NodeName, targetNodeName))


### PR DESCRIPTION
Add events reporting of the failing pods to simplify debugging test failures when needed.