### PR TITLE
e2e: remove opt-in skip in the node-selector workload placement test

### DIFF
--- a/test/e2e/serial/tests/workload_placement_nodesel.go
+++ b/test/e2e/serial/tests/workload_placement_nodesel.go
@@ -27,6 +27,7 @@ import (
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 	e2efixture "github.com/openshift-kni/numaresources-operator/test/utils/fixture"
 	e2enrt "github.com/openshift-kni/numaresources-operator/test/utils/noderesourcetopologies"
+	"github.com/openshift-kni/numaresources-operator/test/utils/nodes"
 	"github.com/openshift-kni/numaresources-operator/test/utils/nrosched"
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 	e2ewait "github.com/openshift-kni/numaresources-operator/test/utils/objects/wait"
@@ -94,9 +95,15 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				Skip(fmt.Sprintf("not enough nodes with %d NUMA Zones: found %d, needed %d", requiredNUMAZones, len(nrtCandidates), neededNodes))
 			}
 
+			// TODO: this should be >= 5 baseload
 			requiredRes := corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("1000Mi"),
+				corev1.ResourceCPU:    resource.MustParse("16"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+			}
+			// WARNING: This should be calculated as 3/4 of requiredRes
+			paddingRes := corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("12"),
+				corev1.ResourceMemory: resource.MustParse("12Gi"),
 			}
 
 			By("filtering available nodes with allocatable resources on at least one NUMA zone that can match request")
@@ -144,21 +151,23 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			// we nee to also pad one of the labeled nodes.
 			nrtToPadNames := append(nrtCandidateNames.List(), toAlsoLabelNodeName)
 
-			// WARNING: This should be calculated as 3/4 of requiredRes
-			paddingRes := corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("750m"),
-				corev1.ResourceMemory: resource.MustParse("750Mi"),
-			}
-
 			var paddingPods []*corev1.Pod
-			for nidx, nodeName := range nrtToPadNames {
+			for nIdx, nodeName := range nrtToPadNames {
 
 				nrtInfo, err := e2enrt.FindFromList(nrtCandidates, nodeName)
 				Expect(err).NotTo(HaveOccurred(), "missing NRT info for %q", nodeName)
 
-				for zidx, zone := range nrtInfo.Zones {
-					podName := fmt.Sprintf("padding%d-%d", nidx, zidx)
-					padPod, err := makePaddingPod(fxt.Namespace.Name, podName, zone, paddingRes)
+				baseload, err := nodes.GetLoad(fxt.K8sClient, nodeName)
+				Expect(err).NotTo(HaveOccurred(), "cannot get the base load for %q", nodeName)
+
+				for zIdx, zone := range nrtInfo.Zones {
+					zoneRes := paddingRes.DeepCopy() // to be extra safe
+					if zIdx == 0 {                   // any zone is fine
+						baseload.Apply(zoneRes)
+					}
+
+					podName := fmt.Sprintf("padding%d-%d", nIdx, zIdx)
+					padPod, err := makePaddingPod(fxt.Namespace.Name, podName, zone, zoneRes)
 					Expect(err).NotTo(HaveOccurred(), "unable to create padding pod %q on zone %q", podName, zone.Name)
 
 					padPod, err = pinPodTo(padPod, nodeName, zone.Name)
@@ -190,13 +199,12 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			err = fxt.Client.Create(context.TODO(), pod)
 			Expect(err).NotTo(HaveOccurred(), "unable to create pod %q", pod.Name)
 
-			By("waiting for node to be up&running")
-			podRunningTimeout := 1 * time.Minute
-			updatedPod, err := e2ewait.ForPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodRunning, podRunningTimeout)
+			By("waiting for pod to be running")
+			updatedPod, err := e2ewait.ForPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodRunning, 1*time.Minute)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
 			}
-			Expect(err).NotTo(HaveOccurred(), "Pod %q not up&running after %v", pod.Name, podRunningTimeout)
+			Expect(err).NotTo(HaveOccurred())
 
 			By("checking the pod has been scheduled in the proper node")
 			Expect(updatedPod.Spec.NodeName).To(Equal(targetNodeName))

--- a/test/e2e/serial/tests/workload_placement_nodesel.go
+++ b/test/e2e/serial/tests/workload_placement_nodesel.go
@@ -111,11 +111,11 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			// and the other one will not have enough resources on only one numa zone
 			// but will fulfill the node selector filter.
 			targetNodeName, ok := nrtCandidateNames.PopAny()
-			Expect(ok).To(BeTrue(), "cannot select a targe node among %#v", nrtCandidateNames.List())
+			Expect(ok).To(BeTrue(), "cannot select a target node among %#v", nrtCandidateNames.List())
 			By(fmt.Sprintf("selecting node to schedule the pod: %q", targetNodeName))
 
 			toAlsoLabelNodeName, ok := nrtCandidateNames.PopAny()
-			Expect(ok).To(BeTrue(), "cannot select a targe node among %#v", nrtCandidateNames.List())
+			Expect(ok).To(BeTrue(), "cannot select a target node among %#v", nrtCandidateNames.List())
 			By(fmt.Sprintf("selecting node to schedule the pod: %q", toAlsoLabelNodeName))
 
 			labelName := "size"
@@ -127,7 +127,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			defer func() {
 				err := unlabelOneFunc()
 				if err != nil {
-					klog.Errorf("Error while trying to unlable node %q. %v", targetNodeName, err)
+					klog.Errorf("Error while trying to unlabel node %q. %v", targetNodeName, err)
 				}
 			}()
 
@@ -136,7 +136,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			defer func() {
 				err := unlabelTwoFunc()
 				if err != nil {
-					klog.Errorf("Error while trying to unlable node %q. %v", toAlsoLabelNodeName, err)
+					klog.Errorf("Error while trying to unlabel node %q. %v", toAlsoLabelNodeName, err)
 				}
 			}()
 
@@ -180,7 +180,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(failedPods).To(BeEmpty(), "some padding pods have failed to run")
 
 			By("Scheduling the testing pod")
-			pod := objects.NewTestPodPause(fxt.Namespace.Name, "testPod")
+			pod := objects.NewTestPodPause(fxt.Namespace.Name, "testpod")
 			pod.Spec.SchedulerName = serialconfig.Config.SchedulerName
 			pod.Spec.Containers[0].Resources.Limits = requiredRes
 			pod.Spec.NodeSelector = map[string]string{

--- a/test/e2e/serial/tests/workload_placement_nodesel.go
+++ b/test/e2e/serial/tests/workload_placement_nodesel.go
@@ -83,9 +83,6 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 	// and will we want to start lean and mean.
 	Context("with two nodes with two NUMA zones", func() {
 		It("[test_id:47598][tier2] should place the pod in the node with available resources in one NUMA zone and fulfilling node selector", func() {
-
-			skipUnlessEnvVar("E2E_SERIAL_STAGING", "FIXME: NRT filter clashes with the noderesources fit plugin")
-
 			requiredNUMAZones := 2
 			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", requiredNUMAZones))
 			nrtCandidates := e2enrt.FilterZoneCountEqual(nrts, requiredNUMAZones)

--- a/test/e2e/serial/tests/workload_placement_nodesel.go
+++ b/test/e2e/serial/tests/workload_placement_nodesel.go
@@ -122,7 +122,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			labelValue := "medium"
 			By(fmt.Sprintf("Labeling nodes %q and %q with label %q:%q", targetNodeName, toAlsoLabelNodeName, labelName, labelValue))
 
-			unlabelOneFunc, err := labelNodeWithValue(fxt.Client, labelName, labelName, targetNodeName)
+			unlabelOneFunc, err := labelNodeWithValue(fxt.Client, labelName, labelValue, targetNodeName)
 			Expect(err).NotTo(HaveOccurred(), "unable to label node %q", targetNodeName)
 			defer func() {
 				err := unlabelOneFunc()
@@ -131,7 +131,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				}
 			}()
 
-			unlabelTwoFunc, err := labelNodeWithValue(fxt.Client, labelName, labelName, toAlsoLabelNodeName)
+			unlabelTwoFunc, err := labelNodeWithValue(fxt.Client, labelName, labelValue, toAlsoLabelNodeName)
 			Expect(err).NotTo(HaveOccurred(), "unable to label node %q", toAlsoLabelNodeName)
 			defer func() {
 				err := unlabelTwoFunc()


### PR DESCRIPTION
Add the fixes which allow us to always run this test, so removing the opt-in skip.
See individual patches for details.