### PR TITLE
gh actions: split the CI static check lanes

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -1,4 +1,4 @@
-name: CI Go
+name: CI Build
 
 on:
   push:
@@ -11,33 +11,6 @@ defaults:
     shell: bash
 
 jobs:
-  lint:
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v2
-
-    - name: Verify
-      uses: golangci/golangci-lint-action@v2
-      with:
-        version: v1.41.1
-        args: --timeout=15m0s --verbose
-
-  format:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-
-    - name: set up golang
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.17
-
-    - name: format
-      run: ./hack/check-format.sh
-
   build:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/ciformat.yml
+++ b/.github/workflows/ciformat.yml
@@ -1,0 +1,27 @@
+name: CI Format
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  format:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: set up golang
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - name: format
+      run: ./hack/check-format.sh

--- a/.github/workflows/cilint.yml
+++ b/.github/workflows/cilint.yml
@@ -20,5 +20,5 @@ jobs:
     - name: Verify
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.41.1
+        version: v1.42.1
         args: --timeout=15m0s --verbose

--- a/.github/workflows/cilint.yml
+++ b/.github/workflows/cilint.yml
@@ -1,0 +1,24 @@
+name: CI Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  golint:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Verify
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.41.1
+        args: --timeout=15m0s --verbose


### PR DESCRIPTION
First and foremost, we do this to get rid of the annoying
cache corruption issue we hit lately.
The end result should be the same, no intended changes in behaviour.

Signed-off-by: Francesco Romani <fromani@redhat.com>