### PR TITLE
gh actions: add lane avoiding the gh actions lint

### DIFF
--- a/.github/workflows/cilint-custom.yml
+++ b/.github/workflows/cilint-custom.yml
@@ -1,0 +1,34 @@
+name: CI Lint custom
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  golint:
+    runs-on: ubuntu-20.04
+    env:
+      GOLANGCI_LINT_VERSION: "1.41.1"
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Set up golang
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - name: Fetch golangci-lint
+      run: |
+        curl -L -o golangci-lint.tar.gz https://github.com/golangci/golangci-lint/releases/download/v$GOLANGCI_LINT_VERSION/golangci-lint-$GOLANGCI_LINT_VERSION-linux-amd64.tar.gz
+        tar zxvf golangci-lint.tar.gz
+
+    - name: Verify
+      run: |
+        ./golangci-lint-$GOLANGCI_LINT_VERSION-linux-amd64/golangci-lint run --timeout=15m0s --verbose --out-format=github-actions


### PR DESCRIPTION
Since golangci-lint "works on my machine", let's try the same steps on CI.

Signed-off-by: Francesco Romani <fromani@redhat.com>