### PR TITLE
loglevel: rewrite log message

### DIFF
--- a/pkg/loglevel/loglevel.go
+++ b/pkg/loglevel/loglevel.go
@@ -55,7 +55,7 @@ func UpdatePodSpec(podSpec *corev1.PodSpec, level operatorv1.LogLevel) error {
 		return fmt.Errorf("cannot modify the arguments for container %s", cnt.Name)
 	}
 	flags.SetOption("--v", kLog.String())
-	klog.InfoS("RTE container klog level", "container", cnt.Name, "--v", kLog.String())
+	klog.InfoS("container klog level", "container", cnt.Name, "--v", kLog.String())
 	cnt.Args = flags.Argv()
 	return nil
 }


### PR DESCRIPTION
The word RTE in the log line is a bit misleading since this not always and RTE container, there are times when it's the scheduler container which gets updated.
We know which container got updated because the container name is part of the log message.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>