### PR TITLE
e2e: serial: remove skip if `E2E_SERIAL_STAGING` variable set

### DIFF
--- a/internal/baseload/baseload.go
+++ b/internal/baseload/baseload.go
@@ -68,13 +68,11 @@ func (nl Load) Round() Load {
 	// OTOH
 	// roundUp(2900, 2000) -> 4000 -> 4000/1000 -> 4 (intended behaviour).
 	// Value() round up the millis and roundUp rounds it up to multiples of 2 if needed.
-	memory := nl.Memory
-	// FIXME: this rounds to G (1000) not to Gi (1024) which works but is not what we intended
-	memory.RoundUp(resource.Giga)
+	cpu, mem := resourcelist.RoundUpCoreResources(nl.CPU, nl.Memory)
 	return Load{
 		Name:   nl.Name,
-		CPU:    *resource.NewQuantity(roundUp(nl.CPU.Value(), 2), resource.DecimalSI),
-		Memory: memory,
+		CPU:    cpu,
+		Memory: mem,
 	}
 }
 
@@ -98,8 +96,4 @@ func (nl Load) Deduct(res corev1.ResourceList) {
 	adjustedMemory := res.Memory()
 	adjustedMemory.Sub(nl.Memory)
 	res[corev1.ResourceMemory] = *adjustedMemory
-}
-
-func roundUp(num, multiple int64) int64 {
-	return ((num + multiple - 1) / multiple) * multiple
 }

--- a/internal/baseload/baseload.go
+++ b/internal/baseload/baseload.go
@@ -21,6 +21,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 )
 
 // we don't use corev1.ResourceList because we need values for CPU and Memory
@@ -83,13 +85,7 @@ func (nl Load) String() string {
 // Apply adjust the given ResourceList with the current node load by mutating
 // the parameter in place
 func (nl Load) Apply(res corev1.ResourceList) {
-	adjustedCPU := res.Cpu()
-	adjustedCPU.Add(nl.CPU)
-	res[corev1.ResourceCPU] = *adjustedCPU
-
-	adjustedMemory := res.Memory()
-	adjustedMemory.Add(nl.Memory)
-	res[corev1.ResourceMemory] = *adjustedMemory
+	resourcelist.AddCoreResources(res, nl.CPU, nl.Memory)
 }
 
 // Deduct subtract the current node load from the given ResourceList by mutating

--- a/internal/resourcelist/resourcelist.go
+++ b/internal/resourcelist/resourcelist.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func ToString(res corev1.ResourceList) string {
@@ -52,4 +53,14 @@ func FromGuaranteedPod(pod corev1.Pod) corev1.ResourceList {
 		}
 	}
 	return res
+}
+
+func AddCoreResources(res corev1.ResourceList, cpu, mem resource.Quantity) {
+	adjustedCPU := res.Cpu()
+	adjustedCPU.Add(cpu)
+	res[corev1.ResourceCPU] = *adjustedCPU
+
+	adjustedMemory := res.Memory()
+	adjustedMemory.Add(mem)
+	res[corev1.ResourceMemory] = *adjustedMemory
 }

--- a/internal/resourcelist/resourcelist.go
+++ b/internal/resourcelist/resourcelist.go
@@ -64,3 +64,15 @@ func AddCoreResources(res corev1.ResourceList, cpu, mem resource.Quantity) {
 	adjustedMemory.Add(mem)
 	res[corev1.ResourceMemory] = *adjustedMemory
 }
+
+func RoundUpCoreResources(cpu, mem resource.Quantity) (resource.Quantity, resource.Quantity) {
+	retCpu := *resource.NewQuantity(roundUp(cpu.Value(), 2), resource.DecimalSI)
+	retMem := mem.DeepCopy() // TODO: this is out of over caution
+	// FIXME: this rounds to G (1000) not to Gi (1024) which works but is not what we intended
+	retMem.RoundUp(resource.Giga)
+	return retCpu, retMem
+}
+
+func roundUp(num, multiple int64) int64 {
+	return ((num + multiple - 1) / multiple) * multiple
+}

--- a/internal/resourcelist/resourcelist_test.go
+++ b/internal/resourcelist/resourcelist_test.go
@@ -112,3 +112,45 @@ func TestAddCoreResources(t *testing.T) {
 		})
 	}
 }
+
+func TestRoundUpCoreResources(t *testing.T) {
+	type testCase struct {
+		cpu         resource.Quantity
+		mem         resource.Quantity
+		expectedCpu resource.Quantity
+		expectedMem resource.Quantity
+	}
+
+	testCases := []testCase{
+		{
+			cpu:         resource.MustParse("1"),
+			mem:         resource.MustParse("2Gi"),
+			expectedCpu: resource.MustParse("2"),
+			expectedMem: resource.MustParse("3G"),
+		},
+		{
+			cpu:         resource.MustParse("2"),
+			mem:         resource.MustParse("2Gi"),
+			expectedCpu: resource.MustParse("2"),
+			expectedMem: resource.MustParse("3G"),
+		},
+		{
+			cpu:         resource.MustParse("3"),
+			mem:         resource.MustParse("4Gi"),
+			expectedCpu: resource.MustParse("4"),
+			expectedMem: resource.MustParse("5G"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			gotCpu, gotMem := RoundUpCoreResources(tc.cpu, tc.mem)
+			if gotCpu.Cmp(tc.expectedCpu) != 0 {
+				t.Errorf("expected CPU %v got %v", tc.expectedCpu, gotCpu)
+			}
+			if gotMem.Cmp(tc.expectedMem) != 0 {
+				t.Errorf("expected Memory %v got %v", tc.expectedMem, gotMem)
+			}
+		})
+	}
+}

--- a/internal/resourcelist/resourcelist_test.go
+++ b/internal/resourcelist/resourcelist_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func TestRound(t *testing.T) {
+func TestToString(t *testing.T) {
 	type testCase struct {
 		data     corev1.ResourceList
 		expected string
@@ -71,6 +71,43 @@ func TestRound(t *testing.T) {
 			got := ToString(tc.data)
 			if got != tc.expected {
 				t.Errorf("expected %q got %q", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestAddCoreResources(t *testing.T) {
+	type testCase struct {
+		res      corev1.ResourceList
+		cpu      resource.Quantity
+		mem      resource.Quantity
+		expected corev1.ResourceList
+	}
+
+	testCases := []testCase{
+		{
+			res: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			cpu: resource.MustParse("2"),
+			mem: resource.MustParse("2Gi"),
+			expected: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("3"),
+				corev1.ResourceMemory: resource.MustParse("3Gi"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(ToString(tc.expected), func(t *testing.T) {
+			res := tc.res.DeepCopy()
+			AddCoreResources(res, tc.cpu, tc.mem)
+			// comparing strings it just easier
+			got := ToString(res)
+			expected := ToString(tc.expected)
+			if got != expected {
+				t.Errorf("expected %q got %q", expected, got)
 			}
 		})
 	}

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -135,8 +135,6 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 			})
 			It("[test_id:47582][tier2] schedule a guaranteed Pod in a single NUMA zone and check overhead is not accounted in NRT", func() {
 
-				skipUnlessEnvVar("E2E_SERIAL_STAGING", "FIXME: NRT filter clashes with the noderesources fit plugin")
-
 				// even if it is not a hard rule, and even if there are a LOT of edge cases, a good starting point is usually
 				// in the ballpark of 5x the base load. We start like this
 				podResources := corev1.ResourceList{

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -19,8 +19,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	"os"
-	"strconv"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -607,23 +605,4 @@ func matchLogLevelToKlog(cnt *corev1.Container, level operatorv1.LogLevel) (bool
 
 	val, found := rteFlags.GetFlag("--v")
 	return found, val.Data == kLvl.String()
-}
-
-func skipUnlessEnvVar(envVar, message string) {
-	if isEnvTrue(envVar) {
-		return
-	}
-	Skip(message, 1)
-}
-
-func isEnvTrue(envVar string) bool {
-	val, ok := os.LookupEnv(envVar)
-	if !ok {
-		return false
-	}
-	enabled, err := strconv.ParseBool(val)
-	if err != nil {
-		return false
-	}
-	return enabled
 }

--- a/test/utils/noderesourcetopologies/noderesourcetopologies.go
+++ b/test/utils/noderesourcetopologies/noderesourcetopologies.go
@@ -232,7 +232,7 @@ func FilterAnyZoneMatchingResources(nrts []nrtv1alpha1.NodeResourceTopology, req
 	for _, nrt := range nrts {
 		matches := 0
 		for _, zone := range nrt.Zones {
-			klog.Infof(" ----> node %q zone %q provides %s requrst %s", nrt.Name, zone.Name, e2ereslist.ToString(AvailableFromZone(zone)), reqStr)
+			klog.Infof(" ----> node %q zone %q provides %s request %s", nrt.Name, zone.Name, e2ereslist.ToString(AvailableFromZone(zone)), reqStr)
 			if !ZoneResourcesMatchesRequest(zone.Resources, requests) {
 				continue
 			}


### PR DESCRIPTION
fix the pod overhead test. This also allows to remove the last `E2E_SERIAL_STAGING` instance.