### PR TITLE
e2e: serial: config: clean up config API

### DIFF
--- a/test/e2e/serial/config/config.go
+++ b/test/e2e/serial/config/config.go
@@ -35,10 +35,8 @@ const (
 // and indisturbed on the cluster. No concurrency at all is possible,
 // each test "owns" the cluster - but again, must leave no leftovers.
 
-var Config *E2EConfig
-
 func Setup() {
-	Config = SetupFixture()
+	SetupFixture()
 	SetupInfra(Config.Fixture, Config.NROOperObj, Config.NRTList)
 }
 
@@ -48,5 +46,5 @@ func Teardown() {
 	}
 	TeardownInfra(Config.Fixture, Config.NRTList)
 	// numacell daemonset automatically cleaned up when we remove the namespace
-	TeardownFixture(Config)
+	TeardownFixture()
 }

--- a/test/e2e/serial/config/fixture.go
+++ b/test/e2e/serial/config/fixture.go
@@ -41,11 +41,18 @@ type E2EConfig struct {
 	SchedulerName string
 }
 
-func SetupFixture() *E2EConfig {
-	return SetupFixtureWithOptions("e2e-test-infra", e2efixture.OptionRandomizeName)
+var Config *E2EConfig
+
+func SetupFixture() {
+	Config = NewFixtureWithOptions("e2e-test-infra", e2efixture.OptionRandomizeName)
 }
 
-func SetupFixtureWithOptions(nsName string, options e2efixture.Options) *E2EConfig {
+func TeardownFixture() {
+	err := e2efixture.Teardown(Config.Fixture)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func NewFixtureWithOptions(nsName string, options e2efixture.Options) *E2EConfig {
 	var err error
 	cfg := E2EConfig{
 		NROOperObj:  &nropv1alpha1.NUMAResourcesOperator{},
@@ -71,9 +78,4 @@ func SetupFixtureWithOptions(nsName string, options e2efixture.Options) *E2EConf
 	klog.Infof("scheduler name: %q", cfg.SchedulerName)
 
 	return &cfg
-}
-
-func TeardownFixture(cfg *E2EConfig) {
-	err := e2efixture.Teardown(cfg.Fixture)
-	Expect(err).NotTo(HaveOccurred())
 }


### PR DESCRIPTION
The `config` module is in a bit of awkward state, with functions
partially manipulating the global state and partially trying to
avoid it. However, this module holds and manages global state,
so let's just embrace this requirement and have {Setup,Teardown}Fixture
functions always operating on the global state.

Signed-off-by: Francesco Romani <fromani@redhat.com>