### PR TITLE
e2e: serial: config module modularization (take 2)

### DIFF
--- a/test/e2e/serial/config/config.go
+++ b/test/e2e/serial/config/config.go
@@ -18,6 +18,8 @@ package config
 
 import (
 	"os"
+
+	. "github.com/onsi/gomega"
 )
 
 const (
@@ -36,7 +38,9 @@ const (
 // each test "owns" the cluster - but again, must leave no leftovers.
 
 func Setup() {
-	SetupFixture()
+	err := SetupFixture()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 	SetupInfra(Config.Fixture, Config.NROOperObj, Config.NRTList)
 }
 
@@ -46,5 +50,6 @@ func Teardown() {
 	}
 	TeardownInfra(Config.Fixture, Config.NRTList)
 	// numacell daemonset automatically cleaned up when we remove the namespace
-	TeardownFixture()
+	err := TeardownFixture()
+	Expect(err).NotTo(HaveOccurred())
 }

--- a/test/e2e/serial/config/fixture.go
+++ b/test/e2e/serial/config/fixture.go
@@ -39,6 +39,19 @@ type E2EConfig struct {
 	SchedulerName string
 }
 
+func (cfg *E2EConfig) Ready() bool {
+	if cfg == nil {
+		return false
+	}
+	if cfg.Fixture == nil || cfg.NROOperObj == nil || cfg.NROSchedObj == nil {
+		return false
+	}
+	if cfg.SchedulerName == "" {
+		return false
+	}
+	return true
+}
+
 var Config *E2EConfig
 
 func SetupFixture() error {

--- a/test/e2e/serial/config/infra.go
+++ b/test/e2e/serial/config/infra.go
@@ -46,7 +46,6 @@ import (
 
 func SetupInfra(fxt *e2efixture.Fixture, nroOperObj *nropv1alpha1.NUMAResourcesOperator, nrtList nrtv1alpha1.NodeResourceTopologyList) {
 	setupNUMACell(fxt, nroOperObj.Spec.NodeGroups, 3*time.Minute)
-
 	LabelNodes(fxt.Client, nrtList)
 }
 
@@ -56,6 +55,8 @@ func TeardownInfra(fxt *e2efixture.Fixture, nrtList nrtv1alpha1.NodeResourceTopo
 
 func setupNUMACell(fxt *e2efixture.Fixture, nodeGroups []nropv1alpha1.NodeGroup, timeout time.Duration) {
 	klog.Infof("e2e infra setup begin")
+
+	Expect(nodeGroups).ToNot(BeEmpty(), "cannot autodetect the TAS node groups from the cluster")
 
 	mcps, err := machineconfigpools.GetNodeGroupsMCPs(context.TODO(), fxt.Client, nodeGroups)
 	Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -65,6 +65,9 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 	var nrts []nrtv1alpha1.NodeResourceTopology
 
 	BeforeEach(func() {
+		Expect(serialconfig.Config).ToNot(BeNil())
+		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
+
 		var err error
 		fxt, err = e2efixture.Setup("e2e-test-configuration")
 		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")

--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -30,6 +30,7 @@ import (
 
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 
+	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 	e2efixture "github.com/openshift-kni/numaresources-operator/test/utils/fixture"
 	e2enrt "github.com/openshift-kni/numaresources-operator/test/utils/noderesourcetopologies"
 	e2enodes "github.com/openshift-kni/numaresources-operator/test/utils/nodes"
@@ -45,6 +46,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 	var nrts []nrtv1alpha1.NodeResourceTopology
 
 	BeforeEach(func() {
+		Expect(serialconfig.Config).ToNot(BeNil())
+		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
+
 		var err error
 		fxt, err = e2efixture.Setup("e2e-test-non-regression")
 		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -55,6 +55,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload resourc
 
 	BeforeEach(func() {
 		Expect(serialconfig.Config).ToNot(BeNil())
+		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 
 		var err error
 		fxt, err = e2efixture.Setup("e2e-test-resource-accounting")

--- a/test/e2e/serial/tests/sched_removal.go
+++ b/test/e2e/serial/tests/sched_removal.go
@@ -42,6 +42,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources scheduler remova
 
 	BeforeEach(func() {
 		Expect(serialconfig.Config).ToNot(BeNil())
+		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 
 		var err error
 		fxt, err = e2efixture.Setup("e2e-test-sched-remove")

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -49,6 +49,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 
 	BeforeEach(func() {
 		Expect(serialconfig.Config).ToNot(BeNil())
+		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 
 		var err error
 		fxt, err = e2efixture.Setup("e2e-test-workload-overhead")

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -64,6 +64,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 	BeforeEach(func() {
 		Expect(serialconfig.Config).ToNot(BeNil())
+		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 
 		var err error
 		fxt, err = e2efixture.Setup("e2e-test-workload-placement")

--- a/test/e2e/serial/tests/workload_placement_nodesel.go
+++ b/test/e2e/serial/tests/workload_placement_nodesel.go
@@ -45,6 +45,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 	BeforeEach(func() {
 		Expect(serialconfig.Config).ToNot(BeNil())
+		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 
 		var err error
 		fxt, err = e2efixture.Setup("e2e-test-workload-placement-nodesel")

--- a/test/e2e/serial/tests/workload_placement_taint.go
+++ b/test/e2e/serial/tests/workload_placement_taint.go
@@ -53,6 +53,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 	BeforeEach(func() {
 		Expect(serialconfig.Config).ToNot(BeNil())
+		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 
 		var err error
 		fxt, err = e2efixture.Setup("e2e-test-workload-placement")

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -59,6 +59,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 	BeforeEach(func() {
 		Expect(serialconfig.Config).ToNot(BeNil())
+		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 
 		var err error
 		fxt, err = e2efixture.Setup("e2e-test-workload-placement-tmpol")


### PR DESCRIPTION
To facilitate the integration with cnf-tests, we need to allow the caller to handle the error, possibly Expect()ing to not happen, unless of always doing that ourselves.
This means we now need a bit more protection to fail with a clear error (and, say, not panic) if this preconditions is not met.
Which should never happen, unless we have bugs.