### PR TITLE
e2e: serial: config: avoid NPE on teardown

### DIFF
--- a/test/e2e/serial/config/config.go
+++ b/test/e2e/serial/config/config.go
@@ -48,6 +48,9 @@ func Teardown() {
 	if _, ok := os.LookupEnv("E2E_INFRA_NO_TEARDOWN"); ok {
 		return
 	}
+	if !Config.Ready() { // nothing to do
+		return
+	}
 	TeardownInfra(Config.Fixture, Config.NRTList)
 	// numacell daemonset automatically cleaned up when we remove the namespace
 	err := TeardownFixture()


### PR DESCRIPTION
Teardown should exit silently if the fixture is not ready,
which can happen in the cnf-tests integration if no numaresources
tests have been enabled.

Signed-off-by: Francesco Romani <fromani@redhat.com>