### PR TITLE
numaresourcesscheduler: respond to owned objects` modifications

### DIFF
--- a/test/e2e/sched/sched_test.go
+++ b/test/e2e/sched/sched_test.go
@@ -91,7 +91,8 @@ var _ = Describe("[Scheduler] imageReplacement", func() {
 			dp, err := schedutils.GetDeploymentByOwnerReference(nroSchedObj.GetUID())
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(wait.ForDeploymentComplete(e2eclient.Client, dp, time.Second*30, time.Minute*2)).ToNot(HaveOccurred())
+			_, err = wait.ForDeploymentComplete(e2eclient.Client, dp, time.Second*30, time.Minute*2)
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should react to owned objects changes", func() {


### PR DESCRIPTION
Prior to this change, every external/manual tamper to the generated objects wouldn't be detected by the controller, hence it keeps the objects in an undesired state.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>