### PR TITLE
e2e: serial: make untainting more robust

### DIFF
--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -52,8 +52,6 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 )
 
-const testKey = "testkey"
-
 var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement", func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
@@ -482,20 +480,6 @@ func dumpNRTForNode(cli client.Client, nodeName, tag string) {
 	data, err := yaml.Marshal(nrt)
 	Expect(err).ToNot(HaveOccurred())
 	klog.Infof("NRT for node %q (%s):\n%s", nodeName, tag, data)
-}
-
-func testTaint() string {
-	return fmt.Sprintf("%s:%s", testKey, corev1.TaintEffectNoSchedule)
-}
-
-func testToleration() []corev1.Toleration {
-	return []corev1.Toleration{
-		{
-			Key:      testKey,
-			Operator: corev1.TolerationOpExists,
-			Effect:   corev1.TaintEffectNoSchedule,
-		},
-	}
 }
 
 func labelNode(cli client.Client, label, nodeName string) (func() error, error) {

--- a/test/e2e/serial/tests/workload_placement_taint.go
+++ b/test/e2e/serial/tests/workload_placement_taint.go
@@ -257,3 +257,19 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		})
 	})
 })
+
+const testKey = "testkey"
+
+func testTaint() string {
+	return fmt.Sprintf("%s:%s", testKey, corev1.TaintEffectNoSchedule)
+}
+
+func testToleration() []corev1.Toleration {
+	return []corev1.Toleration{
+		{
+			Key:      testKey,
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	}
+}


### PR DESCRIPTION
fixes to make the test which requires taints more robust by removing taints more carefully:
- record the tainted nodes explicitly and do target remove
- keep doing a full sweep to make sure no taints are left
- before to finish, wait for taints to be gone from all worker nodes, fail if it not the case