### PR TITLE
e2e: serial: log pullSpec actually used

### DIFF
--- a/test/e2e/serial/config/infra.go
+++ b/test/e2e/serial/config/infra.go
@@ -85,7 +85,7 @@ func setupNUMACell(fxt *e2efixture.Fixture, nodeGroups []nropv1alpha1.NodeGroup,
 		dsName := objectnames.GetComponentName(numacellmanifests.Prefix, mcp.Name)
 		klog.Infof("setting e2e infra for %q: daemonset %q", mcp.Name, dsName)
 
-		pullSpec := getNUMACellDevicePluginPullSpec()
+		pullSpec := GetNUMACellDevicePluginPullSpec()
 		ds := numacellmanifests.DaemonSet(mcp.Spec.NodeSelector.MatchLabels, fxt.Namespace.Name, dsName, sa.Name, pullSpec)
 		err = fxt.Client.Create(context.TODO(), ds)
 		Expect(err).ToNot(HaveOccurred(), "cannot create the numacell daemonset %q in the namespace %q", ds.Name, ds.Namespace)
@@ -112,6 +112,12 @@ func setupNUMACell(fxt *e2efixture.Fixture, nodeGroups []nropv1alpha1.NodeGroup,
 	wg.Wait()
 
 	klog.Infof("e2e infra setup completed")
+}
+
+func GetNUMACellDevicePluginPullSpec() string {
+	pullSpec := getNUMACellDevicePluginPullSpec()
+	klog.Infof("using NUMACell image: %q", pullSpec)
+	return pullSpec
 }
 
 func getNUMACellDevicePluginPullSpec() string {

--- a/test/utils/images/images.go
+++ b/test/utils/images/images.go
@@ -16,9 +16,19 @@ limitations under the License.
 
 package images
 
-import "os"
+import (
+	"os"
+
+	"k8s.io/klog/v2"
+)
 
 func GetPauseImage() string {
+	pullSpec := getPauseImage()
+	klog.Infof("using pause image: %q", pullSpec)
+	return pullSpec
+}
+
+func getPauseImage() string {
 	if pullSpec, ok := os.LookupEnv("E2E_NROP_URL_PAUSE_IMAGE"); ok {
 		return pullSpec
 	}


### PR DESCRIPTION
We don't ever log the pullSpecs we are about to use,
which makes troubleshooting unnecessarily hard.
Fix this adding the logs.

Signed-off-by: Francesco Romani <fromani@redhat.com>