### PR TITLE
e2e: wait: terser logging when wait

### DIFF
--- a/test/utils/objects/wait/daemonset.go
+++ b/test/utils/objects/wait/daemonset.go
@@ -30,23 +30,23 @@ import (
 func ForDaemonSetReady(cli client.Client, ds *appsv1.DaemonSet, pollInterval, pollTimeout time.Duration) (*appsv1.DaemonSet, error) {
 	updatedDs := &appsv1.DaemonSet{}
 	err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
-		key := client.ObjectKeyFromObject(ds)
-		err := cli.Get(context.TODO(), key, updatedDs)
+		key := ObjectKeyFromObject(ds)
+		err := cli.Get(context.TODO(), key.AsKey(), updatedDs)
 		if err != nil {
-			klog.Warningf("failed to get the daemonset %#v: %v", key, err)
+			klog.Warningf("failed to get the daemonset %s: %v", key.String(), err)
 			return false, err
 		}
 
 		if !AreDaemonSetPodsReady(&updatedDs.Status) {
-			klog.Warningf("daemonset %#v desired %d scheduled %d ready %d",
-				key,
+			klog.Warningf("daemonset %s desired %d scheduled %d ready %d",
+				key.String(),
 				updatedDs.Status.DesiredNumberScheduled,
 				updatedDs.Status.CurrentNumberScheduled,
 				updatedDs.Status.NumberReady)
 			return false, nil
 		}
 
-		klog.Infof("daemonset %#v ready", key)
+		klog.Infof("daemonset %s ready", key.String())
 		return true, nil
 	})
 	return updatedDs, err

--- a/test/utils/objects/wait/deployment.go
+++ b/test/utils/objects/wait/deployment.go
@@ -30,19 +30,19 @@ import (
 func ForDeploymentComplete(cli client.Client, dp *appsv1.Deployment, pollInterval, pollTimeout time.Duration) error {
 	return wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
 		updatedDp := &appsv1.Deployment{}
-		key := client.ObjectKeyFromObject(dp)
-		err := cli.Get(context.TODO(), key, updatedDp)
+		key := ObjectKeyFromObject(dp)
+		err := cli.Get(context.TODO(), key.AsKey(), updatedDp)
 		if err != nil {
-			klog.Warningf("failed to get the deployment %#v: %v", key, err)
+			klog.Warningf("failed to get the deployment %s: %v", key.String(), err)
 			return false, err
 		}
 
 		if !IsDeploymentComplete(dp, &updatedDp.Status) {
-			klog.Warningf("deployment %#v not yet complete", key)
+			klog.Warningf("deployment %s not yet complete", key.String())
 			return false, nil
 		}
 
-		klog.Infof("deployment %#v complete", key)
+		klog.Infof("deployment %s complete", key.String())
 		return true, nil
 	})
 }

--- a/test/utils/objects/wait/errors.go
+++ b/test/utils/objects/wait/errors.go
@@ -19,18 +19,17 @@ package wait
 import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func deletionStatusFromError(kind string, key client.ObjectKey, err error) (bool, error) {
+func deletionStatusFromError(kind string, key ObjectKey, err error) (bool, error) {
 	if err == nil {
-		klog.Infof("%s %#v still present", kind, key)
+		klog.Infof("%s %s still present", kind, key.String())
 		return false, nil
 	}
 	if apierrors.IsNotFound(err) {
-		klog.Infof("%s %#v is gone", kind, key)
+		klog.Infof("%s %s is gone", kind, key.String())
 		return true, nil
 	}
-	klog.Warningf("failed to get the %s %#v: %v", kind, key, err)
+	klog.Warningf("failed to get the %s %s: %v", kind, key.String(), err)
 	return false, err
 }

--- a/test/utils/objects/wait/machineconfig.go
+++ b/test/utils/objects/wait/machineconfig.go
@@ -31,8 +31,8 @@ import (
 func ForMachineConfigPoolDeleted(cli client.Client, mcp *machineconfigv1.MachineConfigPool, pollInterval, pollTimeout time.Duration) error {
 	err := wait.Poll(pollInterval, pollTimeout, func() (bool, error) {
 		updatedMcp := machineconfigv1.MachineConfigPool{}
-		key := client.ObjectKeyFromObject(mcp)
-		err := cli.Get(context.TODO(), key, &updatedMcp)
+		key := ObjectKeyFromObject(mcp)
+		err := cli.Get(context.TODO(), key.AsKey(), &updatedMcp)
 		return deletionStatusFromError("MachineConfigPool", key, err)
 	})
 	return err
@@ -41,8 +41,8 @@ func ForMachineConfigPoolDeleted(cli client.Client, mcp *machineconfigv1.Machine
 func ForKubeletConfigDeleted(cli client.Client, kc *machineconfigv1.KubeletConfig, pollInterval, pollTimeout time.Duration) error {
 	err := wait.Poll(pollInterval, pollTimeout, func() (bool, error) {
 		updatedKc := machineconfigv1.KubeletConfig{}
-		key := client.ObjectKeyFromObject(kc)
-		err := cli.Get(context.TODO(), key, &updatedKc)
+		key := ObjectKeyFromObject(kc)
+		err := cli.Get(context.TODO(), key.AsKey(), &updatedKc)
 		return deletionStatusFromError("KubeletConfig", key, err)
 	})
 	return err
@@ -51,8 +51,8 @@ func ForKubeletConfigDeleted(cli client.Client, kc *machineconfigv1.KubeletConfi
 func ForMachineConfigPoolCondition(cli client.Client, mcp *machineconfigv1.MachineConfigPool, condType machineconfigv1.MachineConfigPoolConditionType, pollInterval, pollTimeout time.Duration) error {
 	err := wait.Poll(pollInterval, pollTimeout, func() (bool, error) {
 		updatedMcp := machineconfigv1.MachineConfigPool{}
-		key := client.ObjectKeyFromObject(mcp)
-		err := cli.Get(context.TODO(), key, &updatedMcp)
+		key := ObjectKeyFromObject(mcp)
+		err := cli.Get(context.TODO(), key.AsKey(), &updatedMcp)
 		if err != nil {
 			return false, err
 		}

--- a/test/utils/objects/wait/numaresources.go
+++ b/test/utils/objects/wait/numaresources.go
@@ -29,8 +29,8 @@ import (
 func ForNUMAResourcesOperatorDeleted(cli client.Client, nrop *nropv1alpha1.NUMAResourcesOperator, pollInterval, pollTimeout time.Duration) error {
 	err := wait.Poll(pollInterval, pollTimeout, func() (bool, error) {
 		updatedNrop := nropv1alpha1.NUMAResourcesOperator{}
-		key := client.ObjectKeyFromObject(nrop)
-		err := cli.Get(context.TODO(), key, &updatedNrop)
+		key := ObjectKeyFromObject(nrop)
+		err := cli.Get(context.TODO(), key.AsKey(), &updatedNrop)
 		return deletionStatusFromError("NUMAResourcesOperator", key, err)
 	})
 	return err


### PR DESCRIPTION
Add helpers to make the logs terser while carrying the same amount of info.

Before:
```
I0426 12:10:45.481323   42652 pod.go:67] pod types.NamespacedName{Namespace:"e2e-test-resource-accounting-6505", Name:"tgtpadpod-node-0"} phase Pending desired Running
I0426 12:10:45.482760   42652 pod.go:67] pod types.NamespacedName{Namespace:"e2e-test-resource-accounting-6505", Name:"tgtpadpod-node-1"} phase Pending desired Running
I0426 12:10:55.581299   42652 pod.go:63] pod types.NamespacedName{Namespace:"e2e-test-resource-accounting-6505", Name:"tgtpadpod-node-1"} reached phase Running
I0426 12:10:55.583247   42652 pod.go:63] pod types.NamespacedName{Namespace:"e2e-test-resource-accounting-6505", Name:"tgtpadpod-node-0"} reached phase Running
```

After:
```
I0426 15:58:55.297050   61132 pod.go:89] pod e2e-test-workload-unschedulable-1142/padder-4720 phase Pending desired Running
I0426 15:58:55.298089   61132 pod.go:89] pod e2e-test-workload-unschedulable-1142/padder-6355 phase Pending desired Running
I0426 15:58:55.384992   61132 pod.go:89] pod e2e-test-workload-unschedulable-1142/padder-7971 phase Pending desired Running
I0426 15:58:55.384992   61132 pod.go:89] pod e2e-test-workload-unschedulable-1142/padder-2772 phase Pending desired Running
I0426 15:59:05.391546   61132 pod.go:85] pod e2e-test-workload-unschedulable-1142/padder-4720 reached phase Running
I0426 15:59:05.392263   61132 pod.go:85] pod e2e-test-workload-unschedulable-1142/padder-6355 reached phase Running
I0426 15:59:05.479219   61132 pod.go:85] pod e2e-test-workload-unschedulable-1142/padder-2772 reached phase Running
I0426 15:59:05.486123   61132 pod.go:85] pod e2e-test-workload-unschedulable-1142/padder-7971 reached phase Running
```

Signed-off-by: Francesco Romani <fromani@redhat.com>