### PR TITLE
err: properly wrap errors

### DIFF
--- a/pkg/k8sclientset/config.go
+++ b/pkg/k8sclientset/config.go
@@ -41,7 +41,7 @@ func GetConfig(kubeconfig string) (*rest.Config, error) {
 		config, err = rest.InClusterConfig()
 	}
 	if err != nil {
-		return nil, fmt.Errorf("could not get the client: %v", err)
+		return nil, fmt.Errorf("could not get the client: %w", err)
 	}
 
 	return config, nil

--- a/rte/main.go
+++ b/rte/main.go
@@ -67,7 +67,7 @@ func main() {
 	klog.Infof("=== System information ===\n")
 	sysInfo, err := sysinfo.NewSysinfo(parsedArgs.LocalArgs.SysConf)
 	if err != nil {
-		klog.Fatalf("failed to query system info: %v", err)
+		klog.Fatalf("failed to query system info: %w", err)
 	}
 	klog.Infof("\n%s", sysInfo)
 	klog.Infof("==========================\n")


### PR DESCRIPTION
In few places we still use the old-way to construct errors.
Let's make another step towards go 1.13+ error handling.
See https://go.dev/blog/go1.13-errors

Signed-off-by: Francesco Romani <fromani@redhat.com>