### PR TITLE
log: Improve log message to clearly indicate the wait

### DIFF
--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -684,7 +684,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 				Expect(err).ToNot(HaveOccurred())
 
 				if dp.Status.ReadyReplicas != expectedReadyReplicas {
-					klog.Warningf("deployment: %q has a wrong number of ready replicas, expected: %d got %d", dpKey.String(), expectedReadyReplicas, dp.Status.ReadyReplicas)
+					klog.Warningf("Waiting for deployment: %q to have %d replicas ready, current number of replicas: %d", dpKey.String(), expectedReadyReplicas, dp.Status.ReadyReplicas)
 					return false
 				}
 				return true


### PR DESCRIPTION
This patch updates a log message to clearly indicate that
we are waiting for the deployment to reach a certain number
of replicas. The previous log message gave an impression
of a failure causing confusion and making the person running
the test suite question why the test suite passed even though
the log messages indicated failures

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>