### PR TITLE
e2e serial: fix baseload accounting in placement-by-resources tests

### DIFF
--- a/internal/baseload/baseload.go
+++ b/internal/baseload/baseload.go
@@ -97,3 +97,9 @@ func (nl Load) Deduct(res corev1.ResourceList) {
 	adjustedMemory.Sub(nl.Memory)
 	res[corev1.ResourceMemory] = *adjustedMemory
 }
+
+func (nl Load) ToResourceList() corev1.ResourceList {
+	res := make(corev1.ResourceList)
+	nl.Apply(res)
+	return res
+}

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -719,7 +719,7 @@ func setupPaddingForUnsuitableNodes(offset int, fxt *e2efixture.Fixture, nrtList
 		By(fmt.Sprintf("computed base load: %s", baseload))
 
 		for zoneIdx, zone := range nrtInfo.Zones {
-			padRes := padInfo.unsuitableFreeRes[zoneIdx]
+			padRes := padInfo.unsuitableFreeRes[zoneIdx].DeepCopy()
 			name := fmt.Sprintf("unsuitable%d", nodeIdx)
 
 			By(fmt.Sprintf("saturating node %q -> %q zone %q to fit only (vanilla) %s", nrtInfo.Name, name, zone.Name, e2ereslist.ToString(padRes)))


### PR DESCRIPTION
In the e2e serial resource placement tests, we need to consider the baseload when padding nodes.
This was previously missing because a oversight.