### PR TITLE
utils: fix fetching the scheduler name

### DIFF
--- a/test/utils/nrosched/nrosched.go
+++ b/test/utils/nrosched/nrosched.go
@@ -123,5 +123,5 @@ func IsSchedulingErrorCannotAlign(msg string) bool {
 
 func GetNROSchedulerName(cli client.Client, NUMAResourcesSchedObjName string) string {
 	nroSchedObj := CheckNROSchedulerAvailable(cli, NUMAResourcesSchedObjName)
-	return nroSchedObj.Spec.SchedulerName
+	return nroSchedObj.Status.SchedulerName
 }


### PR DESCRIPTION
Fetch the scheduler name from the scheduler object from under the Status instead of Specs.