### PR TITLE
scheduler: force order of filters

### DIFF
--- a/pkg/numaresourcesscheduler/manifests/yaml/configmap.nrt.yaml
+++ b/pkg/numaresourcesscheduler/manifests/yaml/configmap.nrt.yaml
@@ -13,8 +13,26 @@ data:
       - schedulerName: topo-aware-scheduler
         plugins:
           filter:
+            disabled:
+              - name: '*'
             enabled:
+              - name: NodeUnschedulable
+              - name: NodeName
+              - name: TaintToleration
+              - name: NodeAffinity
+              - name: NodePorts
+              - name: KNIDebug
+              - name: NodeResourcesFit
               - name: NodeResourceTopologyMatch
+              - name: VolumeRestrictions
+              - name: EBSLimits
+              - name: GCEPDLimits
+              - name: NodeVolumeLimits
+              - name: AzureDiskLimits
+              - name: VolumeBinding
+              - name: VolumeZone
+              - name: PodTopologySpread
+              - name: InterPodAffinity
           score:
             enabled:
               - name: NodeResourceTopologyMatch


### PR DESCRIPTION
In order to clarify and make explicit the interplay between NRT filter and the noderesourcefit filter, we now explicit spell out the filter chain, instead of relying on the implicit default behaviour.