### PR TITLE
build: introduce buildhelper replacing git-semver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,14 +131,14 @@ binary: build-tools
 	CGO_ENABLED=0 go build \
 		-mod=vendor \
 		-o bin/manager \
-		-ldflags "-s -w -X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/git-semver)" \
+		-ldflags "-s -w -X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/buildhelper version) -X github.com/openshift-kni/numaresources-operator/pkg/version.gitcommit=$(shell bin/buildhelper commit)" \
 		main.go
 
 binary-rte: build-tools
 	CGO_ENABLED=0 go build \
 		-mod=vendor \
 		-o bin/exporter \
-		-ldflags "-s -w -X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/git-semver)" \
+		-ldflags "-s -w -X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/buildhelper version) -X github.com/openshift-kni/numaresources-operator/pkg/version.gitcommit=$(shell bin/buildhelper commit)" \
 		rte/main.go
 
 binary-numacell: build-tools
@@ -152,7 +152,7 @@ binary-nrocli: build-tools
 	CGO_ENABLED=0 go build \
 		-mod=vendor \
 		-o bin/nrocli \
-		-ldflags "-s -w -X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/git-semver)" \
+		-ldflags "-s -w -X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/buildhelper version)" \
 		nrocli/main.go
 
 binary-all: binary binary-rte
@@ -332,10 +332,10 @@ goversion:
 	@go version
 
 .PHONY: build-tools
-build-tools: goversion bin/git-semver bin/envsubst bin/lsplatform
+build-tools: goversion bin/buildhelper bin/envsubst bin/lsplatform
 
-bin/git-semver:
-	@go build -o bin/git-semver vendor/github.com/mdomke/git-semver/main.go
+bin/buildhelper:
+	@go build -o bin/buildhelper hack/buildhelper/buildhelper.go
 
 bin/envsubst:
 	@go build -o bin/envsubst hack/envsubst/envsubst.go

--- a/hack/buildhelper/buildhelper.go
+++ b/hack/buildhelper/buildhelper.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/mdomke/git-semver/version"
+)
+
+func showVersion() int {
+	if ver, ok := os.LookupEnv("NRO_BUILD_VERSION"); ok {
+		fmt.Println(ver)
+		return 0
+	}
+
+	v, err := version.Derive()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		return 1
+	}
+	fmt.Println(v)
+	return 0
+}
+
+func showCommit() int {
+	if cm, ok := os.LookupEnv("NRO_BUILD_COMMIT"); ok {
+		fmt.Println(cm)
+		return 0
+	}
+
+	cmd := exec.Command("git", "log", "-1", "--pretty=format:%h")
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		return 1
+	}
+	fmt.Println(strings.TrimSpace(string(out)))
+	return 0
+}
+
+func help() {
+	fmt.Fprintf(os.Stderr, "usage: %s [version|commit]\n", filepath.Base(os.Args[0]))
+	os.Exit(1)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		help()
+	}
+
+	switch os.Args[1] {
+	case "version":
+		showVersion()
+	case "commit":
+		showCommit()
+	default:
+		help()
+	}
+}

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -21,6 +21,5 @@ limitations under the License.
 package tools
 
 import (
-	_ "github.com/mdomke/git-semver"
 	_ "k8s.io/code-generator"
 )

--- a/main.go
+++ b/main.go
@@ -109,11 +109,11 @@ func main() {
 	flag.Parse()
 
 	if showVersion {
-		fmt.Printf("%s %s (%s)\n", version.ProgramName(), version.Get(), runtime.Version())
+		fmt.Printf("%s %s %s %s\n", version.ProgramName(), version.Get(), version.GetGitCommit(), runtime.Version())
 		os.Exit(0)
 	}
 
-	klog.InfoS("starting", "program", version.ProgramName(), "version", version.Get(), "golang", runtime.Version())
+	klog.InfoS("starting", "program", version.ProgramName(), "version", version.Get(), "gitcommit", version.GetGitCommit(), "golang", runtime.Version())
 
 	// if it is unknown, it's fine
 	userPlatform, _ := platform.FromString(platformName)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -22,11 +22,14 @@ import (
 )
 
 const (
-	undefinedVersion string = "undefined"
+	undefined string = "undefined"
 )
 
 // version Must not be const, supposed to be set using ldflags at build time
-var version = undefinedVersion
+var version = undefined
+
+// gitcommit Must not be const, supposed to be set using ldflags at build time
+var gitcommit = undefined
 
 // Get returns the version as a string
 func Get() string {
@@ -35,7 +38,15 @@ func Get() string {
 
 // Undefined returns if version is at it's default value
 func Undefined() bool {
-	return version == undefinedVersion
+	return version == undefined
+}
+
+func GetGitCommit() string {
+	return gitcommit
+}
+
+func UndefinedGitCommit() bool {
+	return gitcommit == undefined
 }
 
 func ProgramName() string {

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -30,6 +30,18 @@ func TestUndefined(t *testing.T) {
 	}
 }
 
+func TestGetGitCommit(t *testing.T) {
+	if GetGitCommit() == "" {
+		t.Errorf("empty gitcommit")
+	}
+}
+
+func TestUndefinedGitCommit(t *testing.T) {
+	if !UndefinedGitCommit() {
+		t.Errorf("final gitcommit should be defined at link stage")
+	}
+}
+
 func TestProgramName(t *testing.T) {
 	if ProgramName() == "undefined" {
 		t.Errorf("program name should always be defined")

--- a/rte/main.go
+++ b/rte/main.go
@@ -59,11 +59,10 @@ func main() {
 	}
 
 	if parsedArgs.Version {
-		fmt.Printf("%s %s (%s)\n", version.ProgramName(), version.Get(), runtime.Version())
+		fmt.Printf("%s %s %s %s\n", version.ProgramName(), version.Get(), version.GetGitCommit(), runtime.Version())
 		os.Exit(0)
 	}
-
-	klog.Infof("starting %s %s (%s)\n", version.ProgramName(), version.Get(), runtime.Version())
+	klog.Infof("starting %s %s %s %s\n", version.ProgramName(), version.Get(), version.GetGitCommit(), runtime.Version())
 
 	// only for debug purposes
 	// printing the header so early includes any debug message from the sysinfo package


### PR DESCRIPTION
Replace git-semver, which we were using in the build step,
with another tailor-made tool superset of it.
What we gain is: we can now report the git commit from which
the build is done, and we can inject the values from outside,
bypassing the autodetection, to be friendlier with isolated build
systems, which would otherwise fail the autodetection.

Signed-off-by: Francesco Romani <fromani@redhat.com>