### PR TITLE
[release-4.10][manual] fix versioning 4.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,14 +131,14 @@ binary: build-tools
 	CGO_ENABLED=0 go build \
 		-mod=vendor \
 		-o bin/manager \
-		-ldflags "-s -w -X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/git-semver)" \
+		-ldflags "-s -w -X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/buildhelper version) -X github.com/openshift-kni/numaresources-operator/pkg/version.gitcommit=$(shell bin/buildhelper commit)" \
 		main.go
 
 binary-rte: build-tools
 	CGO_ENABLED=0 go build \
 		-mod=vendor \
 		-o bin/exporter \
-		-ldflags "-s -w -X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/git-semver)" \
+		-ldflags "-s -w -X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/buildhelper version) -X github.com/openshift-kni/numaresources-operator/pkg/version.gitcommit=$(shell bin/buildhelper commit)" \
 		rte/main.go
 
 binary-numacell: build-tools
@@ -317,10 +317,10 @@ deps-update:
 #
 #
 .PHONY: build-tools
-build-tools: bin/git-semver
+build-tools: bin/buildhelper
 
-bin/git-semver:
-	@go build -o bin/git-semver vendor/github.com/mdomke/git-semver/main.go
+bin/buildhelper:
+	@go build -o bin/buildhelper hack/buildhelper/buildhelper.go
 
 verify-generated: bundle generate
 	@echo "Verifying that all code is committed after updating deps and formatting and generating code"

--- a/hack/buildhelper/buildhelper.go
+++ b/hack/buildhelper/buildhelper.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/mdomke/git-semver/version"
+)
+
+func showVersion() int {
+	if ver, ok := os.LookupEnv("NRO_BUILD_VERSION"); ok {
+		fmt.Println(ver)
+		return 0
+	}
+
+	v, err := version.Derive()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		return 1
+	}
+	fmt.Println(v)
+	return 0
+}
+
+func showCommit() int {
+	if cm, ok := os.LookupEnv("NRO_BUILD_COMMIT"); ok {
+		fmt.Println(cm)
+		return 0
+	}
+
+	cmd := exec.Command("git", "log", "-1", "--pretty=format:%h")
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		return 1
+	}
+	fmt.Println(strings.TrimSpace(string(out)))
+	return 0
+}
+
+func help() {
+	fmt.Fprintf(os.Stderr, "usage: %s [version|commit]\n", filepath.Base(os.Args[0]))
+	os.Exit(1)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		help()
+	}
+
+	switch os.Args[1] {
+	case "version":
+		showVersion()
+	case "commit":
+		showCommit()
+	default:
+		help()
+	}
+}

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -20,6 +20,5 @@ limitations under the License.
 package tools
 
 import (
-	_ "github.com/mdomke/git-semver"
 	_ "k8s.io/code-generator"
 )

--- a/main.go
+++ b/main.go
@@ -109,11 +109,11 @@ func main() {
 	flag.Parse()
 
 	if showVersion {
-		fmt.Printf("%s %s (%s)\n", version.ProgramName(), version.Get(), runtime.Version())
+		fmt.Printf("%s %s %s %s\n", version.ProgramName(), version.Get(), version.GetGitCommit(), runtime.Version())
 		os.Exit(0)
 	}
 
-	klog.InfoS("starting", "program", version.ProgramName(), "version", version.Get(), "golang", runtime.Version())
+	klog.InfoS("starting", "program", version.ProgramName(), "version", version.Get(), "gitcommit", version.GetGitCommit(), "golang", runtime.Version())
 
 	// if it is unknown, it's fine
 	userPlatform, _ := platform.FromString(platformName)

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -38,7 +39,7 @@ import (
 	securityv1 "github.com/openshift/api/security/v1"
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
@@ -58,7 +59,7 @@ import (
 )
 
 var (
-	scheme = runtime.NewScheme()
+	scheme = k8sruntime.NewScheme()
 
 	defaultImage     = ""
 	defaultNamespace = "numaresources-operator"
@@ -108,9 +109,11 @@ func main() {
 	flag.Parse()
 
 	if showVersion {
-		fmt.Println(version.ProgramName(), version.Get())
+		fmt.Printf("%s %s (%s)\n", version.ProgramName(), version.Get(), runtime.Version())
 		os.Exit(0)
 	}
+
+	klog.InfoS("starting", "program", version.ProgramName(), "version", version.Get(), "golang", runtime.Version())
 
 	// if it is unknown, it's fine
 	userPlatform, _ := platform.FromString(platformName)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -22,11 +22,14 @@ import (
 )
 
 const (
-	undefinedVersion string = "undefined"
+	undefined string = "undefined"
 )
 
 // version Must not be const, supposed to be set using ldflags at build time
-var version = undefinedVersion
+var version = undefined
+
+// gitcommit Must not be const, supposed to be set using ldflags at build time
+var gitcommit = undefined
 
 // Get returns the version as a string
 func Get() string {
@@ -35,7 +38,15 @@ func Get() string {
 
 // Undefined returns if version is at it's default value
 func Undefined() bool {
-	return version == undefinedVersion
+	return version == undefined
+}
+
+func GetGitCommit() string {
+	return gitcommit
+}
+
+func UndefinedGitCommit() bool {
+	return gitcommit == undefined
 }
 
 func ProgramName() string {

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -30,6 +30,18 @@ func TestUndefined(t *testing.T) {
 	}
 }
 
+func TestGetGitCommit(t *testing.T) {
+	if GetGitCommit() == "" {
+		t.Errorf("empty gitcommit")
+	}
+}
+
+func TestUndefinedGitCommit(t *testing.T) {
+	if !UndefinedGitCommit() {
+		t.Errorf("final gitcommit should be defined at link stage")
+	}
+}
+
 func TestProgramName(t *testing.T) {
 	if ProgramName() == "undefined" {
 		t.Errorf("program name should always be defined")

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package version
+
+import "testing"
+
+func TestGet(t *testing.T) {
+	if Get() == "" {
+		t.Errorf("empty version")
+	}
+}
+
+func TestUndefined(t *testing.T) {
+	if !Undefined() {
+		t.Errorf("final version should be defined at link stage")
+	}
+}
+
+func TestProgramName(t *testing.T) {
+	if ProgramName() == "undefined" {
+		t.Errorf("program name should always be defined")
+	}
+}

--- a/rte/main.go
+++ b/rte/main.go
@@ -59,11 +59,10 @@ func main() {
 	}
 
 	if parsedArgs.Version {
-		fmt.Printf("%s %s (%s)\n", version.ProgramName(), version.Get(), runtime.Version())
+		fmt.Printf("%s %s %s %s\n", version.ProgramName(), version.Get(), version.GetGitCommit(), runtime.Version())
 		os.Exit(0)
 	}
-
-	klog.Infof("starting %s %s (%s)\n", version.ProgramName(), version.Get(), runtime.Version())
+	klog.Infof("starting %s %s %s %s\n", version.ProgramName(), version.Get(), version.GetGitCommit(), runtime.Version())
 
 	// only for debug purposes
 	// printing the header so early includes any debug message from the sysinfo package

--- a/rte/main.go
+++ b/rte/main.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -58,9 +59,11 @@ func main() {
 	}
 
 	if parsedArgs.Version {
-		fmt.Println(version.ProgramName(), version.Get())
+		fmt.Printf("%s %s (%s)\n", version.ProgramName(), version.Get(), runtime.Version())
 		os.Exit(0)
 	}
+
+	klog.Infof("starting %s %s (%s)\n", version.ProgramName(), version.Get(), runtime.Version())
 
 	// only for debug purposes
 	// printing the header so early includes any debug message from the sysinfo package


### PR DESCRIPTION
Replace git-semver, which we were using in the build step, with another tailor-made tool superset of it.
What we gain is: we can now report the git commit from which the build is done, and we can inject the values from outside,
bypassing the autodetection, to be friendlier with isolated build systems, which would otherwise fail the autodetection.