### PR TITLE
e2e:serial: scope=container tests enablement

### DIFF
--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -19,7 +19,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	"github.com/openshift-kni/numaresources-operator/test/utils/images"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -38,6 +37,7 @@ import (
 	schedutils "github.com/openshift-kni/numaresources-operator/test/e2e/sched/utils"
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 	e2efixture "github.com/openshift-kni/numaresources-operator/test/utils/fixture"
+	"github.com/openshift-kni/numaresources-operator/test/utils/images"
 	e2enrt "github.com/openshift-kni/numaresources-operator/test/utils/noderesourcetopologies"
 	"github.com/openshift-kni/numaresources-operator/test/utils/nodes"
 	"github.com/openshift-kni/numaresources-operator/test/utils/nrosched"
@@ -646,6 +646,160 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 			[]corev1.ResourceList{},
 		),
+		Entry("[tier1][testtype4][tmscope:container] should make a pod with three gu cnt land on a node with enough resources, containers should be spread on a different zone",
+			nrtv1alpha1.SingleNUMANodeContainerLevel,
+			setupPaddingContainerLevel,
+			e2enrt.CheckNodeConsumedResourcesAtLeast,
+			podResourcesRequest{
+				appCnt: []corev1.ResourceList{
+					{
+						corev1.ResourceCPU:    resource.MustParse("4"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					{
+						corev1.ResourceCPU:    resource.MustParse("4"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					{
+						corev1.ResourceCPU:    resource.MustParse("8"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				},
+			},
+			// we need keep the gap between Node level fit and NUMA level fit wide enough.
+			// for example if only 2 cpus are separating unsuitable node from becoming suitable,
+			// it's not good because the baseload should be added as well (which is around 2 cpus)
+			// and then the pod might land on the unsuitable node.
+			[]corev1.ResourceList{
+				{
+					corev1.ResourceCPU:    resource.MustParse("12"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+			[]corev1.ResourceList{
+				{
+					corev1.ResourceCPU:    resource.MustParse("8"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				{
+					corev1.ResourceCPU:    resource.MustParse("8"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+		),
+		Entry("[tier1][testtype11][tmscope:container] should make a pod with one init cnt and three gu cnt land on a node with enough resources, containers should be spread on a different zone",
+			nrtv1alpha1.SingleNUMANodeContainerLevel,
+			setupPaddingContainerLevel,
+			e2enrt.CheckNodeConsumedResourcesAtLeast,
+			podResourcesRequest{
+				initCnt: []corev1.ResourceList{
+					{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+				},
+				appCnt: []corev1.ResourceList{
+					{
+						corev1.ResourceCPU:    resource.MustParse("4"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					{
+						corev1.ResourceCPU:    resource.MustParse("4"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					{
+						corev1.ResourceCPU:    resource.MustParse("8"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				},
+			},
+			// we need keep the gap between Node level fit and NUMA level fit wide enough.
+			// for example if only 2 cpus are separating unsuitable node from becoming suitable,
+			// it's not good because the baseload should be added as well (which is around 2 cpus)
+			// and then the pod might land on the unsuitable node.
+			[]corev1.ResourceList{
+				{
+					corev1.ResourceCPU:    resource.MustParse("12"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+			[]corev1.ResourceList{
+				{
+					corev1.ResourceCPU:    resource.MustParse("8"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				{
+					corev1.ResourceCPU:    resource.MustParse("8"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+		),
+		Entry("[tier1][testtype29][tmscope:container] should make a pod with 3 gu cnt and 3 init cnt land on a node with enough resources, when sum of init and app cnt resources are more than node resources",
+			nrtv1alpha1.SingleNUMANodeContainerLevel,
+			setupPaddingContainerLevel,
+			e2enrt.CheckNodeConsumedResourcesAtLeast,
+			podResourcesRequest{
+				initCnt: []corev1.ResourceList{
+					{
+						corev1.ResourceCPU:    resource.MustParse("8"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					{
+						corev1.ResourceCPU:    resource.MustParse("8"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					{
+						corev1.ResourceCPU:    resource.MustParse("8"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				},
+				appCnt: []corev1.ResourceList{
+					{
+						corev1.ResourceCPU:    resource.MustParse("4"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					{
+						corev1.ResourceCPU:    resource.MustParse("4"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					{
+						corev1.ResourceCPU:    resource.MustParse("8"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				},
+			},
+			// we need keep the gap between Node level fit and NUMA level fit wide enough.
+			// for example if only 2 cpus are separating unsuitable node from becoming suitable,
+			// it's not good because the baseload should be added as well (which is around 2 cpus)
+			// and then the pod might land on the unsuitable node.
+			[]corev1.ResourceList{
+				{
+					corev1.ResourceCPU:    resource.MustParse("12"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+			[]corev1.ResourceList{
+				{
+					corev1.ResourceCPU:    resource.MustParse("8"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				{
+					corev1.ResourceCPU:    resource.MustParse("8"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
 		),
 	)
 })
@@ -784,12 +938,12 @@ func setupPaddingForUnsuitableNodes(offset int, fxt *e2efixture.Fixture, nrtList
 func makeInitTestContainers(pod *corev1.Pod, initCnt []corev1.ResourceList, timeout string) *corev1.Pod {
 	for i := 0; i < len(initCnt); i++ {
 		pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
-			Name:  fmt.Sprintf("inittestcnt-%d", i),
-			Image: images.SchedTestImageCI,
+			Name:    fmt.Sprintf("inittestcnt-%d", i),
+			Image:   images.SchedTestImageCI,
 			Command: []string{"/bin/sleep"},
-			Args: []string{timeout},
+			Args:    []string{timeout},
 			Resources: corev1.ResourceRequirements{
-				Limits:  initCnt[i],
+				Limits: initCnt[i],
 			},
 		})
 	}

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -446,9 +446,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			By("running the test pod")
-			if data, err := yaml.Marshal(pod); err != nil {
-				klog.Infof("Pod:\n%s", data)
-			}
+			data, err := yaml.Marshal(pod)
+			Expect(err).ToNot(HaveOccurred())
+			klog.Infof("Pod:\n%s", data)
 
 			By("running the test pod")
 			err = fxt.Client.Create(context.TODO(), pod)

--- a/test/utils/noderesourcetopologies/noderesourcetopologies.go
+++ b/test/utils/noderesourcetopologies/noderesourcetopologies.go
@@ -233,6 +233,7 @@ func checkConsumedResourcesAtLeast(resourcesInitial, resourcesUpdated []nrtv1alp
 		expectedQty.Sub(resQty)
 		ret := updatedQty.Cmp(expectedQty)
 		if ret > 0 {
+			klog.Infof("quantity for resource %q is greater than expected. expected=%s actual=%s", resName, expectedQty.String(), updatedQty.String())
 			return false, nil
 		}
 	}

--- a/test/utils/noderesourcetopologies/noderesourcetopologies.go
+++ b/test/utils/noderesourcetopologies/noderesourcetopologies.go
@@ -107,6 +107,53 @@ func CheckZoneConsumedResourcesAtLeast(nrtInitial, nrtUpdated nrtv1alpha1.NodeRe
 	return "", nil
 }
 
+func CheckNodeConsumedResourcesAtLeast(nrtInitial, nrtUpdated nrtv1alpha1.NodeResourceTopology, required corev1.ResourceList) (string, error) {
+	nodeResInitialInfo, err := accumulateNodeAvailableResources(nrtInitial)
+	if err != nil {
+		return "", err
+	}
+	nodeResUpdatedInfo, err := accumulateNodeAvailableResources(nrtUpdated)
+	if err != nil {
+		return "", err
+	}
+	ok, err := checkConsumedResourcesAtLeast(nodeResInitialInfo, nodeResUpdatedInfo, required)
+	if err != nil {
+		klog.Errorf("error checking node %q: %v", nrtInitial.Name, err)
+		return "", err
+	}
+	if ok {
+		klog.Infof("match for node %q", nrtInitial.Name)
+		return nrtInitial.Name, nil
+	}
+	return "", nil
+}
+
+func accumulateNodeAvailableResources(nrt nrtv1alpha1.NodeResourceTopology) ([]nrtv1alpha1.ResourceInfo, error) {
+	resList := make(corev1.ResourceList, 2)
+	for _, zone := range nrt.Zones {
+		for _, res := range zone.Resources {
+			if q, ok := resList[corev1.ResourceName(res.Name)]; ok {
+				q.Add(res.Available)
+				resList[corev1.ResourceName(res.Name)] = q
+			} else {
+				resList[corev1.ResourceName(res.Name)] = res.Available
+			}
+		}
+	}
+	var resInfoList []nrtv1alpha1.ResourceInfo
+	for r, q := range resList {
+		resInfo := nrtv1alpha1.ResourceInfo{
+			Name:      string(r),
+			Available: q,
+		}
+		resInfoList = append(resInfoList, resInfo)
+	}
+	if len(resInfoList) < 1 {
+		return resInfoList, fmt.Errorf("failed to accumulate resources for node %q", nrt.Name)
+	}
+	klog.Infof("resInfoList=%v", resInfoList)
+	return resInfoList, nil
+}
 func SaturateZoneUntilLeft(zone nrtv1alpha1.Zone, requiredRes corev1.ResourceList) (corev1.ResourceList, error) {
 	paddingRes := make(corev1.ResourceList)
 	for resName, resQty := range requiredRes {


### PR DESCRIPTION
This PR contains a bunch of fixes and modifications to the current tmpolicy tests in order to enable scope=container tests.
In addition, more tests have been added to verify the core functionality of the scheduler when scope=container.

The tests types` are taken from https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/pkg/noderesourcetopology/TESTS.md

We took the liberty to add the most critical and diverse types of tests
among the tier1 ones.
We can add more later if we find it necessary.

All tests have been verified locally on a cluster with a pair of multi-NUMA nodes.