### PR TITLE
static-pods: Document the behaviour of static pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,11 @@ There is **no support** for these e2e tests images, and they are recommended to 
 
 See `README.tests.md` for detailed instructions about how to run the suite.
 See `tests/e2e/serial/README.md` for fine details about the suite and developer instructions.
+
+## Known Issues
+
+### Static pod resources not accounted
+
+Resource information (request and limit) provided in the static pod spec cannot be seen in the corresponding mirror pod status. Because of this, even if resource request==limit for a static pod, the pod QoS Class is BestEffort. Static pods are allocated resources from shared pool and resources requested by them are hence not accounted for when evaluating resources avaiable per NUMA.
+
+Kubernetes issue capturing this behaviour is [here](https://github.com/kubernetes/kubernetes/issues/110944).


### PR DESCRIPTION
This patch documents that resources requested by static pods
are not accounted for when per NUMA resource availablity is
calculated.

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>