### PR TITLE
e2e:serial: check scheduling error per topology scope

### DIFF
--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -248,7 +248,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			podLabels := map[string]string{
 				"test": "test-daemonset",
 			}
-			nodeSelector := map[string]string{}
+			nodeSelector := map[string]string{
+				serialconfig.MultiNUMALabel: "2",
+			}
 			ds := objects.NewTestDaemonset(podLabels, nodeSelector, fxt.Namespace.Name, dsName, objects.PauseImage, []string{objects.PauseCommand}, []string{})
 			ds.Spec.Template.Spec.SchedulerName = serialconfig.Config.SchedulerName
 			ds.Spec.Template.Spec.Containers[0].Resources.Limits = requiredRes
@@ -350,7 +352,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			podLabels := map[string]string{
 				"test": "test-daemonset",
 			}
-			nodeSelector := map[string]string{}
+			nodeSelector := map[string]string{
+				serialconfig.MultiNUMALabel: "2",
+			}
 			ds := objects.NewTestDaemonset(podLabels, nodeSelector, fxt.Namespace.Name, dsName, objects.PauseImage, []string{objects.PauseCommand}, []string{})
 			ds.Spec.Template.Spec.SchedulerName = serialconfig.Config.SchedulerName
 			ds.Spec.Template.Spec.Containers[0].Resources.Limits = requiredRes


### PR DESCRIPTION
When the scheduler plugin failed to align a pod into a node it reports an error.
The error message is varies upon the `TopologyManagerScope` configuration.

We should support a check of the scheduling error for both container and pod scope configurations.
This patch adds the support for the container scope (pod scope support is already exists)

Signed-off-by: Talor Itzhak <titzhak@redhat.com>