### PR TITLE
e2e: serial: tests for non-guaranteed pods

### DIFF
--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -417,6 +417,36 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload resourc
 			expectNrtUnchanged(fxt, targetNrtListInitial, updatedPod.Spec.NodeName, "scheduling best-effort pod")
 		})
 
+		It("[test_id:48686][tier1] should properly schedule a burstable pod with no changes in NRTs", func() {
+			By("create a burstable pod")
+
+			pod := objects.NewTestPodPause(fxt.Namespace.Name, "testpod-bu")
+			pod.Spec.SchedulerName = serialconfig.Config.SchedulerName
+			pod.Spec.NodeSelector = map[string]string{
+				serialconfig.MultiNUMALabel: "2",
+			}
+			// make it burstable
+			pod.Spec.Containers[0].Resources.Requests = reqResources
+			err = fxt.Client.Create(context.TODO(), pod)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for the pod to be scheduled")
+			// 3 minutes is plenty, should never timeout
+			updatedPod, err := e2ewait.ForPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodRunning, 3*time.Minute)
+			if err != nil {
+				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
+			}
+			Expect(err).ToNot(HaveOccurred())
+
+			By(fmt.Sprintf("checking the pod has been scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName))
+			schedOK, err := nrosched.CheckPODWasScheduledWith(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
+
+			By("Verifying NRT reflects no updates after scheduling the burstable pod")
+			expectNrtUnchanged(fxt, targetNrtListInitial, updatedPod.Spec.NodeName, "scheduling burstable pod")
+		})
+
 		It("[test_id:47618][tier2] should properly schedule deployment with burstable pod with no changes in NRTs", func() {
 			By("create a deployment with one burstable pod")
 			deploymentName := "test-dp"

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -389,6 +389,34 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload resourc
 			Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 		})
 
+		It("[test_id:48685][tier1] should properly schedule a best-effort pod with no changes in NRTs", func() {
+			By("create a best-effort pod")
+
+			pod := objects.NewTestPodPause(fxt.Namespace.Name, "testpod-be")
+			pod.Spec.SchedulerName = serialconfig.Config.SchedulerName
+			pod.Spec.NodeSelector = map[string]string{
+				serialconfig.MultiNUMALabel: "2",
+			}
+			err = fxt.Client.Create(context.TODO(), pod)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for the pod to be scheduled")
+			// 3 minutes is plenty, should never timeout
+			updatedPod, err := e2ewait.ForPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodRunning, 3*time.Minute)
+			if err != nil {
+				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
+			}
+			Expect(err).ToNot(HaveOccurred())
+
+			By(fmt.Sprintf("checking the pod has been scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName))
+			schedOK, err := nrosched.CheckPODWasScheduledWith(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
+
+			By("Verifying NRT reflects no updates after scheduling the best-effort pod")
+			expectNrtUnchanged(fxt, targetNrtListInitial, updatedPod.Spec.NodeName, "scheduling best-effort pod")
+		})
+
 		It("[test_id:47618][tier2] should properly schedule deployment with burstable pod with no changes in NRTs", func() {
 			By("create a deployment with one burstable pod")
 			deploymentName := "test-dp"
@@ -432,5 +460,19 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload resourc
 		})
 
 	})
-
 })
+
+func expectNrtUnchanged(fxt *e2efixture.Fixture, targetNrtListInitial nrtv1alpha1.NodeResourceTopologyList, nodeName, reason string) {
+	targetNrtListCurrent, err := e2enrt.GetUpdated(fxt.Client, targetNrtListInitial, 1*time.Minute)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	targetNrtInitial, err := e2enrt.FindFromList(targetNrtListInitial.Items, nodeName)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	targetNrtCurrent, err := e2enrt.FindFromList(targetNrtListCurrent.Items, nodeName)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	isEqual, err := e2enrt.CheckEqualAvailableResources(*targetNrtInitial, *targetNrtCurrent)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	ExpectWithOffset(1, isEqual).To(BeTrue(), "new resources are accounted on %q in NRT (%s)", nodeName)
+}


### PR DESCRIPTION
verify that once a best-effort or burstable pod is scheduled with the NUMA-aware scheduler, no NRT resources are consumed.
This is again because the NRT only accounts exclusively allocated resources - to guaranteed pods.