### PR TITLE
e2e:serial: deflake podscope failures

### DIFF
--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -232,7 +232,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				Expect(err).NotTo(HaveOccurred(), "unable to create deployment %q", deployment.Name)
 
 				By("waiting for deployment to be up&running")
-				dpRunningTimeout := 1 * time.Minute
+				dpRunningTimeout := 2 * time.Minute
 				dpRunningPollInterval := 10 * time.Second
 				_, err = e2ewait.ForDeploymentComplete(fxt.Client, deployment, dpRunningPollInterval, dpRunningTimeout)
 				Expect(err).NotTo(HaveOccurred(), "Deployment %q not up&running after %v", deployment.Name, dpRunningTimeout)

--- a/test/e2e/serial/tests/workload_placement_nodelabel.go
+++ b/test/e2e/serial/tests/workload_placement_nodelabel.go
@@ -293,7 +293,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 					Expect(err).NotTo(HaveOccurred(), "unable to create deployment %q", deployment.Name)
 
 					By("waiting for deployment to be up & running")
-					dpRunningTimeout := 1 * time.Minute
+					dpRunningTimeout := 2 * time.Minute
 					dpRunningPollInterval := 10 * time.Second
 					_, err = e2ewait.ForDeploymentComplete(fxt.Client, deployment, dpRunningPollInterval, dpRunningTimeout)
 					Expect(err).NotTo(HaveOccurred(), "Deployment %q not up & running after %v", deployment.Name, dpRunningTimeout)

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -572,11 +572,11 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			[]corev1.ResourceList{
 				{
 					corev1.ResourceCPU:    resource.MustParse("14"),
-					corev1.ResourceMemory: resource.MustParse("10Gi"),
+					corev1.ResourceMemory: resource.MustParse("6Gi"),
 				},
 				{
 					corev1.ResourceCPU:    resource.MustParse("10"),
-					corev1.ResourceMemory: resource.MustParse("16Gi"),
+					corev1.ResourceMemory: resource.MustParse("20Gi"),
 				},
 			},
 			[]corev1.ResourceList{},


### PR DESCRIPTION
A couple of improvements for the serial e2e tests.
Some are intended to solve actual failures and some are just best-effort tuning.

The tests were performed on a cluster with nodes configured with a pod scope policy.  