### PR TITLE
api: bundle: add OLM spec desc refs for logLevel

### DIFF
--- a/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_types.go
+++ b/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_types.go
@@ -35,6 +35,7 @@ type NUMAResourcesOperatorSpec struct {
 	// Defaults to "Normal".
 	// +optional
 	// +kubebuilder:default=Normal
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="RTE log verbosity"
 	LogLevel operatorv1.LogLevel `json:"logLevel,omitempty"`
 }
 

--- a/api/numaresourcesoperator/v1alpha1/numaresourcesscheduler_types.go
+++ b/api/numaresourcesoperator/v1alpha1/numaresourcesscheduler_types.go
@@ -34,6 +34,7 @@ type NUMAResourcesSchedulerSpec struct {
 	// Defaults to "Normal".
 	// +optional
 	// +kubebuilder:default=Normal
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Scheduler log verbosity"
 	LogLevel operatorv1.LogLevel `json:"logLevel,omitempty"`
 }
 

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -58,6 +58,10 @@ spec:
         path: imageSpec
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: 'Valid values are: "Normal", "Debug", "Trace", "TraceAll". Defaults
+          to "Normal".'
+        displayName: RTE log verbosity
+        path: logLevel
       - description: Group of Nodes to enable RTE on
         displayName: Group of nodes to enable RTE on
         path: nodeGroups
@@ -84,6 +88,10 @@ spec:
         path: imageSpec
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: 'Valid values are: "Normal", "Debug", "Trace", "TraceAll". Defaults
+          to "Normal".'
+        displayName: Scheduler log verbosity
+        path: logLevel
       - description: Scheduler name to be used in pod templates
         displayName: Scheduler name
         path: schedulerName

--- a/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
@@ -26,6 +26,10 @@ spec:
         path: imageSpec
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: 'Valid values are: "Normal", "Debug", "Trace", "TraceAll". Defaults
+          to "Normal".'
+        displayName: RTE log verbosity
+        path: logLevel
       - description: Group of Nodes to enable RTE on
         displayName: Group of nodes to enable RTE on
         path: nodeGroups
@@ -52,6 +56,10 @@ spec:
         path: imageSpec
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: 'Valid values are: "Normal", "Debug", "Trace", "TraceAll". Defaults
+          to "Normal".'
+        displayName: Scheduler log verbosity
+        path: logLevel
       - description: Scheduler name to be used in pod templates
         displayName: Scheduler name
         path: schedulerName


### PR DESCRIPTION
see: https://github.com/openshift/console/blob/master/frontend/packages/operator-lifecycle-manager/src/components/descriptors/reference/reference.md
regenerated the manifests with `make bundle`
validated with `operator-sdk scorecard bundle/`

Signed-off-by: Francesco Romani <fromani@redhat.com>