### PR TITLE
Dockerfile: fully qualified builder images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# Build the manager binary
-FROM golang:1.18 as builder
+FROM docker.io/golang:1.18 AS builder
 
 WORKDIR /go/src/github.com/openshift-kni/numaresources-operator
 COPY . .

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,5 +1,4 @@
-# Build all the e2e suites
-FROM golang:1.18 as builder
+FROM docker.io/golang:1.18 AS builder
 
 WORKDIR /go/src/github.com/openshift-kni/numaresources-operator
 COPY . .


### PR DESCRIPTION
Until we find better builder images, we actually want to
use the dockerhub images, so let's be explicit about that.

Signed-off-by: Francesco Romani <fromani@redhat.com>