### PR TITLE
e2e: install: minimal fixes

### DIFF
--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -287,7 +287,10 @@ func (r *NUMAResourcesOperatorReconciler) syncMachineConfigPoolsStatuses(instanc
 				Conditions: mcp.Status.Conditions,
 			})
 
-			if !IsMachineConfigPoolUpdated(instance.Name, mcp) {
+			isUpdated := IsMachineConfigPoolUpdated(instance.Name, mcp)
+			klog.V(5).InfoS("Machine Config Pool state", "name", mcp.Name, "instance", instance.Name, "updated", isUpdated)
+
+			if !isUpdated {
 				return false
 			}
 		}

--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -328,6 +328,7 @@ var _ = Describe("[Install] durability", func() {
 				ds, err := getDaemonSetByOwnerReference(updatedNroObj.GetUID())
 				if err != nil {
 					klog.Warningf("failed to get the RTE DaemonSet: %v", err)
+					klog.Warningf("NRO:\n%s\n", objects.ToYAML(updatedNroObj))
 					return false
 				}
 

--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -308,13 +308,12 @@ var _ = Describe("[Install] durability", func() {
 			}, 5*time.Minute, 10*time.Second).Should(BeTrue())
 
 			By("redeploy with other parameters")
+			nroObjRedep := objects.TestNRO(objects.EmptyMatchLabels())
+			nroObjRedep.Spec = *deployedObj.nroObj.Spec.DeepCopy()
 			// TODO change to an image which is test dedicated
-			nroObj.Spec.ExporterImage = e2eimages.RTETestImageCI
-			// resourceVersion should not be set on objects to be created
-			// TODO: don't reuse existing objects
-			nroObj.ResourceVersion = ""
+			nroObjRedep.Spec.ExporterImage = e2eimages.RTETestImageCI
 
-			err = e2eclient.Client.Create(context.TODO(), nroObj)
+			err = e2eclient.Client.Create(context.TODO(), nroObjRedep)
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() bool {

--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -248,8 +248,6 @@ var _ = Describe("[Install] durability", func() {
 		})
 
 		It("should be able to delete NUMAResourceOperator CR and redeploy without polluting cluster state", func() {
-			Skip("broken and need more resources to be fixed")
-
 			nname := client.ObjectKeyFromObject(deployedObj.nroObj)
 			Expect(nname.Name).NotTo(BeEmpty())
 

--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -87,7 +87,7 @@ var _ = Describe("[Install] continuousIntegration", func() {
 					return false
 				}
 
-				klog.Infof("condition: %v", cond)
+				klog.Infof("condition for %s: %v", nname.Name, cond)
 
 				return cond.Status == metav1.ConditionTrue
 			}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "RTE condition did not become available")
@@ -190,61 +190,74 @@ var _ = Describe("[Install] durability", func() {
 
 		It("[test_id:47587][tier1] should restart RTE DaemonSet when image is updated in NUMAResourcesOperator", func() {
 
-			By("wait for DaemonSet to be ready")
-			nname := client.ObjectKeyFromObject(deployedObj.nroObj)
-			Expect(nname.Name).NotTo(BeEmpty())
+			By("getting up-to-date NRO object")
+			nroKey := client.ObjectKeyFromObject(deployedObj.nroObj)
+			Expect(nroKey.Name).NotTo(BeEmpty())
 
 			nroObj := &nropv1alpha1.NUMAResourcesOperator{}
-			err := e2eclient.Client.Get(context.TODO(), nname, nroObj)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("waiting for the DaemonSet to be created")
-			uid := nroObj.GetUID()
-			ds := &appsv1.DaemonSet{}
-
-			dsReadyTimeOut := 5 * time.Minute
-			dsReadyPollPeriod := 10 * time.Second
-			Eventually(func() bool {
-				var err error
-				ds, err = getDaemonSetByOwnerReference(uid)
+			Eventually(func() error {
+				err := e2eclient.Client.Get(context.TODO(), nroKey, nroObj)
 				if err != nil {
-					klog.Warningf("failed to get the daemonset for NRO %v: %v", uid, err)
-					return false
+					return err
 				}
-				return e2ewait.AreDaemonSetPodsReady(&ds.Status)
-			}, dsReadyTimeOut, dsReadyPollPeriod).Should(BeTrue())
+				if len(nroObj.Status.DaemonSets) != 1 {
+					return fmt.Errorf("unsupported daemonsets (/MCP) count: %d", len(nroObj.Status.DaemonSets))
+				}
+				return nil
+			}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).ShouldNot(HaveOccurred(), "inconsistent NRO instance:\n%s", objects.ToYAML(nroObj))
+
+			dsKey := e2ewait.ObjectKey{
+				Namespace: nroObj.Status.DaemonSets[0].Namespace,
+				Name:      nroObj.Status.DaemonSets[0].Name,
+			}
+
+			By("waiting for DaemonSet to be ready")
+			ds, err := e2ewait.ForDaemonSetReadyByKey(e2eclient.Client, dsKey, 10*time.Second, 3*time.Minute)
+			Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
 
 			By("Update RTE image in NRO")
-			err = e2eclient.Client.Get(context.TODO(), nname, nroObj)
-			Expect(err).ToNot(HaveOccurred())
-			nroObj.Spec.ExporterImage = e2eimages.RTETestImageCI
-			err = e2eclient.Client.Update(context.TODO(), nroObj)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Await for daemon to be ready again")
-			updatedNroObj := &nropv1alpha1.NUMAResourcesOperator{}
-			err = e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroObj), updatedNroObj)
-			Expect(err).ToNot(HaveOccurred())
-
-			Eventually(func() bool {
-				updatedDs, err := e2ewait.ForDaemonSetReady(e2eclient.Client, ds, dsReadyPollPeriod, dsReadyTimeOut)
+			Eventually(func() error {
+				err := e2eclient.Client.Get(context.TODO(), nroKey, nroObj)
 				if err != nil {
+					return err
+				}
+				nroObj.Spec.ExporterImage = e2eimages.RTETestImageCI
+				return e2eclient.Client.Update(context.TODO(), nroObj)
+			}).WithTimeout(3 * time.Minute).WithPolling(10 * time.Second).ShouldNot(HaveOccurred())
+
+			By("waiting for the daemonset to be ready again")
+			Eventually(func() bool {
+				updatedDs := &appsv1.DaemonSet{}
+				err := e2eclient.Client.Get(context.TODO(), dsKey.AsKey(), updatedDs)
+				if err != nil {
+					klog.Warningf("failed to get the daemonset %s: %v", dsKey.String(), err)
 					return false
 				}
-				klog.Warningf("Observed %v  Current %v", updatedDs.Status.ObservedGeneration, ds.Generation)
+
+				if !e2ewait.AreDaemonSetPodsReady(&updatedDs.Status) {
+					klog.Warningf("daemonset %s desired %d scheduled %d ready %d",
+						dsKey.String(),
+						updatedDs.Status.DesiredNumberScheduled,
+						updatedDs.Status.CurrentNumberScheduled,
+						updatedDs.Status.NumberReady)
+					return false
+				}
+
+				klog.Infof("daemonset %s ready", dsKey.String())
+
+				klog.Warningf("daemonset Generation observed %v current %v", updatedDs.Status.ObservedGeneration, ds.Generation)
 				isUpdated := updatedDs.Status.ObservedGeneration > ds.Generation
 				if !isUpdated {
 					return false
 				}
 				ds = updatedDs
 				return true
-			}, dsReadyTimeOut, dsReadyPollPeriod).Should(BeTrue())
+			}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).Should(BeTrue(), "failed to get up to date DaemonSet")
 
 			rteContainer, err := findContainerByName(*ds, containerNameRTE)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(rteContainer.Image).To(BeIdenticalTo(e2eimages.RTETestImageCI))
-
 		})
 
 		It("should be able to delete NUMAResourceOperator CR and redeploy without polluting cluster state", func() {

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -253,7 +253,7 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 			wg.Wait()
 
 			Eventually(func() (bool, error) {
-				dss, err := getDsOwnedBy(fxt.Client, nroOperObj.ObjectMeta)
+				dss, err := objects.GetDaemonSetsOwnedBy(fxt.Client, nroOperObj.ObjectMeta)
 				Expect(err).ToNot(HaveOccurred())
 
 				if len(dss) == 0 {
@@ -280,7 +280,7 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 
 			By("checking RTE has the correct image")
 			Eventually(func() (bool, error) {
-				dss, err := getDsOwnedBy(fxt.Client, nroOperObj.ObjectMeta)
+				dss, err := objects.GetDaemonSetsOwnedBy(fxt.Client, nroOperObj.ObjectMeta)
 				Expect(err).ToNot(HaveOccurred())
 
 				if len(dss) == 0 {
@@ -309,7 +309,7 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 
 			By("checking the correct LogLevel")
 			Eventually(func() (bool, error) {
-				dss, err := getDsOwnedBy(fxt.Client, nroOperObj.ObjectMeta)
+				dss, err := objects.GetDaemonSetsOwnedBy(fxt.Client, nroOperObj.ObjectMeta)
 				Expect(err).ToNot(HaveOccurred())
 
 				if len(dss) == 0 {

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -26,7 +26,6 @@ import (
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -569,21 +568,6 @@ func unlabelNode(cli client.Client, key, val, nodeName string) (func() error, er
 		return nil
 	}
 	return labelFunc, nil
-}
-
-func getDsOwnedBy(cli client.Client, objMeta metav1.ObjectMeta) ([]*appsv1.DaemonSet, error) {
-	dsList := &appsv1.DaemonSetList{}
-	if err := cli.List(context.TODO(), dsList); err != nil {
-		return nil, err
-	}
-
-	var dss []*appsv1.DaemonSet
-	for i := range dsList.Items {
-		if objects.IsOwnedBy(dsList.Items[i].ObjectMeta, objMeta) {
-			dss = append(dss, &dsList.Items[i])
-		}
-	}
-	return dss, nil
 }
 
 func availableResourceType(nrtInfo nrtv1alpha1.NodeResourceTopology, resName corev1.ResourceName) resource.Quantity {

--- a/test/utils/objects/objects.go
+++ b/test/utils/objects/objects.go
@@ -18,7 +18,10 @@ package objects
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
+
+	"github.com/ghodss/yaml"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -164,4 +167,12 @@ func getKubeletConfig() *kubeletconfigv1beta1.KubeletConfiguration {
 		TopologyManagerPolicy: "single-numa-node",
 		TopologyManagerScope:  "pod",
 	}
+}
+
+func ToYAML(obj interface{}) string {
+	data, err := yaml.Marshal(obj)
+	if err != nil {
+		return fmt.Sprintf("<SERIALIZE ERROR: %v>", err)
+	}
+	return string(data)
 }

--- a/test/utils/objects/wait/daemonset.go
+++ b/test/utils/objects/wait/daemonset.go
@@ -27,10 +27,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ForDaemonSetReady(cli client.Client, ds *appsv1.DaemonSet, pollInterval, pollTimeout time.Duration) (*appsv1.DaemonSet, error) {
+func ForDaemonSetReadyByKey(cli client.Client, key ObjectKey, pollInterval, pollTimeout time.Duration) (*appsv1.DaemonSet, error) {
 	updatedDs := &appsv1.DaemonSet{}
 	err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
-		key := ObjectKeyFromObject(ds)
 		err := cli.Get(context.TODO(), key.AsKey(), updatedDs)
 		if err != nil {
 			klog.Warningf("failed to get the daemonset %s: %v", key.String(), err)
@@ -50,6 +49,10 @@ func ForDaemonSetReady(cli client.Client, ds *appsv1.DaemonSet, pollInterval, po
 		return true, nil
 	})
 	return updatedDs, err
+}
+
+func ForDaemonSetReady(cli client.Client, ds *appsv1.DaemonSet, pollInterval, pollTimeout time.Duration) (*appsv1.DaemonSet, error) {
+	return ForDaemonSetReadyByKey(cli, ObjectKeyFromObject(ds), pollInterval, pollTimeout)
 }
 
 func AreDaemonSetPodsReady(newStatus *appsv1.DaemonSetStatus) bool {


### PR DESCRIPTION
This e2e install test:
```
[Install] durability
/go/src/github.com/openshift-kni/numaresources-operator/test/e2e/install/install_test.go:138
  with a running cluster with all the components and overall deployment
  /go/src/github.com/openshift-kni/numaresources-operator/test/e2e/install/install_test.go:180
    should be able to delete NUMAResourceOperator CR and redeploy without polluting cluster state [It] 
```
started to fail reliably. This PR wants to add troubleshooting aids and, ultimately, the fix. Spawned off from #324 