### PR TITLE
e2e: serial: unschedulable: requesting allocatable resources on a node

### DIFF
--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -584,6 +584,20 @@ func availableResourceType(nrtInfo nrtv1alpha1.NodeResourceTopology, resName cor
 	return res.DeepCopy()
 }
 
+func allocatableResourceType(nrtInfo nrtv1alpha1.NodeResourceTopology, resName corev1.ResourceName) resource.Quantity {
+	var res resource.Quantity
+
+	for _, zone := range nrtInfo.Zones {
+		zoneQty, ok := e2enrt.FindResourceAllocatableByName(zone.Resources, resName.String())
+		if !ok {
+			continue
+		}
+
+		res.Add(zoneQty)
+	}
+	return res.DeepCopy()
+}
+
 func matchLogLevelToKlog(cnt *corev1.Container, level operatorv1.LogLevel) (bool, bool) {
 	rteFlags := flagcodec.ParseArgvKeyValue(cnt.Args)
 	kLvl := loglevel.ToKlog(level)

--- a/test/utils/noderesourcetopologies/noderesourcetopologies.go
+++ b/test/utils/noderesourcetopologies/noderesourcetopologies.go
@@ -357,6 +357,16 @@ func FindResourceAvailableByName(resources []nrtv1alpha1.ResourceInfo, name stri
 	return *resource.NewQuantity(0, resource.DecimalSI), false
 }
 
+func FindResourceAllocatableByName(resources []nrtv1alpha1.ResourceInfo, name string) (resource.Quantity, bool) {
+	for _, resource := range resources {
+		if resource.Name != name {
+			continue
+		}
+		return resource.Allocatable, true
+	}
+	return *resource.NewQuantity(0, resource.DecimalSI), false
+}
+
 func contains(items []string, st string) bool {
 	for _, item := range items {
 		if item == st {


### PR DESCRIPTION
These set of tests deploy pod, deployment and daemonset such that the
workload requests allocatable and not the available resources at a
node level because of which the workload is not scheduled on the node.

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>