### PR TITLE
e2e: serial: default scheduler: deployment with gu pod on a node

### DIFF
--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -289,7 +289,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(err).NotTo(HaveOccurred(), "Unable to get pods from Deployment %q:  %v", deployment.Name, err)
 
 			for _, pod := range pods {
-				isFailed, err := nrosched.CheckPODSchedulingFailedForAlignment(fxt.K8sClient, pod.Namespace, pod.Name, corev1.DefaultSchedulerName, tmPolicy)
+				isFailed, err := nrosched.CheckPODKubeletRejectWithTopologyAffinityError(fxt.K8sClient, pod.Namespace, pod.Name)
 				if err != nil {
 					_ = objects.LogEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
 				}


### PR DESCRIPTION
Test case: Deployment with a gu pod scheduled by default scheduler
requesting resources available on one node but not on a single numa.

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>