### PR TITLE
numaresourcesscheduler: fix service-account's merge function

### DIFF
--- a/pkg/numaresourcesscheduler/objectstate/sched/sched.go
+++ b/pkg/numaresourcesscheduler/objectstate/sched/sched.go
@@ -56,7 +56,7 @@ func (em ExistingManifests) State(mf schedmanifests.Manifests) []objectstate.Obj
 			Error:    em.serviceAccountError,
 			Desired:  mf.ServiceAccount.DeepCopy(),
 			Compare:  compare.Object,
-			Merge:    merge.MetadataForUpdate,
+			Merge:    merge.ServiceAccountForUpdate,
 		},
 		{
 			Existing: em.Existing.ConfigMap,


### PR DESCRIPTION
Due to inappropriate handling of ```ServiceAccount```'s update we endded up with race conditions between the Token controller: https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#token-controller and the NUMAResourcesScheduler controller which in turn leads to infinite UPDATEs which in turn overwhelmed the kube-api-server.

By using the correct merge function for the ```ServiceAccount``` object, we're getting the correct secret and avoiding the mentioned race condition.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>