### PR TITLE
e2e: change image for init containers

### DIFF
--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -1151,7 +1151,7 @@ func makeInitTestContainers(pod *corev1.Pod, initCnt []corev1.ResourceList, time
 	for i := 0; i < len(initCnt); i++ {
 		pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
 			Name:    fmt.Sprintf("inittestcnt-%d", i),
-			Image:   images.SchedTestImageCI,
+			Image:   images.GetPauseImage(),
 			Command: []string{"/bin/sleep"},
 			Args:    []string{timeout},
 			Resources: corev1.ResourceRequirements{


### PR DESCRIPTION
For disconnected environments (like we use in NROP CI) using quay images will cause the pod to fail to start running due to unreachable image url.since we mainly care about the amount of time the init container is alive, change the image to from test-ci to Pause image that would be replaced by the url passed into one of the following env vars: E2E_PAUSE_IMAGE_URL , E2E_NUMACELL_DEVICE_PLUGIN_URL.