### PR TITLE
WIP: rte: securitycontext: enforce dropping of unneeded privileges

### DIFF
--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -97,9 +97,19 @@ func DaemonSetRunAsIDs(ds *appsv1.DaemonSet) error {
 	if cnt.SecurityContext == nil {
 		cnt.SecurityContext = &corev1.SecurityContext{}
 	}
+
 	var rootID int64 = 0
 	cnt.SecurityContext.RunAsUser = &rootID
 	cnt.SecurityContext.RunAsGroup = &rootID
+	cnt.SecurityContext.Capabilities = &corev1.Capabilities{
+		Drop: []corev1.Capability{
+			"ALL",
+		},
+	}
+	cnt.SecurityContext.SeccompProfile = &corev1.SeccompProfile{
+		Type: corev1.SeccompProfileTypeRuntimeDefault,
+	}
+
 	klog.InfoS("RTE container elevated privileges", "container", cnt.Name, "user", rootID, "group", rootID)
 	return nil
 }


### PR DESCRIPTION
To access the podresources socket, we need uid=0 - gid=0
is not enough, unfortunately - but we don't actually need
any real root privileges. Make sure we drop them.

Signed-off-by: Francesco Romani <fromani@redhat.com>