### PR TITLE
e2e: serial: fix usage of the pause container image in the e2e serial suite

### DIFF
--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -19,10 +19,11 @@ package tests
 import (
 	"context"
 	"fmt"
-	"k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/apis/core/helper"
 	"strings"
 	"time"
+
+	"k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/apis/core/helper"
 
 	"github.com/ghodss/yaml"
 	. "github.com/onsi/ginkgo"

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -375,7 +375,6 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		func(tmPolicy nrtv1alpha1.TopologyManagerPolicy, setupPadding setupPaddingFunc, checkConsumedRes checkConsumedResFunc, podRes podResourcesRequest, unsuitableFreeRes, targetFreeResPerNUMA []corev1.ResourceList) {
 
 			hostsRequired := 2
-			sleepTimeoutInSec := "5"
 
 			nrts := e2enrt.FilterTopologyManagerPolicy(nrtList.Items, tmPolicy)
 			if len(nrts) < hostsRequired {
@@ -397,7 +396,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				pod.Spec.Containers[i].Resources.Limits = podRes.appCnt[i]
 			}
 			// we expect init containers to be required less often than app containers, so we delegate that
-			makeInitTestContainers(pod, podRes.initCnt, sleepTimeoutInSec)
+			makeInitTestContainers(pod, podRes.initCnt)
 
 			requiredRes := e2ereslist.FromGuaranteedPod(*pod)
 
@@ -1022,7 +1021,6 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		func(tmPolicy nrtv1alpha1.TopologyManagerPolicy, setupPadding setupPaddingFunc, errMsg string, podRes podResourcesRequest, unsuitableFreeRes, targetFreeResPerNUMA []corev1.ResourceList) {
 
 			hostsRequired := 2
-			sleepTimeoutInSec := "5"
 
 			nrts := e2enrt.FilterTopologyManagerPolicy(nrtList.Items, tmPolicy)
 			if len(nrts) < hostsRequired {
@@ -1053,7 +1051,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				pod.Spec.Containers[i].Resources.Limits = podRes.appCnt[i]
 			}
 			// we expect init containers to be required less often than app containers, so we delegate that
-			makeInitTestContainers(pod, podRes.initCnt, sleepTimeoutInSec)
+			makeInitTestContainers(pod, podRes.initCnt)
 
 			requiredRes := e2ereslist.FromGuaranteedPod(*pod)
 
@@ -1497,13 +1495,12 @@ func setupPaddingForUnsuitableNodes(offset int, fxt *e2efixture.Fixture, nrtList
 	return paddingPods
 }
 
-func makeInitTestContainers(pod *corev1.Pod, initCnt []corev1.ResourceList, timeout string) *corev1.Pod {
+func makeInitTestContainers(pod *corev1.Pod, initCnt []corev1.ResourceList) *corev1.Pod {
 	for i := 0; i < len(initCnt); i++ {
 		pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
 			Name:    fmt.Sprintf("inittestcnt-%d", i),
 			Image:   images.GetPauseImage(),
-			Command: []string{"/bin/sleep"},
-			Args:    []string{timeout},
+			Command: []string{objects.PauseCommand},
 			Resources: corev1.ResourceRequirements{
 				Limits: initCnt[i],
 			},

--- a/test/utils/images/consts.go
+++ b/test/utils/images/consts.go
@@ -23,6 +23,6 @@ const (
 	// NEVER EVER USE THIS OUTSIDE CI or (early) DEVELOPMENT ENVIRONMENTS
 	NUMACellDevicePluginTestImageCI = "quay.io/openshift-kni/numacell-device-plugin:test-ci"
 
-	//the default image used for test pods
+	// the default image used for test pods
 	PauseImage = "gcr.io/google_containers/pause-amd64:3.0"
 )


### PR DESCRIPTION
The reference pause image is the google's (https://hub.docker.com/r/google/pause/tags) which doesn't ship `/bin/sleep` - but only `/sleep`. The e2e serial suite support images replacements, but all of them must be compatible with the pause container.

Fix usage of the pause container images in the e2e serial suite - use `pause`, not `sleep`.

Otherwise:
```
STEP: waiting for the pod to be scheduled
I0801 12:34:56.034474   39136 pod.go:89] pod e2e-test-workload-placement-tmpol-5840/testpod phase Pending desired Running
I0801 12:35:06.149543   39136 pod.go:89] pod e2e-test-workload-placement-tmpol-5840/testpod phase Pending desired Running
I0801 12:35:16.155004   39136 pod.go:89] pod e2e-test-workload-placement-tmpol-5840/testpod phase Pending desired Running
I0801 12:35:26.161026   39136 pod.go:89] pod e2e-test-workload-placement-tmpol-5840/testpod phase Pending desired Running
I0801 12:35:36.161910   39136 pod.go:89] pod e2e-test-workload-placement-tmpol-5840/testpod phase Pending desired Running
I0801 12:35:46.172528   39136 pod.go:89] pod e2e-test-workload-placement-tmpol-5840/testpod phase Pending desired Running
I0801 12:35:56.162612   39136 pod.go:89] pod e2e-test-workload-placement-tmpol-5840/testpod phase Pending desired Running
I0801 12:36:06.151310   39136 pod.go:89] pod e2e-test-workload-placement-tmpol-5840/testpod phase Pending desired Running
I0801 12:36:16.168671   39136 pod.go:89] pod e2e-test-workload-placement-tmpol-5840/testpod phase Pending desired Running
I0801 12:36:26.147087   39136 pod.go:89] pod e2e-test-workload-placement-tmpol-5840/testpod phase Pending desired Running
I0801 12:36:36.174835   39136 pod.go:89] pod e2e-test-workload-placement-tmpol-5840/testpod phase Pending desired Running
I0801 12:36:46.146269   39136 pod.go:89] pod e2e-test-workload-placement-tmpol-5840/testpod phase Pending desired Running
I0801 12:36:56.147096   39136 pod.go:89] pod e2e-test-workload-placement-tmpol-5840/testpod phase Pending desired Running
I0801 12:36:56.257056   39136 pod.go:89] pod e2e-test-workload-placement-tmpol-5840/testpod phase Pending desired Running
I0801 12:36:56.257085   39136 pod.go:86] checking events for pod e2e-test-workload-placement-tmpol-5840/testpod
I0801 12:36:56.480696   39136 pod.go:63] begin events for e2e-test-workload-placement-tmpol-5840/testpod
I0801 12:36:56.480758   39136 pod.go:65] +- event: Normal topo-aware-scheduler: Scheduled Successfully assigned e2e-test-workload-placement-tmpol-5840/testpod to cnfdt11.lab.eng.tlv2.redhat.com
I0801 12:36:56.480784   39136 pod.go:65] +- event: Warning : DNSConfigForming Search Line limits were exceeded, some search paths have been omitted, the applied search line is: e2e-test-workload-placement-tmpol-5840.svc.cluster.local svc.cluster.local cluster.local cnfdt11.lab.eng.tlv2.redhat.com lab.eng.tlv2.redhat.com eng.lab.tlv.redhat.com
I0801 12:36:56.480820   39136 pod.go:65] +- event: Normal : AddedInterface Add eth0 [10.132.3.31/23] from ovn-kubernetes
I0801 12:36:56.480851   39136 pod.go:65] +- event: Normal : Pulled Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine
I0801 12:36:56.480888   39136 pod.go:65] +- event: Warning : Failed Error: container create failed: time="2022-08-01T10:34:59Z" level=error msg="runc create failed: unable to start container process: exec: \"/bin/sleep\": stat /bin/sleep: no such file or directory"
I0801 12:36:56.480924   39136 pod.go:65] +- event: Warning : Failed Error: container create failed: time="2022-08-01T10:35:00Z" level=error msg="runc create failed: unable to start container process: exec: \"/bin/sleep\": stat /bin/sleep: no such file or directory"
I0801 12:36:56.480970   39136 pod.go:65] +- event: Warning : Failed Error: container create failed: time="2022-08-01T10:35:13Z" level=error msg="runc create failed: unable to start container process: exec: \"/bin/sleep\": stat /bin/sleep: no such file or directory"
I0801 12:36:56.481006   39136 pod.go:65] +- event: Warning : Failed Error: container create failed: time="2022-08-01T10:35:27Z" level=error msg="runc create failed: unable to start container process: exec: \"/bin/sleep\": stat /bin/sleep: no such file or directory"
I0801 12:36:56.481051   39136 pod.go:65] +- event: Warning : Failed Error: container create failed: time="2022-08-01T10:35:42Z" level=error msg="runc create failed: unable to start container process: exec: \"/bin/sleep\": stat /bin/sleep: no such file or directory"
I0801 12:36:56.481096   39136 pod.go:65] +- event: Warning : Failed Error: container create failed: time="2022-08-01T10:35:58Z" level=error msg="runc create failed: unable to start container process: exec: \"/bin/sleep\": stat /bin/sleep: no such file or directory"
I0801 12:36:56.481137   39136 pod.go:65] +- event: Warning : Failed Error: container create failed: time="2022-08-01T10:36:09Z" level=error msg="runc create failed: unable to start container process: exec: \"/bin/sleep\": stat /bin/sleep: no such file or directory"
I0801 12:36:56.481170   39136 pod.go:67] end events for e2e-test-workload-placement-tmpol-5840/testpod
STEP: tearing down the test namespace "e2e-test-workload-placement-tmpol-5840"
W0801 12:37:02.823490   39136 fixture.go:86] cooling down for 30s

• Failure [188.571 seconds]
[serial][disruptive][scheduler] numaresources workload placement considering TM policy
/home/fromani/go/src/github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests/workload_placement_tmpol.go:67
  [placement] cluster with multiple worker nodes suitable
  /home/fromani/go/src/github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests/workload_placement_tmpol.go:373
    [tier1][testtype11][tmscope:container] should make a pod with one init cnt and three gu cnt land on a node with enough resources, containers should be spread on a different zone [It]
    /home/fromani/go/src/github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests/workload_placement_tmpol.go:909

    Unexpected error:
        <*errors.errorString | 0xc0002e7390>: {
            s: "timed out waiting for the condition",
        }
        timed out waiting for the condition
    occurred

    /home/fromani/go/src/github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests/workload_placement_tmpol.go:474
------------------------------

```
