### PR TITLE
e2e:install: wait for DaemonSet to show-up

### DIFF
--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -196,7 +196,8 @@ var _ = Describe("[Install] durability", func() {
 					return false, err
 				}
 				if len(nroObj.Status.DaemonSets) != 1 {
-					return false, fmt.Errorf("unsupported daemonsets (/MCP) count: %d", len(nroObj.Status.DaemonSets))
+					klog.Warningf("unsupported daemonsets (/MCP) count: %d", len(nroObj.Status.DaemonSets))
+					return false, nil
 				}
 				return true, nil
 			})

--- a/test/utils/deploy/deploy.go
+++ b/test/utils/deploy/deploy.go
@@ -49,7 +49,7 @@ type NroDeployment struct {
 	NroObj *nropv1alpha1.NUMAResourcesOperator
 }
 
-// overallDeployment returns a struct containing all the deployed objects,
+// OverallDeployment returns a struct containing all the deployed objects,
 // so it will be easier to introspect and delete them later.
 func OverallDeployment() NroDeployment {
 	var matchLabels map[string]string
@@ -95,6 +95,7 @@ func OverallDeployment() NroDeployment {
 	err = e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroObj), nroObj)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
+	By("waiting for MCP to get updated")
 	WaitForMCPUpdatedAfterNROCreated(2, nroObj)
 
 	return deployedObj


### PR DESCRIPTION
We should wait, until timeout, for the DaemonSet count under NRO's status to be equal to 1, and not immediately return an error on the first falling try

Should fix https://github.com/openshift-kni/numaresources-operator/issues/369 

Signed-off-by: Talor Itzhak <titzhak@redhat.com>