### PR TITLE
e2e: serial: handle > 2 workers

### DIFF
--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -429,7 +429,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates)))
 			}
 
-			singleNUMAPolicyNrts := e2enrt.FilterByPolicies(nrtInitialList.Items, []nrtv1alpha1.TopologyManagerPolicy{nrtv1alpha1.SingleNUMANodePodLevel, nrtv1alpha1.SingleNUMANodeContainerLevel})
+			singleNUMAPolicyNrts := e2enrt.FilterByPolicies(nrtCandidates, []nrtv1alpha1.TopologyManagerPolicy{nrtv1alpha1.SingleNUMANodePodLevel, nrtv1alpha1.SingleNUMANodeContainerLevel})
 			nodesNameSet := e2enrt.AccumulateNames(singleNUMAPolicyNrts)
 
 			// the only node which was not padded is the targetedNode


### PR DESCRIPTION
In case we have more than two workers, but some of them have
inconsistent NUMA zones (e.g. BM + VM workers in the same pool),
we can have a panic due to the void assumptions that all the workers
have the same NUMA zones.

This is arguably more a cluster configuration issue than a test flaw,
but the test should not panic nevertheless.

Signed-off-by: Francesco Romani <fromani@redhat.com>