### PR TITLE
logs: improvement split from #363

### DIFF
--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -388,7 +388,7 @@ func (r *NUMAResourcesOperatorReconciler) deleteUnusedDaemonSets(ctx context.Con
 					klog.ErrorS(err, "error while deleting daemonset", "DaemonSet", ds.Name)
 					errors = append(errors, err)
 				} else {
-					klog.V(3).Infof("Daemonset [%s] deleted", ds.Name)
+					klog.V(3).InfoS("Daemonset deleted", "name", ds.Name)
 				}
 			}
 		}
@@ -419,7 +419,7 @@ func (r *NUMAResourcesOperatorReconciler) deleteUnusedMachineConfigs(ctx context
 					klog.ErrorS(err, "error while deleting machineconfig", "MachineConfig", mc.Name)
 					errors = append(errors, err)
 				} else {
-					klog.V(3).Infof("Machineconfig [%s] deleted", mc.Name)
+					klog.V(3).InfoS("Machineconfig deleted", "name", mc.Name)
 				}
 			}
 		}

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -153,7 +153,7 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 }
 
 func (r *NUMAResourcesOperatorReconciler) updateStatus(ctx context.Context, instance *nropv1alpha1.NUMAResourcesOperator, condition string, reason string, message string) (ctrl.Result, error) {
-	klog.Error(message)
+	klog.InfoS("updateStatus", "condition", condition, "reason", reason, "message", message)
 
 	if _, err := updateStatus(ctx, r.Client, instance, condition, reason, message); err != nil {
 		klog.InfoS("Failed to update numaresourcesoperator status", "Desired condition", status.ConditionDegraded, "error", err)

--- a/controllers/numaresourcesscheduler_controller.go
+++ b/controllers/numaresourcesscheduler_controller.go
@@ -135,8 +135,6 @@ func (r *NUMAResourcesSchedulerReconciler) SetupWithManager(mgr ctrl.Manager) er
 }
 
 func (r *NUMAResourcesSchedulerReconciler) reconcileResource(ctx context.Context, instance *nrsv1alpha1.NUMAResourcesScheduler) (reconcile.Result, string, error) {
-	klog.Info("SchedulerSync start")
-
 	deploymentInfo, schedulerName, err := r.syncNUMASchedulerResources(ctx, instance)
 	if err != nil {
 		return ctrl.Result{}, status.ConditionDegraded, errors.Wrapf(err, "FailedSchedulerSync")
@@ -173,6 +171,9 @@ func isDeploymentRunning(ctx context.Context, c client.Client, key nrsv1alpha1.N
 }
 
 func (r *NUMAResourcesSchedulerReconciler) syncNUMASchedulerResources(ctx context.Context, instance *nrsv1alpha1.NUMAResourcesScheduler) (nrsv1alpha1.NamespacedName, string, error) {
+	klog.V(4).Info("SchedulerSync start")
+	defer klog.V(4).Info("SchedulerSync stop")
+
 	var deploymentNName nrsv1alpha1.NamespacedName
 	schedulerName := instance.Spec.SchedulerName
 

--- a/main.go
+++ b/main.go
@@ -120,7 +120,7 @@ func main() {
 	userPlatformVersion, _ := platform.ParseVersion(platformVersion)
 
 	plat, reason, err := detect.FindPlatform(userPlatform)
-	klog.Infof("platform %s (%s)", plat.Discovered, reason)
+	klog.InfoS("platform detection", "kind", plat.Discovered, "reason", reason)
 	clusterPlatform := plat.Discovered
 	if clusterPlatform == platform.Unknown {
 		klog.ErrorS(err, "cannot autodetect the platform, and no platform given")
@@ -128,7 +128,7 @@ func main() {
 	}
 
 	platVersion, source, err := detect.FindVersion(clusterPlatform, userPlatformVersion)
-	klog.Infof("platform version %s (%s)", platVersion.Discovered, source)
+	klog.InfoS("platform detection", "version", platVersion.Discovered, "reason", source)
 	clusterPlatformVersion := version.Minimize(platVersion.Discovered)
 	if clusterPlatformVersion == platform.MissingVersion {
 		klog.ErrorS(err, "cannot autodetect the platform version, and no platform given")

--- a/main.go
+++ b/main.go
@@ -212,7 +212,7 @@ func main() {
 	imageSpec, pullPolicy, err := images.GetCurrentImage(context.Background())
 	if err != nil {
 		// intentionally continue
-		klog.ErrorS(err, "unable to find current image, using hardcoded")
+		klog.InfoS("unable to find current image, using hardcoded", "error", err)
 	}
 	klog.InfoS("using RTE image", "spec", imageSpec)
 


### PR DESCRIPTION
split safe fixes and improvements from #363. Leave the core changes (use common logger + enable iso8601 format) in #363.