### PR TITLE
gh actions: bootstrap the tools lane

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.1
+        go-version: 1.18.4
 
     - name: Verify modules
       run: go mod verify

--- a/.github/workflows/ciformat.yml
+++ b/.github/workflows/ciformat.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.1
+        go-version: 1.18.4
 
     - name: format
       run: ./hack/check-format.sh

--- a/.github/workflows/cilint-custom.yml
+++ b/.github/workflows/cilint-custom.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.1
+        go-version: 1.18.4
 
     - name: Fetch golangci-lint
       run: |

--- a/.github/workflows/cilint.yml
+++ b/.github/workflows/cilint.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.1
+        go-version: 1.18.4
 
     - name: Verify
       uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/e2e-tools.yml
+++ b/.github/workflows/e2e-tools.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Create K8s Kind Cluster
       run: |
-        # kind is part of 20.04 image, see: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
+        # kind is part of 20.04 image, see relevant READMEs in https://github.com/actions/virtual-environments/tree/main/images/linux
         kind version
         kind create cluster --config=hack/kind-config-e2e-no-registry.yaml --image kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
         kubectl label node kind-worker node-role.kubernetes.io/worker=''

--- a/.github/workflows/e2e-tools.yml
+++ b/.github/workflows/e2e-tools.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.1
+        go-version: 1.18.4
 
     - name: Verify modules
       run: go mod verify

--- a/.github/workflows/e2e-tools.yml
+++ b/.github/workflows/e2e-tools.yml
@@ -1,4 +1,4 @@
-name: CI E2E
+name: CI E2E - for tools
 
 on:
   push:
@@ -9,17 +9,17 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+"
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 defaults:
   run:
     shell: bash
 
 jobs:
-  e2e:
+  e2e-tools:
     runs-on: ubuntu-20.04
     env:
-      built_image: "numaresources-operator:ci" # Arbitrary name
-      E2E_NAMESPACE_NAME: numaresources
-      E2E_TOPOLOGY_MANAGER_POLICY: SingleNUMANodePodLevel
       LOG_DIR: /tmp/test_e2e_logs
     steps:
     - name: Checkout
@@ -35,13 +35,13 @@ jobs:
     - name: Verify modules
       run: go mod verify
 
-    - name: build test binary
+    - name: Build tools test binary
       run: |
-        make binary-e2e-rte binary-e2e-install binary-e2e-uninstall
+        make binary-e2e-tools
 
-    - name: Build image
+    - name: Build tools
       run: |
-        docker build . -t ${built_image}
+        make build-tools binary-nrocli
 
     - name: Create K8s Kind Cluster
       run: |
@@ -49,16 +49,16 @@ jobs:
         kind version
         kind create cluster --config=hack/kind-config-e2e-no-registry.yaml --image kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
         kubectl label node kind-worker node-role.kubernetes.io/worker=''
-        kind load docker-image ${built_image}
 
     - name: Deploy RTE Operator
       run: |
-        IMG=${built_image} KUSTOMIZE_DEPLOY_DIR="config/kind-ci/" make deploy
+        # no operator image, no problem
+        KUSTOMIZE_DEPLOY_DIR="config/kind-ci/" make deploy
 
     - name: E2E Tests
       run: |
         export KUBECONFIG=${HOME}/.kube/config
-        NO_TEARDOWN=true make test-e2e
+        hack/run-test-tools-e2e.sh --no-color
 
     - name: Export E2E Tests logs
       if: ${{ failure() }}

--- a/.github/workflows/e2e-tools.yml
+++ b/.github/workflows/e2e-tools.yml
@@ -47,12 +47,12 @@ jobs:
       run: |
         # kind is part of 20.04 image, see: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
         kind version
-        kind create cluster --config=hack/kind-config-e2e-no-registry.yaml --image kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+        kind create cluster --config=hack/kind-config-e2e-no-registry.yaml --image kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
         kubectl label node kind-worker node-role.kubernetes.io/worker=''
 
     - name: Deploy RTE Operator
       run: |
-        # no operator image, no problem
+        # we only need the manifests, this happens to be the easiest way known to date
         KUSTOMIZE_DEPLOY_DIR="config/kind-ci/" make deploy
 
     - name: E2E Tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         # kind is part of 20.04 image, see: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
         kind version
-        kind create cluster --config=hack/kind-config-e2e-no-registry.yaml --image kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+        kind create cluster --config=hack/kind-config-e2e-no-registry.yaml --image kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
         kubectl label node kind-worker node-role.kubernetes.io/worker=''
         kind load docker-image ${built_image}
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Create K8s Kind Cluster
       run: |
-        # kind is part of 20.04 image, see: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
+        # kind is part of 20.04 image, see relevant READMEs in https://github.com/actions/virtual-environments/tree/main/images/linux
         kind version
         kind create cluster --config=hack/kind-config-e2e-no-registry.yaml --image kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
         kubectl label node kind-worker node-role.kubernetes.io/worker=''

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.1
+        go-version: 1.18.4
 
     - name: Verify modules
       run: go mod verify


### PR DESCRIPTION
Add new lane to exercise the helper tools we collected
over time. The new lane will run against a intentionally
unconfigured cluster: we need only the CRDs (and some CRs)
deployed, not the full NROP.

Signed-off-by: Francesco Romani <fromani@redhat.com>