### PR TITLE
gh actions: reuse host kustomize

### DIFF
--- a/.github/workflows/e2e-tools.yml
+++ b/.github/workflows/e2e-tools.yml
@@ -35,6 +35,10 @@ jobs:
     - name: Verify modules
       run: go mod verify
 
+    - name: Reuse kustomize from the host
+      run: |
+        if kustomize version | grep -Eq 'v4\.5'; then mkdir -p bin/ && ln -s $(which kustomize) bin/kustomize; fi
+
     - name: Build tools test binary
       run: |
         make binary-e2e-tools

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,6 +35,10 @@ jobs:
     - name: Verify modules
       run: go mod verify
 
+    - name: Reuse kustomize from the host
+      run: |
+        if kustomize version | grep -Eq 'v4\.5'; then mkdir -p bin/ && ln -s $(which kustomize) bin/kustomize; fi
+
     - name: build test binary
       run: |
         make binary-e2e-rte binary-e2e-install binary-e2e-uninstall


### PR DESCRIPTION
Among the tools part of the base images the gh actions runners
use, there's kustomize; so let's use it instead of wasting
time downloading and building it.

Signed-off-by: Francesco Romani <fromani@redhat.com>