### PR TITLE
serial: check pod requesting unallocatable resources is unschedulable 

### DIFF
--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -1049,19 +1049,7 @@ func allocatableResourceType(nrtInfo nrtv1alpha1.NodeResourceTopology, resName c
 // NUMA nodes so that all the replicas can successfully obtain resources
 // from all the NUMA nodes.
 func leastAvailableResourceQtyInAllZone(nrtInfo nrtv1alpha1.NodeResourceTopology, baseload baseload.Load, resName corev1.ResourceName) resource.Quantity {
-	var maxResAllocatable resource.Quantity
-
-	// Finding the maximum allocatable resources of a resource type across all zones
-	for _, zone := range nrtInfo.Zones {
-		zoneQty, ok := e2enrt.FindResourceAllocatableByName(zone.Resources, resName.String())
-		if !ok {
-			continue
-		}
-		if zoneQty.Cmp(maxResAllocatable) > 0 {
-			maxResAllocatable = zoneQty
-		}
-	}
-
+	maxResAllocatable := e2enrt.GetMaxAllocatableResourceNumaLevel(nrtInfo, resName)
 	return getLeastAvailableResourceQty(maxResAllocatable, nrtInfo.Zones, resName, baseload)
 }
 

--- a/test/utils/noderesourcetopologies/noderesourcetopologies.go
+++ b/test/utils/noderesourcetopologies/noderesourcetopologies.go
@@ -367,6 +367,22 @@ func FindResourceAllocatableByName(resources []nrtv1alpha1.ResourceInfo, name st
 	return *resource.NewQuantity(0, resource.DecimalSI), false
 }
 
+func GetMaxAllocatableResourceNumaLevel(nrtInfo nrtv1alpha1.NodeResourceTopology, resName corev1.ResourceName) resource.Quantity {
+	var maxAllocatable resource.Quantity
+
+	// Finding the maximum allocatable resources of a resource type across all zones
+	for _, zone := range nrtInfo.Zones {
+		zoneQty, ok := FindResourceAllocatableByName(zone.Resources, resName.String())
+		if !ok {
+			continue
+		}
+		if zoneQty.Cmp(maxAllocatable) > 0 {
+			maxAllocatable = zoneQty
+		}
+	}
+	return maxAllocatable
+}
+
 func contains(items []string, st string) bool {
 	for _, item := range items {
 		if item == st {


### PR DESCRIPTION
Add new test that attempts to schedule a pod requesting resources that are greater than allocatable at numa level, and verifies the pod keeps on pending.
