### PR TITLE
e2e:must-gather: Run must-gather e2e test suite only in OCP Platform

### DIFF
--- a/test/e2e/must-gather/must_gather_suite_test.go
+++ b/test/e2e/must-gather/must_gather_suite_test.go
@@ -17,14 +17,18 @@
 package mustgather
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 
 	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	"github.com/openshift-kni/numaresources-operator/test/utils/configuration"
 	"github.com/openshift-kni/numaresources-operator/test/utils/deploy"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 )
 
 var deployment deploy.NroDeployment
@@ -37,6 +41,9 @@ func TestMustGather(t *testing.T) {
 }
 
 var _ = ginkgo.BeforeSuite(func() {
+	if configuration.Plat != platform.OpenShift {
+		ginkgo.Skip(fmt.Sprintf("running on %q platfrom but must-gather is only supported on %q platform", configuration.Plat, platform.OpenShift))
+	}
 	deployment = deploy.OverallDeployment()
 	nroSchedObj = deploy.DeployNROScheduler()
 })

--- a/test/e2e/must-gather/must_gather_test.go
+++ b/test/e2e/must-gather/must_gather_test.go
@@ -28,10 +28,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects/wait"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 )
 
 var _ = ginkgo.Describe("[must-gather] NRO data collected", func() {
@@ -133,7 +134,6 @@ var _ = ginkgo.Describe("[must-gather] NRO data collected", func() {
 					podFolderNames = append(podFolderNames, podFolder.Name())
 				}
 				gomega.Expect(podFolderNames).To(gomega.ContainElement(gomega.MatchRegexp("^numaresources-controller-manager*")))
-				gomega.Expect(podFolderNames).To(gomega.ContainElement(gomega.MatchRegexp("^numaresourcesoperator-mcp-test*")))
 				gomega.Expect(podFolderNames).To(gomega.ContainElement(gomega.MatchRegexp("^secondary-scheduler*")))
 			}
 		})


### PR DESCRIPTION
must-gather is only supported on OCP platform so we should skip all the test suite in any other platform

correction over: #339 
issue: #330 
blocks: openshift/release#31102