### PR TITLE
e2e:serial: requesting available resources with replicaset

### DIFF
--- a/test/e2e/sched/utils/replicaset.go
+++ b/test/e2e/sched/utils/replicaset.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ListPodsByReplicaSet(aclient client.Client, rs appsv1.ReplicaSet) ([]corev1.Pod, error) {
+	podList := &corev1.PodList{}
+	sel, err := metav1.LabelSelectorAsSelector(rs.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+
+	err = aclient.List(context.TODO(), podList, &client.ListOptions{Namespace: rs.Namespace, LabelSelector: sel})
+	if err != nil {
+		return nil, err
+	}
+
+	return podList.Items, nil
+}

--- a/test/utils/noderesourcetopologies/noderesourcetopologies.go
+++ b/test/utils/noderesourcetopologies/noderesourcetopologies.go
@@ -61,7 +61,7 @@ func GetUpdated(cli client.Client, ref nrtv1alpha1.NodeResourceTopologyList, tim
 			return false, err
 		}
 		klog.Infof("NRT List current ResourceVersion %s reference %s", updatedNrtList.ListMeta.ResourceVersion, ref.ListMeta.ResourceVersion)
-		return (updatedNrtList.ListMeta.ResourceVersion != ref.ListMeta.ResourceVersion), nil
+		return updatedNrtList.ListMeta.ResourceVersion != ref.ListMeta.ResourceVersion, nil
 	})
 	return updatedNrtList, err
 }

--- a/test/utils/objects/replicaset.go
+++ b/test/utils/objects/replicaset.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objects
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewTestReplicaSetWithPodSpec(replicas int32, podLabels map[string]string, nodeSelector map[string]string, namespace, name string, podSpec corev1.PodSpec) *appsv1.ReplicaSet {
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: podLabels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+				},
+				Spec: podSpec,
+			},
+		},
+	}
+	if nodeSelector != nil {
+		rs.Spec.Template.Spec.NodeSelector = nodeSelector
+	}
+	return rs
+}


### PR DESCRIPTION
This test will schedule a `ReplicaSet` with multiple replicas and check NRT reflects resource consumption correctly.
In addition the test compares between the scheduling time of default and TAS scheduler and make sure we don't have a regression.
IOW, TAS scheduler doesn't take too much time comparing to the default one.