### PR TITLE
serial: fix memory requests and free resources on target node

### DIFF
--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -1018,7 +1018,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 	)
-	DescribeTable("[placement][negative] cluster with multiple worker nodes suitable",
+	DescribeTable("[placement][negative] cluster with one worker nodes suitable",
 		func(tmPolicy nrtv1alpha1.TopologyManagerPolicy, setupPadding setupPaddingFunc, errMsg string, podRes podResourcesRequest, unsuitableFreeRes, targetFreeResPerNUMA []corev1.ResourceList) {
 
 			hostsRequired := 2
@@ -1151,7 +1151,11 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			// we don't need to wait for NRT update since we already checked it hasn't changed in prior step
 		},
 
-		Entry("[tier1][negative][tmscope:container][cpu] pod with two gu cnt keep on pending",
+		// below tests try to schedule a multi-container pod, when having only one worker node with available resources (target node) for the total pod's containers,
+		// but only one container can be aligned to a single numa node while the second container cannot. Because of that, the pod should keep on pending and we expect
+		// to see the reason for not scheduling the pod on that target node as "cannot align container: testcnt-1", because the other worker nodes have insufficient
+		// free resources to accommodate the pod thus they will be rejected as candidates at earlier stage
+		Entry("[tier1][negative][tmscope:container][cpu] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
 			nrtv1alpha1.SingleNUMANodeContainerLevel,
 			setupPaddingContainerLevel,
 			"cannot align container: testcnt-1",
@@ -1204,7 +1208,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				},
 			},
 		),
-		Entry("[tier1][negative][tmscope:container][memory] pod with two gu cnt keep on pending",
+		Entry("[tier1][negative][tmscope:container][memory] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
 			nrtv1alpha1.SingleNUMANodeContainerLevel,
 			setupPaddingContainerLevel,
 			"cannot align container: testcnt-1",
@@ -1257,7 +1261,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				},
 			},
 		),
-		Entry("[tier1][negative][tmscope:container][hugepages2Mi] pod with two gu cnt keep on pending",
+		Entry("[tier1][negative][tmscope:container][hugepages2Mi] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
 			nrtv1alpha1.SingleNUMANodeContainerLevel,
 			setupPaddingContainerLevel,
 			"cannot align container: testcnt-1",
@@ -1310,7 +1314,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				},
 			},
 		),
-		Entry("[tier1][negative][tmscope:container][hugepages1Gi] pod with two gu cnt keep on pending",
+		Entry("[tier1][negative][tmscope:container][hugepages1Gi] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
 			nrtv1alpha1.SingleNUMANodeContainerLevel,
 			setupPaddingContainerLevel,
 			"cannot align container: testcnt-1",

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -1187,7 +1187,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 					"hugepages-1Gi":       resource.MustParse("1Gi"),
 				},
 				{
-					corev1.ResourceCPU:    resource.MustParse("7"),
+					corev1.ResourceCPU:    resource.MustParse("4"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
 					"hugepages-2Mi":       resource.MustParse("32Mi"),
 					"hugepages-1Gi":       resource.MustParse("1Gi"),
@@ -1234,7 +1234,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			// and then the pod might land on the unsuitable node.
 			[]corev1.ResourceList{
 				{
-					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
 					"hugepages-2Mi":       resource.MustParse("32Mi"),
 					"hugepages-1Gi":       resource.MustParse("1Gi"),
@@ -1293,7 +1293,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 					"hugepages-1Gi":       resource.MustParse("1Gi"),
 				},
 				{
-					corev1.ResourceCPU:    resource.MustParse("7"),
+					corev1.ResourceCPU:    resource.MustParse("4"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
 					"hugepages-2Mi":       resource.MustParse("32Mi"),
 					"hugepages-1Gi":       resource.MustParse("1Gi"),
@@ -1345,7 +1345,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 					"hugepages-1Gi":       resource.MustParse("1Gi"),
 				},
 				{
-					corev1.ResourceCPU:    resource.MustParse("7"),
+					corev1.ResourceCPU:    resource.MustParse("4"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
 					"hugepages-2Mi":       resource.MustParse("32Mi"),
 					"hugepages-1Gi":       resource.MustParse("1Gi"),

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/helper"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/ghodss/yaml"
 	. "github.com/onsi/ginkgo"
@@ -1119,10 +1120,13 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			By("verify the pod keep on pending")
-			updatedPod, err := wait.ForPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodPending, 2*time.Minute)
+			err = wait.WhileInPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodPending, 10*time.Second, 5)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
 			}
+			Expect(err).ToNot(HaveOccurred())
+			updatedPod := &corev1.Pod{}
+			err = fxt.Client.Get(context.TODO(), client.ObjectKey{Namespace: pod.Namespace, Name: pod.Name}, updatedPod)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("checking the scheduler report the expected error in the pod events`")

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -1202,11 +1202,16 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 					"hugepages-1Gi":       resource.MustParse("1Gi"),
 				},
 			},
+			// the free resources that should be left on the target node should not depend that there will be some baseload added upon padding the node,
+			// those free resources should match the pod requests in total. The reason behind that is that Noderesourcesfit plugin (the plugin that is
+			// responsible for accepting/rejecting compute nodes as candidates for placing the pod) actually accounts for the baseload, it compares the
+			// actual available resources on node with the pod requested resources, if the available resources can accommodate the pod resources then it
+			// will mark the node as a possible candidate, if not it will reject it.
 			[]corev1.ResourceList{
 				{
 					// the baseload will be added to the first numa zone upon padding, this need to consider
 					// that baseCpus + targetNodeFreeCpus does not make the first numa a candidate for any of the containers. Take into account that the baseCpus can be at least 2 cpus
-					//so for example if cpus(cont1) = 5 and cpus(cont2) = 5 then cpus(numa0)<5 and since teh basecpus usually is 2 then we should make pass at most 2 free cpus as the free cpus in numa0
+					//so for example if cpus(cont1) = 5 and cpus(cont2) = 5 then cpus(numa0)<5 and since the basecpus usually is 2 then we should make pass at most 2 free cpus as the free cpus in numa0
 					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
 					"hugepages-2Mi":       resource.MustParse("32Mi"),
@@ -1228,13 +1233,13 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				appCnt: []corev1.ResourceList{
 					{
 						corev1.ResourceCPU:    resource.MustParse("4"),
-						corev1.ResourceMemory: resource.MustParse("4Gi"),
+						corev1.ResourceMemory: resource.MustParse("7Gi"),
 						"hugepages-2Mi":       resource.MustParse("32Mi"),
 						"hugepages-1Gi":       resource.MustParse("1Gi"),
 					},
 					{
 						corev1.ResourceCPU:    resource.MustParse("4"),
-						corev1.ResourceMemory: resource.MustParse("5Gi"),
+						corev1.ResourceMemory: resource.MustParse("7Gi"),
 						"hugepages-2Mi":       resource.MustParse("32Mi"),
 						"hugepages-1Gi":       resource.MustParse("1Gi"),
 					},
@@ -1258,16 +1263,22 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 					"hugepages-1Gi":       resource.MustParse("1Gi"),
 				},
 			},
+			// the free resources that should be left on the target node should not depend that there will be some baseload added upon padding the node,
+			// those free resources should match the pod requests in total. The reason behind that is that Noderesourcesfit plugin (the plugin that is
+			// responsible for accepting/rejecting compute nodes as candidates for placing the pod) actually accounts for the baseload, it compares the
+			// actual available resources on node with the pod requested resources, if the available resources can accommodate the pod resources then it
+			// will mark the node as a possible candidate, if not it will reject it.
 			[]corev1.ResourceList{
 				{
-					corev1.ResourceCPU:    resource.MustParse("4"),
-					corev1.ResourceMemory: resource.MustParse("4Gi"),
+					corev1.ResourceCPU: resource.MustParse("4"),
+					//the base memory on the node could be 4.5Gi, so we need to consider that 4.5Gi + 1Gi is not enough for any of the pod containers
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
 					"hugepages-2Mi":       resource.MustParse("32Mi"),
 					"hugepages-1Gi":       resource.MustParse("1Gi"),
 				},
 				{
 					corev1.ResourceCPU:    resource.MustParse("4"),
-					corev1.ResourceMemory: resource.MustParse("4Gi"),
+					corev1.ResourceMemory: resource.MustParse("13Gi"),
 					"hugepages-2Mi":       resource.MustParse("32Mi"),
 					"hugepages-1Gi":       resource.MustParse("1Gi"),
 				},
@@ -1311,6 +1322,11 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 					"hugepages-1Gi":       resource.MustParse("1Gi"),
 				},
 			},
+			// the free resources that should be left on the target node should not depend that there will be some baseload added upon padding the node,
+			// those free resources should match the pod requests in total. The reason behind that is that Noderesourcesfit plugin (the plugin that is
+			// responsible for accepting/rejecting compute nodes as candidates for placing the pod) actually accounts for the baseload, it compares the
+			// actual available resources on node with the pod requested resources, if the available resources can accommodate the pod resources then it
+			// will mark the node as a possible candidate, if not it will reject it.
 			[]corev1.ResourceList{
 				{
 					corev1.ResourceCPU:    resource.MustParse("4"),
@@ -1363,6 +1379,11 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 					"hugepages-1Gi":       resource.MustParse("1Gi"),
 				},
 			},
+			// the free resources that should be left on the target node should not depend that there will be some baseload added upon padding the node,
+			// those free resources should match the pod requests in total. The reason behind that is that Noderesourcesfit plugin (the plugin that is
+			// responsible for accepting/rejecting compute nodes as candidates for placing the pod) actually accounts for the baseload, it compares the
+			// actual available resources on node with the pod requested resources, if the available resources can accommodate the pod resources then it
+			// will mark the node as a possible candidate, if not it will reject it.
 			[]corev1.ResourceList{
 				{
 					corev1.ResourceCPU:    resource.MustParse("4"),

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -1126,6 +1126,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			By("checking the scheduler report the expected error in the pod events`")
+			loggedEvents := false
 			Eventually(func() bool {
 				events, err := objects.GetEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
 				if err != nil {
@@ -1137,6 +1138,10 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 					}
 				}
 				klog.Warningf("failed to find the expected event with Reason=\"FailedScheduling\" and Message contains: %q", errMsg)
+				if !loggedEvents {
+					objects.LogEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
+					loggedEvents = true
+				}
 				return false
 			}).WithTimeout(2*time.Minute).WithPolling(10*time.Second).Should(BeTrue(), "pod %s/%s doesn't contains the expected event error", updatedPod.Namespace, updatedPod.Name)
 

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -1162,7 +1162,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
 					{
-						corev1.ResourceCPU:    resource.MustParse("4"),
+						corev1.ResourceCPU:    resource.MustParse("5"),
 						corev1.ResourceMemory: resource.MustParse("4Gi"),
 						"hugepages-2Mi":       resource.MustParse("32Mi"),
 						"hugepages-1Gi":       resource.MustParse("1Gi"),
@@ -1195,13 +1195,16 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 			[]corev1.ResourceList{
 				{
-					corev1.ResourceCPU:    resource.MustParse("4"),
+					// the baseload will be added to the first numa zone upon padding, this need to consider
+					// that baseCpus + targetNodeFreeCpus does not make the first numa a candidate for any of the containers. Take into account that the baseCpus can be at least 2 cpus
+					//so for example if cpus(cont1) = 5 and cpus(cont2) = 5 then cpus(numa0)<5 and since teh basecpus usually is 2 then we should make pass at most 2 free cpus as the free cpus in numa0
+					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
 					"hugepages-2Mi":       resource.MustParse("32Mi"),
 					"hugepages-1Gi":       resource.MustParse("1Gi"),
 				},
 				{
-					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceCPU:    resource.MustParse("9"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
 					"hugepages-2Mi":       resource.MustParse("32Mi"),
 					"hugepages-1Gi":       resource.MustParse("1Gi"),


### PR DESCRIPTION
The memory alignment test was expecting to find a message in the pod events indicating that although the pod resources were available on compute node level, alignment of both containers could not be achieved on a single numa node, one container per numa as per the assumption that the tests run only when TMscope=container.
The test failed to find that expected message because there were no candidate nodes in the first place, the reason was a lack of memory resources. The pod was requesting 9Gi, while the free resources left on the target node were only 8. The reason it was set to 8 is because of the false thought that there will be base memory on that node, which is usually 4.5Gi, which makes sense that 4.5Gi + 8Gi is way more than enough, but that is a mistake. because when noderesourcefit filters the nodes it compares the actual available resources on the node with the pod requested resources, if the available resources can accommodate the pod resources then it will mark the node as a possible candidate, if not it will reject it. The result we get from Fit when the test fails is that there is only 8.3 free memory on the target node, hence it is rejected.

To fix the test, first set minimum free resources on the first numa of the target node: 1Gi, because we know for sure that the baseload will be added to the first numa upon padding the node. the base memory is around 4.5Gi, so we need to consider that both pod containers requests at least 6Gi so none of them could fit into the first numa. To be on the safe side, let both containers request 7Gi.
OTOH the target node should have total free memory that matches the total memory requested by the pod, which is 14Gi, thus let the second numa on the target node have the rest of 13Gi free memory.
