### PR TITLE
e2e: fixture: add podsecurity labels

### DIFF
--- a/test/utils/fixture/fixture.go
+++ b/test/utils/fixture/fixture.go
@@ -101,6 +101,11 @@ func setupNamespace(cli client.Client, baseName string, randomize bool) (corev1.
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
+			Labels: map[string]string{
+				"pod-security.kubernetes.io/audit":   "privileged",
+				"pod-security.kubernetes.io/enforce": "privileged",
+				"pod-security.kubernetes.io/warn":    "privileged",
+			},
 		},
 	}
 


### PR DESCRIPTION
OCP >= 4.12 wants to have stricter podsecurity rules.
In our e2e tests we do a bunch of stuff, including running privileged
pods. We just annotate the test namespace(s) to signal we need top
privileges. Since e2e tests run in very controlled envs (CI mostly),
and since test namespace should be gone anyway once the e2e tests
are finished, this is still fair game.

Signed-off-by: Francesco Romani <fromani@redhat.com>