### PR TITLE
e2e: serial lane cleanup and fixes

### DIFF
--- a/rte/main.go
+++ b/rte/main.go
@@ -204,6 +204,10 @@ func parseArgs(args ...string) (ProgArgs, error) {
 	if pArgs.RTE.TopologyManagerScope == "" {
 		pArgs.RTE.TopologyManagerScope = conf.TopologyManagerScope
 	}
+	klog.Infof("using Topology Manager scope %q (conf=%s) policy %q (conf=%s)",
+		pArgs.RTE.TopologyManagerScope, conf.TopologyManagerScope,
+		pArgs.RTE.TopologyManagerPolicy, conf.TopologyManagerPolicy,
+	)
 
 	return pArgs, nil
 }

--- a/rte/main.go
+++ b/rte/main.go
@@ -201,9 +201,7 @@ func parseArgs(args ...string) (ProgArgs, error) {
 	if pArgs.RTE.TopologyManagerPolicy == "" {
 		pArgs.RTE.TopologyManagerPolicy = conf.TopologyManagerPolicy
 	}
-
-	// overwrite if explicitly mentioned in conf
-	if conf.TopologyManagerScope != "" {
+	if pArgs.RTE.TopologyManagerScope == "" {
 		pArgs.RTE.TopologyManagerScope = conf.TopologyManagerScope
 	}
 

--- a/rte/main.go
+++ b/rte/main.go
@@ -64,15 +64,14 @@ func main() {
 		os.Exit(0)
 	}
 
-	// only for debug purposes
-	// printing the header so early includes any debug message from the sysinfo package
-	klog.Infof("=== System information ===\n")
 	sysInfo, err := sysinfo.NewSysinfo(parsedArgs.LocalArgs.SysConf)
 	if err != nil {
 		klog.Fatalf("failed to query system info: %w", err)
 	}
-	klog.Infof("\n%s", sysInfo)
-	klog.Infof("==========================\n")
+	klog.Infof(`
+=== System information ===
+%s
+==========================`, sysInfo)
 
 	if parsedArgs.SysinfoOnly {
 		os.Exit(0)

--- a/rte/pkg/sysinfo/sysinfo.go
+++ b/rte/pkg/sysinfo/sysinfo.go
@@ -183,7 +183,7 @@ func FormatSize(v int64) string {
 
 func (si SysInfo) String() string {
 	b := strings.Builder{}
-	fmt.Fprintf(&b, "cpus: allocatable %q\n", si.CPUs.String())
+	fmt.Fprintf(&b, "cpus:\n  allocatable %q\n", si.CPUs.String())
 	for memoryType, numaMem := range si.Memory {
 		fmt.Fprintf(&b, "%s:\n", memoryType)
 		for numaNode, amount := range numaMem {

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -114,7 +114,12 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				corev1.ResourceMemory: resource.MustParse("8G"),
 			}
 			By("padding the nodes before test start")
-			err := padder.Nodes(numOfNodeToBePadded).UntilAvailableIsResourceList(rl).Pad(timeout, e2epadder.PaddingOptions{})
+			labSel, err := labels.Parse(serialconfig.MultiNUMALabel + "=2")
+			Expect(err).ToNot(HaveOccurred())
+
+			err = padder.Nodes(numOfNodeToBePadded).UntilAvailableIsResourceList(rl).Pad(timeout, e2epadder.PaddingOptions{
+				LabelSelector: labSel,
+			})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -158,7 +163,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			podLabels := map[string]string{
 				"test": "test-dp",
 			}
-			nodeSelector := map[string]string{}
+			nodeSelector := map[string]string{
+				serialconfig.MultiNUMALabel: "2",
+			}
 
 			// the pod is asking for 4 CPUS and 200Mi in total
 			requiredRes := corev1.ResourceList{
@@ -923,6 +930,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 							},
 						},
 					},
+				},
+				NodeSelector: map[string]string{
+					serialconfig.MultiNUMALabel: "2",
 				},
 			})
 

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -96,16 +96,29 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 	// and will we want to start lean and mean.
 
 	Context("cluster has at least one suitable node", func() {
+		hostsRequired := 2
 		timeout := 5 * time.Minute
 		// will be called at the end of the test to make sure we're not polluting the cluster
 		var cleanFuncs []func() error
 
 		BeforeEach(func() {
-			tmPolicy := nrtv1alpha1.SingleNUMANodeContainerLevel
-			nrts = e2enrt.FilterTopologyManagerPolicy(nrtList.Items, tmPolicy)
-			if len(nrts) < 2 {
-				Skip(fmt.Sprintf("not enough nodes with policy %q - found %d", string(tmPolicy), len(nrts)))
+			// so we can't support ATM zones > 2. HW with zones > 2 is rare anyway, so not to big of a deal now.
+			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", 2))
+			nrtCandidates := e2enrt.FilterZoneCountEqual(nrtList.Items, 2)
+			if len(nrtCandidates) < hostsRequired {
+				Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates)))
 			}
+			klog.Infof("Found node with 2 NUMA zones: %d", len(nrtCandidates))
+
+			policies := []nrtv1alpha1.TopologyManagerPolicy{
+				nrtv1alpha1.SingleNUMANodeContainerLevel,
+				nrtv1alpha1.SingleNUMANodePodLevel,
+			}
+			nrts = e2enrt.FilterByPolicies(nrtCandidates, policies)
+			if len(nrts) < hostsRequired {
+				Skip(fmt.Sprintf("not enough nodes with valid policy - found %d", len(nrts)))
+			}
+			klog.Infof("Found node with 2 NUMA zones: %d", len(nrts))
 
 			numOfNodeToBePadded := len(nrts) - 1
 
@@ -133,31 +146,22 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				Expect(err).ToNot(HaveOccurred())
 			}
 		})
+
 		It("[test_id:47591][tier1] should modify workload post scheduling while keeping the resource requests available", func() {
-			hostsRequired := 2
-			paddedNodes := padder.GetPaddedNodes()
-			paddedNodesSet := sets.NewString(paddedNodes...)
-
-			nrtInitialList, err := e2enrt.GetUpdated(fxt.Client, nrtv1alpha1.NodeResourceTopologyList{}, time.Second*10)
-			Expect(err).ToNot(HaveOccurred())
-
-			// so we can't support ATM zones > 2. HW with zones > 2 is rare anyway, so not to big of a deal now.
-			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", 2))
-			nrtCandidates := e2enrt.FilterZoneCountEqual(nrtInitialList.Items, 2)
-			if len(nrtCandidates) < hostsRequired {
-				Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates)))
-			}
-
-			singleNUMAPolicyNrts := e2enrt.FilterByPolicies(nrtInitialList.Items, []nrtv1alpha1.TopologyManagerPolicy{nrtv1alpha1.SingleNUMANodePodLevel, nrtv1alpha1.SingleNUMANodeContainerLevel})
-			nodesNameSet := e2enrt.AccumulateNames(singleNUMAPolicyNrts)
-
+			paddedNodeNames := sets.NewString(padder.GetPaddedNodes()...)
+			nodesNameSet := e2enrt.AccumulateNames(nrts)
 			// the only node which was not padded is the targetedNode
 			// since we know exactly how the test setup looks like we expect only targeted node here
-			targetNodeNameSet := nodesNameSet.Difference(paddedNodesSet)
+			targetNodeNameSet := nodesNameSet.Difference(paddedNodeNames)
 			Expect(targetNodeNameSet.Len()).To(Equal(1), "could not find the target node")
 
 			targetNodeName, ok := e2efixture.PopNodeName(targetNodeNameSet)
 			Expect(ok).To(BeTrue())
+
+			klog.Infof("target node will be %q", targetNodeName)
+
+			nrtInitialList, err := e2enrt.GetUpdated(fxt.Client, nrtv1alpha1.NodeResourceTopologyList{}, time.Second*10)
+			Expect(err).ToNot(HaveOccurred())
 
 			var replicas int32 = 1
 			podLabels := map[string]string{
@@ -433,30 +437,20 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		})
 
 		It("[test_id:47628][tier2] should schedule a workload (with TAS) and then keep a subsequent one (with default scheduler) pending ", func() {
-			hostsRequired := 2
-			paddedNodes := padder.GetPaddedNodes()
-			paddedNodesSet := sets.NewString(paddedNodes...)
-
-			nrtInitialList, err := e2enrt.GetUpdated(fxt.Client, nrtv1alpha1.NodeResourceTopologyList{}, time.Second*10)
-			Expect(err).ToNot(HaveOccurred())
-
-			// so we can't support ATM zones > 2. HW with zones > 2 is rare anyway, so not to big of a deal now.
-			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", 2))
-			nrtCandidates := e2enrt.FilterZoneCountEqual(nrtInitialList.Items, 2)
-			if len(nrtCandidates) < hostsRequired {
-				Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates)))
-			}
-
-			singleNUMAPolicyNrts := e2enrt.FilterByPolicies(nrtCandidates, []nrtv1alpha1.TopologyManagerPolicy{nrtv1alpha1.SingleNUMANodePodLevel, nrtv1alpha1.SingleNUMANodeContainerLevel})
-			nodesNameSet := e2enrt.AccumulateNames(singleNUMAPolicyNrts)
-
+			paddedNodeNames := sets.NewString(padder.GetPaddedNodes()...)
+			nodesNameSet := e2enrt.AccumulateNames(nrts)
 			// the only node which was not padded is the targetedNode
 			// since we know exactly how the test setup looks like we expect only targeted node here
-			targetNodeNameSet := nodesNameSet.Difference(paddedNodesSet)
+			targetNodeNameSet := nodesNameSet.Difference(paddedNodeNames)
 			Expect(targetNodeNameSet.Len()).To(Equal(1), "could not find the target node")
 
 			targetNodeName, ok := e2efixture.PopNodeName(targetNodeNameSet)
 			Expect(ok).To(BeTrue())
+
+			klog.Infof("target node will be %q", targetNodeName)
+
+			nrtInitialList, err := e2enrt.GetUpdated(fxt.Client, nrtv1alpha1.NodeResourceTopologyList{}, time.Second*10)
+			Expect(err).ToNot(HaveOccurred())
 
 			nrtInitial, err := e2enrt.FindFromList(nrtInitialList.Items, targetNodeName)
 			Expect(err).ToNot(HaveOccurred())
@@ -635,20 +629,31 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}).WithTimeout(time.Minute).WithPolling(time.Second*5).Should(BeTrue(), "resources not restored on %q", updatedPod.Spec.NodeName)
 		})
 	})
+
 	Context("cluster has at least one suitable node with Topology Manager single numa policy (both container and pod scope acceptable)", func() {
+		hostsRequired := 2
 		timeout := 5 * time.Minute
 		// will be called at the end of the test to make sure we're not polluting the cluster
 		var cleanFuncs []func() error
 
 		BeforeEach(func() {
+			// so we can't support ATM zones > 2. HW with zones > 2 is rare anyway, so not to big of a deal now.
+			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", 2))
+			nrtCandidates := e2enrt.FilterZoneCountEqual(nrtList.Items, 2)
+			if len(nrtCandidates) < hostsRequired {
+				Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates)))
+			}
+			klog.Infof("Found node with 2 NUMA zones: %d", len(nrtCandidates))
+
 			policies := []nrtv1alpha1.TopologyManagerPolicy{
 				nrtv1alpha1.SingleNUMANodeContainerLevel,
 				nrtv1alpha1.SingleNUMANodePodLevel,
 			}
-			nrts = e2enrt.FilterByPolicies(nrtList.Items, policies)
-			if len(nrts) < 2 {
+			nrts = e2enrt.FilterByPolicies(nrtCandidates, policies)
+			if len(nrts) < hostsRequired {
 				Skip(fmt.Sprintf("not enough nodes with valid policy - found %d", len(nrts)))
 			}
+			klog.Infof("Found node with 2 NUMA zones: %d", len(nrts))
 
 			numOfNodeToBePadded := len(nrts) - 1
 
@@ -657,7 +662,12 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				corev1.ResourceMemory: resource.MustParse("8G"),
 			}
 			By("padding the nodes before test start")
-			err := padder.Nodes(numOfNodeToBePadded).UntilAvailableIsResourceList(rl).Pad(timeout, e2epadder.PaddingOptions{})
+			labSel, err := labels.Parse(serialconfig.MultiNUMALabel + "=2")
+			Expect(err).ToNot(HaveOccurred())
+
+			err = padder.Nodes(numOfNodeToBePadded).UntilAvailableIsResourceList(rl).Pad(timeout, e2epadder.PaddingOptions{
+				LabelSelector: labSel,
+			})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -671,33 +681,24 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				Expect(err).ToNot(HaveOccurred())
 			}
 		})
+
 		It("[test_id:48746][tier2] should modify workload post scheduling while keeping the resource requests available across all NUMA node", func() {
-
-			hostsRequired := 2
-			paddedNodes := padder.GetPaddedNodes()
-			paddedNodesSet := sets.NewString(paddedNodes...)
-
-			err := fxt.Client.List(context.TODO(), &nrtList)
-			Expect(err).ToNot(HaveOccurred())
-
-			// so we can't support ATM zones > 2. HW with zones > 2 is rare anyway, so not to big of a deal now.
-			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", 2))
-			nrtCandidates := e2enrt.FilterZoneCountEqual(nrtList.Items, 2)
-			if len(nrtCandidates) < hostsRequired {
-				Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates)))
-			}
-
+			paddedNodeNames := sets.NewString(padder.GetPaddedNodes()...)
 			nodesNameSet := e2enrt.AccumulateNames(nrts)
-
 			// the only node which was not padded is the targetedNode
 			// since we know exactly how the test setup looks like we expect only targeted node here
-			targetNodeNameSet := nodesNameSet.Difference(paddedNodesSet)
+			targetNodeNameSet := nodesNameSet.Difference(paddedNodeNames)
 			Expect(targetNodeNameSet.Len()).To(Equal(1), "could not find the target node")
 
 			targetNodeName, ok := e2efixture.PopNodeName(targetNodeNameSet)
 			Expect(ok).To(BeTrue())
 
-			targetNrtInitial, err := e2enrt.FindFromList(nrtList.Items, targetNodeName)
+			klog.Infof("target node will be %q", targetNodeName)
+
+			nrtInitialList, err := e2enrt.GetUpdated(fxt.Client, nrtv1alpha1.NodeResourceTopologyList{}, time.Second*10)
+			Expect(err).ToNot(HaveOccurred())
+
+			targetNrtInitial, err := e2enrt.FindFromList(nrtInitialList.Items, targetNodeName)
 			Expect(err).NotTo(HaveOccurred())
 
 			var replicas int32 = 2
@@ -867,17 +868,29 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}, time.Minute, time.Second*5).Should(BeTrue(), "resources not restored on %q", targetNodeName)
 		})
 	})
+
 	Context("cluster with at least two available nodes", func() {
+		hostsRequired := 2
 		timeout := 5 * time.Minute
+
 		BeforeEach(func() {
+			// so we can't support ATM zones > 2. HW with zones > 2 is rare anyway, so not to big of a deal now.
+			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", 2))
+			nrtCandidates := e2enrt.FilterZoneCountEqual(nrtList.Items, 2)
+			if len(nrtCandidates) < hostsRequired {
+				Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates)))
+			}
+			klog.Infof("Found node with 2 NUMA zones: %d", len(nrtCandidates))
+
 			policies := []nrtv1alpha1.TopologyManagerPolicy{
 				nrtv1alpha1.SingleNUMANodeContainerLevel,
 				nrtv1alpha1.SingleNUMANodePodLevel,
 			}
-			nrts = e2enrt.FilterByPolicies(nrtList.Items, policies)
-			if len(nrts) < 2 {
+			nrts = e2enrt.FilterByPolicies(nrtCandidates, policies)
+			if len(nrts) < hostsRequired {
 				Skip(fmt.Sprintf("not enough nodes with valid policy - found %d", len(nrts)))
 			}
+			klog.Infof("Found node with 2 NUMA zones: %d", len(nrts))
 
 			numOfNodeToBePadded := len(nrts) - 1
 
@@ -886,7 +899,12 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				corev1.ResourceMemory: resource.MustParse("4G"),
 			}
 			By("padding the nodes before test start")
-			err := padder.Nodes(numOfNodeToBePadded).UntilAvailableIsResourceList(rl).Pad(timeout, e2epadder.PaddingOptions{})
+			labSel, err := labels.Parse(serialconfig.MultiNUMALabel + "=2")
+			Expect(err).ToNot(HaveOccurred())
+
+			err = padder.Nodes(numOfNodeToBePadded).UntilAvailableIsResourceList(rl).Pad(timeout, e2epadder.PaddingOptions{
+				LabelSelector: labSel,
+			})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -894,8 +912,8 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			By("unpadding the nodes after test finish")
 			err := padder.Clean()
 			Expect(err).ToNot(HaveOccurred())
-
 		})
+
 		It("[test_id:47627] should be able to schedule many replicas with performance time equals to the default scheduler", func() {
 			nrtInitial, err := e2enrt.GetUpdated(fxt.Client, nrtList, timeout)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -161,7 +161,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			var replicas int32 = 1
 			podLabels := map[string]string{
-				"test": "test-dp",
+				"test": "test-dp-47591",
 			}
 			nodeSelector := map[string]string{
 				serialconfig.MultiNUMALabel: "2",
@@ -177,7 +177,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				SchedulerName: serialconfig.Config.SchedulerName,
 				Containers: []corev1.Container{
 					{
-						Name:    "testdp-cnt",
+						Name:    "test-dp-47591-cnt-1",
 						Image:   objects.PauseImage,
 						Command: []string{objects.PauseCommand},
 						Resources: corev1.ResourceRequirements{
@@ -186,7 +186,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 						},
 					},
 					{
-						Name:    "testdp-cnt2",
+						Name:    "test-dp-47591-cnt-2",
 						Image:   objects.PauseImage,
 						Command: []string{objects.PauseCommand},
 						Resources: corev1.ResourceRequirements{
@@ -199,7 +199,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}
 
 			By(fmt.Sprintf("creating a deployment with a guaranteed pod with two containers requiring total %s", e2ereslist.ToString(e2ereslist.FromContainers(podSpec.Containers))))
-			dp := objects.NewTestDeploymentWithPodSpec(replicas, podLabels, nodeSelector, fxt.Namespace.Name, "testdp", *podSpec)
+			dp := objects.NewTestDeploymentWithPodSpec(replicas, podLabels, nodeSelector, fxt.Namespace.Name, "testdp47591", *podSpec)
 
 			err = fxt.Client.Create(context.TODO(), dp)
 			Expect(err).ToNot(HaveOccurred())
@@ -728,7 +728,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}
 
 			By(fmt.Sprintf("creating a deployment with a deployment pod with two replicas requiring %s", e2ereslist.ToString(reqResources)))
-			dp := objects.NewTestDeployment(replicas, podLabels, nodeSelector, fxt.Namespace.Name, "testdp", objects.PauseImage, []string{objects.PauseCommand}, []string{})
+			dp := objects.NewTestDeployment(replicas, podLabels, nodeSelector, fxt.Namespace.Name, "testdp48746", objects.PauseImage, []string{objects.PauseCommand}, []string{})
 			dp.Spec.Template.Spec.SchedulerName = serialconfig.Config.SchedulerName
 			dp.Spec.Template.Spec.Containers[0].Resources.Limits = reqResources
 

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -77,6 +77,12 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 		if len(nrts) < 2 {
 			Skip(fmt.Sprintf("not enough nodes with valid policy - found %d", len(nrts)))
 		}
+
+		nrts = e2enrt.FilterZoneCountEqual(nrts, 2)
+		if len(nrts) < 2 {
+			Skip(fmt.Sprintf("not enough nodes with %d NUMA zones - found %d", 2, len(nrts)))
+		}
+
 		// we expect having the same policy across all NRTs
 		tmPolicy = nrts[0].TopologyPolicies[0]
 

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -27,6 +27,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -622,7 +623,12 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 				corev1.ResourceCPU:    resource.MustParse("3"),
 				corev1.ResourceMemory: resource.MustParse("8Gi"),
 			}
-			err := padder.Nodes(len(nrts)).UntilAvailableIsResourceList(padUntilRes).Pad(time.Minute*2, e2epadder.PaddingOptions{})
+
+			labSel, err := labels.Parse(serialconfig.MultiNUMALabel + "=2")
+			Expect(err).ToNot(HaveOccurred())
+			err = padder.Nodes(len(nrts)).UntilAvailableIsResourceList(padUntilRes).Pad(time.Minute*2, e2epadder.PaddingOptions{
+				LabelSelector: labSel,
+			})
 			Expect(err).ToNot(HaveOccurred())
 
 			nrtInitialList, err := e2enrt.GetUpdated(fxt.Client, nrtv1alpha1.NodeResourceTopologyList{}, time.Second*10)


### PR DESCRIPTION
In the latest internal CI cluster run we have a string of failures:
```
Summarizing 9 Failures:

[Fail] [serial][disruptive][scheduler] numaresources workload placement considering taints when cluster has two feasible nodes with taint but only one has the requested resources on a single NUMA zone [BeforeEach] [test_id:47594][tier1] should make a pod with a toleration land on a node with enough resources on a specific NUMA zone 
/home/fromani/go/src/github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests/workload_placement_taint.go:111

[Fail] [serial][disruptive][scheduler] numaresources workload placement Requesting resources that are greater than allocatable at numa level [It] [test_id:47613][tier3] should not schedule a pod requesting resources that are not allocatable at numa level 
/home/fromani/go/src/github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests/non_regression.go:369

[Fail] [serial][disruptive][scheduler] numaresources workload placement cluster has at least one suitable node [It] [test_id:47591][tier1] should modify workload post scheduling while keeping the resource requests available 
/home/fromani/go/src/github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests/workload_placement.go:219

[Fail] [serial][disruptive][scheduler] numaresources workload placement cluster has at least one suitable node [It] [test_id:47628][tier2] should schedule a workload (with TAS) and then keep a subsequent one (with default scheduler) pending  
/home/fromani/go/src/github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests/workload_placement.go:456

[Fail] [serial][disruptive][scheduler] numaresources workload placement cluster has at least one suitable node with Topology Manager single numa policy (both container and pod scope acceptable) [It] [test_id:48746][tier2] should modify workload post scheduling while keeping the resource requests available across all NUMA node 
/home/fromani/go/src/github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests/workload_placement.go:745

[Fail] [serial][disruptive][scheduler] numaresources workload placement cluster with at least two available nodes [It] [test_id:47627] should be able to schedule many replicas with performance time equals to the default scheduler 
/home/fromani/go/src/github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests/workload_placement.go:967

[Fail] [serial][disruptive][scheduler] numaresources workload placement considering TM policy [placement] cluster with multiple worker nodes suitable [It] [tier1][testtype11][tmscope:container] should make a pod with one init cnt and three gu cnt land on a node with enough resources, containers should be spread on a different zone 
/home/fromani/go/src/github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests/workload_placement_tmpol.go:476

[Fail] [serial][disruptive][scheduler] numaresources workload placement considering TM policy [placement] cluster with multiple worker nodes suitable [It] [tier1][testtype29][tmscope:container] should make a pod with 3 gu cnt and 3 init cnt land on a node with enough resources, when sum of init and app cnt resources are more than node resources 
/home/fromani/go/src/github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests/workload_placement_tmpol.go:476

[Fail] [serial][disruptive][scheduler] numaresources workload unschedulable with zero suitable nodes [It] [test_id:47615][tier2][unsched] a deployment with multiple guaranteed pods resources that doesn't fit at the NUMA level 
/home/fromani/go/src/github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests/workload_unschedulable.go:688
```

This PR addresses them

--

UPDATE 20220909 with the fixes in this PR all the failures except `testtype11` and `testtype29` are now fixed. We gathered quite some changes already, so I think it's best to move forward and to address these failures on a separate PR