### PR TITLE
e2e: serial: enhance and use the pause image

### DIFF
--- a/Dockerfile.pause
+++ b/Dockerfile.pause
@@ -1,0 +1,9 @@
+FROM docker.io/golang:1.18 AS builder
+
+WORKDIR /go/src/github.com/openshift-kni/numaresources-operator
+COPY . .
+
+RUN make build-pause
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/pause /

--- a/Makefile
+++ b/Makefile
@@ -216,8 +216,11 @@ build-e2e-all: fmt vet binary-e2e-all
 
 build-must-gather-e2e: fmt vet binary-must-gather-e2e
 
-build-pause:
+build-pause: bin-dir
 	install -m 755 hack/pause bin/
+
+bin-dir:
+	@mkdir -p bin || :
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go

--- a/README.tests.md
+++ b/README.tests.md
@@ -63,7 +63,7 @@ podman run -ti \
 
 The E2E suite depends on few extra images. These images are very stable, lightweight and little concern most of times:
 - `quay.io/openshift-kni/numacell-device-plugin:test-ci`
-- `gcr.io/google_containers/pause-amd64:3.0`
+- `quay.io/openshift-kni/pause:test-ci`
 
 However, in some cases it may be unpractical to depend on third party images.
 The E2E test image can act as replacement for all its dependencies, providing either the same code or replacements suitables for its use case.

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -1538,7 +1538,8 @@ func makeInitTestContainers(pod *corev1.Pod, initCnt []corev1.ResourceList) *cor
 		pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
 			Name:    fmt.Sprintf("inittestcnt-%d", i),
 			Image:   images.GetPauseImage(),
-			Command: []string{objects.PauseCommand},
+			Command: []string{"/bin/sleep"},
+			Args:    []string{"1s"},
 			Resources: corev1.ResourceRequirements{
 				Limits: initCnt[i],
 			},

--- a/test/utils/images/consts.go
+++ b/test/utils/images/consts.go
@@ -24,5 +24,5 @@ const (
 	NUMACellDevicePluginTestImageCI = "quay.io/openshift-kni/numacell-device-plugin:test-ci"
 
 	// the default image used for test pods
-	PauseImage = "gcr.io/google_containers/pause-amd64:3.0"
+	PauseImage = "quay.io/openshift-kni/pause:test-ci"
 )

--- a/test/utils/objects/consts.go
+++ b/test/utils/objects/consts.go
@@ -17,6 +17,6 @@
 package objects
 
 const (
-	PauseImage   = "gcr.io/google_containers/pause-amd64:3.0"
+	PauseImage   = "quay.io/openshift-kni/pause:test-ci"
 	PauseCommand = "/pause"
 )


### PR DESCRIPTION
We should never use `pause` as entrypoint in initcnt, because `pause` by design will never terminate, so the init containers
will never terminate, so the pod will never go running.

Now that we have an enhanced pause image (or a image with both pause and sleep in general), we can safely change the entrypoint to just sleep for a tiny bit as entry point.