### PR TITLE
e2e: fixture: serial: configurable cooldown

### DIFF
--- a/test/e2e/serial/README.md
+++ b/test/e2e/serial/README.md
@@ -34,3 +34,5 @@ they found it before they run.
   failed unexpectedly on standard output, alongside (not replacing) the logging of the said events.
 - `E2E_NROP_TARGET_NODE` (accepts string, e.g. `node-0.my-cluster.io`) instructs the suite to always pick the
   node matching the given name when a random node is needed.
+- `E2E_NROP_TEST_COOLDOWN` (accepts string expressing time unit, e.g. `30s`) instructs the suite to wait for
+  the specified amount of time after each spec, to give tome to the cluster to settle up.


### PR DESCRIPTION
We originally added the cooldown time to allow the cluster state to settle down after a test run. But that was always meant a safeguard. Now we have 50+ specs, and 50+ specs each waiting 30s is now contributing significantly to the suite wall clock execution time.

Let's start to improve. Let's add a env var to override this value, so we can start checking if lower values (ideally zero) are now OK.

Signed-off-by: Francesco Romani <fromani@redhat.com>