### PR TITLE
[release-4.11][manual] e2e:install: wait for DaemonSet to show-up

### DIFF
--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -203,7 +203,8 @@ var _ = Describe("[Install] durability", func() {
 					return false, err
 				}
 				if len(nroObj.Status.DaemonSets) != 1 {
-					return false, fmt.Errorf("unsupported daemonsets (/MCP) count: %d", len(nroObj.Status.DaemonSets))
+					klog.Warningf("unsupported daemonsets (/MCP) count: %d", len(nroObj.Status.DaemonSets))
+					return false, nil
 				}
 				return true, nil
 			})


### PR DESCRIPTION
We should wait, until timeout, for the DaemonSet count under NRO's status to be equal to 1, and not immediately return an error on the first falling try.

Should fix #369

Partial cherry-pick
from https://github.com/openshift-kni/numaresources-operator/pull/375/commits/5dfe861a292b88be560a127729a20ba2a2653da8

Signed-off-by: Talor Itzhak <titzhak@redhat.com>
Signed-off-by: Francesco Romani <fromani@redhat.com>