### PR TITLE
serial: add tests with device resources

### DIFF
--- a/test/e2e/serial/README.md
+++ b/test/e2e/serial/README.md
@@ -38,3 +38,10 @@ they found it before they run.
   for the specified amount of time after each spec, to give time to the cluster to settle up.
 - `E2E_NROP_TEST_TEARDOWN` (accepts string expressing time unit, e.g. `30s`) instructs the suite to wait
   *up* to the specified amount of time while tearing down the resources needed by each spec.
+- `E2E_NROP_DEVICE_A` (accepts string, e.g `example.com/deviceA`) declares name of a device type that exists on
+  the cluster and will be used as a resource of type `device-a` in the tests.
+- `E2E_NROP_DEVICE_B` (accepts string, e.g `example.com/deviceB`) declares name of a device type that exists on
+  the cluster and will be used as a resource of type `device-b` in the tests.
+- `E2E_NROP_DEVICE_C` (accepts string, e.g `example.com/deviceC`) declares name of a device type that exists on
+  the cluster and will be used as a resource of type `device-c` in the tests.
+  

--- a/test/utils/fixture/devices.go
+++ b/test/utils/fixture/devices.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fixture
+
+import (
+	"os"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	devType1EnvVar = "E2E_NROP_DEVICE_TYPE_1"
+	devType2EnvVar = "E2E_NROP_DEVICE_TYPE_2"
+	devType3EnvVar = "E2E_NROP_DEVICE_TYPE_3"
+)
+
+func GetDeviceType1Name() string {
+	if devType1, ok := os.LookupEnv(devType1EnvVar); ok {
+		return devType1
+	}
+	klog.Errorf("%q environment variable is not set", devType1EnvVar)
+	return ""
+}
+
+func GetDeviceType2Name() string {
+	if devType2, ok := os.LookupEnv(devType2EnvVar); ok {
+		return devType2
+	}
+	klog.Errorf("%q environment variable is not set", devType2EnvVar)
+	return ""
+}
+
+func GetDeviceType3Name() string {
+	if devType3, ok := os.LookupEnv(devType3EnvVar); ok {
+		return devType3
+	}
+	klog.Errorf("%q environment variable is not set", devType3EnvVar)
+	return ""
+}


### PR DESCRIPTION
Add new environment variables for the devices names E2E_NROP_DEVICE_A, E2E_NROP_DEVICE_B, and E2E_NROP_DEVICE_C, that is to enable running the tests with any device type and not limited to specific types.
Add new tests with pods requesting device resources and check the alignment of these pods to the nodes.