### PR TITLE
e2e: serial: fixture: configurable teardown time

### DIFF
--- a/test/e2e/serial/README.md
+++ b/test/e2e/serial/README.md
@@ -34,5 +34,7 @@ they found it before they run.
   failed unexpectedly on standard output, alongside (not replacing) the logging of the said events.
 - `E2E_NROP_TARGET_NODE` (accepts string, e.g. `node-0.my-cluster.io`) instructs the suite to always pick the
   node matching the given name when a random node is needed.
-- `E2E_NROP_TEST_COOLDOWN` (accepts string expressing time unit, e.g. `30s`) instructs the suite to wait for
-  the specified amount of time after each spec, to give tome to the cluster to settle up.
+- `E2E_NROP_TEST_COOLDOWN` (accepts string expressing time unit, e.g. `30s`) instructs the suite to wait
+  for the specified amount of time after each spec, to give time to the cluster to settle up.
+- `E2E_NROP_TEST_TEARDOWN` (accepts string expressing time unit, e.g. `30s`) instructs the suite to wait
+  *up* to the specified amount of time while tearing down the resources needed by each spec.


### PR DESCRIPTION
We continue our quest to cut down the test execution wall clock time begun in 3aed1168f2684f29276bc308890de319e72046eb .

One of the reasons why we introduced the cooldown at all, was to make sure the cluster was settled after the test execution. But this should actually be done at test teardown time.

The test teardown must ensure the cluster is restore at its state before the current test started, or it's a bug in the test fixture.

In practical terms, we add another knob to configure the test *teardown* time, so we can play with lower cooldown but increase the teardown if needed, to improve the execution time without destabilizing (read: uncover too many issues at once) the suite.

The key difference is we always wait for the full cooldown time, inconditionally, while we wait UP TO the teardown time. So lower (ideally zero) cooldown but higher teardown time should yield both a more robust and faster test suite.

Signed-off-by: Francesco Romani <fromani@redhat.com>