### PR TITLE
e2e: serial: add scheduler cache non-regression

### DIFF
--- a/test/utils/fixture/wait.go
+++ b/test/utils/fixture/wait.go
@@ -32,7 +32,7 @@ import (
 // WaitPodsRunning waits for all padding pods to be up and running ( or fail)
 func WaitForPaddingPodsRunning(fxt *Fixture, paddingPods []*corev1.Pod) []string {
 	var failedPodIds []string
-	failedPods := wait.ForPodListAllRunning(fxt.Client, paddingPods)
+	failedPods, _ := wait.ForPodListAllRunning(fxt.Client, paddingPods)
 	for _, failedPod := range failedPods {
 		_ = objects.LogEventsForPod(fxt.K8sClient, failedPod.Namespace, failedPod.Name)
 		//note that this test does not use podOverhead thus pod req and lim would be the pod's resources as set upon creating

--- a/test/utils/padder/padder.go
+++ b/test/utils/padder/padder.go
@@ -201,7 +201,7 @@ func (p *Padder) Pad(timeout time.Duration, options PaddingOptions) error {
 		}
 	}
 
-	if failedPods := wait.ForPodListAllRunning(p.Client, pods); len(failedPods) > 0 {
+	if failedPods, _ := wait.ForPodListAllRunning(p.Client, pods); len(failedPods) > 0 {
 		var asStrings []string
 		for _, pod := range failedPods {
 			asStrings = append(asStrings, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))


### PR DESCRIPTION
We add more non-regression tests to cover the future planned addition of the scheduler cache.

We want to cover the cases which are no bother for the default and non-caching NUMA-aware scheduler, but needs to be checked for the caching NUMA-aware scheduler.

All these cases are *NOT* expected to cover the quality of the scheduling decisions - we have plenty of targeted tests for that. Here we want to check the scheduler fundamentals actually works.

Signed-off-by: Francesco Romani <fromani@redhat.com>