### PR TITLE
kustomize: allow the workload type management in ns

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    workload.openshift.io/allowed: management
   labels:
     control-plane: controller-manager
   name: system


### PR DESCRIPTION
This annotation will allow deployment of the operator inside the numaresources ns when management workload partitioning enabled

Signed-off-by: Talor Itzhak <titzhak@redhat.com>