### PR TITLE
serial: add the new variable E2E_RTE_CI_IMAGE

### DIFF
--- a/test/e2e/serial/README.md
+++ b/test/e2e/serial/README.md
@@ -16,7 +16,7 @@ run in isolation with any other workload, and in isolation to each other.
 
 IOW, the suite expects to run against a pristine, unloaded cluster to validate it.
 
-It is responsability of the tests in this suite to clean up properly and to restore the cluster state as
+It is responsibility of the tests in this suite to clean up properly and to restore the cluster state as
 they found it before they run.
 
 ### configuring using the environment variables
@@ -44,4 +44,6 @@ they found it before they run.
   the cluster and will be used as a resource of type `device-b` in the tests.
 - `E2E_NROP_DEVICE_C` (accepts string, e.g `example.com/deviceC`) declares name of a device type that exists on
   the cluster and will be used as a resource of type `device-c` in the tests.
+- `E2E_RTE_CI_IMAGE` (accepts string, e.g `quay.io/openshift-kni/resource-topology-exporter:test-ci`) sets the 
+  RTE image to be used for testing purposes particularly for modifying the operator object.
   

--- a/test/e2e/serial/config/config.go
+++ b/test/e2e/serial/config/config.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	MultiNUMALabel    = "numa.hardware.openshift-kni.io/cell-count"
-	NropTestCIImage   = "quay.io/openshift-kni/resource-topology-exporter:test-ci"
+	nropTestCIImage   = "quay.io/openshift-kni/resource-topology-exporter:test-ci"
 	SchedulerTestName = "test-topology-scheduler"
 )
 
@@ -59,4 +59,11 @@ func Teardown() {
 	// numacell daemonset automatically cleaned up when we remove the namespace
 	err := TeardownFixture()
 	Expect(err).NotTo(HaveOccurred())
+}
+
+func GetRteCiImage() string {
+	if pullSpec, ok := os.LookupEnv("E2E_RTE_CI_IMAGE"); ok {
+		return pullSpec
+	}
+	return nropTestCIImage
 }

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -274,11 +274,11 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 				return true, nil
 			}).WithTimeout(10 * time.Minute).WithPolling(30 * time.Second).Should(BeTrue())
 
-			By(fmt.Sprintf("modifing the NUMAResourcesOperator ExporterImage filed to %q", serialconfig.NropTestCIImage))
+			By(fmt.Sprintf("modifying the NUMAResourcesOperator ExporterImage field to %q", serialconfig.GetRteCiImage()))
 			err = fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroOperObj), nroOperObj)
 			Expect(err).ToNot(HaveOccurred())
 
-			nroOperObj.Spec.ExporterImage = serialconfig.NropTestCIImage
+			nroOperObj.Spec.ExporterImage = serialconfig.GetRteCiImage()
 			err = fxt.Client.Update(context.TODO(), nroOperObj)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -295,13 +295,13 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 				for _, ds := range dss {
 					// RTE container shortcut
 					cnt := ds.Spec.Template.Spec.Containers[0]
-					if cnt.Image != serialconfig.NropTestCIImage {
-						klog.Warningf("container: %q image not updated yet. expected %q actual %q", cnt.Name, serialconfig.NropTestCIImage, cnt.Image)
+					if cnt.Image != serialconfig.GetRteCiImage() {
+						klog.Warningf("container: %q image not updated yet. expected %q actual %q", cnt.Name, serialconfig.GetRteCiImage(), cnt.Image)
 						return false, nil
 					}
 				}
 				return true, nil
-			}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).Should(BeTrue(), "failed to update RTE container with image %q", serialconfig.NropTestCIImage)
+			}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).Should(BeTrue(), "failed to update RTE container with image %q", serialconfig.GetRteCiImage())
 
 			By(fmt.Sprintf("modifing the NUMAResourcesOperator LogLevel filed to %q", operatorv1.Trace))
 			err = fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroOperObj), nroOperObj)


### PR DESCRIPTION
Enable the user to use the RTE image they want in the test by setting this environment variable E2E_RTE_CI_IMAGE. This is especially needed for d/s CI as it is using disconnected environments which cannot pull quay images if they are not mirroredas anticipated.

Signed-off-by: shereenH <shajmakh@redhat.com>