### PR TITLE
e2e: serial: avoid cooldown on test skip

### DIFF
--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -73,7 +73,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", 2))
 		nrtCandidates := e2enrt.FilterZoneCountEqual(nrtList.Items, 2)
 		if len(nrtCandidates) < 2 {
-			Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates)))
+			e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates))
 		}
 		klog.Infof("Found node with 2 NUMA zones: %d", len(nrtCandidates))
 
@@ -85,7 +85,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		}
 		nrts = e2enrt.FilterByPolicies(nrtCandidates, policies)
 		if len(nrts) < 2 {
-			Skip(fmt.Sprintf("not enough nodes with valid policy - found %d", len(nrts)))
+			e2efixture.Skipf(fxt, "not enough nodes with valid policy - found %d", len(nrts))
 		}
 		klog.Infof("Found node with 2 NUMA zones: %d", len(nrts))
 

--- a/test/e2e/serial/tests/non_regression_fundamentals.go
+++ b/test/e2e/serial/tests/non_regression_fundamentals.go
@@ -64,7 +64,7 @@ var _ = Describe("[serial][fundamentals][scheduler][nonreg] numaresources fundam
 
 		BeforeEach(func() {
 			if len(nrtList.Items) > 0 {
-				Skip("this test require empty NRT data")
+				e2efixture.Skip(fxt, "this test require empty NRT data")
 			}
 		})
 

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -80,7 +80,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 		}
 		nrts = e2enrt.FilterByPolicies(nrtList.Items, policies)
 		if len(nrts) < 2 {
-			Skip(fmt.Sprintf("not enough nodes with valid policy - found %d", len(nrts)))
+			e2efixture.Skipf(fxt, "not enough nodes with valid policy - found %d", len(nrts))
 		}
 
 		// Note that this test, being part of "serial", expects NO OTHER POD being scheduled
@@ -108,7 +108,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", requiredNumaZones))
 			nrtTwoZoneCandidates = e2enrt.FilterZoneCountEqual(nrts, requiredNumaZones)
 			if len(nrtTwoZoneCandidates) < requiredNodeNumber {
-				Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d", len(nrtTwoZoneCandidates)))
+				e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d", len(nrtTwoZoneCandidates))
 			}
 		})
 
@@ -129,7 +129,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			By("filtering available nodes with allocatable resources on each NUMA zone that can match request")
 			nrtCandidates := e2enrt.FilterAnyZoneMatchingResources(nrtTwoZoneCandidates, requiredRes)
 			if len(nrtCandidates) < 1 {
-				Skip(fmt.Sprintf("not enough nodes with NUMA zones each of them can match requests: found %d", len(nrtCandidates)))
+				e2efixture.Skipf(fxt, "not enough nodes with NUMA zones each of them can match requests: found %d", len(nrtCandidates))
 			}
 
 			candidateNodeNames := e2enrt.AccumulateNames(nrtCandidates)
@@ -321,7 +321,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 
 			const neededNodes = 1
 			if len(nrtCandidates) < neededNodes {
-				Skip(fmt.Sprintf("not enough nodes with at least %d NUMA Zones: found %d, needed %d", requiredNUMAZones, len(nrtCandidates), neededNodes))
+				e2efixture.Skipf(fxt, "not enough nodes with at least %d NUMA Zones: found %d, needed %d", requiredNUMAZones, len(nrtCandidates), neededNodes)
 			}
 
 			nrtCandidateNames := e2enrt.AccumulateNames(nrtCandidates)

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -75,7 +75,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 		}
 		nrts = e2enrt.FilterByPolicies(nrtList.Items, policies)
 		if len(nrts) < 2 {
-			Skip(fmt.Sprintf("not enough nodes with valid policy - found %d", len(nrts)))
+			e2efixture.Skipf(fxt, "not enough nodes with valid policy - found %d", len(nrts))
 		}
 
 		// Note that this test, being part of "serial", expects NO OTHER POD being scheduled
@@ -103,7 +103,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", requiredNumaZones))
 			nrtTwoZoneCandidates = e2enrt.FilterZoneCountEqual(nrts, requiredNumaZones)
 			if len(nrtTwoZoneCandidates) < requiredNodeNumber {
-				Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d", len(nrtTwoZoneCandidates)))
+				e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d", len(nrtTwoZoneCandidates))
 			}
 		})
 
@@ -173,7 +173,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				nrtCandidates := e2enrt.FilterAnyZoneMatchingResources(nrtTwoZoneCandidates, zoneRequiredResources)
 				minCandidates := 1
 				if len(nrtCandidates) < minCandidates {
-					Skip(fmt.Sprintf("There should be at least %d nodes with at least %s resources: found %d", minCandidates, resStr, len(nrtCandidates)))
+					e2efixture.Skipf(fxt, "There should be at least %d nodes with at least %s resources: found %d", minCandidates, resStr, len(nrtCandidates))
 				}
 
 				candidateNodeNames := e2enrt.AccumulateNames(nrtCandidates)

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -111,7 +111,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", 2))
 			nrtCandidates := e2enrt.FilterZoneCountEqual(nrtList.Items, 2)
 			if len(nrtCandidates) < hostsRequired {
-				Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates)))
+				e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates))
 			}
 			klog.Infof("Found node with 2 NUMA zones: %d", len(nrtCandidates))
 
@@ -121,7 +121,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}
 			nrts = e2enrt.FilterByPolicies(nrtCandidates, policies)
 			if len(nrts) < hostsRequired {
-				Skip(fmt.Sprintf("not enough nodes with valid policy - found %d", len(nrts)))
+				e2efixture.Skipf(fxt, "not enough nodes with valid policy - found %d", len(nrts))
 			}
 			klog.Infof("Found node with 2 NUMA zones: %d", len(nrts))
 
@@ -627,7 +627,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", 2))
 			nrtCandidates := e2enrt.FilterZoneCountEqual(nrtList.Items, 2)
 			if len(nrtCandidates) < hostsRequired {
-				Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates)))
+				e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates))
 			}
 			klog.Infof("Found node with 2 NUMA zones: %d", len(nrtCandidates))
 
@@ -637,7 +637,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}
 			nrts = e2enrt.FilterByPolicies(nrtCandidates, policies)
 			if len(nrts) < hostsRequired {
-				Skip(fmt.Sprintf("not enough nodes with valid policy - found %d", len(nrts)))
+				e2efixture.Skipf(fxt, "not enough nodes with valid policy - found %d", len(nrts))
 			}
 			klog.Infof("Found node with 2 NUMA zones: %d", len(nrts))
 
@@ -864,7 +864,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", 2))
 			nrtCandidates := e2enrt.FilterZoneCountEqual(nrtList.Items, 2)
 			if len(nrtCandidates) < hostsRequired {
-				Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates)))
+				e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates))
 			}
 			klog.Infof("Found node with 2 NUMA zones: %d", len(nrtCandidates))
 
@@ -874,7 +874,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}
 			nrts = e2enrt.FilterByPolicies(nrtCandidates, policies)
 			if len(nrts) < hostsRequired {
-				Skip(fmt.Sprintf("not enough nodes with valid policy - found %d", len(nrts)))
+				e2efixture.Skipf(fxt, "not enough nodes with valid policy - found %d", len(nrts))
 			}
 			klog.Infof("Found node with 2 NUMA zones: %d", len(nrts))
 

--- a/test/e2e/serial/tests/workload_placement_nodelabel.go
+++ b/test/e2e/serial/tests/workload_placement_nodelabel.go
@@ -78,7 +78,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		}
 		nrts = e2enrt.FilterByPolicies(nrtList.Items, policies)
 		if len(nrts) < 2 {
-			Skip(fmt.Sprintf("not enough nodes with valid policy - found %d", len(nrts)))
+			e2efixture.Skipf(fxt, "not enough nodes with valid policy - found %d", len(nrts))
 		}
 
 		// Note that this test, being part of "serial", expects NO OTHER POD being scheduled
@@ -111,7 +111,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			neededNodes := 2
 			if len(nrtCandidates) < neededNodes {
-				Skip(fmt.Sprintf("not enough nodes with %d NUMA Zones: found %d, needed %d", requiredNUMAZones, len(nrtCandidates), neededNodes))
+				e2efixture.Skipf(fxt, "not enough nodes with %d NUMA Zones: found %d, needed %d", requiredNUMAZones, len(nrtCandidates), neededNodes)
 			}
 
 			// TODO: this should be >= 5x baseload
@@ -128,7 +128,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			By("filtering available nodes with allocatable resources on at least one NUMA zone that can match request")
 			nrtCandidates = e2enrt.FilterAnyZoneMatchingResources(nrtCandidates, requiredRes)
 			if len(nrtCandidates) < neededNodes {
-				Skip(fmt.Sprintf("not enough nodes with NUMA zones each of them can match requests: found %d, needed: %d, request: %v", len(nrtCandidates), neededNodes, requiredRes))
+				e2efixture.Skipf(fxt, "not enough nodes with NUMA zones each of them can match requests: found %d, needed: %d, request: %v", len(nrtCandidates), neededNodes, requiredRes)
 			}
 			nrtCandidateNames := e2enrt.AccumulateNames(nrtCandidates)
 

--- a/test/e2e/serial/tests/workload_placement_resources.go
+++ b/test/e2e/serial/tests/workload_placement_resources.go
@@ -95,7 +95,7 @@ var _ = Describe("[serial][disruptive][scheduler][byres] numaresources workload 
 
 				nrts := e2enrt.FilterTopologyManagerPolicy(nrtCandidates, tmPolicy)
 				if len(nrts) != len(nrtCandidates) {
-					Skip(fmt.Sprintf("not enough nodes with policy %q - found %d", string(tmPolicy), len(nrts)))
+					e2efixture.Skipf(fxt, "not enough nodes with policy %q - found %d", string(tmPolicy), len(nrts))
 				}
 
 				By("Scheduling the testing pod")
@@ -174,13 +174,13 @@ func setupNodes(fxt *e2efixture.Fixture, nodesState desiredNodesState) ([]nrtv1a
 	nrtCandidates := e2enrt.FilterZoneCountEqual(nodesState.NRTList.Items, nodesState.RequiredNUMAZones)
 
 	if len(nrtCandidates) < nodesState.RequiredNodes {
-		Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d, needed %d", len(nrtCandidates), nodesState.RequiredNodes))
+		e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d, needed %d", len(nrtCandidates), nodesState.RequiredNodes)
 	}
 
 	By("filtering available nodes with allocatable resources on at least one NUMA zone that can match request")
 	nrtCandidates = e2enrt.FilterAnyZoneMatchingResources(nrtCandidates, nodesState.RequiredResources)
 	if len(nrtCandidates) < nodesState.RequiredNodes {
-		Skip(fmt.Sprintf("not enough nodes with NUMA zones each of them can match requests: found %d, needed: %d", len(nrtCandidates), nodesState.RequiredNodes))
+		e2efixture.Skipf(fxt, "not enough nodes with NUMA zones each of them can match requests: found %d, needed: %d", len(nrtCandidates), nodesState.RequiredNodes)
 	}
 	nrtCandidateNames := e2enrt.AccumulateNames(nrtCandidates)
 

--- a/test/e2e/serial/tests/workload_placement_taint.go
+++ b/test/e2e/serial/tests/workload_placement_taint.go
@@ -72,7 +72,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		// so we can't support ATM zones > 2. HW with zones > 2 is rare anyway, so not to big of a deal now.
 		nrtCandidates := e2enrt.FilterZoneCountEqual(nrtList.Items, 2)
 		if len(nrtCandidates) < 2 {
-			Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates)))
+			e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates))
 		}
 		klog.Infof("Found node with 2 NUMA zones: %d", len(nrtCandidates))
 
@@ -84,7 +84,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		}
 		nrts = e2enrt.FilterByPolicies(nrtCandidates, policies)
 		if len(nrts) < 2 {
-			Skip(fmt.Sprintf("not enough nodes with valid policy - found %d", len(nrts)))
+			e2efixture.Skipf(fxt, "not enough nodes with valid policy - found %d", len(nrts))
 		}
 		klog.Infof("Found node with 2 NUMA zones: %d", len(nrts))
 

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -116,13 +116,13 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			neededNodes := 2
 			if len(nrtCandidates) < neededNodes {
-				Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d, needed %d", len(nrtCandidates), neededNodes))
+				e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d, needed %d", len(nrtCandidates), neededNodes)
 			}
 
 			By("filtering available nodes with allocatable resources on at least one NUMA zone that can match request")
 			nrtCandidates = e2enrt.FilterAnyZoneMatchingResources(nrtCandidates, requiredRes)
 			if len(nrtCandidates) < neededNodes {
-				Skip(fmt.Sprintf("not enough nodes with NUMA zones each of them can match requests: found %d, needed: %d", len(nrtCandidates), neededNodes))
+				e2efixture.Skipf(fxt, "not enough nodes with NUMA zones each of them can match requests: found %d, needed: %d", len(nrtCandidates), neededNodes)
 			}
 			nrtCandidateNames := e2enrt.AccumulateNames(nrtCandidates)
 
@@ -172,7 +172,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 				nrts := e2enrt.FilterTopologyManagerPolicy(nrtCandidates, tmPolicy)
 				if len(nrts) != len(nrtCandidates) {
-					Skip(fmt.Sprintf("not enough nodes with policy %q - found %d", string(tmPolicy), len(nrts)))
+					e2efixture.Skipf(fxt, "not enough nodes with policy %q - found %d", string(tmPolicy), len(nrts))
 				}
 
 				targetNrtListInitial, err := e2enrt.GetUpdated(fxt.Client, nrtList, 1*time.Minute)
@@ -277,7 +277,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 				nrts := e2enrt.FilterTopologyManagerPolicy(nrtCandidates, tmPolicy)
 				if len(nrts) != len(nrtCandidates) {
-					Skip(fmt.Sprintf("not enough nodes with policy %q - found %d", string(tmPolicy), len(nrts)))
+					e2efixture.Skipf(fxt, "not enough nodes with policy %q - found %d", string(tmPolicy), len(nrts))
 				}
 
 				targetNrtListInitial, err := e2enrt.GetUpdated(fxt.Client, nrtList, 1*time.Minute)
@@ -390,7 +390,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			nrts := e2enrt.FilterTopologyManagerPolicy(nrtList.Items, policyFuncs.name())
 			if len(nrts) < hostsRequired {
-				Skip(fmt.Sprintf("not enough nodes with policy %q - found %d", string(policyFuncs.name()), len(nrts)))
+				e2efixture.Skipf(fxt, "not enough nodes with policy %q - found %d", string(policyFuncs.name()), len(nrts))
 			}
 
 			Expect(len(unsuitableFreeRes)).To(Equal(hostsRequired), "mismatch unsuitable resource declarations expected %d items, but found %d", hostsRequired, len(unsuitableFreeRes))
@@ -417,12 +417,12 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", numaZonesRequired))
 			nrtCandidates := e2enrt.FilterZoneCountEqual(nrts, numaZonesRequired)
 			if len(nrtCandidates) < hostsRequired {
-				Skip(fmt.Sprintf("not enough nodes with %d NUMA Zones: found %d", numaZonesRequired, len(nrtCandidates)))
+				e2efixture.Skipf(fxt, "not enough nodes with %d NUMA Zones: found %d", numaZonesRequired, len(nrtCandidates))
 			}
 			By("filtering available nodes with allocatable resources on each NUMA zone that can match request")
 			nrtCandidates = policyFuncs.filterMatchingResources(nrtCandidates, requiredRes)
 			if len(nrtCandidates) < hostsRequired {
-				Skip(fmt.Sprintf("not enough nodes with NUMA zones each of them can match requests: found %d", len(nrtCandidates)))
+				e2efixture.Skipf(fxt, "not enough nodes with NUMA zones each of them can match requests: found %d", len(nrtCandidates))
 			}
 
 			candidateNodeNames := e2enrt.AccumulateNames(nrtCandidates)
@@ -1161,7 +1161,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			nrts := e2enrt.FilterTopologyManagerPolicy(nrtList.Items, policyFuncs.name())
 			if len(nrts) < hostsRequired {
-				Skip(fmt.Sprintf("not enough nodes with policy %q - found %d", string(policyFuncs.name()), len(nrts)))
+				e2efixture.Skipf(fxt, "not enough nodes with policy %q - found %d", string(policyFuncs.name()), len(nrts))
 			}
 
 			Expect(len(unsuitableFreeRes)).To(Equal(hostsRequired), "mismatch unsuitable resource declarations expected %d items, but found %d", hostsRequired, len(unsuitableFreeRes))
@@ -1170,7 +1170,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				for _, zone := range nrt.Zones {
 					avail := e2enrt.AvailableFromZone(zone)
 					if !isHugePageInAvailable(avail) && isHugepageNeeded(podRes) {
-						Skip(fmt.Sprintf("hugepages requested but not found under node: %q", nrt.Name))
+						e2efixture.Skipf(fxt, "hugepages requested but not found under node: %q", nrt.Name)
 					}
 				}
 			}
@@ -1197,12 +1197,12 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", numaZonesRequired))
 			nrtCandidates := e2enrt.FilterZoneCountEqual(nrts, numaZonesRequired)
 			if len(nrtCandidates) < hostsRequired {
-				Skip(fmt.Sprintf("not enough nodes with %d NUMA Zones: found %d", numaZonesRequired, len(nrtCandidates)))
+				e2efixture.Skipf(fxt, "not enough nodes with %d NUMA Zones: found %d", numaZonesRequired, len(nrtCandidates))
 			}
 			By("filtering available nodes with allocatable resources on each NUMA zone that can match request")
 			nrtCandidates = e2enrt.FilterAnyZoneMatchingResources(nrtCandidates, requiredRes)
 			if len(nrtCandidates) < hostsRequired {
-				Skip(fmt.Sprintf("not enough nodes with NUMA zones each of them can match requests: found %d", len(nrtCandidates)))
+				e2efixture.Skipf(fxt, "not enough nodes with NUMA zones each of them can match requests: found %d", len(nrtCandidates))
 			}
 
 			candidateNodeNames := e2enrt.AccumulateNames(nrtCandidates)

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -76,12 +76,12 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 		}
 		nrts = e2enrt.FilterByPolicies(nrtList.Items, policies)
 		if len(nrts) < 2 {
-			Skip(fmt.Sprintf("not enough nodes with valid policy - found %d", len(nrts)))
+			e2efixture.Skipf(fxt, "not enough nodes with valid policy - found %d", len(nrts))
 		}
 
 		nrts = e2enrt.FilterZoneCountEqual(nrts, 2)
 		if len(nrts) < 2 {
-			Skip(fmt.Sprintf("not enough nodes with %d NUMA zones - found %d", 2, len(nrts)))
+			e2efixture.Skipf(fxt, "not enough nodes with %d NUMA zones - found %d", 2, len(nrts))
 		}
 
 		// we expect having the same policy across all NRTs
@@ -113,7 +113,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", requiredNUMAZones))
 			nrtCandidates := e2enrt.FilterZoneCountEqual(nrts, requiredNUMAZones)
 			if len(nrtCandidates) < neededNodes {
-				Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d, needed %d", len(nrtCandidates), neededNodes))
+				e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d, needed %d", len(nrtCandidates), neededNodes)
 			}
 
 			nrtCandidateNames := e2enrt.AccumulateNames(nrtCandidates)
@@ -317,7 +317,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 
 			neededNodes := 2
 			if len(nrtCandidates) < neededNodes {
-				Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d, needed %d", len(nrtCandidates), neededNodes))
+				e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d, needed %d", len(nrtCandidates), neededNodes)
 			}
 
 			nrtCandidateNames := e2enrt.AccumulateNames(nrtCandidates)
@@ -455,14 +455,14 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			// filter by policy
 			nrtCandidates := e2enrt.FilterTopologyManagerPolicy(nrtList.Items, tmPolicy)
 			if len(nrtCandidates) < neededNodes {
-				Skip(fmt.Sprintf("not enough nodes with policy %q - found %d", string(tmPolicy), len(nrtCandidates)))
+				e2efixture.Skipf(fxt, "not enough nodes with policy %q - found %d", string(tmPolicy), len(nrtCandidates))
 			}
 
 			// Filter by number of numa zones
 			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", requiredNUMAZones))
 			nrtCandidates = e2enrt.FilterZoneCountEqual(nrtCandidates, requiredNUMAZones)
 			if len(nrtCandidates) < neededNodes {
-				Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d, needed %d", len(nrtCandidates), neededNodes))
+				e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d, needed %d", len(nrtCandidates), neededNodes)
 			}
 
 			// filter by resources on each numa zone
@@ -479,7 +479,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			By("filtering available nodes with allocatable resources on at least one NUMA zone that can match request")
 			nrtCandidates = filterNRTsEachRequestOnADifferentZone(nrtCandidates, requiredResCnt1, requiredResCnt2)
 			if len(nrtCandidates) < neededNodes {
-				Skip(fmt.Sprintf("not enough nodes with NUMA zones each of them can match requests: found %d, needed: %d", len(nrtCandidates), neededNodes))
+				e2efixture.Skipf(fxt, "not enough nodes with NUMA zones each of them can match requests: found %d, needed: %d", len(nrtCandidates), neededNodes)
 			}
 
 			// After filter get one of the candidate nodes left
@@ -613,7 +613,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			neededNodes := 1
 			numOfnrtCandidates := len(nrts)
 			if numOfnrtCandidates < neededNodes {
-				Skip(fmt.Sprintf("not enough nodes with 2 NUMA Zones: found %d, needed %d", numOfnrtCandidates, neededNodes))
+				e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d, needed %d", numOfnrtCandidates, neededNodes)
 			}
 
 			By("padding all the nodes")
@@ -782,7 +782,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 
 			const neededNodes = 1
 			if len(nrtCandidates) < neededNodes {
-				Skip(fmt.Sprintf("not enough nodes with at least %d NUMA Zones: found %d, needed %d", requiredNUMAZones, len(nrtCandidates), neededNodes))
+				e2efixture.Skipf(fxt, "not enough nodes with at least %d NUMA Zones: found %d, needed %d", requiredNUMAZones, len(nrtCandidates), neededNodes)
 			}
 			nrtCandidateNames := e2enrt.AccumulateNames(nrtCandidates)
 


### PR DESCRIPTION
regardless of the cooldown time, it doesn't make sense to cooldown if the test skipped for unmet prererquisites, which is actually the only reason why we should skip at all in this suite.

Signed-off-by: Francesco Romani <fromani@redhat.com>