### PR TITLE
e2e: fixture: add pod-security label

### DIFF
--- a/test/utils/fixture/fixture.go
+++ b/test/utils/fixture/fixture.go
@@ -128,9 +128,10 @@ func setupNamespace(cli client.Client, baseName string, randomize bool) (corev1.
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
-				"pod-security.kubernetes.io/audit":   "privileged",
-				"pod-security.kubernetes.io/enforce": "privileged",
-				"pod-security.kubernetes.io/warn":    "privileged",
+				"pod-security.kubernetes.io/audit":               "privileged",
+				"pod-security.kubernetes.io/enforce":             "privileged",
+				"pod-security.kubernetes.io/warn":                "privileged",
+				"security.openshift.io/scc.podSecurityLabelSync": "false",
 			},
 		},
 	}


### PR DESCRIPTION
NROP tests are failing on OCP 4.12 due to the stricter podsecurity rules as it causes the pods created on the test namespaces to not get created due to the following error message:

```
 Message: "pods \"padder-6757\" is forbidden: violates PodSecurity \"restricted:v1.24\": allowPrivilegeEscalation != false (container \"padder-6757-cnt\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container \"padder-6757-cnt\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"padder-6757-cnt\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container \"padder-6757-cnt\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")",
```

Add missing pod security label `security.openshift.io/scc.podSecurityLabelSync: false` to turn off the automatic label synchronization for the test namespace.

Signed-off-by: shereenH <shajmakh@redhat.com>