### PR TITLE
rte: sched: manifest: enable sched plugin tracing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/jaypipes/pcidb v1.0.0
 	github.com/k8stopologyawareschedwg/deployer v0.7.3-0.20220913163638-4d990c6a4f14
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.12
-	github.com/k8stopologyawareschedwg/podfingerprint v0.0.3
-	github.com/k8stopologyawareschedwg/resource-topology-exporter v0.7.5
+	github.com/k8stopologyawareschedwg/podfingerprint v0.1.1
+	github.com/k8stopologyawareschedwg/resource-topology-exporter v0.7.6
 	github.com/kubevirt/device-plugin-manager v1.19.3
 	github.com/mdomke/git-semver v1.0.0
 	github.com/onsi/ginkgo v1.16.5

--- a/go.sum
+++ b/go.sum
@@ -617,10 +617,10 @@ github.com/k8stopologyawareschedwg/deployer v0.7.3-0.20220913163638-4d990c6a4f14
 github.com/k8stopologyawareschedwg/deployer v0.7.3-0.20220913163638-4d990c6a4f14/go.mod h1:MSR75HEnznUBtJWOiNmdtoLZKNvHbpb4RUCbDdIArfg=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.12 h1:NhXbOjO1st8hIcVpegr3zw/AGG12vs3z//tCDDcfPpE=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.12/go.mod h1:AkACMQGiTgCt0lQw3m7TTU8PLH9lYKNK5e9DqFf5VuM=
-github.com/k8stopologyawareschedwg/podfingerprint v0.0.3 h1:UPq+pw4iElwAjYbNekLUyy8NeqFxTQAOO4IkQmV3bwo=
-github.com/k8stopologyawareschedwg/podfingerprint v0.0.3/go.mod h1:C23pM15t06dXg/OihGlqBvnYzLr+MXDXJ7zMfbNAyXI=
-github.com/k8stopologyawareschedwg/resource-topology-exporter v0.7.5 h1:mVNHaRxz+LIjouI35ObcY4fRrOGT1LQsVnLfzXDB/d4=
-github.com/k8stopologyawareschedwg/resource-topology-exporter v0.7.5/go.mod h1:IgKFaPOOkH/HyVuZR8oOfOE0LN56X3JwF+sDEQn/RSw=
+github.com/k8stopologyawareschedwg/podfingerprint v0.1.1 h1:uNEj+avp3yJkJMvkmk6iosibVauSo+owEKV2JyuKNsQ=
+github.com/k8stopologyawareschedwg/podfingerprint v0.1.1/go.mod h1:C23pM15t06dXg/OihGlqBvnYzLr+MXDXJ7zMfbNAyXI=
+github.com/k8stopologyawareschedwg/resource-topology-exporter v0.7.6 h1:4dAU2wXl6BT5MlDSHGv91L+HhKPOP0Cr+f46qUYm87E=
+github.com/k8stopologyawareschedwg/resource-topology-exporter v0.7.6/go.mod h1:1tqTXCc/7dtX44LjG8dR4JrECQyRs2S6KPenSzFb+/k=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/errcheck v1.6.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/pkg/numaresourcesscheduler/manifests/yaml/deployment.yaml
+++ b/pkg/numaresourcesscheduler/manifests/yaml/deployment.yaml
@@ -43,8 +43,16 @@ spec:
           volumeMounts:
             - mountPath: "/etc/kubernetes"
               name: "etckubernetes"
+            - mountPath: "/run/nrtcache"
+              name: "runnrtcache"
       serviceAccountName: "secondary-scheduler"
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+      volumes:
+      - name: "etckubernetes" # placeholder
+      - name: "runnrtcache"
+        emptyDir:
+          medium: Memory
+          sizeLimit: 64Mi
 

--- a/rte/main.go
+++ b/rte/main.go
@@ -123,6 +123,7 @@ func parseArgs(args ...string) (ProgArgs, error) {
 	flags.BoolVar(&pArgs.Resourcemonitor.PodSetFingerprint, "pods-fingerprint", false, "If enable, compute and report the pod set fingerprint.")
 	flags.BoolVar(&pArgs.Resourcemonitor.ExposeTiming, "expose-timing", false, "If enable, expose expected and actual sleep interval as annotations.")
 	flags.BoolVar(&pArgs.Resourcemonitor.RefreshNodeResources, "refresh-node-resources", false, "If enable, track changes in node's resources")
+	flags.StringVar(&pArgs.Resourcemonitor.PodSetFingerprintStatusFile, "pods-fingerprint-status-file", "", "File to dump the pods fingerprint status. Use \"\" to disable.")
 
 	flags.StringVar(&pArgs.LocalArgs.ConfigPath, "config", "/etc/resource-topology-exporter/config.yaml", "Configuration file path. Use this to set the exclude list.")
 

--- a/vendor/github.com/k8stopologyawareschedwg/podfingerprint/README.md
+++ b/vendor/github.com/k8stopologyawareschedwg/podfingerprint/README.md
@@ -13,3 +13,28 @@ Note this package will *NOT* restrict itself to use only cryptographically secur
 
 apache v2
 
+## known issues and limitations
+
+### fingerprint v1: pod aliasing issue
+
+the pod fingerprinting algorithm v1 uses the `namespace+name` pair to identify a pod. In case of high pod churn when burstable or guaranteed pods get deleted and
+recreated with non-identical pod specs (e.g. changing pod resources requests/limits), the fingerprint will clash. So, two different set of pods will yield
+the same fingerprint. [Future versions of the fingerprint will address this issue](https://github.com/k8stopologyawareschedwg/podfingerprint/issues/3).
+
+#### mitigations
+
+Kubernetes best practices [suggest to always use controllers, not "naked" pods](https://kubernetes.io/docs/concepts/configuration/overview/#naked-pods-vs-replicasets-deployments-and-jobs).
+Kubernetes controllers [will generate create unique names for pods](https://github.com/kubernetes/kubernetes/blob/v1.24.1/pkg/controller/controller_utils.go#L553),
+hence in this scenario the name clash described above should occur very rarely.
+
+#### more details
+
+The v1 fingerprint algorithm uses the `namespace+name` pair to identify a pod because of a conscious design decision due to a survey of the data source available
+to the perspective consumers of this package.
+Considering that the source of truth for resource allocation is the kubelet, and preferring node-local APIs, the agents running on the node have only few
+data source options:
+- the `pods` kubelet endpoint: reports the full pod spec, but does not report the resource allocation.
+- the `podresources` kubelet endpoint: to learn about resource allocation, but does not report the pod UID, only the `namespace+name` pair.
+Designing the v1 algo, we decided to create an API which we can used with _only_ the data provided by the `podresources` endpoint.
+This is meant to avoid the perspective consumers of the package to avoid the impose the requirement to join these two data sources, preventing races and complications.
+

--- a/vendor/github.com/k8stopologyawareschedwg/podfingerprint/podfingerprint.go
+++ b/vendor/github.com/k8stopologyawareschedwg/podfingerprint/podfingerprint.go
@@ -87,11 +87,23 @@ type Fingerprint struct {
 // The size parameter is a hint for the expected size of the pod set. Use 0 if you don't know.
 // Values of size < 0 are ignored.
 func NewFingerprint(size int) *Fingerprint {
+	fp := &Fingerprint{}
+	fp.Reset(size)
+	return fp
+}
+
+// Reset clears the internal state of the Fingerprint to empty (pristine) state.
+// The size parameter is a hint for the expected size of the pod set. Use 0 if you don't know.
+// Values of size < 0 are ignored.
+// Explicit usage of this function is not recommended. Client code should not recycle Fingerprint
+// objects, but rather discarded them after they are used - even though calling multiple times
+// Sign() or Check() once reached steady state is perfectly fine.
+func (fp *Fingerprint) Reset(size int) {
 	data := []uint64{}
 	if size > 0 {
 		data = make([]uint64, 0, size)
 	}
-	return &Fingerprint{hashes: data}
+	fp.hashes = data
 }
 
 // AddPod adds a pod to the pod set.
@@ -124,7 +136,8 @@ func (fp *Fingerprint) Sum() []byte {
 // The string should be considered a opaque identifier and checked only for
 // equality, or fed into Check
 func (fp *Fingerprint) Sign() string {
-	return Prefix + Version + hex.EncodeToString(fp.Sum())
+	sign := Prefix + Version + hex.EncodeToString(fp.Sum())
+	return sign
 }
 
 // Check verifies if the provided fingerprint matches the current pod set.

--- a/vendor/github.com/k8stopologyawareschedwg/podfingerprint/tracing.go
+++ b/vendor/github.com/k8stopologyawareschedwg/podfingerprint/tracing.go
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package podfingerprint
+
+import (
+	"fmt"
+	"strings"
+)
+
+// NamespacedName is a Namespace/Name pair
+type NamespacedName struct {
+	Namespace string
+	Name      string
+}
+
+func (nn NamespacedName) GetNamespace() string {
+	return nn.Namespace
+}
+
+func (nn NamespacedName) GetName() string {
+	return nn.Name
+}
+
+func (nn NamespacedName) String() string {
+	return nn.Namespace + "/" + nn.Name
+}
+
+// Tracer tracks the actions needed to compute a fingerprint
+type Tracer interface {
+	// Start is called when the Fingerprint is initialized
+	Start(numPods int)
+	// Add is called when a new pod data is fed to the fingerprint,
+	// respecting the invocation order (no reordering done)
+	Add(namespace, name string)
+	// Sign is called when the fingerprint is asked for the signature
+	Sign(computed string)
+	// Check is called when the fingerprint is asked to check
+	Check(expected string)
+}
+
+// NullTracer implements the Tracer interface and does nothing
+type NullTracer struct{}
+
+func (nt NullTracer) Start(numPods int)          {}
+func (nt NullTracer) Add(namespace, name string) {}
+func (nt NullTracer) Sign(computed string)       {}
+func (nt NullTracer) Check(expected string)      {}
+
+// Status represents the working status of a Fingerprint
+type Status struct {
+	FingerprintExpected string           `json:"fingerprintExpected,omitempty"`
+	FingerprintComputed string           `json:"fingerprintComputed,omitempty"`
+	Pods                []NamespacedName `json:"pods,omitempty"`
+}
+
+func (st *Status) Start(numPods int) {
+	st.Pods = make([]NamespacedName, 0, numPods)
+}
+
+func (st *Status) Add(namespace, name string) {
+	st.Pods = append(st.Pods, NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	})
+}
+
+func (st *Status) Sign(computed string) {
+	st.FingerprintComputed = computed
+}
+
+func (st *Status) Check(expected string) {
+	st.FingerprintExpected = expected
+}
+
+// Repr represents the Status as compact yet human-friendly string
+func (st Status) Repr() string {
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("> processing %d pods\n", len(st.Pods)))
+	for _, pod := range st.Pods {
+		sb.WriteString("+ " + pod.Namespace + "/" + pod.Name + "\n")
+	}
+
+	sb.WriteString("= " + st.FingerprintComputed + "\n")
+	if st.FingerprintExpected != "" {
+		sb.WriteString("V " + st.FingerprintExpected + "\n")
+	}
+
+	return sb.String()
+}
+
+type TracingFingerprint struct {
+	Fingerprint
+	tracer Tracer
+}
+
+// NewTracingFingerprint creates a empty Fingerprint.
+// The size parameter is a hint for the expected size of the pod set. Use 0 if you don't know.
+// Values of size < 0 are ignored.
+// The tracer parameter attach a tracer to this fingerprint. Client code can peek inside the
+// fingerprint parameters, for debug purposes.
+func NewTracingFingerprint(size int, tracer Tracer) *TracingFingerprint {
+	tf := &TracingFingerprint{}
+	tf.Fingerprint.Reset(size)
+	tf.tracer = tracer
+	return tf
+}
+
+// AddPod adds a pod to the pod set.
+func (tf *TracingFingerprint) AddPod(pod PodIdentifier) error {
+	tf.tracer.Add(pod.GetNamespace(), pod.GetName())
+	return tf.Fingerprint.AddPod(pod)
+}
+
+// AddPod add a pod by its namespace/name pair to the pod set.
+func (tf *TracingFingerprint) Add(namespace, name string) error {
+	tf.tracer.Add(namespace, name)
+	return tf.Fingerprint.Add(namespace, name)
+}
+
+// Sum computes the fingerprint of the *current* pod set as slice of bytes.
+// It is legal to keep adding pods after calling Sum, but the fingerprint of
+// the set will change. The output of Sum is guaranteed to be stable if the
+// content of the pod set is stable.
+func (tf *TracingFingerprint) Sum() []byte {
+	return tf.Fingerprint.Sum()
+}
+
+// Sign computes the pod set fingerprint as string.
+// The string should be considered a opaque identifier and checked only for
+// equality, or fed into Check
+func (tf *TracingFingerprint) Sign() string {
+	sign := tf.Fingerprint.Sign()
+	tf.tracer.Sign(sign)
+	return sign
+}
+
+// Check verifies if the provided fingerprint matches the current pod set.
+// Returns nil if the verification holds, error otherwise, or if the fingerprint
+// string is malformed.
+func (tf *TracingFingerprint) Check(sign string) error {
+	tf.tracer.Check(sign)
+	return tf.Fingerprint.Check(sign)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -235,10 +235,10 @@ github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned/scheme
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned/typed/topology/v1alpha1
-# github.com/k8stopologyawareschedwg/podfingerprint v0.0.3
+# github.com/k8stopologyawareschedwg/podfingerprint v0.1.1
 ## explicit; go 1.17
 github.com/k8stopologyawareschedwg/podfingerprint
-# github.com/k8stopologyawareschedwg/resource-topology-exporter v0.7.5
+# github.com/k8stopologyawareschedwg/resource-topology-exporter v0.7.6
 ## explicit; go 1.18
 github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/dump
 github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/k8sannotations


### PR DESCRIPTION
Create empty directory using tmpfs to hold the NRT cache traces if they are enabled; if not this is not to consume relevant resources, so we can keep it always enabled.

Note this is a NOP at this point in time - the scheduler plugin code is still under development. But the above reasoning still holds: from both operator and scheduler plugin this is a very cheap and backward compatible change.

Enable PFP debugging for  RTEs, consuming the functionality from the latest u/s release. Enable dumping on their PFP status files on tmpfs. Even more than for the scheduler plugin, we can keep this always enabled from storage perspective.

Signed-off-by: Francesco Romani <fromani@redhat.com>