### PR TITLE
validator: add validation for scheduler cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,16 @@ binary-nrovalidate: build-tools
 		-ldflags "$$LDFLAGS" \
 		nrovalidate/main.go
 
+binary-nrtcacheck: build-tools
+	LDFLAGS="-s -w "; \
+	LDFLAGS+="-X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/buildhelper version) "; \
+	CGO_ENABLED=0 go build \
+		-mod=vendor \
+		-o bin/nrtcacheck \
+		-ldflags "$$LDFLAGS" \
+		nrtcacheck/main.go
+
+
 binary-all: binary binary-rte
 
 binary-e2e-rte:

--- a/internal/remoteexec/command.go
+++ b/internal/remoteexec/command.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package remoteexec
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/remotecommand"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+// ExecCommandOnPod runs command in the pod and returns buffer output
+func CommandOnPod(c kubernetes.Interface, pod *corev1.Pod, command []string) ([]byte, []byte, error) {
+	return CommandOnPodByNames(c, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name, command)
+}
+
+func CommandOnPodByNames(c kubernetes.Interface, podNamespace, podName, cntName string, command []string) ([]byte, []byte, error) {
+	var outputBuf bytes.Buffer
+	var errorBuf bytes.Buffer
+
+	req := c.CoreV1().RESTClient().
+		Post().
+		Namespace(podNamespace).
+		Resource("pods").
+		Name(podName).
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Container: cntName,
+			Command:   command,
+			Stdin:     true,
+			Stdout:    true,
+			Stderr:    true,
+			TTY:       true,
+		}, scheme.ParameterCodec)
+
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	exec, err := remotecommand.NewSPDYExecutor(cfg, "POST", req.URL())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  os.Stdin,
+		Stdout: &outputBuf,
+		Stderr: &errorBuf,
+		Tty:    true,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to run command %v: %w", command, err)
+	}
+
+	return outputBuf.Bytes(), errorBuf.Bytes(), nil
+
+}

--- a/internal/schedcache/synced.go
+++ b/internal/schedcache/synced.go
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package schedcache
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/k8stopologyawareschedwg/podfingerprint"
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
+	"github.com/openshift-kni/numaresources-operator/pkg/status"
+
+	"github.com/openshift-kni/numaresources-operator/internal/podlist"
+	"github.com/openshift-kni/numaresources-operator/internal/remoteexec"
+)
+
+const (
+	TracingDirectory = "/run/nrtcache"
+)
+
+type CacheStatus string
+
+const (
+	CacheClean CacheStatus = "Clean"
+	CacheDirty CacheStatus = "Dirty"
+)
+
+type Status struct {
+	LogKey              string                 `json:"id"`
+	LastUpdate          time.Time              `json:"lastUpdate"`
+	NodeName            string                 `json:"nodeName"`
+	Cache               CacheStatus            `json:"cacheStatus"`
+	FingerprintExpected string                 `json:"fingerprintExpected,omitempty"`
+	FingerprintComputed string                 `json:"fingerprintComputed,omitempty"`
+	Pods                []types.NamespacedName `json:"pods,omitempty"`
+}
+
+func HasSynced(cli client.Client, k8sCli kubernetes.Interface, nodeNames []string) (bool, map[string]sets.String, error) {
+	var err error
+	var nroSched nropv1alpha1.NUMAResourcesScheduler
+	nroKey := client.ObjectKey{Name: objectnames.DefaultNUMAResourcesSchedulerCrName}
+
+	err = cli.Get(context.TODO(), nroKey, &nroSched)
+	if err != nil {
+		return false, nil, err
+	}
+
+	cond := status.FindCondition(nroSched.Status.Conditions, status.ConditionAvailable)
+	if cond == nil {
+		return false, nil, fmt.Errorf("missing condition: available")
+	}
+
+	dp, err := podlist.GetDeploymentByOwnerReference(cli, nroSched.UID)
+	if err != nil {
+		return false, nil, err
+	}
+
+	if dp.Status.ReadyReplicas != *dp.Spec.Replicas {
+		return false, nil, fmt.Errorf("scheduler dp not ready (%d/%d)", dp.Status.ReadyReplicas, *dp.Spec.Replicas)
+	}
+
+	unsynced := make(map[string]sets.String)
+
+	podList, err := podlist.ByDeployment(cli, *dp)
+	for idx := range podList {
+		pod := &podList[idx]
+
+		notReady, err := ReplicaHasSynced(k8sCli, pod, nodeNames)
+		mergeUnsynced(unsynced, notReady)
+		if err != nil {
+			return len(unsynced) == 0, unsynced, err
+		}
+	}
+
+	return len(unsynced) == 0, unsynced, nil
+}
+
+func ReplicaHasSynced(k8sCli kubernetes.Interface, pod *corev1.Pod, nodeNames []string) (map[string]sets.String, error) {
+	unsynced := make(map[string]sets.String)
+	for _, nodeName := range nodeNames {
+		ok, detectedPods, err := ReplicaHasSyncedNode(k8sCli, pod, nodeName)
+		if err != nil {
+			return unsynced, err
+		}
+		if ok {
+			continue
+		}
+		unsynced[nodeName] = detectedPods
+	}
+
+	return unsynced, nil
+}
+
+func ReplicaHasSyncedNode(k8sCli kubernetes.Interface, pod *corev1.Pod, nodeName string) (bool, sets.String, error) {
+	detectedPods := make(sets.String)
+	stdout, _, err := remoteexec.CommandOnPod(k8sCli, pod, []string{"/bin/cat", filepath.Join(TracingDirectory, nodeName)})
+	if err != nil {
+		return false, detectedPods, err
+	}
+	var status Status
+	err = json.Unmarshal(stdout, &status)
+	if err != nil {
+		return false, detectedPods, err
+	}
+
+	hasSync := status.Cache == CacheClean
+
+	if !hasSync {
+		klog.Warningf("unsynced cache on %q - fingerprint expected %q computed %q", status.NodeName, status.FingerprintExpected, status.FingerprintComputed)
+		klog.Warningf("unsynced cache on %q - detected pods (%d)", status.NodeName, len(status.Pods))
+		for idx, nn := range status.Pods {
+			detected := nn.String()
+			detectedPods.Insert(detected)
+			klog.Warningf("- %3d/%3d %s", idx+1, len(status.Pods), detected)
+		}
+	}
+	return hasSync, detectedPods, nil
+}
+
+func GetUpdaterFingerprintStatus(k8sCli kubernetes.Interface, podNamespace, podName, cntName string) (podfingerprint.Status, error) {
+	var st podfingerprint.Status
+	stdout, _, err := remoteexec.CommandOnPodByNames(k8sCli, podNamespace, podName, cntName, []string{"/bin/cat", "/run/pfpstatus/dump.json"})
+	if err != nil {
+		return st, err
+	}
+	err = json.Unmarshal([]byte(stdout), &st)
+	return st, err
+}
+
+func mergeUnsynced(total, partial map[string]sets.String) {
+	for nodeName, detectedPods := range partial {
+		existing := total[nodeName]
+		total[nodeName] = existing.Union(detectedPods)
+	}
+}

--- a/nrtcacheck/main.go
+++ b/nrtcacheck/main.go
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil"
+	appsv1 "k8s.io/api/apps/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
+
+	securityv1 "github.com/openshift/api/security/v1"
+	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+
+	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
+	rteupdate "github.com/openshift-kni/numaresources-operator/pkg/objectupdate/rte"
+	"github.com/openshift-kni/numaresources-operator/pkg/version"
+
+	"github.com/openshift-kni/numaresources-operator/internal/nodes"
+	"github.com/openshift-kni/numaresources-operator/internal/podlist"
+	"github.com/openshift-kni/numaresources-operator/internal/schedcache"
+)
+
+var (
+	scheme = k8sruntime.NewScheme()
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+	utilruntime.Must(nropv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(machineconfigv1.Install(scheme))
+	utilruntime.Must(securityv1.Install(scheme))
+}
+
+type ProgArgs struct {
+	Version bool
+	Verbose bool
+}
+
+func main() {
+	parsedArgs, err := parseArgs(os.Args[1:]...)
+	if err != nil {
+		klog.V(1).ErrorS(err, "parsing args")
+		os.Exit(1)
+	}
+
+	if parsedArgs.Version {
+		fmt.Println(version.ProgramName(), version.Get())
+		os.Exit(0)
+	}
+
+	cli, err := NewClientWithScheme(scheme)
+	if err != nil {
+		klog.V(1).ErrorS(err, "creating client with scheme")
+		os.Exit(1)
+	}
+
+	rtePodsByNode, err := findRTEPodsByNodeName(cli)
+	if err != nil {
+		klog.V(1).ErrorS(err, "mapping RTE pods to nodes")
+		os.Exit(1)
+	}
+
+	for node, podnn := range rtePodsByNode {
+		klog.V(1).InfoS("RTE:", "node", node, "pod", podnn.String())
+	}
+
+	k8sCli, err := clientutil.NewK8s()
+	if err != nil {
+		klog.V(1).ErrorS(err, "creating k8s client")
+		os.Exit(1)
+	}
+
+	workers, err := nodes.GetWorkerNodes(cli)
+	if err != nil {
+		klog.V(1).ErrorS(err, "getting worker nodes")
+		os.Exit(1)
+	}
+
+	ok, unsynced, err := schedcache.HasSynced(cli, k8sCli, nodes.GetNames(workers))
+	if err != nil {
+		klog.V(1).ErrorS(err, "checking sched cache state")
+		os.Exit(1)
+	}
+	if ok {
+		if parsedArgs.Verbose {
+			fmt.Fprintf(os.Stderr, "all nodes synced\n")
+		}
+		os.Exit(0)
+	}
+
+	for nodeName, podsBySched := range unsynced {
+		podnn, ok := rtePodsByNode[nodeName]
+		if !ok {
+			klog.Warningf("no RTE pod on %q?", nodeName)
+			continue
+		}
+
+		st, err := schedcache.GetUpdaterFingerprintStatus(k8sCli, podnn.Namespace, podnn.Name, rteupdate.MainContainerName)
+		if err != nil {
+			klog.V(1).ErrorS(err, "cannot get RTE pfp status from %q %s", nodeName, podnn.String())
+			continue
+		}
+
+		podsByRTE := sets.String{}
+		for _, nn := range st.Pods {
+			podsByRTE.Insert(nn.String())
+		}
+
+		klog.InfoS("pods on sched, not on RTE", "node", nodeName, "pods", podsBySched.Difference(podsByRTE).List())
+		klog.InfoS("pods on RTE, not on sched", "node", nodeName, "pods", podsByRTE.Difference(podsBySched).List())
+	}
+}
+
+func findRTEPodsByNodeName(cli client.Client) (map[string]types.NamespacedName, error) {
+	nroNName := types.NamespacedName{
+		Name: objectnames.DefaultNUMAResourcesOperatorCrName,
+	}
+	nroObj := nropv1alpha1.NUMAResourcesOperator{}
+	err := cli.Get(context.TODO(), nroNName, &nroObj)
+	if err != nil {
+		return nil, err
+	}
+
+	podsByName := make(map[string]types.NamespacedName)
+	for _, ds := range nroObj.Status.DaemonSets {
+		dsObj := appsv1.DaemonSet{}
+		err = cli.Get(context.TODO(), types.NamespacedName{Namespace: ds.Namespace, Name: ds.Name}, &dsObj)
+		if err != nil {
+			return nil, err
+		}
+
+		pods, err := podlist.ByDaemonset(cli, dsObj)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, pod := range pods {
+			podsByName[pod.Spec.NodeName] = types.NamespacedName{
+				Namespace: pod.Namespace,
+				Name:      pod.Name,
+			}
+		}
+	}
+
+	return podsByName, nil
+}
+
+func parseArgs(args ...string) (ProgArgs, error) {
+	pArgs := ProgArgs{}
+
+	flags := flag.NewFlagSet(version.ProgramName(), flag.ExitOnError)
+
+	flags.BoolVar(&pArgs.Version, "version", false, "Output version and exit")
+
+	klog.InitFlags(flags)
+	err := flags.Parse(args)
+	return pArgs, err
+}
+
+func NewClientWithScheme(scheme *k8sruntime.Scheme) (client.Client, error) {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	return client.New(cfg, client.Options{Scheme: scheme})
+}

--- a/pkg/validator/schedcache.go
+++ b/pkg/validator/schedcache.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package validator
+
+import (
+	"context"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil"
+	deployervalidator "github.com/k8stopologyawareschedwg/deployer/pkg/validator"
+	"github.com/openshift-kni/numaresources-operator/internal/nodes"
+	"github.com/openshift-kni/numaresources-operator/internal/schedcache"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	ValidatorSchedCache = "schedcache"
+)
+
+func CollectSchedCache(ctx context.Context, cli client.Client, data *ValidatorData) error {
+	k8sCli, err := clientutil.NewK8s()
+	if err != nil {
+		return err
+	}
+
+	workers, err := nodes.GetWorkerNodes(cli)
+	if err != nil {
+		return err
+	}
+
+	_, unsynced, err := schedcache.HasSynced(cli, k8sCli, nodes.GetNames(workers))
+	if err != nil {
+		return err
+	}
+
+	data.unsynchedCaches = unsynced
+
+	return nil
+}
+
+func ValidateSchedCache(data ValidatorData) ([]deployervalidator.ValidationResult, error) {
+	var ret []deployervalidator.ValidationResult
+	for nodeName := range data.unsynchedCaches {
+		ret = append(ret, deployervalidator.ValidationResult{
+			Area:      deployervalidator.AreaCluster,
+			Component: "scheduler",
+			Node:      nodeName,
+			Setting:   "cache",
+			Expected:  "clean",
+			Detected:  "unsync",
+		})
+	}
+
+	return ret, nil
+}

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -78,6 +78,7 @@ func Available() sets.String {
 		ValidatorKubeletConfig,
 		ValidatorNodeResourceTopologies,
 		ValidatorPodStatus,
+		ValidatorSchedCache,
 	)
 }
 
@@ -85,6 +86,7 @@ type ValidatorData struct {
 	tasEnabledNodeNames  sets.String
 	nonRunningPodsByNode map[string]map[string]corev1.PodPhase
 	kConfigs             map[string]*kubeletconfigv1beta1.KubeletConfiguration
+	unsynchedCaches      map[string]sets.String
 	nrtCrdMissing        bool
 	nrtList              *nrtv1alpha1.NodeResourceTopologyList
 	versionInfo          *version.Info
@@ -98,6 +100,7 @@ func Collectors() map[string]CollectFunc {
 		ValidatorKubeletConfig:          CollectKubeletConfig,
 		ValidatorNodeResourceTopologies: CollectNodeResourceTopologies,
 		ValidatorPodStatus:              CollectPodStatus,
+		ValidatorSchedCache:             CollectSchedCache,
 	}
 }
 
@@ -197,6 +200,7 @@ func Validators() map[string]ValidateFunc {
 		ValidatorKubeletConfig:          ValidateKubeletConfig,
 		ValidatorNodeResourceTopologies: ValidateNodeResourceTopologies,
 		ValidatorPodStatus:              ValidatePodStatus,
+		ValidatorSchedCache:             ValidateSchedCache,
 	}
 }
 

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -53,15 +53,15 @@ func TestRequested(t *testing.T) {
 			expectedValue: available,
 		},
 		{
-			what:          "k8scfg,podst,nrt",
+			what:          "k8scfg,podst,nrt,schedcache",
 			expectedValue: available,
 		},
 		{
-			what:          "nrt,k8scfg,podst",
+			what:          "nrt,k8scfg,schedcache,podst",
 			expectedValue: available,
 		},
 		{
-			what:          " nrt,  k8scfg ,   podst ",
+			what:          "     schedcache,nrt,  k8scfg ,   podst ",
 			expectedValue: available,
 		},
 	}


### PR DESCRIPTION
Add helper packages to check the state of the scheduler cache. The first and most obvious troubleshooting step is to check if the scheduler cache is clean (vs dirty, thus not sending pods to a node because the overallocation).

To do so, we rely on the tracing functionality introduced in podfingerprint package >= 0.1.0. Components computing the pod fingerprint can now expose the debug data in JSON format, which this code reads, consumes and crosschecks.

The output can tell the client (human or machine) if the scheduler cache is clean for each node, and if not, why the computation drifted.

Drifted is caused by different perspective on which pods are present on which node. There's only one key scenario on which this happen and it is not eventually self-healed: lingering terminated pods, which stay around and are terminated *before* the scheduler plugin starts.

Arguably, the scheduler plugin (aka the go k8s client) can make steps to make sure it gets these pods, but until (if) this happens, better to detect this scenario.

Signed-off-by: Francesco Romani <fromani@redhat.com>