### PR TITLE
rte: config: fix setting of TM scope

### DIFF
--- a/rte/main.go
+++ b/rte/main.go
@@ -15,6 +15,7 @@ limitations under the License.
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -56,6 +57,7 @@ type ProgArgs struct {
 	LocalArgs       localArgs
 	Version         bool
 	SysinfoOnly     bool
+	DumpConfig      bool
 }
 
 func main() {
@@ -68,6 +70,15 @@ func main() {
 
 	if parsedArgs.Version {
 		fmt.Printf("%s %s %s %s\n", version.ProgramName(), version.Get(), version.GetGitCommit(), runtime.Version())
+		os.Exit(0)
+	}
+
+	if parsedArgs.DumpConfig {
+		data, err := json.Marshal(parsedArgs)
+		if err != nil {
+			klog.Fatalf("encoding the configuration to JSON")
+		}
+		fmt.Printf("%s\n", string(data))
 		os.Exit(0)
 	}
 
@@ -156,7 +167,7 @@ func parseArgs(args ...string) (ProgArgs, error) {
 	flags.StringVar(&sysReservedMemory, "system-info-reserved-memory", "", "kubelet reserved memory: comma-separated 'numaID=amount' (example: '0=16Gi,1=8192Mi,3=1Gi')")
 	flags.StringVar(&sysResourceMapping, "system-info-resource-mapping", "", "kubelet resource mapping: comma-separated 'vendor:device=resourcename'")
 	flags.BoolVar(&pArgs.SysinfoOnly, "system-info", false, "Output detected system info and exit")
-
+	flags.BoolVar(&pArgs.DumpConfig, "dump-config", false, "Output the configuration settings and exit - the output format is JSON, subjected to change without notice.")
 	flags.BoolVar(&pArgs.Version, "version", false, "Output version and exit")
 
 	err := flags.Parse(args)

--- a/rte/main.go
+++ b/rte/main.go
@@ -37,6 +37,13 @@ import (
 	"github.com/openshift-kni/numaresources-operator/rte/pkg/sysinfo"
 )
 
+const (
+	// k8s 1.25 https://kubernetes.io/docs/tasks/administer-cluster/topology-manager/#topology-manager-policies
+	defaultTopologyManagerPolicy = "none"
+	// k8s 1.25 https://kubernetes.io/docs/tasks/administer-cluster/topology-manager/#topology-manager-scopes
+	defaultTopologyManagerScope = "container"
+)
+
 type localArgs struct {
 	SysConf    sysinfo.Config
 	ConfigPath string
@@ -128,8 +135,8 @@ func parseArgs(args ...string) (ProgArgs, error) {
 	flags.StringVar(&pArgs.LocalArgs.ConfigPath, "config", "/etc/resource-topology-exporter/config.yaml", "Configuration file path. Use this to set the exclude list.")
 
 	flags.BoolVar(&pArgs.RTE.Debug, "debug", false, " Enable debug output.")
-	flags.StringVar(&pArgs.RTE.TopologyManagerPolicy, "topology-manager-policy", defaultTopologyManagerPolicy(), "Explicitly set the topology manager policy instead of reading from the kubelet.")
-	flags.StringVar(&pArgs.RTE.TopologyManagerScope, "topology-manager-scope", defaultTopologyManagerScope(), "Explicitly set the topology manager scope instead of reading from the kubelet.")
+	flags.StringVar(&pArgs.RTE.TopologyManagerPolicy, "topology-manager-policy", "", "Explicitly set the topology manager policy instead of reading from the kubelet.")
+	flags.StringVar(&pArgs.RTE.TopologyManagerScope, "topology-manager-scope", "", "Explicitly set the topology manager scope instead of reading from the kubelet.")
 	flags.DurationVar(&pArgs.RTE.SleepInterval, "sleep-interval", 60*time.Second, "Time to sleep between podresources API polls.")
 	flags.StringVar(&pArgs.RTE.KubeletConfigFile, "kubelet-config-file", "/podresources/config.yaml", "Kubelet config file path.")
 	flags.StringVar(&pArgs.RTE.PodResourcesSocketPath, "podresources-socket", "unix:///podresources/kubelet.sock", "Pod Resource Socket path to use.")
@@ -197,17 +204,10 @@ func parseArgs(args ...string) (ProgArgs, error) {
 
 	klog.Infof("using sysinfo:\n%s", pArgs.LocalArgs.SysConf.ToYAMLString())
 
-	// do not overwrite with empty an existing value (e.g. from opts)
-	if pArgs.RTE.TopologyManagerPolicy == "" {
-		pArgs.RTE.TopologyManagerPolicy = conf.TopologyManagerPolicy
+	err = setupTopologyManagerConfig(&pArgs, conf)
+	if err != nil {
+		return pArgs, err
 	}
-	if pArgs.RTE.TopologyManagerScope == "" {
-		pArgs.RTE.TopologyManagerScope = conf.TopologyManagerScope
-	}
-	klog.Infof("using Topology Manager scope %q (conf=%s) policy %q (conf=%s)",
-		pArgs.RTE.TopologyManagerScope, conf.TopologyManagerScope,
-		pArgs.RTE.TopologyManagerPolicy, conf.TopologyManagerPolicy,
-	)
 
 	return pArgs, nil
 }
@@ -225,20 +225,77 @@ func defaultHostName() string {
 	return val
 }
 
-func defaultTopologyManagerPolicy() string {
-	if val, ok := os.LookupEnv("TOPOLOGY_MANAGER_POLICY"); ok {
-		return val
-	}
-	// empty string is a valid value here, so just keep going
-	return ""
-}
+func setupTopologyManagerConfig(pArgs *ProgArgs, conf config.Config) error {
+	// general flow: do not overwrite with empty an existing value (e.g. from opts)
+	// precedence order:
+	// - args, which overrides
+	// - env var, which overrides
+	// - config file, which overrides
+	// - defaults (hardcoded)
 
-func defaultTopologyManagerScope() string {
-	if val, ok := os.LookupEnv("TOPOLOGY_MANAGER_SCOPE"); ok {
-		return val
+	type choice struct {
+		value  string
+		origin string
 	}
-	//https://kubernetes.io/docs/tasks/administer-cluster/topology-manager/#topology-manager-scopes
-	return "container"
+
+	pickFirstNonEmpty := func(choices []choice) choice {
+		for _, ch := range choices {
+			if ch.value != "" {
+				return ch
+			}
+		}
+		return choice{}
+	}
+
+	policy := pickFirstNonEmpty([]choice{
+		{
+			value:  pArgs.RTE.TopologyManagerPolicy,
+			origin: "args",
+		},
+		{
+			value:  os.Getenv("TOPOLOGY_MANAGER_POLICY"),
+			origin: "env",
+		},
+		{
+			value:  conf.TopologyManagerPolicy,
+			origin: "conf",
+		},
+		{
+			value:  defaultTopologyManagerPolicy,
+			origin: "default",
+		},
+	})
+	pArgs.RTE.TopologyManagerPolicy = policy.value
+
+	scope := pickFirstNonEmpty([]choice{
+		{
+			value:  pArgs.RTE.TopologyManagerScope,
+			origin: "args",
+		},
+		{
+			value:  os.Getenv("TOPOLOGY_MANAGER_SCOPE"),
+			origin: "env",
+		},
+		{
+			value:  conf.TopologyManagerScope,
+			origin: "conf",
+		},
+		{
+			value:  defaultTopologyManagerScope,
+			origin: "default",
+		},
+	})
+	pArgs.RTE.TopologyManagerScope = scope.value
+
+	klog.Infof("using Topology Manager scope %q from %q (conf=%s) policy %q from %q (conf=%s)",
+		pArgs.RTE.TopologyManagerScope, scope.origin, conf.TopologyManagerScope,
+		pArgs.RTE.TopologyManagerPolicy, policy.origin, conf.TopologyManagerPolicy,
+	)
+
+	if pArgs.RTE.TopologyManagerPolicy == "" || pArgs.RTE.TopologyManagerScope == "" {
+		return fmt.Errorf("incomplete Topology Manager configuration")
+	}
+	return nil
 }
 
 func setKubeletStateDirs(value string) ([]string, error) {

--- a/test/e2e/rte/rte_e2e_suite_test.go
+++ b/test/e2e/rte/rte_e2e_suite_test.go
@@ -18,8 +18,10 @@ package rte
 
 import (
 	"flag"
+	"fmt"
 	"math/rand"
 	"os"
+	"os/exec"
 	"testing"
 	"time"
 
@@ -28,6 +30,8 @@ import (
 
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
+
+	"github.com/openshift-kni/numaresources-operator/test/utils/runtime"
 
 	_ "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/rte"
 	_ "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/topology_updater"
@@ -48,4 +52,28 @@ func TestMain(m *testing.M) {
 func TestRTE(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "RTE Test Suite")
+}
+
+var BinariesPath string
+
+var _ = BeforeSuite(func() {
+	By("Finding the binaries path")
+
+	binPath, err := runtime.GetBinariesPath()
+	Expect(err).ToNot(HaveOccurred())
+	BinariesPath = binPath
+
+	By(fmt.Sprintf("Using the binaries path %q", BinariesPath))
+})
+
+func expectExecutableExists(path string) {
+	cmdline := []string{
+		path,
+		"-h",
+	}
+
+	cmd := exec.Command(cmdline[0], cmdline[1:]...)
+	out, err := cmd.CombinedOutput()
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, out).ToNot(BeEmpty())
 }

--- a/test/e2e/rte/rte_local_test.go
+++ b/test/e2e/rte/rte_local_test.go
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rte
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nrtupdater"
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcemonitor"
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcetopologyexporter"
+)
+
+type ProgArgs struct {
+	NRTupdater      nrtupdater.Args
+	Resourcemonitor resourcemonitor.Args
+	RTE             resourcetopologyexporter.Args
+}
+
+var _ = Describe("[rte][local][config] RTE configuration", func() {
+	Context("with the binary available", func() {
+		It("should have any default for TM params", func() {
+			args := runConfig([]string{}, map[string]string{})
+			Expect(args.RTE.TopologyManagerScope).ToNot(BeEmpty())
+			Expect(args.RTE.TopologyManagerPolicy).ToNot(BeEmpty())
+		})
+
+		It("should override defaults for TM params using args", func() {
+			args := runConfig([]string{
+				"--topology-manager-scope=pod",
+				"--topology-manager-policy=restricted",
+			}, map[string]string{})
+			Expect(args.RTE.TopologyManagerScope).To(Equal("pod"))
+			Expect(args.RTE.TopologyManagerPolicy).To(Equal("restricted"))
+		})
+
+		It("should override defaults for TM params using env", func() {
+			args := runConfig([]string{}, map[string]string{
+				"TOPOLOGY_MANAGER_SCOPE":  "pod",
+				"TOPOLOGY_MANAGER_POLICY": "restricted",
+			})
+			Expect(args.RTE.TopologyManagerScope).To(Equal("pod"))
+			Expect(args.RTE.TopologyManagerPolicy).To(Equal("restricted"))
+		})
+
+		It("should override defaults for TM params using args, overriding env", func() {
+			args := runConfig([]string{
+				"--topology-manager-scope=pod",
+				"--topology-manager-policy=restricted",
+			}, map[string]string{
+				"TOPOLOGY_MANAGER_SCOPE":  "container",
+				"TOPOLOGY_MANAGER_POLICY": "best-effort",
+			})
+			Expect(args.RTE.TopologyManagerScope).To(Equal("pod"))
+			Expect(args.RTE.TopologyManagerPolicy).To(Equal("restricted"))
+		})
+
+		// TODO: add tests with config
+	})
+})
+
+func runConfig(argv []string, env map[string]string) ProgArgs {
+	cmdline := []string{
+		filepath.Join(BinariesPath, "exporter"),
+		"--dump-config",
+	}
+	cmdline = append(cmdline, argv...)
+
+	expectExecutableExists(cmdline[0])
+
+	fmt.Fprintf(GinkgoWriter, "running: %v\n", cmdline)
+
+	cmd := exec.Command(cmdline[0], cmdline[1:]...)
+	cmd.Stderr = GinkgoWriter
+	if len(env) > 0 {
+		cmd.Env = flattenEnv(env)
+	}
+
+	out, err := cmd.Output()
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	var args ProgArgs
+	err = json.Unmarshal(out, &args)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	return args
+}
+
+func flattenEnv(env map[string]string) []string {
+	ret := make([]string, len(env))
+	for key, value := range env {
+		ret = append(ret, strings.TrimSpace(key)+"="+strings.TrimSpace(value))
+	}
+	return ret
+}


### PR DESCRIPTION
We used to have the default TM scope "container".
This works - and it is actually the k8s default, but prevents the overriding from every source.

Fix the code allowing override of TM scope.
Note this now requires the value to be always provided in some form. Since we always provide the configmap with the scope and policy settings, this should be ho harm.

Signed-off-by: Francesco Romani <fromani@redhat.com>