### PR TITLE
test: e2e: rte: fix configuration test

### DIFF
--- a/test/e2e/rte/rte_e2e_suite_test.go
+++ b/test/e2e/rte/rte_e2e_suite_test.go
@@ -54,16 +54,16 @@ func TestRTE(t *testing.T) {
 	RunSpecs(t, "RTE Test Suite")
 }
 
-var BinariesPath string
+var BinaryPath string
 
 var _ = BeforeSuite(func() {
 	By("Finding the binaries path")
 
-	binPath, err := runtime.GetBinariesPath()
+	binPath, err := runtime.FindBinaryPath("exporter")
 	Expect(err).ToNot(HaveOccurred())
-	BinariesPath = binPath
+	BinaryPath = binPath
 
-	By(fmt.Sprintf("Using the binaries path %q", BinariesPath))
+	By(fmt.Sprintf("Using the binary at %q", BinaryPath))
 })
 
 func expectExecutableExists(path string) {

--- a/test/e2e/rte/rte_local_test.go
+++ b/test/e2e/rte/rte_local_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
@@ -81,7 +80,7 @@ var _ = Describe("[rte][local][config] RTE configuration", func() {
 
 func runConfig(argv []string, env map[string]string) ProgArgs {
 	cmdline := []string{
-		filepath.Join(BinariesPath, "exporter"),
+		BinaryPath,
 		"--dump-config",
 	}
 	cmdline = append(cmdline, argv...)


### PR DESCRIPTION
The prow CI stores the `exporter` binary in a different path when running the e2e tests. Handle different path in the suite setup.

Signed-off-by: Francesco Romani <fromani@redhat.com>