### PR TITLE
e2e: fix unsuitable free devices amount

### DIFF
--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -1098,11 +1098,12 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				{
 					corev1.ResourceCPU:    resource.MustParse("6"),
 					corev1.ResourceMemory: resource.MustParse("2Gi"),
+					corev1.ResourceName(e2efixture.GetDeviceType1Name()): resource.MustParse("2"),
 				},
 				{
 					corev1.ResourceCPU:    resource.MustParse("12"),
 					corev1.ResourceMemory: resource.MustParse("12Gi"),
-					corev1.ResourceName(e2efixture.GetDeviceType1Name()): resource.MustParse("8"),
+					corev1.ResourceName(e2efixture.GetDeviceType1Name()): resource.MustParse("3"),
 				},
 			},
 			[]corev1.ResourceList{


### PR DESCRIPTION
The test is failing because the test pod was scheduled on a non-target node, hence on a node that was supposed to be unsuitable because it has free resources but are not enough for allocating the test pod.

In order to make the node unsuitable, we must specify the amount of the free resource's type that is being requested by the pod, otherwise, that kind of resource will stay entirely free and will not be padded as expected, making the "unsuitable" nodes as candidates for the test pod, a thing which happened in this test case.

Adjust the unsuitable amount of free devices of Type1 making it impossible to count those nodes as candidates for the test pod.

Signed-off-by: shereenH <shajmakh@redhat.com>