### PR TITLE
rte: cleanup code

### DIFF
--- a/rte/pkg/config/config.go
+++ b/rte/pkg/config/config.go
@@ -1,16 +1,18 @@
 /*
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package config
 

--- a/rte/pkg/config/config_test.go
+++ b/rte/pkg/config/config_test.go
@@ -1,16 +1,18 @@
 /*
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package config
 

--- a/rte/pkg/podrescompat/client.go
+++ b/rte/pkg/podrescompat/client.go
@@ -1,16 +1,18 @@
 /*
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package podrescompat
 

--- a/rte/pkg/podrescompat/client_test.go
+++ b/rte/pkg/podrescompat/client_test.go
@@ -1,16 +1,18 @@
 /*
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package podrescompat
 

--- a/rte/pkg/podresfilter/client.go
+++ b/rte/pkg/podresfilter/client.go
@@ -38,7 +38,7 @@ func (fc *filteringClient) FilterListResponse(resp *podresourcesapi.ListPodResou
 		PodResources: make([]*podresourcesapi.PodResources, 0, len(resp.GetPodResources())),
 	}
 	for _, podRes := range resp.GetPodResources() {
-		if shouldExclude(fc.podExcludes, podRes.GetNamespace(), podRes.GetName(), fc.debug) {
+		if ShouldExclude(fc.podExcludes, podRes.GetNamespace(), podRes.GetName(), fc.debug) {
 			continue
 		}
 		retResp.PodResources = append(retResp.PodResources, podRes)
@@ -77,7 +77,7 @@ func NewFromLister(cli podresourcesapi.PodResourcesListerClient, debug bool, pod
 	}
 }
 
-func shouldExclude(podExcludes map[string]string, namespace, name string, debug bool) bool {
+func ShouldExclude(podExcludes map[string]string, namespace, name string, debug bool) bool {
 	for namespaceGlob, nameGlob := range podExcludes {
 		nsMatch, err := filepath.Match(namespaceGlob, namespace)
 		if err != nil && debug {

--- a/rte/pkg/podresfilter/client_test.go
+++ b/rte/pkg/podresfilter/client_test.go
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package podresfilter
+
+import (
+	"testing"
+)
+
+func TestShouldExclude(t *testing.T) {
+	var testCases = []struct {
+		name         string
+		podExcludes  map[string]string
+		podNamespace string
+		podName      string
+		excluded     bool
+	}{
+		{
+			name:         "no excludes",
+			podExcludes:  map[string]string{},
+			podNamespace: "foo-bar",
+			podName:      "quux-bar",
+			excluded:     false,
+		},
+		{
+			name: "name no match",
+			podExcludes: map[string]string{
+				"foo-bar": "baz",
+			},
+			podNamespace: "foo-bar",
+			podName:      "quux-bar",
+			excluded:     false,
+		},
+		{
+			name: "name no match, star",
+			podExcludes: map[string]string{
+				"foo-bar": "baz-*",
+			},
+			podNamespace: "foo-bar",
+			podName:      "quux-bar",
+			excluded:     false,
+		},
+		{
+			name: "name match",
+			podExcludes: map[string]string{
+				"foo-bar": "quux-bar",
+			},
+			podNamespace: "foo-bar",
+			podName:      "quux-bar",
+			excluded:     true,
+		},
+		{
+			name: "name match, star",
+			podExcludes: map[string]string{
+				"foo-bar": "*-bar",
+			},
+			podNamespace: "foo-bar",
+			podName:      "quux-bar",
+			excluded:     true,
+		},
+
+		{
+			name: "namespace no match",
+			podExcludes: map[string]string{
+				"blah": "quux-bar",
+			},
+			podNamespace: "foo-bar",
+			podName:      "quux-bar",
+			excluded:     false,
+		},
+		{
+			name: "namespace no match, star",
+			podExcludes: map[string]string{
+				"blah-*": "quux-bar",
+			},
+			podNamespace: "foo-bar",
+			podName:      "quux-bar",
+			excluded:     false,
+		},
+		{
+			name: "namespace match",
+			podExcludes: map[string]string{
+				"foo-bar": "quux-bar",
+			},
+			podNamespace: "foo-bar",
+			podName:      "quux-bar",
+			excluded:     true,
+		},
+		{
+			name: "namespace match, star",
+			podExcludes: map[string]string{
+				"foo-*": "quux-bar",
+			},
+			podNamespace: "foo-bar",
+			podName:      "quux-bar",
+			excluded:     true,
+		},
+		{
+			name: "everything",
+			podExcludes: map[string]string{
+				"*": "*",
+			},
+			podNamespace: "foo-bar",
+			podName:      "quux-bar",
+			excluded:     true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			debug := true
+			exc := ShouldExclude(testCase.podExcludes, testCase.podNamespace, testCase.podName, debug)
+			if exc != testCase.excluded {
+				t.Errorf("excluded=%v expected=%v for %s/%s with %v", exc, testCase.excluded, testCase.podNamespace, testCase.podName, testCase.podExcludes)
+			}
+		})
+	}
+}

--- a/rte/pkg/sysinfo/sysinfo.go
+++ b/rte/pkg/sysinfo/sysinfo.go
@@ -1,16 +1,18 @@
 /*
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package sysinfo
 

--- a/rte/pkg/sysinfo/sysinfo_test.go
+++ b/rte/pkg/sysinfo/sysinfo_test.go
@@ -1,16 +1,18 @@
 /*
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package sysinfo
 


### PR DESCRIPTION
tidy up the boilerplate and add tests to the `podresfilter` pkg, which weren't mistakely left out from #457 