### PR TITLE
serial: update scheduler name properly

### DIFF
--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -298,7 +298,7 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 			err = fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroSchedObj), nroSchedObj)
 			Expect(err).ToNot(HaveOccurred())
 
-			nroSchedObj.Spec.SchedulerName = serialconfig.SchedulerTestName
+			nroSchedObj.Status.SchedulerName = serialconfig.SchedulerTestName
 			err = fxt.Client.Update(context.TODO(), nroSchedObj)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -308,7 +308,7 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 				err := fxt.Client.Get(context.TODO(), client.ObjectKey{Name: nrosched.NROSchedObjectName}, currentSchedObj)
 				Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", nrosched.NROSchedObjectName)
 
-				currentSchedObj.Spec = initialNroSchedObj.Spec
+				currentSchedObj.Status = initialNroSchedObj.Status
 				err = fxt.Client.Update(context.TODO(), currentSchedObj)
 				Expect(err).ToNot(HaveOccurred())
 			}()
@@ -428,7 +428,7 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 			nroSchedObj := &nropv1alpha1.NUMAResourcesScheduler{}
 			err = fxt.Client.Get(context.TODO(), client.ObjectKey{Name: nrosched.NROSchedObjectName}, nroSchedObj)
 			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", nrosched.NROSchedObjectName)
-			schedulerName := nroSchedObj.Spec.SchedulerName
+			schedulerName := nroSchedObj.Status.SchedulerName
 
 			nrtPreCreatePodList, err := e2enrt.GetUpdated(fxt.Client, initialNrtList, timeout)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
The test fails to set the scheduler name under the test's pod because nroSchedObj.Spec.SchedulerName does not exist, thus it returns an empty value, which later would be translated to the default kube scheduler name instead of the test scheduler name. The scheduler name is defined under Status not under Spec of the numaresourcesscheduler CR.

Modify the scheduler name properly in Status.SchedulerName to check the anticipated test's result.

get it from status instead of spec.

Signed-off-by: shereenH <shajmakh@redhat.com>