### PR TITLE
RTE: further improvements about node group config status reporting

### DIFF
--- a/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_types.go
+++ b/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_types.go
@@ -116,7 +116,7 @@ type MachineConfigPool struct {
 	// +optional
 	Conditions []mcov1.MachineConfigPoolCondition `json:"conditions,omitempty"`
 	// NodeGroupConfig represents the latest available configuration applied to this MachineConfigPool
-	Config NodeGroupConfig `json:"defaultNodeGroupConfig,omitempty"`
+	Config NodeGroupConfig `json:"config,omitempty"`
 }
 
 //+genclient

--- a/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -271,7 +271,7 @@ spec:
                         - type
                         type: object
                       type: array
-                    defaultNodeGroupConfig:
+                    config:
                       description: NodeGroupConfig represents the latest available
                         configuration applied to this MachineConfigPool
                       properties:

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -273,7 +273,7 @@ spec:
                         - type
                         type: object
                       type: array
-                    defaultNodeGroupConfig:
+                    config:
                       description: NodeGroupConfig represents the latest available
                         configuration applied to this MachineConfigPool
                       properties:

--- a/controllers/numaresourcesoperator_controller_test.go
+++ b/controllers/numaresourcesoperator_controller_test.go
@@ -622,7 +622,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 			Expect(len(nroUpdated.Status.MachineConfigPools)).To(Equal(1))
 			Expect(nroUpdated.Status.MachineConfigPools[0].Name).To(Equal(mcp.Name))
-			Expect(nroUpdated.Status.MachineConfigPools[0].Config).To(Equal(conf))
+			// TODO check the actual returned config. We need to force the condition as Available for this.
 		})
 
 		It("should allow to alter all the settings of the DS objects", func() {

--- a/pkg/machineconfigpools/machineconfigpools.go
+++ b/pkg/machineconfigpools/machineconfigpools.go
@@ -36,6 +36,17 @@ type NodeGroupTree struct {
 	MachineConfigPools []*mcov1.MachineConfigPool
 }
 
+func (ngt NodeGroupTree) Clone() NodeGroupTree {
+	ret := NodeGroupTree{
+		NodeGroup:          ngt.NodeGroup.DeepCopy(),
+		MachineConfigPools: make([]*mcov1.MachineConfigPool, 0, len(ngt.MachineConfigPools)),
+	}
+	for _, mcp := range ngt.MachineConfigPools {
+		ret.MachineConfigPools = append(ret.MachineConfigPools, mcp.DeepCopy())
+	}
+	return ret
+}
+
 func GetTreesByNodeGroup(ctx context.Context, cli client.Client, nodeGroups []nropv1alpha1.NodeGroup) ([]NodeGroupTree, error) {
 	mcps := &mcov1.MachineConfigPoolList{}
 	if err := cli.List(ctx, mcps); err != nil {

--- a/pkg/normalize/normalize.go
+++ b/pkg/normalize/normalize.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package normalize
+
+import (
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	"github.com/openshift-kni/numaresources-operator/pkg/machineconfigpools"
+	"github.com/openshift-kni/numaresources-operator/pkg/objectstate/merge"
+)
+
+func NodeGroupTreesConfig(trees []machineconfigpools.NodeGroupTree) {
+	for idx := range trees {
+		tree := &trees[idx]
+		NodeGroupConfig(tree.NodeGroup)
+	}
+}
+
+func NodeGroupConfig(nodeGroup *nropv1alpha1.NodeGroup) {
+	conf := nropv1alpha1.DefaultNodeGroupConfig()
+	if nodeGroup.DisablePodsFingerprinting != nil {
+		// handle the bool added in 4.11. We will deprecate once we move out from v1alpha1.
+		setNodeGroupConfigFromNodeGroup(&conf, *nodeGroup)
+	}
+	if nodeGroup.Config != nil {
+		conf = merge.NodeGroupConfig(conf, *nodeGroup.Config)
+	}
+	nodeGroup.Config = &conf
+}
+
+func setNodeGroupConfigFromNodeGroup(conf *nropv1alpha1.NodeGroupConfig, ng nropv1alpha1.NodeGroup) {
+	var podsFp nropv1alpha1.PodsFingerprintingMode
+	if *ng.DisablePodsFingerprinting {
+		podsFp = nropv1alpha1.PodsFingerprintingDisabled
+	} else {
+		podsFp = nropv1alpha1.PodsFingerprintingEnabled
+	}
+	conf.PodsFingerprinting = &podsFp
+}

--- a/pkg/normalize/normalize_test.go
+++ b/pkg/normalize/normalize_test.go
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package normalize
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	"github.com/openshift-kni/numaresources-operator/pkg/machineconfigpools"
+)
+
+func TestNormalizeNodeGroupConfig(t *testing.T) {
+	type testCase struct {
+		name         string
+		nodeGroup    nropv1alpha1.NodeGroup
+		expectedConf nropv1alpha1.NodeGroupConfig
+	}
+
+	testcases := []testCase{
+		{
+			name:         "nil conf",
+			nodeGroup:    nropv1alpha1.NodeGroup{},
+			expectedConf: nropv1alpha1.DefaultNodeGroupConfig(),
+		},
+		{
+			name: "4.11 disable PFP",
+			nodeGroup: nropv1alpha1.NodeGroup{
+				DisablePodsFingerprinting: boolPtr(true),
+			},
+			expectedConf: makeNodeGroupConfig(
+				nropv1alpha1.PodsFingerprintingDisabled,
+				nropv1alpha1.InfoRefreshPeriodicAndEvents,
+				10*time.Second,
+			),
+		},
+		{
+			name: "defaults passthrough",
+			nodeGroup: nropv1alpha1.NodeGroup{
+				Config: makeNodeGroupConfigPtr(
+					nropv1alpha1.PodsFingerprintingEnabled,
+					nropv1alpha1.InfoRefreshPeriodicAndEvents,
+					10*time.Second,
+				),
+			},
+			expectedConf: nropv1alpha1.DefaultNodeGroupConfig(),
+		},
+		{
+			name: "conf disable PFP",
+			nodeGroup: nropv1alpha1.NodeGroup{
+				Config: makeNodeGroupConfigPtr(
+					nropv1alpha1.PodsFingerprintingDisabled,
+					nropv1alpha1.InfoRefreshPeriodicAndEvents,
+					10*time.Second,
+				),
+			},
+			expectedConf: makeNodeGroupConfig(
+				nropv1alpha1.PodsFingerprintingDisabled,
+				nropv1alpha1.InfoRefreshPeriodicAndEvents,
+				10*time.Second,
+			),
+		},
+		{
+			name: "conf tuning",
+			nodeGroup: nropv1alpha1.NodeGroup{
+				Config: makeNodeGroupConfigPtr(
+					nropv1alpha1.PodsFingerprintingEnabled,
+					nropv1alpha1.InfoRefreshPeriodic,
+					20*time.Second,
+				),
+			},
+			expectedConf: makeNodeGroupConfig(
+				nropv1alpha1.PodsFingerprintingEnabled,
+				nropv1alpha1.InfoRefreshPeriodic,
+				20*time.Second,
+			),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.nodeGroup.DeepCopy()
+			NodeGroupConfig(got)
+			if got.Config == nil {
+				t.Fatalf("nil config! %#v", got)
+			}
+			if !cmp.Equal(*got.Config, tc.expectedConf) {
+				t.Errorf("config differs, got=%#v expected=%#v", *got.Config, tc.expectedConf)
+			}
+		})
+	}
+}
+
+func TestNormalizeNodeGroupConfigTree(t *testing.T) {
+	type testCase struct {
+		name          string
+		trees         []machineconfigpools.NodeGroupTree
+		expectedConfs []nropv1alpha1.NodeGroupConfig
+	}
+
+	testcases := []testCase{
+		{
+			name: "set defaults - full",
+			trees: []machineconfigpools.NodeGroupTree{
+				{
+					NodeGroup: &nropv1alpha1.NodeGroup{},
+				},
+				{
+					NodeGroup: &nropv1alpha1.NodeGroup{},
+				},
+			},
+			expectedConfs: []nropv1alpha1.NodeGroupConfig{
+				nropv1alpha1.DefaultNodeGroupConfig(),
+				nropv1alpha1.DefaultNodeGroupConfig(),
+			},
+		},
+		{
+			name: "partial 4.11 disable PFP",
+			trees: []machineconfigpools.NodeGroupTree{
+				{
+					NodeGroup: &nropv1alpha1.NodeGroup{
+						DisablePodsFingerprinting: boolPtr(true),
+					},
+				},
+				{
+					NodeGroup: &nropv1alpha1.NodeGroup{},
+				},
+			},
+			expectedConfs: []nropv1alpha1.NodeGroupConfig{
+				makeNodeGroupConfig(
+					nropv1alpha1.PodsFingerprintingDisabled,
+					nropv1alpha1.InfoRefreshPeriodicAndEvents,
+					10*time.Second,
+				),
+				nropv1alpha1.DefaultNodeGroupConfig(),
+			},
+		},
+		{
+			name: "partial defaults passthrough",
+			trees: []machineconfigpools.NodeGroupTree{
+				{
+					NodeGroup: &nropv1alpha1.NodeGroup{},
+				},
+				{
+					NodeGroup: &nropv1alpha1.NodeGroup{
+						Config: makeNodeGroupConfigPtr(
+							nropv1alpha1.PodsFingerprintingEnabled,
+							nropv1alpha1.InfoRefreshPeriodicAndEvents,
+							10*time.Second,
+						),
+					},
+				},
+			},
+			expectedConfs: []nropv1alpha1.NodeGroupConfig{
+				nropv1alpha1.DefaultNodeGroupConfig(),
+				nropv1alpha1.DefaultNodeGroupConfig(),
+			},
+		},
+		{
+			name: "total defaults passthrough",
+			trees: []machineconfigpools.NodeGroupTree{
+				{
+					NodeGroup: &nropv1alpha1.NodeGroup{
+						Config: makeNodeGroupConfigPtr(
+							nropv1alpha1.PodsFingerprintingEnabled,
+							nropv1alpha1.InfoRefreshPeriodicAndEvents,
+							10*time.Second,
+						),
+					},
+				},
+				{
+					NodeGroup: &nropv1alpha1.NodeGroup{
+						Config: makeNodeGroupConfigPtr(
+							nropv1alpha1.PodsFingerprintingEnabled,
+							nropv1alpha1.InfoRefreshPeriodicAndEvents,
+							10*time.Second,
+						),
+					},
+				},
+			},
+			expectedConfs: []nropv1alpha1.NodeGroupConfig{
+				nropv1alpha1.DefaultNodeGroupConfig(),
+				nropv1alpha1.DefaultNodeGroupConfig(),
+			},
+		},
+		{
+			name: "partial tuning",
+			trees: []machineconfigpools.NodeGroupTree{
+				{
+					NodeGroup: &nropv1alpha1.NodeGroup{},
+				},
+				{
+					NodeGroup: &nropv1alpha1.NodeGroup{
+						Config: makeNodeGroupConfigPtr(
+							nropv1alpha1.PodsFingerprintingEnabled,
+							nropv1alpha1.InfoRefreshPeriodic,
+							21*time.Second,
+						),
+					},
+				},
+			},
+			expectedConfs: []nropv1alpha1.NodeGroupConfig{
+				nropv1alpha1.DefaultNodeGroupConfig(),
+				makeNodeGroupConfig(
+					nropv1alpha1.PodsFingerprintingEnabled,
+					nropv1alpha1.InfoRefreshPeriodic,
+					21*time.Second,
+				),
+			},
+		},
+		{
+			name: "totall tuning",
+			trees: []machineconfigpools.NodeGroupTree{
+				{
+					NodeGroup: &nropv1alpha1.NodeGroup{
+						Config: makeNodeGroupConfigPtr(
+							nropv1alpha1.PodsFingerprintingDisabled,
+							nropv1alpha1.InfoRefreshEvents,
+							0*time.Second,
+						),
+					},
+				},
+				{
+					NodeGroup: &nropv1alpha1.NodeGroup{
+						Config: makeNodeGroupConfigPtr(
+							nropv1alpha1.PodsFingerprintingEnabled,
+							nropv1alpha1.InfoRefreshPeriodic,
+							21*time.Second,
+						),
+					},
+				},
+			},
+			expectedConfs: []nropv1alpha1.NodeGroupConfig{
+				makeNodeGroupConfig(
+					nropv1alpha1.PodsFingerprintingDisabled,
+					nropv1alpha1.InfoRefreshEvents,
+					0*time.Second,
+				),
+				makeNodeGroupConfig(
+					nropv1alpha1.PodsFingerprintingEnabled,
+					nropv1alpha1.InfoRefreshPeriodic,
+					21*time.Second,
+				),
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cloneTrees(tc.trees)
+			NodeGroupTreesConfig(got)
+
+			if len(got) != len(tc.expectedConfs) {
+				t.Fatalf("mismatched length got=%v expected=%v", len(got), len(tc.expectedConfs))
+			}
+
+			gotConfs := make([]nropv1alpha1.NodeGroupConfig, 0, len(got))
+			for _, ngt := range got {
+				if ngt.NodeGroup == nil || ngt.NodeGroup.Config == nil {
+					t.Fatalf("unexpected nil: %s", jsonDump(ngt))
+				}
+				gotConfs = append(gotConfs, *ngt.NodeGroup.Config)
+			}
+
+			if !cmp.Equal(gotConfs, tc.expectedConfs) {
+				t.Errorf("config differs:\ngot=%s\nexpected=%s", jsonDump(gotConfs), jsonDump(tc.expectedConfs))
+			}
+		})
+	}
+
+}
+
+func jsonDump(v interface{}) string {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return "<JSON MARSHAL ERROR>"
+	}
+	return string(data)
+}
+
+func cloneTrees(trees []machineconfigpools.NodeGroupTree) []machineconfigpools.NodeGroupTree {
+	ret := make([]machineconfigpools.NodeGroupTree, 0, len(trees))
+	for _, ngt := range trees {
+		ret = append(ret, ngt.Clone())
+	}
+	return ret
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func makeNodeGroupConfigPtr(podsFp nropv1alpha1.PodsFingerprintingMode, refMode nropv1alpha1.InfoRefreshMode, dur time.Duration) *nropv1alpha1.NodeGroupConfig {
+	conf := makeNodeGroupConfig(podsFp, refMode, dur)
+	return &conf
+}
+
+func makeNodeGroupConfig(podsFp nropv1alpha1.PodsFingerprintingMode, refMode nropv1alpha1.InfoRefreshMode, dur time.Duration) nropv1alpha1.NodeGroupConfig {
+	period := metav1.Duration{
+		Duration: dur,
+	}
+	return nropv1alpha1.NodeGroupConfig{
+		PodsFingerprinting: &podsFp,
+		InfoRefreshPeriod:  &period,
+		InfoRefreshMode:    &refMode,
+	}
+}


### PR DESCRIPTION
This is another refinement of #431 and a followup of #456 
We want to normalize earlier the NodeGroupConfig (see specific commit) to make sure we do meaningful reports of the observed config, and we want to decouple the NodeGroupConfig reporting from the MCP status reporting. Even though both share the same Status object, they should be updated indpendently and in different places in the flow.

Add cleanups and refactorings to improve testability (and some tests) along the way.