### PR TITLE
serial: support test for pod TMscope

### DIFF
--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -574,6 +574,10 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			err = fxt.Client.Delete(context.TODO(), pod2)
 			Expect(err).ToNot(HaveOccurred())
 
+			By(fmt.Sprintf("verify the pod %s/%s is removed", pod2.Namespace, pod2.Name))
+			err = wait.ForPodDeleted(fxt.Client, pod2.Namespace, pod2.Name, 3*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+
 			// the NRT updaters MAY be slow to react for a number of reasons including factors out of our control
 			// (kubelet, runtime). This is a known behaviour. We can only tolerate some delay in reporting on pod removal.
 			By(fmt.Sprintf("checking the resources haven't changed in NRTs of node %q after deleting the pending pod %s/%s", targetNodeName, pod2.Namespace, pod2.Name))
@@ -594,6 +598,10 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			By(fmt.Sprintf("deleting the first pod %s/%s", updatedPod.Namespace, updatedPod.Name))
 			err = fxt.Client.Delete(context.TODO(), updatedPod)
+			Expect(err).ToNot(HaveOccurred())
+
+			By(fmt.Sprintf("verify the pod %s/%s is removed", updatedPod.Namespace, updatedPod.Name))
+			err = wait.ForPodDeleted(fxt.Client, updatedPod.Namespace, updatedPod.Name, 3*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 
 			By(fmt.Sprintf("checking the resources are restored as expected on node %q after deleting the running pod %s/%s", updatedPod.Spec.NodeName, updatedPod.Namespace, updatedPod.Name))


### PR DESCRIPTION
The test with its older version is supporting only TMscope=container, because it creates the test's pods with two containers each expected to be placed on different numa zones of the target node. When running this scenario on a cluster with tmscope=pod the test's pod with TAS scheduler fails to run because of insufficient resource availability on a single numa node, while the pod with default scheduler hits TAE.

Support this TC to run on TMscope=pod by padding the target node zones leaving room only for the one pod resource and adjusting the pod.Spec accordingly.

Signed-off-by: shereenH <shajmakh@redhat.com>