### PR TITLE
serial: fix failing test

### DIFF
--- a/internal/wait/replicaset.go
+++ b/internal/wait/replicaset.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wait
+
+import (
+	"context"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ForReplicaSetComplete(cli client.Client, rs *appsv1.ReplicaSet, pollInterval, pollTimeout time.Duration) (*appsv1.ReplicaSet, error) {
+	key := ObjectKeyFromObject(rs)
+	updatedRs := &appsv1.ReplicaSet{}
+	err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+		err := cli.Get(context.TODO(), key.AsKey(), updatedRs)
+		if err != nil {
+			klog.Warningf("failed to get the replicaset %s: %v", key.String(), err)
+			return false, err
+		}
+
+		if !IsReplicasetComplete(rs, &updatedRs.Status) {
+			klog.Warningf("replicaset %s not yet complete", key.String())
+			return false, nil
+		}
+
+		klog.Infof("replicaset %s complete", key.String())
+		return true, nil
+	})
+	return updatedRs, err
+}
+
+func AreReplicasAvailable(newStatus *appsv1.ReplicaSetStatus, replicas int32) bool {
+	return newStatus.ReadyReplicas == replicas &&
+		newStatus.Replicas == replicas &&
+		newStatus.AvailableReplicas == replicas
+}
+
+func IsReplicasetComplete(rs *appsv1.ReplicaSet, newStatus *appsv1.ReplicaSetStatus) bool {
+	return AreReplicasAvailable(newStatus, *(rs.Spec.Replicas)) &&
+		newStatus.ObservedGeneration >= rs.Generation
+}

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -1019,7 +1019,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				Expect(err).ToNot(HaveOccurred())
 				dataAfter, err := yaml.Marshal(updatedTargetNrt)
 				Expect(err).ToNot(HaveOccurred())
-				match, err := e2enrt.CheckZoneConsumedResourcesAtLeast(*nrtInitialTarget, *updatedTargetNrt, rl, podQoS)
+				match, err := e2enrt.CheckNodeConsumedResourcesAtLeast(*nrtInitialTarget, *updatedTargetNrt, rl, podQoS)
 				Expect(err).ToNot(HaveOccurred())
 
 				if match == "" {
@@ -1123,7 +1123,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				Expect(err).ToNot(HaveOccurred())
 				dataAfter, err := yaml.Marshal(updatedTargetNrt)
 				Expect(err).ToNot(HaveOccurred())
-				match, err := e2enrt.CheckZoneConsumedResourcesAtLeast(*nrtInitialTarget, *updatedTargetNrt, rl, podQoS)
+				match, err := e2enrt.CheckNodeConsumedResourcesAtLeast(*nrtInitialTarget, *updatedTargetNrt, rl, podQoS)
 				Expect(err).ToNot(HaveOccurred())
 
 				if match == "" {

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -906,7 +906,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:47627] should be able to schedule many replicas with performance time equals to the default scheduler", func() {
+		It("[test_id:47627] should be able to schedule many replicas with TAS scheduler with performance time equals to the default scheduler", func() {
 			nrtInitial, err := e2enrt.GetUpdated(fxt.Client, nrtList, timeout)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -947,7 +947,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			})
 
 			dpCreateStart := time.Now()
-			By(fmt.Sprintf("creating a replicaset %s/%s with %d replicas scheduling with: %s", fxt.Namespace.Name, rsName, replicaNumber, corev1.DefaultSchedulerName))
+			By(fmt.Sprintf("creating a replicaset %s/%s with %d replicas scheduling with scheduler: %s", fxt.Namespace.Name, rsName, replicaNumber, corev1.DefaultSchedulerName))
 			err = fxt.Client.Create(context.TODO(), rs)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -967,10 +967,10 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 					return false
 				}
 				return true
-			}, time.Minute, 5*time.Second).Should(BeTrue(), "there should be %d pods under deployment: %q", replicaNumber, namespacedRsName.String())
+			}, time.Minute, 5*time.Second).Should(BeTrue(), "there should be %d pods under replicaset: %q", replicaNumber, namespacedRsName.String())
 			schedTimeWithDefaultScheduler := time.Now().Sub(dpCreateStart)
 
-			By(fmt.Sprintf("checking the pod was scheduled with the topology aware scheduler %q", corev1.DefaultSchedulerName))
+			By(fmt.Sprintf("checking the pods were scheduled with scheduler %q", corev1.DefaultSchedulerName))
 			for _, pod := range pods {
 				schedOK, err := nrosched.CheckPODWasScheduledWith(fxt.K8sClient, pod.Namespace, pod.Name, corev1.DefaultSchedulerName)
 				Expect(err).ToNot(HaveOccurred())
@@ -1004,7 +1004,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				Expect(err).ToNot(HaveOccurred())
 
 				if match == "" {
-					klog.Warningf("inconsistent accounting: no resources consumed by the running pod,\nNRT before test deployment: %s \nNRT after: %s \npod resources: %v", dataBefore, dataAfter, e2ereslist.ToString(rl))
+					klog.Warningf("inconsistent accounting: no resources consumed by the running pod,\nNRT before test replicaset: %s \nNRT after: %s \npod resources: %v", dataBefore, dataAfter, e2ereslist.ToString(rl))
 					return false
 				}
 				return true
@@ -1081,10 +1081,10 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 					return false
 				}
 				return true
-			}, time.Minute, 5*time.Second).Should(BeTrue(), "there should be %d pods under deployment: %q", replicaNumber, namespacedRsName.String())
+			}, time.Minute, 5*time.Second).Should(BeTrue(), "there should be %d pods under replicaset: %q", replicaNumber, namespacedRsName.String())
 			schedTimeWithTopologyScheduler := time.Now().Sub(dpCreateStart)
 
-			By(fmt.Sprintf("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName))
+			By(fmt.Sprintf("checking the pods were scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName))
 			for _, pod := range pods {
 				schedOK, err := nrosched.CheckPODWasScheduledWith(fxt.K8sClient, pod.Namespace, pod.Name, serialconfig.Config.SchedulerName)
 				Expect(err).ToNot(HaveOccurred())
@@ -1117,7 +1117,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				Expect(err).ToNot(HaveOccurred())
 
 				if match == "" {
-					klog.Warningf("inconsistent accounting: no resources consumed by the running pod,\nNRT before test deployment: %s \nNRT after: %s \npod resources: %v", dataBefore, dataAfter, e2ereslist.ToString(rl))
+					klog.Warningf("inconsistent accounting: no resources consumed by the running pod,\nNRT before test replicaset: %s \nNRT after: %s \npod resources: %v", dataBefore, dataAfter, e2ereslist.ToString(rl))
 					return false
 				}
 				return true

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -962,7 +962,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			By("wait for replicaset to be up and running with all its replicas")
-			rs, err = wait.ForReplicaSetComplete(fxt.Client, rs, time.Second*10, 2*time.Minute)
+			rs, err = wait.ForReplicaSetComplete(fxt.Client, rs, time.Second, 2*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 
 			namespacedRsName := client.ObjectKeyFromObject(rs)
@@ -981,7 +981,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 					return false
 				}
 				return true
-			}, time.Minute, 5*time.Second).Should(BeTrue(), "there should be %d pods under replicaset: %q", replicaNumber, namespacedRsName.String())
+			}, time.Minute, time.Second).Should(BeTrue(), "there should be %d pods under replicaset: %q", replicaNumber, namespacedRsName.String())
 			schedTimeWithDefaultScheduler := time.Now().Sub(rsCreateStart)
 
 			By(fmt.Sprintf("checking the pods were scheduled with scheduler %q", corev1.DefaultSchedulerName))
@@ -1092,7 +1092,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			By("wait for replicaset to be up and running with all its replicas")
-			rs, err = wait.ForReplicaSetComplete(fxt.Client, rs, time.Second*10, 2*time.Minute)
+			rs, err = wait.ForReplicaSetComplete(fxt.Client, rs, time.Second, 2*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 
 			namespacedRsName = client.ObjectKeyFromObject(rs)
@@ -1110,7 +1110,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 					return false
 				}
 				return true
-			}, time.Minute, 5*time.Second).Should(BeTrue(), "there should be %d pods under replicaset: %q", replicaNumber, namespacedRsName.String())
+			}, time.Minute, time.Second).Should(BeTrue(), "there should be %d pods under replicaset: %q", replicaNumber, namespacedRsName.String())
 			schedTimeWithTopologyScheduler := time.Now().Sub(rsCreateStart)
 
 			By(fmt.Sprintf("checking the pods were scheduled on the target node %q", targetNodeName))

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -925,32 +925,33 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			podLabels := map[string]string{
 				"test": "test-rs",
 			}
-
-			rs := objects.NewTestReplicaSetWithPodSpec(replicaNumber, podLabels, map[string]string{}, fxt.Namespace.Name, rsName, corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Name:    "c0",
-						Image:   images.GetPauseImage(),
-						Command: []string{images.PauseCommand},
-						Resources: corev1.ResourceRequirements{
-							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("2"),
-								corev1.ResourceMemory: resource.MustParse("200Mi"),
-							},
-						},
-					},
-					{
-						Name:    "c1",
-						Image:   images.GetPauseImage(),
-						Command: []string{images.PauseCommand},
-						Resources: corev1.ResourceRequirements{
-							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("2"),
-								corev1.ResourceMemory: resource.MustParse("100Mi"),
-							},
+			rsContainers := []corev1.Container{
+				{
+					Name:    "c0",
+					Image:   images.GetPauseImage(),
+					Command: []string{images.PauseCommand},
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("2"),
+							corev1.ResourceMemory: resource.MustParse("200Mi"),
 						},
 					},
 				},
+				{
+					Name:    "c1",
+					Image:   images.GetPauseImage(),
+					Command: []string{images.PauseCommand},
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("2"),
+							corev1.ResourceMemory: resource.MustParse("100Mi"),
+						},
+					},
+				},
+			}
+
+			rs := objects.NewTestReplicaSetWithPodSpec(replicaNumber, podLabels, map[string]string{}, fxt.Namespace.Name, rsName, corev1.PodSpec{
+				Containers: rsContainers,
 				NodeSelector: map[string]string{
 					serialconfig.MultiNUMALabel: "2",
 				},
@@ -1058,30 +1059,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			rs = objects.NewTestReplicaSetWithPodSpec(replicaNumber, podLabels, map[string]string{}, fxt.Namespace.Name, rsName, corev1.PodSpec{
 				SchedulerName: serialconfig.Config.SchedulerName,
-				Containers: []corev1.Container{
-					{
-						Name:    "c0",
-						Image:   images.GetPauseImage(),
-						Command: []string{images.PauseCommand},
-						Resources: corev1.ResourceRequirements{
-							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("2"),
-								corev1.ResourceMemory: resource.MustParse("200Mi"),
-							},
-						},
-					},
-					{
-						Name:    "c1",
-						Image:   images.GetPauseImage(),
-						Command: []string{images.PauseCommand},
-						Resources: corev1.ResourceRequirements{
-							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("2"),
-								corev1.ResourceMemory: resource.MustParse("100Mi"),
-							},
-						},
-					},
-				},
+				Containers:    rsContainers,
 			})
 			nrtInitial, err = e2enrt.GetUpdated(fxt.Client, nrtv1alpha1.NodeResourceTopologyList{}, timeout)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Test case 47627 was failing on the NRT consumed resources verification after creating the replica set. The expected resources were negative (CPU: -2) although the actual NRT reflects correct consumption on the target node.
Fix the test by:
- Adding missing checks like waiting for replicaset to be ready & for pods to get deleted
- Checking for consumed resources on node level b/c there are several replicas being scheduled and there is no guarantee of placement of all the pods on one numa zone. 
Additionally to other test code cleanup and enhancements, please refer to the commits for more details.