### PR TITLE
internal: unexport and rename internal helper functions

### DIFF
--- a/internal/wait/deployment.go
+++ b/internal/wait/deployment.go
@@ -48,13 +48,13 @@ func ForDeploymentComplete(cli client.Client, dp *appsv1.Deployment, pollInterva
 	return updatedDp, err
 }
 
-func AreDeploymentReplicasAvailable(newStatus *appsv1.DeploymentStatus, replicas int32) bool {
+func areDeploymentReplicasAvailable(newStatus *appsv1.DeploymentStatus, replicas int32) bool {
 	return newStatus.UpdatedReplicas == replicas &&
 		newStatus.Replicas == replicas &&
 		newStatus.AvailableReplicas == replicas
 }
 
 func IsDeploymentComplete(dp *appsv1.Deployment, newStatus *appsv1.DeploymentStatus) bool {
-	return AreDeploymentReplicasAvailable(newStatus, *(dp.Spec.Replicas)) &&
+	return areDeploymentReplicasAvailable(newStatus, *(dp.Spec.Replicas)) &&
 		newStatus.ObservedGeneration >= dp.Generation
 }

--- a/internal/wait/replicaset.go
+++ b/internal/wait/replicaset.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ForReplicaSetComplete(cli client.Client, rs *appsv1.ReplicaSet, pollInterval, pollTimeout time.Duration) (*appsv1.ReplicaSet, error) {
+func ForReplicasetComplete(cli client.Client, rs *appsv1.ReplicaSet, pollInterval, pollTimeout time.Duration) (*appsv1.ReplicaSet, error) {
 	key := ObjectKeyFromObject(rs)
 	updatedRs := &appsv1.ReplicaSet{}
 	err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {

--- a/internal/wait/replicaset.go
+++ b/internal/wait/replicaset.go
@@ -37,7 +37,7 @@ func ForReplicaSetComplete(cli client.Client, rs *appsv1.ReplicaSet, pollInterva
 			return false, err
 		}
 
-		if !IsReplicasetComplete(rs, &updatedRs.Status) {
+		if !isReplicasetComplete(rs, &updatedRs.Status) {
 			klog.Warningf("replicaset %s not yet complete", key.String())
 			return false, nil
 		}
@@ -48,13 +48,10 @@ func ForReplicaSetComplete(cli client.Client, rs *appsv1.ReplicaSet, pollInterva
 	return updatedRs, err
 }
 
-func AreReplicasAvailable(newStatus *appsv1.ReplicaSetStatus, replicas int32) bool {
-	return newStatus.ReadyReplicas == replicas &&
+func isReplicasetComplete(rs *appsv1.ReplicaSet, newStatus *appsv1.ReplicaSetStatus) bool {
+	replicas := *(rs.Spec.Replicas)
+	areReplicasAvailable := newStatus.ReadyReplicas == replicas &&
 		newStatus.Replicas == replicas &&
 		newStatus.AvailableReplicas == replicas
-}
-
-func IsReplicasetComplete(rs *appsv1.ReplicaSet, newStatus *appsv1.ReplicaSetStatus) bool {
-	return AreReplicasAvailable(newStatus, *(rs.Spec.Replicas)) &&
-		newStatus.ObservedGeneration >= rs.Generation
+	return areReplicasAvailable && newStatus.ObservedGeneration >= rs.Generation
 }

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -963,7 +963,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			By("wait for replicaset to be up and running with all its replicas")
-			rs, err = wait.ForReplicaSetComplete(fxt.Client, rs, time.Second, 2*time.Minute)
+			rs, err = wait.ForReplicasetComplete(fxt.Client, rs, time.Second, 2*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 
 			namespacedRsName := client.ObjectKeyFromObject(rs)
@@ -1070,7 +1070,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			By("wait for replicaset to be up and running with all its replicas")
-			rs, err = wait.ForReplicaSetComplete(fxt.Client, rs, time.Second, 2*time.Minute)
+			rs, err = wait.ForReplicasetComplete(fxt.Client, rs, time.Second, 2*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 
 			namespacedRsName = client.ObjectKeyFromObject(rs)


### PR DESCRIPTION
The functions are used only in this internal file and not called in other packages, thus unexport them, and rename ForReplicaSetComplete (to areReplicasAvailable) to keep consistent naming.