### PR TITLE
hack: add ginkgo v2 timeout for serial

### DIFF
--- a/hack/run-test-e2e.sh
+++ b/hack/run-test-e2e.sh
@@ -8,7 +8,7 @@ NO_TEARDOWN="${NO_TEARDOWN:-false}"
 function test_sched() {
   # Run install test suite
   echo "Running NROScheduler install test suite"
-  ${BIN_DIR}/e2e-nrop-sched-install.test ${NO_COLOR} --ginkgo.v --ginkgo.fail-fast --ginkgo.junit-report=${REPORT_DIR}/sched-install.xml
+  ${BIN_DIR}/e2e-nrop-sched-install.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.junit-report=${REPORT_DIR}/sched-install.xml
 
   # The install failed, no taste to continue
   if [ $? -ne 0 ]; then
@@ -18,11 +18,12 @@ function test_sched() {
 
   echo "Running Functional Tests: ${GINKGO_SUITS}"
   # -v: print out the text and location for each spec before running it and flush output to stdout in realtime
+  # -timeout: exit the suite after the specified time
   # -r: run suites recursively
   # --fail-fast: ginkgo will stop the suite right after the first spec failure
   # --flake-attempts: rerun the test if it fails
   # -requireSuite: fail if tests are not executed because of missing suite
-  ${BIN_DIR}/e2e-nrop-sched.test ${NO_COLOR} --ginkgo.v --ginkgo.fail-fast --ginkgo.flake-attempts=2 --ginkgo.junit-report=${REPORT_DIR}/e2e-sched.xml
+  ${BIN_DIR}/e2e-nrop-sched.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.flake-attempts=2 --ginkgo.junit-report=${REPORT_DIR}/e2e-sched.xml
 }
 
 NO_COLOR=""
@@ -37,15 +38,15 @@ setupreport
 trap '{ if [ "${NO_TEARDOWN}" = false ]; then
           if [ "${ENABLE_SCHED_TESTS}" = true ]; then
              echo "Running NROScheduler uninstall test suite";
-             ${BIN_DIR}/e2e-nrop-sched-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.junit-report=${REPORT_DIR}/sched-uninstall.xml
+             ${BIN_DIR}/e2e-nrop-sched-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/sched-uninstall.xml
           fi
           echo "Running NRO uninstall test suite";
-	  ${BIN_DIR}/e2e-nrop-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.junit-report=${REPORT_DIR}/uninstall.xml
+	  ${BIN_DIR}/e2e-nrop-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/uninstall.xml
         fi }' EXIT SIGINT SIGTERM SIGSTOP
 
 # Run install test suite
 echo "Running NRO install test suite"
-${BIN_DIR}/e2e-nrop-install.test ${NO_COLOR} --ginkgo.v --ginkgo.fail-fast --ginkgo.junit-report=${REPORT_DIR}/install.xml --ginkgo.focus='\[Install\] continuousIntegration'
+${BIN_DIR}/e2e-nrop-install.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.junit-report=${REPORT_DIR}/install.xml --ginkgo.focus='\[Install\] continuousIntegration'
 
 # The install failed, no taste to continue
 if [ $? -ne 0 ]; then
@@ -57,11 +58,12 @@ fi
 echo "Running Functional Tests: ${GINKGO_SUITS}"
 export E2E_TOPOLOGY_MANAGER_POLICY="${E2E_TOPOLOGY_MANAGER_POLICY:-SingleNUMANodePodLevel}"
 # -v: print out the text and location for each spec before running it and flush output to stdout in realtime
+# -timeout: exit the suite after the specified time
 # -r: run suites recursively
 # --fail-fast: ginkgo will stop the suite right after the first spec failure
 # --flake-attempts: rerun the test if it fails
 # -requireSuite: fail if tests are not executed because of missing suite
-${BIN_DIR}/e2e-nrop-rte.test ${NO_COLOR} --ginkgo.v --ginkgo.fail-fast --ginkgo.flake-attempts=2 --ginkgo.junit-report=${REPORT_DIR}/e2e.xml --ginkgo.skip='\[Disruptive\]|\[StateDirectories\]|\[NodeRefresh\]|\[local\]'
+${BIN_DIR}/e2e-nrop-rte.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.flake-attempts=2 --ginkgo.junit-report=${REPORT_DIR}/e2e.xml --ginkgo.skip='\[Disruptive\]|\[StateDirectories\]|\[NodeRefresh\]|\[local\]'
 
 
 if [ "$ENABLE_SCHED_TESTS" = true ]; then

--- a/hack/run-test-install-e2e.sh
+++ b/hack/run-test-install-e2e.sh
@@ -11,8 +11,8 @@ fi
 setupreport
 
 # Make sure that we always properly clean the environment
-trap '{ echo "Running NRO uninstall test suite"; ${BIN_DIR}/e2e-nrop-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.junit-report=${REPORT_DIR}/uninstall.xml; }' EXIT SIGINT SIGTERM SIGSTOP
+trap '{ echo "Running NRO uninstall test suite"; ${BIN_DIR}/e2e-nrop-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/uninstall.xml; }' EXIT SIGINT SIGTERM SIGSTOP
 
 # Run install test suite
 echo "Running NRO install test suite"
-${BIN_DIR}/e2e-nrop-install.test ${NO_COLOR} --ginkgo.v --ginkgo.fail-fast --ginkgo.junit-report=${REPORT_DIR}/install.xml --ginkgo.focus='\[Install\] durability'
+${BIN_DIR}/e2e-nrop-install.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.junit-report=${REPORT_DIR}/install.xml --ginkgo.focus='\[Install\] durability'

--- a/hack/run-test-must-gather-e2e.sh
+++ b/hack/run-test-must-gather-e2e.sh
@@ -12,4 +12,4 @@ setupreport
 
 # Run must-gather test suite
 echo "Running NRO must-gather test suite"
-${BIN_DIR}/e2e-nrop-must-gather.test ${NO_COLOR} --ginkgo.v --ginkgo.fail-fast --ginkgo.junit-report=${REPORT_DIR}/must-gather.xml --ginkgo.focus='\[must-gather\]'
+${BIN_DIR}/e2e-nrop-must-gather.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.junit-report=${REPORT_DIR}/must-gather.xml --ginkgo.focus='\[must-gather\]'

--- a/hack/run-test-serial-e2e.sh
+++ b/hack/run-test-serial-e2e.sh
@@ -104,6 +104,7 @@ function setup() {
 	echo "Running NRO install test suite"
 	runcmd ${BIN_DIR}/e2e-nrop-install.test \
 		--ginkgo.v \
+		--ginkgo.timeout="5h" \
 		--ginkgo.fail-fast \
 		--ginkgo.junit-report=${REPORT_DIR}/e2e-serial-install.xml \
 		--ginkgo.focus='\[Install\] continuousIntegration' \
@@ -117,6 +118,7 @@ function setup() {
 	echo "Running NROScheduler install test suite"
 	runcmd ${BIN_DIR}/e2e-nrop-sched-install.test \
 		--ginkgo.v \
+		--ginkgo.timeout="5h" \
 		--ginkgo.fail-fast \
 		--ginkgo.junit-report=${REPORT_DIR}/e2e-serial-install-sched.xml \
 		${NO_COLOR}
@@ -130,6 +132,7 @@ function teardown() {
 	echo "Running NROScheduler uninstall test suite";
 	runcmd ${BIN_DIR}/e2e-nrop-sched-uninstall.test \
 		--ginkgo.v \
+		--ginkgo.timeout="5h" \
 		--ginkgo.junit-report=${REPORT_DIR}/e2e-serial-uninstall-sched.xml \
 		${NO_COLOR}
 
@@ -141,6 +144,7 @@ function teardown() {
 	echo "Running NRO uninstall test suite";
 	runcmd ${BIN_DIR}/e2e-nrop-uninstall.test \
 		--ginkgo.v \
+		--ginkgo.timeout="5h" \
 		--ginkgo.junit-report=${REPORT_DIR}/e2e-serial-uninstall.xml \
 		${NO_COLOR}
 }
@@ -153,6 +157,7 @@ function runtests() {
 	echo "Running Serial, disruptive E2E Tests"
 	runcmd ${BIN_DIR}/e2e-nrop-serial.test \
 		--ginkgo.v \
+		--ginkgo.timeout="5h" \
 		--ginkgo.junit-report=${REPORT_FILE} \
 		${NO_COLOR} \
 		${SKIP} \

--- a/hack/run-test-tools-e2e.sh
+++ b/hack/run-test-tools-e2e.sh
@@ -74,6 +74,7 @@ setupreport
 echo "Running Tools, mostly local, E2E Tests"
 runcmd ${BIN_DIR}/e2e-nrop-tools.test \
 	--ginkgo.v \
+	--ginkgo.timeout=5h \
 	--ginkgo.junit-report=${REPORT_FILE} \
 	${NO_COLOR} \
 	${SKIP} \

--- a/hack/test-e2e-runner.sh
+++ b/hack/test-e2e-runner.sh
@@ -28,7 +28,7 @@ echo "[TEST] --dry-run produces expected output"
 GOT=$( $RUNNER --dry-run --no-color)
 EXPECTED="Ensuring: /tmp/artifacts/nrop
 Running Serial, disruptive E2E Tests
-Running: /usr/local/bin/e2e-nrop-serial.test --ginkgo.v --ginkgo.junit-report=/tmp/artifacts/nrop/e2e-serial-run.xml --ginkgo.no-color"
+Running: /usr/local/bin/e2e-nrop-serial.test --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=/tmp/artifacts/nrop/e2e-serial-run.xml --ginkgo.no-color"
 if [ "${GOT}" != "${EXPECTED}" ]; then
 	echo -e "[FAIL] --dry-run unexpected output:\n${GOT}"
 	echo -e "[FAIL] --dry-run expected output:\n${EXPECTED}"


### PR DESCRIPTION
Migrating ginkgo to V2 causes the suites to exit after 1 hour by default: https://onsi.github.io/ginkgo/MIGRATING_TO_V2#timeout-behavior `Finally, the default timeout has been reduced from 24h down to 1h. Users with long-running tests may need to adjust the timeout in their CI scripts.` Serial suite needs more than that, a thing that causes to skip around 18 tests, so increase that timeout to 5 hours for now.

Signed-off-by: shereenH <shajmakh@redhat.com>