### PR TITLE
build: move to golang 1.19

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.19.3
 
     - name: Verify modules
       run: go mod verify

--- a/.github/workflows/ciformat.yml
+++ b/.github/workflows/ciformat.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.19.3
 
     - name: format
       run: ./hack/check-format.sh

--- a/.github/workflows/cilint-custom.yml
+++ b/.github/workflows/cilint-custom.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.19.3
 
     - name: Fetch golangci-lint
       run: |

--- a/.github/workflows/cilint.yml
+++ b/.github/workflows/cilint.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.19.3
 
     - name: Verify
       uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/e2e-local.yaml
+++ b/.github/workflows/e2e-local.yaml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.19.3
 
     - name: Verify modules
       run: go mod verify

--- a/.github/workflows/e2e-tools.yml
+++ b/.github/workflows/e2e-tools.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.19.3
 
     - name: Verify modules
       run: go mod verify

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.19.3
 
     - name: Verify modules
       run: go mod verify

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-go@v2
         id: go
         with:
-          go-version: 1.18.1
+          go-version: 1.19.3
 
       - name: Set release version env var
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.18 AS builder
+FROM docker.io/golang:1.19 AS builder
 
 WORKDIR /go/src/github.com/openshift-kni/numaresources-operator
 COPY . .

--- a/Dockerfile.pause
+++ b/Dockerfile.pause
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.18 AS builder
+FROM docker.io/golang:1.19 AS builder
 
 WORKDIR /go/src/github.com/openshift-kni/numaresources-operator
 COPY . .

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.18 AS builder
+FROM docker.io/golang:1.19 AS builder
 
 WORKDIR /go/src/github.com/openshift-kni/numaresources-operator
 COPY . .

--- a/api/numaresourcesoperator/v1alpha1/groupversion_info.go
+++ b/api/numaresourcesoperator/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the nodetopology v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=nodetopology.openshift.io
+// +kubebuilder:object:generate=true
+// +groupName=nodetopology.openshift.io
 package v1alpha1
 
 import (

--- a/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_types.go
+++ b/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_types.go
@@ -126,7 +126,7 @@ type MachineConfigPool struct {
 //+kubebuilder:resource:shortName=numaresop,path=numaresourcesoperators,scope=Cluster
 
 // NUMAResourcesOperator is the Schema for the numaresourcesoperators API
-//+operator-sdk:csv:customresourcedefinitions:displayName="NUMA Resources Operator",resources={{DaemonSet,v1,rte-daemonset,ConfigMap,v1,rte-configmap}}
+// +operator-sdk:csv:customresourcedefinitions:displayName="NUMA Resources Operator",resources={{DaemonSet,v1,rte-daemonset,ConfigMap,v1,rte-configmap}}
 type NUMAResourcesOperator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/numaresourcesoperator/v1alpha1/numaresourcesscheduler_types.go
+++ b/api/numaresourcesoperator/v1alpha1/numaresourcesscheduler_types.go
@@ -57,7 +57,7 @@ type NUMAResourcesSchedulerStatus struct {
 //+kubebuilder:resource:shortName=numaressched,path=numaresourcesschedulers,scope=Cluster
 
 // NUMAResourcesScheduler is the Schema for the numaresourcesschedulers API
-//+operator-sdk:csv:customresourcedefinitions:displayName="NUMA Aware Scheduler",resources={{Deployment,v1,secondary-scheduler-deployment}}
+// +operator-sdk:csv:customresourcedefinitions:displayName="NUMA Aware Scheduler",resources={{Deployment,v1,secondary-scheduler-deployment}}
 type NUMAResourcesScheduler struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/k8sclientset/generated/clientset/versioned/fake/register.go
+++ b/pkg/k8sclientset/generated/clientset/versioned/fake/register.go
@@ -36,14 +36,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/k8sclientset/generated/clientset/versioned/scheme/register.go
+++ b/pkg/k8sclientset/generated/clientset/versioned/scheme/register.go
@@ -36,14 +36,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -1003,7 +1003,7 @@ func nrtCanAccomodateEachRequestOnADifferentZone(nrt nrtv1alpha1.NodeResourceTop
 	return eachRequestFitsOnADifferentZone(nrt.Zones[0], nrt.Zones[1], r1, r2)
 }
 
-//returns true if r1 fits on z1 AND r2 on z2 or the other way around
+// returns true if r1 fits on z1 AND r2 on z2 or the other way around
 func eachRequestFitsOnADifferentZone(z1, z2 nrtv1alpha1.Zone, r1, r2 corev1.ResourceList) bool {
 	return (e2enrt.ZoneResourcesMatchesRequest(z1.Resources, r1) && e2enrt.ZoneResourcesMatchesRequest(z2.Resources, r2)) ||
 		(e2enrt.ZoneResourcesMatchesRequest(z1.Resources, r2) && e2enrt.ZoneResourcesMatchesRequest(z2.Resources, r1))


### PR DESCRIPTION
Update the buildchain to golang 1.19, plus the mechanical fixes because gofmt 1.19 is now stricter.