### PR TITLE
tree: move main to 4.13

### DIFF
--- a/.github/workflows/release-testsuite.yaml
+++ b/.github/workflows/release-testsuite.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         with:
           image: numaresources-operator-tests
-          tags: 4.12.999-snapshot
+          tags: 4.13.999-snapshot
           dockerfiles: |
             ./Dockerfile.tests
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 4.12.999-snapshot
+VERSION ?= 4.13.999-snapshot
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/README.tests.md
+++ b/README.tests.md
@@ -34,7 +34,7 @@ podman run -ti \
 	-v $KUBECONFIG:/kubeconfig:z \
 	-e KUBECONFIG=/kubeconfig
 	-e E2E_NROP_INSTALL_SKIP_KC=true \
-	quay.io/openshift-kni/numaresources-operator-tests:4.12.999-snapshot
+	quay.io/openshift-kni/numaresources-operator-tests:4.13.999-snapshot
 ```
 
 To setup the stack from scratch and then run the tests (you may want to do that with *ephemeral* CI clusters)
@@ -43,7 +43,7 @@ podman run -ti \
 	-v $KUBECONFIG:/kubeconfig:z \
 	-e KUBECONFIG=/kubeconfig \
 	-e E2E_NROP_INSTALL_SKIP_KC=true \
-	quay.io/openshift-kni/numaresources-operator-tests:4.12.999-snapshot \
+	quay.io/openshift-kni/numaresources-operator-tests:4.13.999-snapshot \
 	--setup
 ```
 
@@ -53,7 +53,7 @@ podman run -ti \
 	-v $KUBECONFIG:/kubeconfig:z \
 	-e KUBECONFIG=/kubeconfig \
 	-e E2E_NROP_INSTALL_SKIP_KC=true \
-	quay.io/openshift-kni/numaresources-operator-tests:4.12.999-snapshot \
+	quay.io/openshift-kni/numaresources-operator-tests:4.13.999-snapshot \
 	--setup \
 	--teardown
 ```
@@ -69,7 +69,7 @@ However, in some cases it may be unpractical to depend on third party images.
 The E2E test image can act as replacement for all its dependencies, providing either the same code or replacements suitables for its use case.
 To replace the dependencies, you need to set up some environment variables:
 ```bash
-export E2E_IMAGE_URL=quay.io/openshift-kni/numaresources-operator-tests:4.12.999-snapshot
+export E2E_IMAGE_URL=quay.io/openshift-kni/numaresources-operator-tests:4.13.999-snapshot
 podman run -ti \
 	-v $KUBECONFIG:/kubeconfig:z \
 	-e KUBECONFIG=/kubeconfig \
@@ -86,7 +86,7 @@ While the primary source for pre-built test container image is the [numaresource
 will be updated shortly after. **Running the testsuite through CNF tests is fully supported**.
 To run the suite using the CNF tests image, you can run
 ```bash
-export CNF_TESTS_URL="quay.io/openshift-kni/cnf-tests:4.12.0"
+export CNF_TESTS_URL="quay.io/openshift-kni/cnf-tests:4.13.0"
 podman run -ti \
 	-v $KUBECONFIG:/kubeconfig:z \
 	-e KUBECONFIG=/kubeconfig \
@@ -104,7 +104,7 @@ podman run -ti \
 Some E2E tests require to reboot one or more worker node. This is intrinsically fragile and slow, and you may want to avoid to do this in your tier-1 runs.
 To do so, you can run
 ```bash
-export E2E_IMAGE_URL=quay.io/openshift-kni/numaresources-operator-tests:4.12.999-snapshot
+export E2E_IMAGE_URL=quay.io/openshift-kni/numaresources-operator-tests:4.13.999-snapshot
 podman run -ti \
 	-v $KUBECONFIG:/kubeconfig:z \
 	-e KUBECONFIG=/kubeconfig \
@@ -116,7 +116,7 @@ podman run -ti \
 ```
 or, with CNF tests:
 ```bash
-export CNF_TESTS_URL="quay.io/openshift-kni/cnf-tests:4.12.0"
+export CNF_TESTS_URL="quay.io/openshift-kni/cnf-tests:4.13.0"
 podman run -ti \
 	-v $KUBECONFIG:/kubeconfig:z \
 	-e KUBECONFIG=/kubeconfig \

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -29,15 +29,15 @@ metadata:
             "name": "numaresourcesscheduler"
           },
           "spec": {
-            "imageSpec": "quay.io/openshift-kni/scheduler-plugins:4.12-snapshot"
+            "imageSpec": "quay.io/openshift-kni/scheduler-plugins:4.13-snapshot"
           }
         }
       ]
     capabilities: Basic Install
-    olm.skipRange: '>=4.11.0 <4.12.0'
+    olm.skipRange: '>=4.12.0 <4.13.0'
     operators.operatorframework.io/builder: operator-sdk-v1.25.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: numaresources-operator.v4.12.999-snapshot
+  name: numaresources-operator.v4.13.999-snapshot
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -347,7 +347,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/openshift-kni/numaresources-operator:4.12.999-snapshot
+                image: quay.io/openshift-kni/numaresources-operator:4.13.999-snapshot
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -431,4 +431,4 @@ spec:
   minKubeVersion: 1.23.0
   provider:
     name: Red Hat
-  version: 4.12.999-snapshot
+  version: 4.13.999-snapshot

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/openshift-kni/numaresources-operator
-  newTag: 4.12.999-snapshot
+  newTag: 4.13.999-snapshot

--- a/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    olm.skipRange: '>=4.11.0 <4.12.0'
+    olm.skipRange: '>=4.12.0 <4.13.0'
   name: numaresources-operator.v0.0.0
   namespace: placeholder
 spec:
@@ -126,4 +126,4 @@ spec:
   minKubeVersion: 1.23.0
   provider:
     name: Red Hat
-  version: 4.12.0
+  version: 4.13.0

--- a/config/samples/nodetopology_v1alpha1_numaresourcesscheduler.yaml
+++ b/config/samples/nodetopology_v1alpha1_numaresourcesscheduler.yaml
@@ -3,4 +3,4 @@ kind: NUMAResourcesScheduler
 metadata:
   name: numaresourcesscheduler
 spec:
-  imageSpec: "quay.io/openshift-kni/scheduler-plugins:4.12-snapshot"
+  imageSpec: "quay.io/openshift-kni/scheduler-plugins:4.13-snapshot"

--- a/doc/examples/sched.yaml
+++ b/doc/examples/sched.yaml
@@ -3,6 +3,6 @@ kind: NUMAResourcesScheduler
 metadata:
   name: numaresourcesscheduler
 spec:
-  imageSpec: "quay.io/openshift-kni/scheduler-plugins:4.12-snapshot"
+  imageSpec: "quay.io/openshift-kni/scheduler-plugins:4.13-snapshot"
   logLevel: "Trace"
   schedulerName: topo-aware-scheduler

--- a/test/utils/objects/objects.go
+++ b/test/utils/objects/objects.go
@@ -54,7 +54,7 @@ func TestNROScheduler() *nropv1alpha1.NUMAResourcesScheduler {
 			Name: objectnames.DefaultNUMAResourcesSchedulerCrName,
 		},
 		Spec: nropv1alpha1.NUMAResourcesSchedulerSpec{
-			SchedulerImage: "quay.io/openshift-kni/scheduler-plugins:4.12-snapshot",
+			SchedulerImage: "quay.io/openshift-kni/scheduler-plugins:4.13-snapshot",
 		},
 	}
 }


### PR DESCRIPTION
the 4.13 cycle is started, bump versions and references accordingly.

Signed-off-by: Francesco Romani <fromani@redhat.com>