### PR TITLE
[release-4.11][manual][partial] objectnames: add default scheduler CR Name

### DIFF
--- a/pkg/objectnames/objectnames.go
+++ b/pkg/objectnames/objectnames.go
@@ -18,7 +18,10 @@ package objectnames
 
 import "fmt"
 
-const DefaultNUMAResourcesOperatorCrName = "numaresourcesoperator"
+const (
+	DefaultNUMAResourcesOperatorCrName  = "numaresourcesoperator"
+	DefaultNUMAResourcesSchedulerCrName = "numaresourcesscheduler"
+)
 
 func GetMachineConfigName(instanceName, mcpName string) string {
 	return fmt.Sprintf("51-%s-%s", instanceName, mcpName)


### PR DESCRIPTION
This will unlock future backports

Signed-off-by: Francesco Romani <fromani@redhat.com>