### PR TITLE
[release-4.11][manual][partial] avoid cooldown on test skip

### DIFF
--- a/test/e2e/serial/README.md
+++ b/test/e2e/serial/README.md
@@ -32,3 +32,7 @@ they found it before they run.
   autodetection of the platform and force it to the provided value.
 - `E2E_NROP_DUMP_EVENTS` (accepts boolean, e.g. `true`) requests the suite to dump events pertaining to pods
   failed unexpectedly on standard output, alongside (not replacing) the logging of the said events.
+- `E2E_NROP_TEST_COOLDOWN` (accepts string expressing time unit, e.g. `30s`) instructs the suite to wait
+  for the specified amount of time after each spec, to give time to the cluster to settle up.
+- `E2E_NROP_TEST_TEARDOWN` (accepts string expressing time unit, e.g. `30s`) instructs the suite to wait
+  *up* to the specified amount of time while tearing down the resources needed by each spec.


### PR DESCRIPTION
partial backport of https://github.com/openshift-kni/numaresources-operator/pull/434
add facilities to avoid cooldown on skip

partial backport of https://github.com/openshift-kni/numaresources-operator/pull/421
add the option to override cooldown and teardown timeouts using env vars.

Signed-off-by: Francesco Romani <fromani@redhat.com>