### PR TITLE
golang: require golang 1.19 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-kni/numaresources-operator
 
-go 1.18
+go 1.19
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a


### PR DESCRIPTION
Now that we have updated all the deps and the toolchain, we can declare golang 1.19 as minimum required version in go.mod.

Signed-off-by: Francesco Romani <fromani@redhat.com>