### PR TITLE
chore: internal: rename import to nropv1alpha1

### DIFF
--- a/controllers/kubeletconfig_controller_test.go
+++ b/controllers/kubeletconfig_controller_test.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	nrov1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
 
 	testobjs "github.com/openshift-kni/numaresources-operator/internal/objects"
@@ -54,7 +54,7 @@ func NewFakeKubeletConfigReconciler(initObjects ...runtime.Object) (*KubeletConf
 
 var _ = Describe("Test KubeletConfig Reconcile", func() {
 	Context("with KubeletConfig objects already present in the cluster", func() {
-		var nro *nrov1alpha1.NUMAResourcesOperator
+		var nro *nropv1alpha1.NUMAResourcesOperator
 		var mcp1 *machineconfigv1.MachineConfigPool
 		var mcoKc1 *machineconfigv1.KubeletConfig
 		var label1 map[string]string

--- a/controllers/numaresourcesoperator_controller_test.go
+++ b/controllers/numaresourcesoperator_controller_test.go
@@ -45,7 +45,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	nrov1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectstate/rte"
 	"github.com/openshift-kni/numaresources-operator/pkg/status"
@@ -86,7 +86,7 @@ func NewFakeNUMAResourcesOperatorReconciler(plat platform.Platform, platVersion 
 }
 
 var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
-	verifyDegradedCondition := func(nro *nrov1alpha1.NUMAResourcesOperator, reason string) {
+	verifyDegradedCondition := func(nro *nropv1alpha1.NUMAResourcesOperator, reason string) {
 		reconciler, err := NewFakeNUMAResourcesOperatorReconciler(platform.OpenShift, defaultOCPVersion, nro)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -127,7 +127,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 	})
 
 	Context("with correct NRO and more than one NodeGroup", func() {
-		var nro *nrov1alpha1.NUMAResourcesOperator
+		var nro *nropv1alpha1.NUMAResourcesOperator
 		var mcp1 *machineconfigv1.MachineConfigPool
 		var mcp2 *machineconfigv1.MachineConfigPool
 
@@ -214,10 +214,10 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 				By("Update NRO to have just one NodeGroup")
 				key := client.ObjectKeyFromObject(nro)
-				nro := &nrov1alpha1.NUMAResourcesOperator{}
+				nro := &nropv1alpha1.NUMAResourcesOperator{}
 				Expect(reconciler.Client.Get(context.TODO(), key, nro)).NotTo(HaveOccurred())
 
-				nro.Spec.NodeGroups = []nrov1alpha1.NodeGroup{{
+				nro.Spec.NodeGroups = []nropv1alpha1.NodeGroup{{
 					MachineConfigPoolSelector: &metav1.LabelSelector{MatchLabels: label1},
 				}}
 				Expect(reconciler.Client.Update(context.TODO(), nro)).NotTo(HaveOccurred())
@@ -297,7 +297,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 		})
 	})
 	Context("with correct NRO CR", func() {
-		var nro *nrov1alpha1.NUMAResourcesOperator
+		var nro *nropv1alpha1.NUMAResourcesOperator
 		var mcp1 *machineconfigv1.MachineConfigPool
 		var mcp2 *machineconfigv1.MachineConfigPool
 
@@ -484,7 +484,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 					&metav1.LabelSelector{MatchLabels: label3},
 					&metav1.LabelSelector{MatchLabels: label3},
 				)
-				nro.Spec.NodeGroups = []nrov1alpha1.NodeGroup{
+				nro.Spec.NodeGroups = []nropv1alpha1.NodeGroup{
 					{
 						MachineConfigPoolSelector: &metav1.LabelSelector{
 							MatchLabels: label3,
@@ -605,9 +605,9 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 			period := metav1.Duration{
 				Duration: d,
 			}
-			pfpMode := nrov1alpha1.PodsFingerprintingEnabled
-			refMode := nrov1alpha1.InfoRefreshPeriodic
-			conf := nrov1alpha1.NodeGroupConfig{
+			pfpMode := nropv1alpha1.PodsFingerprintingEnabled
+			refMode := nropv1alpha1.InfoRefreshPeriodic
+			conf := nropv1alpha1.NodeGroupConfig{
 				PodsFingerprinting: &pfpMode,
 				InfoRefreshPeriod:  &period,
 				InfoRefreshMode:    &refMode,
@@ -617,7 +617,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 			reconciler := reconcileObjects(nro, mcp)
 
-			nroUpdated := &nrov1alpha1.NUMAResourcesOperator{}
+			nroUpdated := &nropv1alpha1.NUMAResourcesOperator{}
 			Expect(reconciler.Client.Get(context.TODO(), client.ObjectKeyFromObject(nro), nroUpdated)).ToNot(HaveOccurred())
 
 			Expect(len(nroUpdated.Status.MachineConfigPools)).To(Equal(1))
@@ -632,9 +632,9 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 			period := metav1.Duration{
 				Duration: d,
 			}
-			pfpMode := nrov1alpha1.PodsFingerprintingEnabled
-			refMode := nrov1alpha1.InfoRefreshPeriodic
-			conf := nrov1alpha1.NodeGroupConfig{
+			pfpMode := nropv1alpha1.PodsFingerprintingEnabled
+			refMode := nropv1alpha1.InfoRefreshPeriodic
+			conf := nropv1alpha1.NodeGroupConfig{
 				PodsFingerprinting: &pfpMode,
 				InfoRefreshPeriod:  &period,
 				InfoRefreshMode:    &refMode,
@@ -658,8 +658,8 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 		})
 
 		It("should allow to disable pods fingerprinting", func() {
-			pfpMode := nrov1alpha1.PodsFingerprintingDisabled
-			conf := nrov1alpha1.NodeGroupConfig{
+			pfpMode := nropv1alpha1.PodsFingerprintingDisabled
+			conf := nropv1alpha1.NodeGroupConfig{
 				PodsFingerprinting: &pfpMode,
 			}
 			nro := testobjs.NewNUMAResourcesOperatorWithNodeGroupConfig(objectnames.DefaultNUMAResourcesOperatorCrName, &labSel, &conf)
@@ -720,7 +720,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 			period := metav1.Duration{
 				Duration: d,
 			}
-			conf := nrov1alpha1.NodeGroupConfig{
+			conf := nropv1alpha1.NodeGroupConfig{
 				InfoRefreshPeriod: &period,
 			}
 			nro := testobjs.NewNUMAResourcesOperatorWithNodeGroupConfig(objectnames.DefaultNUMAResourcesOperatorCrName, &labSel, &conf)
@@ -739,8 +739,8 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 		})
 
 		It("should allow to tune the update mechanism", func() {
-			refMode := nrov1alpha1.InfoRefreshPeriodic
-			conf := nrov1alpha1.NodeGroupConfig{
+			refMode := nropv1alpha1.InfoRefreshPeriodic
+			conf := nropv1alpha1.NodeGroupConfig{
 				InfoRefreshMode: &refMode,
 			}
 
@@ -774,7 +774,7 @@ func getConditionByType(conditions []metav1.Condition, conditionType string) *me
 	return nil
 }
 
-func reconcileObjects(nro *nrov1alpha1.NUMAResourcesOperator, mcp *machineconfigv1.MachineConfigPool) *NUMAResourcesOperatorReconciler {
+func reconcileObjects(nro *nropv1alpha1.NUMAResourcesOperator, mcp *machineconfigv1.MachineConfigPool) *NUMAResourcesOperatorReconciler {
 	reconciler, err := NewFakeNUMAResourcesOperatorReconciler(platform.OpenShift, defaultOCPVersion, nro, mcp)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
@@ -807,7 +807,7 @@ func reconcileObjects(nro *nrov1alpha1.NUMAResourcesOperator, mcp *machineconfig
 	return reconciler
 }
 
-func nodeGroupConfigToString(conf nrov1alpha1.NodeGroupConfig) string {
+func nodeGroupConfigToString(conf nropv1alpha1.NodeGroupConfig) string {
 	data, err := json.Marshal(conf)
 	if err != nil {
 		return "<ERROR>"

--- a/internal/objects/objects.go
+++ b/internal/objects/objects.go
@@ -26,42 +26,42 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 
-	nrov1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 )
 
-func NewNUMAResourcesOperator(name string, labelSelectors []*metav1.LabelSelector) *nrov1alpha1.NUMAResourcesOperator {
-	var nodeGroups []nrov1alpha1.NodeGroup
+func NewNUMAResourcesOperator(name string, labelSelectors []*metav1.LabelSelector) *nropv1alpha1.NUMAResourcesOperator {
+	var nodeGroups []nropv1alpha1.NodeGroup
 	for _, selector := range labelSelectors {
-		nodeGroups = append(nodeGroups, nrov1alpha1.NodeGroup{
+		nodeGroups = append(nodeGroups, nropv1alpha1.NodeGroup{
 			MachineConfigPoolSelector: selector,
 		})
 	}
 
-	return &nrov1alpha1.NUMAResourcesOperator{
+	return &nropv1alpha1.NUMAResourcesOperator{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "NUMAResourcesOperator",
-			APIVersion: nrov1alpha1.GroupVersion.String(),
+			APIVersion: nropv1alpha1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: nrov1alpha1.NUMAResourcesOperatorSpec{
+		Spec: nropv1alpha1.NUMAResourcesOperatorSpec{
 			NodeGroups: nodeGroups,
 		},
 	}
 }
 
-func NewNUMAResourcesOperatorWithNodeGroupConfig(name string, selector *metav1.LabelSelector, conf *nrov1alpha1.NodeGroupConfig) *nrov1alpha1.NUMAResourcesOperator {
-	return &nrov1alpha1.NUMAResourcesOperator{
+func NewNUMAResourcesOperatorWithNodeGroupConfig(name string, selector *metav1.LabelSelector, conf *nropv1alpha1.NodeGroupConfig) *nropv1alpha1.NUMAResourcesOperator {
+	return &nropv1alpha1.NUMAResourcesOperator{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "NUMAResourcesOperator",
-			APIVersion: nrov1alpha1.GroupVersion.String(),
+			APIVersion: nropv1alpha1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: nrov1alpha1.NUMAResourcesOperatorSpec{
-			NodeGroups: []nrov1alpha1.NodeGroup{
+		Spec: nropv1alpha1.NUMAResourcesOperatorSpec{
+			NodeGroups: []nropv1alpha1.NodeGroup{
 				{
 					MachineConfigPoolSelector: selector,
 					Config:                    conf,
@@ -71,16 +71,16 @@ func NewNUMAResourcesOperatorWithNodeGroupConfig(name string, selector *metav1.L
 	}
 }
 
-func NewNUMAResourcesScheduler(name, imageSpec, schedulerName string, resyncPeriod time.Duration) *nrov1alpha1.NUMAResourcesScheduler {
-	return &nrov1alpha1.NUMAResourcesScheduler{
+func NewNUMAResourcesScheduler(name, imageSpec, schedulerName string, resyncPeriod time.Duration) *nropv1alpha1.NUMAResourcesScheduler {
+	return &nropv1alpha1.NUMAResourcesScheduler{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "NUMAResourcesScheduler",
-			APIVersion: nrov1alpha1.GroupVersion.String(),
+			APIVersion: nropv1alpha1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: nrov1alpha1.NUMAResourcesSchedulerSpec{
+		Spec: nropv1alpha1.NUMAResourcesSchedulerSpec{
 			SchedulerImage: imageSpec,
 			SchedulerName:  schedulerName,
 			CacheResyncPeriod: &metav1.Duration{


### PR DESCRIPTION
We use the renamed import `nropv1alpha` to pull in the API package _almost_ everywhere. Fix the few places where we don't, for uniformity's sake and to make the future v1 API transition a little easier.

No intended change in behavior.

Signed-off-by: Francesco Romani <fromani@redhat.com>