### PR TITLE
chore: make the api package import rename uniform

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -22,7 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	nodetopologyv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 	securityv1 "github.com/openshift/api/security/v1"
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -59,7 +59,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	err = nodetopologyv1alpha1.AddToScheme(scheme.Scheme)
+	err = nropv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = apiextensionsv1.AddToScheme(scheme.Scheme)

--- a/controllers/numaresourcesscheduler_controller_test.go
+++ b/controllers/numaresourcesscheduler_controller_test.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	depmanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
-	nrsv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	schedmanifests "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/manifests/sched"
 	"github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/objectstate/sched"
@@ -64,7 +64,7 @@ func NewFakeNUMAResourcesSchedulerReconciler(initObjects ...runtime.Object) (*NU
 }
 
 var _ = ginkgo.Describe("Test NUMAResourcesScheduler Reconcile", func() {
-	verifyDegradedCondition := func(nrs *nrsv1alpha1.NUMAResourcesScheduler, reason string) {
+	verifyDegradedCondition := func(nrs *nropv1alpha1.NUMAResourcesScheduler, reason string) {
 		reconciler, err := NewFakeNUMAResourcesSchedulerReconciler(nrs)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
@@ -87,7 +87,7 @@ var _ = ginkgo.Describe("Test NUMAResourcesScheduler Reconcile", func() {
 	})
 
 	ginkgo.Context("with correct NRS CR", func() {
-		var nrs *nrsv1alpha1.NUMAResourcesScheduler
+		var nrs *nropv1alpha1.NUMAResourcesScheduler
 		var reconciler *NUMAResourcesSchedulerReconciler
 
 		ginkgo.BeforeEach(func() {

--- a/pkg/numaresourcesscheduler/objectstate/sched/sched.go
+++ b/pkg/numaresourcesscheduler/objectstate/sched/sched.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
 
-	nrsv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 	schedmanifests "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/manifests/sched"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectstate"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectstate/compare"
@@ -132,8 +132,8 @@ func FromClient(ctx context.Context, cli client.Client, mf schedmanifests.Manife
 	return ret
 }
 
-func DeploymentNamespacedNameFromObject(obj client.Object) (nrsv1alpha1.NamespacedName, bool) {
-	res := nrsv1alpha1.NamespacedName{
+func DeploymentNamespacedNameFromObject(obj client.Object) (nropv1alpha1.NamespacedName, bool) {
+	res := nropv1alpha1.NamespacedName{
 		Namespace: obj.GetNamespace(),
 		Name:      obj.GetName(),
 	}

--- a/pkg/numaresourcesscheduler/objectstate/sched/sched_test.go
+++ b/pkg/numaresourcesscheduler/objectstate/sched/sched_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	nrsv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 )
 
 var dp = &appsv1.Deployment{
@@ -55,7 +55,7 @@ func TestDeploymentNamespacedNameFromObject(t *testing.T) {
 	if !ok {
 		t.Errorf("failed to cast object to deployment type")
 	}
-	if !reflect.DeepEqual(nrsv1alpha1.NamespacedName(objKey), nname) {
+	if !reflect.DeepEqual(nropv1alpha1.NamespacedName(objKey), nname) {
 		t.Errorf("expected %v to be equal %v", objKey, nname)
 	}
 }

--- a/test/utils/clients/clients.go
+++ b/test/utils/clients/clients.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	nrtv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
-	numaresourcesoperatorv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
@@ -45,7 +45,7 @@ func init() {
 		klog.Exit(err.Error())
 	}
 
-	if err := numaresourcesoperatorv1alpha1.AddToScheme(scheme.Scheme); err != nil {
+	if err := nropv1alpha1.AddToScheme(scheme.Scheme); err != nil {
 		klog.Exit(err.Error())
 	}
 


### PR DESCRIPTION
make sure we rename the api packages always using the same name, which will make transition to newer API easier.

No changes in behaviour