### PR TITLE
[release-4.12][manual] chore: make the api package import rename uniform

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -22,7 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	nodetopologyv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 	securityv1 "github.com/openshift/api/security/v1"
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -59,7 +59,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	err = nodetopologyv1alpha1.AddToScheme(scheme.Scheme)
+	err = nropv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = apiextensionsv1.AddToScheme(scheme.Scheme)

--- a/controllers/numaresourcesscheduler_controller.go
+++ b/controllers/numaresourcesscheduler_controller.go
@@ -38,7 +38,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	nrsv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 	"github.com/openshift-kni/numaresources-operator/pkg/apply"
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	"github.com/openshift-kni/numaresources-operator/pkg/loglevel"
@@ -83,7 +83,7 @@ func (r *NUMAResourcesSchedulerReconciler) Reconcile(ctx context.Context, req ct
 	klog.V(3).InfoS("Starting NUMAResourcesScheduler reconcile loop", "object", req.NamespacedName)
 	defer klog.V(3).InfoS("Finish NUMAResourcesScheduler reconcile loop", "object", req.NamespacedName)
 
-	instance := &nrsv1alpha1.NUMAResourcesScheduler{}
+	instance := &nropv1alpha1.NUMAResourcesScheduler{}
 	err := r.Get(context.TODO(), req.NamespacedName, instance)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -125,7 +125,7 @@ func (r *NUMAResourcesSchedulerReconciler) SetupWithManager(mgr ctrl.Manager) er
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&nrsv1alpha1.NUMAResourcesScheduler{}).
+		For(&nropv1alpha1.NUMAResourcesScheduler{}).
 		Owns(&rbacv1.ClusterRole{}, builder.WithPredicates(p)).
 		Owns(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(p)).
 		Owns(&corev1.ServiceAccount{}, builder.WithPredicates(p)).
@@ -134,13 +134,13 @@ func (r *NUMAResourcesSchedulerReconciler) SetupWithManager(mgr ctrl.Manager) er
 		Complete(r)
 }
 
-func (r *NUMAResourcesSchedulerReconciler) reconcileResource(ctx context.Context, instance *nrsv1alpha1.NUMAResourcesScheduler) (reconcile.Result, string, error) {
+func (r *NUMAResourcesSchedulerReconciler) reconcileResource(ctx context.Context, instance *nropv1alpha1.NUMAResourcesScheduler) (reconcile.Result, string, error) {
 	deploymentInfo, schedulerName, err := r.syncNUMASchedulerResources(ctx, instance)
 	if err != nil {
 		return ctrl.Result{}, status.ConditionDegraded, errors.Wrapf(err, "FailedSchedulerSync")
 	}
 
-	instance.Status.Deployment = nrsv1alpha1.NamespacedName{}
+	instance.Status.Deployment = nropv1alpha1.NamespacedName{}
 	ok, err := isDeploymentRunning(ctx, r.Client, deploymentInfo)
 	if err != nil {
 		return ctrl.Result{}, status.ConditionDegraded, err
@@ -156,7 +156,7 @@ func (r *NUMAResourcesSchedulerReconciler) reconcileResource(ctx context.Context
 
 }
 
-func isDeploymentRunning(ctx context.Context, c client.Client, key nrsv1alpha1.NamespacedName) (bool, error) {
+func isDeploymentRunning(ctx context.Context, c client.Client, key nropv1alpha1.NamespacedName) (bool, error) {
 	dp := &appsv1.Deployment{}
 	if err := c.Get(ctx, client.ObjectKey(key), dp); err != nil {
 		return false, err
@@ -170,11 +170,12 @@ func isDeploymentRunning(ctx context.Context, c client.Client, key nrsv1alpha1.N
 	return false, nil
 }
 
-func (r *NUMAResourcesSchedulerReconciler) syncNUMASchedulerResources(ctx context.Context, instance *nrsv1alpha1.NUMAResourcesScheduler) (nrsv1alpha1.NamespacedName, string, error) {
+func (r *NUMAResourcesSchedulerReconciler) syncNUMASchedulerResources(ctx context.Context, instance *nropv1alpha1.NUMAResourcesScheduler) (nropv1alpha1.NamespacedName, string, error) {
 	klog.V(4).Info("SchedulerSync start")
 	defer klog.V(4).Info("SchedulerSync stop")
 
-	var deploymentNName nrsv1alpha1.NamespacedName
+	var deploymentNName nropv1alpha1.NamespacedName
+
 	schedulerName := instance.Spec.SchedulerName
 
 	schedupdate.DeploymentImageSettings(r.SchedulerManifests.Deployment, instance.Spec.SchedulerImage)
@@ -188,7 +189,7 @@ func (r *NUMAResourcesSchedulerReconciler) syncNUMASchedulerResources(ctx contex
 	if schedulerName != "" {
 		err := schedupdate.SchedulerName(r.SchedulerManifests.ConfigMap, instance.Spec.SchedulerName)
 		if err != nil {
-			return nrsv1alpha1.NamespacedName{}, schedulerName, err
+			return nropv1alpha1.NamespacedName{}, schedulerName, err
 		}
 	}
 	if err := loglevel.UpdatePodSpec(&r.SchedulerManifests.Deployment.Spec.Template.Spec, instance.Spec.LogLevel); err != nil {
@@ -215,7 +216,7 @@ func (r *NUMAResourcesSchedulerReconciler) syncNUMASchedulerResources(ctx contex
 	return deploymentNName, schedulerName, nil
 }
 
-func (r *NUMAResourcesSchedulerReconciler) updateStatus(ctx context.Context, sched *nrsv1alpha1.NUMAResourcesScheduler, condition string, reason string, message string) error {
+func (r *NUMAResourcesSchedulerReconciler) updateStatus(ctx context.Context, sched *nropv1alpha1.NUMAResourcesScheduler, condition string, reason string, message string) error {
 	sched.Status.Conditions, _ = status.GetUpdatedConditions(sched.Status.Conditions, condition, reason, message)
 	if err := r.Client.Status().Update(ctx, sched); err != nil {
 		return errors.Wrapf(err, "could not update status for object %s", client.ObjectKeyFromObject(sched))

--- a/controllers/numaresourcesscheduler_controller_test.go
+++ b/controllers/numaresourcesscheduler_controller_test.go
@@ -18,8 +18,9 @@ package controllers
 
 import (
 	"context"
-	"k8s.io/klog/v2"
 	"time"
+
+	"k8s.io/klog/v2"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -34,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	nrsv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	schedmanifests "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/manifests/sched"
 	"github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/objectstate/sched"
@@ -61,7 +62,7 @@ func NewFakeNUMAResourcesSchedulerReconciler(initObjects ...runtime.Object) (*NU
 }
 
 var _ = ginkgo.Describe("Test NUMAResourcesScheduler Reconcile", func() {
-	verifyDegradedCondition := func(nrs *nrsv1alpha1.NUMAResourcesScheduler, reason string) {
+	verifyDegradedCondition := func(nrs *nropv1alpha1.NUMAResourcesScheduler, reason string) {
 		reconciler, err := NewFakeNUMAResourcesSchedulerReconciler(nrs)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
@@ -84,7 +85,7 @@ var _ = ginkgo.Describe("Test NUMAResourcesScheduler Reconcile", func() {
 	})
 
 	ginkgo.Context("with correct NRS CR", func() {
-		var nrs *nrsv1alpha1.NUMAResourcesScheduler
+		var nrs *nropv1alpha1.NUMAResourcesScheduler
 		var reconciler *NUMAResourcesSchedulerReconciler
 
 		ginkgo.BeforeEach(func() {

--- a/pkg/numaresourcesscheduler/objectstate/sched/sched.go
+++ b/pkg/numaresourcesscheduler/objectstate/sched/sched.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
 
-	nrsv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 	schedmanifests "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/manifests/sched"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectstate"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectstate/compare"
@@ -132,8 +132,8 @@ func FromClient(ctx context.Context, cli client.Client, mf schedmanifests.Manife
 	return ret
 }
 
-func DeploymentNamespacedNameFromObject(obj client.Object) (nrsv1alpha1.NamespacedName, bool) {
-	res := nrsv1alpha1.NamespacedName{
+func DeploymentNamespacedNameFromObject(obj client.Object) (nropv1alpha1.NamespacedName, bool) {
+	res := nropv1alpha1.NamespacedName{
 		Namespace: obj.GetNamespace(),
 		Name:      obj.GetName(),
 	}

--- a/pkg/numaresourcesscheduler/objectstate/sched/sched_test.go
+++ b/pkg/numaresourcesscheduler/objectstate/sched/sched_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	nrsv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 )
 
 var dp = &appsv1.Deployment{
@@ -55,7 +55,7 @@ func TestDeploymentNamespacedNameFromObject(t *testing.T) {
 	if !ok {
 		t.Errorf("failed to cast object to deployment type")
 	}
-	if !reflect.DeepEqual(nrsv1alpha1.NamespacedName(objKey), nname) {
+	if !reflect.DeepEqual(nropv1alpha1.NamespacedName(objKey), nname) {
 		t.Errorf("expected %v to be equal %v", objKey, nname)
 	}
 }

--- a/test/utils/clients/clients.go
+++ b/test/utils/clients/clients.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	nrtv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
-	numaresourcesoperatorv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	nropv1alpha1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
 	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
@@ -45,7 +45,7 @@ func init() {
 		klog.Exit(err.Error())
 	}
 
-	if err := numaresourcesoperatorv1alpha1.AddToScheme(scheme.Scheme); err != nil {
+	if err := nropv1alpha1.AddToScheme(scheme.Scheme); err != nil {
 		klog.Exit(err.Error())
 	}
 


### PR DESCRIPTION
make sure we rename the api packages always using the same name, which will make transition to newer API easier.

No changes in behaviour
