### PR TITLE
[release-4.10][manual] gh actions: add functionality to refresh the testsuite image

### DIFF
--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -1,4 +1,4 @@
-name: CI release flow
+name: CI operator release flow
 
 on:
   push:

--- a/.github/workflows/release-testsuite.yaml
+++ b/.github/workflows/release-testsuite.yaml
@@ -1,0 +1,41 @@
+name: CI testsuite release flow
+
+on:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  release-build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # note the version is hardcoded here because
+      # we expect to refresh from main branch
+      - name: Build Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: numaresources-operator-tests
+          tags: 4.10.999-snapshot
+          dockerfiles: |
+            ./Dockerfile.tests
+
+      - name: Push to quay
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: quay.io/openshift-kni
+          username: ${{ secrets.QUAY_IO_USERNAME }}
+          password: ${{ secrets.QUAY_IO_ROBOTOKEN }}
+
+      - name: Print image url
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -12,5 +12,4 @@ COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/
 COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/run-e2e-nrop-serial.sh /usr/local/bin
 COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/numacell /bin
 COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/pause /
-USER 65532:65532
 ENTRYPOINT ["/usr/local/bin/run-e2e-nrop-serial.sh"]


### PR DESCRIPTION
Add provisions to build and upload the tests image alongside the existing flow for the operator images

4.10 specific note:
updated hardcoded version to 4.10