### PR TITLE
context: wire up context, avoiding TODO

### DIFF
--- a/controllers/kubeletconfig_controller.go
+++ b/controllers/kubeletconfig_controller.go
@@ -163,14 +163,14 @@ func (r *KubeletConfigReconciler) syncConfigMap(ctx context.Context, mcoKc *mcov
 	cfgManifests := cfgstate.Manifests{
 		Config: rendered,
 	}
-	existing := cfgstate.FromClient(context.TODO(), r.Client, r.Namespace, name)
+	existing := cfgstate.FromClient(ctx, r.Client, r.Namespace, name)
 	for _, objState := range existing.State(cfgManifests) {
 		// the owner should be the KubeletConfig object and not the NUMAResourcesOperator CR
 		// this means that when KubeletConfig will get deleted, the ConfigMap gets deleted as well
 		if err := controllerutil.SetControllerReference(mcoKc, objState.Desired, r.Scheme); err != nil {
 			return nil, errors.Wrapf(err, "Failed to set controller reference to %s %s", objState.Desired.GetNamespace(), objState.Desired.GetName())
 		}
-		if _, err := apply.ApplyObject(context.TODO(), r.Client, objState); err != nil {
+		if _, err := apply.ApplyObject(ctx, r.Client, objState); err != nil {
 			return nil, errors.Wrapf(err, "could not create %s", objState.Desired.GetObjectKind().GroupVersionKind().String())
 		}
 	}

--- a/controllers/numaresourcesscheduler_controller.go
+++ b/controllers/numaresourcesscheduler_controller.go
@@ -85,7 +85,7 @@ func (r *NUMAResourcesSchedulerReconciler) Reconcile(ctx context.Context, req ct
 	defer klog.V(3).InfoS("Finish NUMAResourcesScheduler reconcile loop", "object", req.NamespacedName)
 
 	instance := &nropv1.NUMAResourcesScheduler{}
-	err := r.Get(context.TODO(), req.NamespacedName, instance)
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.

--- a/nrovalidate/main.go
+++ b/nrovalidate/main.go
@@ -82,7 +82,9 @@ func main() {
 		os.Exit(0)
 	}
 
-	err = validateCluster(parsedArgs)
+	ctx := context.Background()
+
+	err = validateCluster(ctx, parsedArgs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error while trying to validate cluster: %v\n", err)
 		os.Exit(2)
@@ -112,7 +114,7 @@ func parseArgs(args ...string) (ProgArgs, error) {
 	return pArgs, err
 }
 
-func validateCluster(args ProgArgs) error {
+func validateCluster(ctx context.Context, args ProgArgs) error {
 	cli, err := NewClientWithScheme(scheme)
 	if err != nil {
 		return err
@@ -122,7 +124,7 @@ func validateCluster(args ProgArgs) error {
 		fmt.Fprintf(os.Stderr, "INFO>>>>: enabled validators: %s\n", strings.Join(args.Validations.List(), ","))
 	}
 
-	data, err := nrovalidator.Collect(context.TODO(), cli, args.Labels, args.Validations)
+	data, err := nrovalidator.Collect(ctx, cli, args.Labels, args.Validations)
 	if err != nil {
 		return err
 	}

--- a/pkg/validator/noderesourcetopologies.go
+++ b/pkg/validator/noderesourcetopologies.go
@@ -43,7 +43,7 @@ func CollectNodeResourceTopologies(ctx context.Context, _ client.Client, data *V
 		return err
 	}
 
-	nrtList, err := cli.TopologyV1alpha1().NodeResourceTopologies().List(context.TODO(), metav1.ListOptions{})
+	nrtList, err := cli.TopologyV1alpha1().NodeResourceTopologies().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		if IsNodeResourceTopologyCRDMissing(err) {
 			data.nrtCrdMissing = true

--- a/test/e2e/sched/install/install_test.go
+++ b/test/e2e/sched/install/install_test.go
@@ -97,7 +97,7 @@ var _ = Describe("[Scheduler] install", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(podList).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
 
-			nodeList, err := nodes.GetControlPlane(e2eclient.Client, configuration.Plat)
+			nodeList, err := nodes.GetControlPlane(e2eclient.Client, context.TODO(), configuration.Plat)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nodeList).ToNot(BeEmpty())
 

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -108,7 +108,7 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", nroKey.String())
 			initialNroOperObj := nroOperObj.DeepCopy()
 
-			workers, err := nodes.GetWorkerNodes(fxt.Client)
+			workers, err := nodes.GetWorkerNodes(fxt.Client, context.TODO())
 			Expect(err).ToNot(HaveOccurred())
 
 			targetIdx, ok := e2efixture.PickNodeIndex(workers)

--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -226,7 +226,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			err := fxt.Client.List(context.TODO(), &nrtInitialList)
 			Expect(err).ToNot(HaveOccurred())
 
-			workers, err := nodes.GetWorkerNodes(fxt.Client)
+			workers, err := nodes.GetWorkerNodes(fxt.Client, context.TODO())
 			Expect(err).ToNot(HaveOccurred())
 
 			targetIdx, ok := e2efixture.PickNodeIndex(workers)
@@ -351,7 +351,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			for _, nodeName := range nrtNames.List() {
 
 				//calculate base load on the node
-				baseload, err := nodes.GetLoad(fxt.K8sClient, nodeName)
+				baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), nodeName)
 				Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", nodeName)
 				klog.Infof(fmt.Sprintf("computed base load: %s", baseload))
 

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -338,7 +338,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(err).NotTo(HaveOccurred())
 
 			//calculate base load on the target node
-			baseload, err := nodes.GetLoad(fxt.K8sClient, targetNodeName)
+			baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), targetNodeName)
 			Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", targetNodeName)
 			By(fmt.Sprintf("considering the computed base load: %s", baseload))
 
@@ -362,7 +362,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 				Expect(err).NotTo(HaveOccurred())
 
 				//calculate base load on the node
-				baseload, err := nodes.GetLoad(fxt.K8sClient, nodeName)
+				baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), nodeName)
 				Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", nodeName)
 				klog.Infof(fmt.Sprintf("computed base load: %s", baseload))
 
@@ -501,7 +501,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			}
 
 			//calculate base load on the target node
-			baseload, err := nodes.GetLoad(fxt.K8sClient, targetNodeName)
+			baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), targetNodeName)
 			Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", targetNodeName)
 			klog.Infof(fmt.Sprintf("computed base load: %s", baseload))
 

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -188,7 +188,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 					nrtInfo, err := e2enrt.FindFromList(nrtCandidates, nodeName)
 					Expect(err).NotTo(HaveOccurred(), "missing NRT Info for node %q", nodeName)
 
-					baseload, err := nodes.GetLoad(fxt.K8sClient, nodeName)
+					baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), nodeName)
 					Expect(err).NotTo(HaveOccurred(), "cannot get the base load for %q", nodeName)
 
 					for zIdx, zone := range nrtInfo.Zones {
@@ -346,7 +346,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 					nrtInfo, err := e2enrt.FindFromList(nrtTwoZoneCandidates, nodeName)
 					Expect(err).NotTo(HaveOccurred(), "missing NRT Info for node %q", nodeName)
 
-					baseload, err := nodes.GetLoad(fxt.K8sClient, nodeName)
+					baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), nodeName)
 					Expect(err).NotTo(HaveOccurred(), "cannot get the base load for %q", nodeName)
 
 					for zIdx, zone := range nrtInfo.Zones {
@@ -376,7 +376,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				By("padding a NUMA node on the target node")
 				var paddingPodsTargetNode []*corev1.Pod
 
-				baseload, err := nodes.GetLoad(fxt.K8sClient, targetNodeName)
+				baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), targetNodeName)
 				Expect(err).NotTo(HaveOccurred(), "cannot get the base load for %q", targetNodeName)
 
 				for zIdx, zone := range targetNrtInitial.Zones {

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -460,7 +460,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			pod := objects.NewTestPodPause(fxt.Namespace.Name, "testpod-gu-with-tas-sched")
 
 			// calculate base load on the target node
-			baseload, err := nodes.GetLoad(fxt.K8sClient, targetNodeName)
+			baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), targetNodeName)
 			Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", targetNodeName)
 			klog.Infof(fmt.Sprintf("computed base load: %s", baseload))
 
@@ -700,7 +700,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}
 
 			// calculate base load on the target node
-			baseload, err := nodes.GetLoad(fxt.K8sClient, targetNodeName)
+			baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), targetNodeName)
 			Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", targetNodeName)
 			klog.Infof(fmt.Sprintf("computed base load: %s", baseload))
 

--- a/test/e2e/serial/tests/workload_placement_nodelabel.go
+++ b/test/e2e/serial/tests/workload_placement_nodelabel.go
@@ -151,7 +151,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				nrtInfo, err := e2enrt.FindFromList(nrtCandidates, nodeName)
 				Expect(err).NotTo(HaveOccurred(), "missing NRT info for %q", nodeName)
 
-				baseload, err := nodes.GetLoad(fxt.K8sClient, nodeName)
+				baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), nodeName)
 				Expect(err).NotTo(HaveOccurred(), "cannot get the base load for %q", nodeName)
 
 				for zIdx, zone := range nrtInfo.Zones {

--- a/test/e2e/serial/tests/workload_placement_resources.go
+++ b/test/e2e/serial/tests/workload_placement_resources.go
@@ -201,7 +201,7 @@ func setupNodes(fxt *e2efixture.Fixture, nodesState desiredNodesState) ([]nrtv1a
 		nrtInfo, err := e2enrt.FindFromList(nrtCandidates, nodeName)
 		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "missing NRT info for %q", nodeName)
 
-		baseload, err := nodes.GetLoad(fxt.K8sClient, nodeName)
+		baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), nodeName)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred(), "missing node load info for %q", nodeName)
 		By(fmt.Sprintf("computed base load: %s", baseload))
 
@@ -218,7 +218,7 @@ func setupNodes(fxt *e2efixture.Fixture, nodesState desiredNodesState) ([]nrtv1a
 
 	By("Padding the target node")
 
-	baseload, err := nodes.GetLoad(fxt.K8sClient, targetNodeName)
+	baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), targetNodeName)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "missing node load info for %q", targetNodeName)
 	By(fmt.Sprintf("computed base load: %s", baseload))
 

--- a/test/e2e/serial/tests/workload_placement_taint.go
+++ b/test/e2e/serial/tests/workload_placement_taint.go
@@ -125,7 +125,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			nodes, err := nodes.GetWorkerNodes(fxt.Client)
+			nodes, err := nodes.GetWorkerNodes(fxt.Client, context.TODO())
 			Expect(err).ToNot(HaveOccurred())
 
 			tnts, _, err := taints.ParseTaints([]string{testTaint()})
@@ -161,7 +161,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			// leaking taints is especially bad AND we had some bugs in the pass, so let's try our very bes
 			// to be really really sure we didn't pollute the cluster.
-			nodes, err := nodes.GetWorkerNodes(fxt.Client)
+			nodes, err := nodes.GetWorkerNodes(fxt.Client, context.TODO())
 			Expect(err).ToNot(HaveOccurred())
 
 			nodeNames := accumulateNodeNames(nodes)

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -2006,7 +2006,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 })
 
 func setupPadding(fxt *e2efixture.Fixture, nrtList nrtv1alpha1.NodeResourceTopologyList, padInfo paddingInfo) []*corev1.Pod {
-	baseload, err := nodes.GetLoad(fxt.K8sClient, padInfo.targetNodeName)
+	baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), padInfo.targetNodeName)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "missing node load info for %q", padInfo.targetNodeName)
 	By(fmt.Sprintf("computed base load: %s", baseload))
 
@@ -2052,7 +2052,7 @@ func setupPaddingForUnsuitableNodes(offset int, fxt *e2efixture.Fixture, nrtList
 		nrtInfo, err := e2enrt.FindFromList(nrtList.Items, unsuitableNodeName)
 		ExpectWithOffset(offset, err).ToNot(HaveOccurred(), "missing NRT info for %q", unsuitableNodeName)
 
-		baseload, err := nodes.GetLoad(fxt.K8sClient, unsuitableNodeName)
+		baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), unsuitableNodeName)
 		ExpectWithOffset(offset, err).ToNot(HaveOccurred(), "missing node load info for %q", unsuitableNodeName)
 		By(fmt.Sprintf("computed base load: %s", baseload))
 

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -139,7 +139,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 				nrtInfo, err := e2enrt.FindFromList(nrtCandidates, nodeName)
 				Expect(err).NotTo(HaveOccurred(), "missing NRT info for %q", nodeName)
 
-				baseload, err := nodes.GetLoad(fxt.K8sClient, nodeName)
+				baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), nodeName)
 				Expect(err).NotTo(HaveOccurred(), "cannot get base load for %q", nodeName)
 
 				for idx, zone := range nrtInfo.Zones {
@@ -363,7 +363,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 				nrtInfo, err := e2enrt.FindFromList(nrtCandidates, nodeName)
 				Expect(err).NotTo(HaveOccurred(), "missing NRT info for %q", nodeName)
 
-				baseload, err := nodes.GetLoad(fxt.K8sClient, nodeName)
+				baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), nodeName)
 				Expect(err).NotTo(HaveOccurred(), "cannot get base load for %q", nodeName)
 
 				for zoneIdx, zone := range nrtInfo.Zones {
@@ -516,7 +516,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 				nrtInfo, err := e2enrt.FindFromList(nrtCandidates, nodeName)
 				Expect(err).NotTo(HaveOccurred(), "missing NRT info for %q", nodeName)
 
-				baseload, err := nodes.GetLoad(fxt.K8sClient, nodeName)
+				baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), nodeName)
 				Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", nodeName)
 
 				paddingResources, err := e2enrt.SaturateNodeUntilLeft(*nrtInfo, baseload.Resources)
@@ -538,7 +538,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 
 			By("Padding target node")
 			//calculate base load on the target node
-			targetNodeBaseLoad, err := nodes.GetLoad(fxt.K8sClient, targetNodeName)
+			targetNodeBaseLoad, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), targetNodeName)
 			Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", targetNodeName)
 
 			// Pad the zones so no one could handle both containers
@@ -837,7 +837,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			for _, nodeName := range nrtCandidateNames.List() {
 
 				//calculate base load on the node
-				baseload, err := nodes.GetLoad(fxt.K8sClient, nodeName)
+				baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), nodeName)
 				Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", nodeName)
 				klog.Infof(fmt.Sprintf("computed base load: %s", baseload))
 


### PR DESCRIPTION
A `context.TODO()`, which is meant as placeholder and prevents cancelation propagation. It's time to clean up our usage of those.
Avoid using `context.TODO()` when calling client functions in our controllers, to enable cancel propagation.
So add explicit context argument to our library functions and update the call sites accordingly.