### PR TITLE
add context using fluent api

### DIFF
--- a/internal/podlist/daemonset.go
+++ b/internal/podlist/daemonset.go
@@ -25,14 +25,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ByDaemonset(cli client.Client, ds appsv1.DaemonSet) ([]corev1.Pod, error) {
+func (fnd Finder) ByDaemonset(ctx context.Context, ds appsv1.DaemonSet) ([]corev1.Pod, error) {
 	podList := &corev1.PodList{}
 	sel, err := metav1.LabelSelectorAsSelector(ds.Spec.Selector)
 	if err != nil {
 		return nil, err
 	}
 
-	err = cli.List(context.TODO(), podList, &client.ListOptions{LabelSelector: sel})
+	err = fnd.List(ctx, podList, &client.ListOptions{LabelSelector: sel})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/podlist/deployment.go
+++ b/internal/podlist/deployment.go
@@ -27,10 +27,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetDeploymentByOwnerReference(cli client.Client, uid types.UID) (*appsv1.Deployment, error) {
+func (fnd Finder) DeploymentByOwnerReference(ctx context.Context, uid types.UID) (*appsv1.Deployment, error) {
 	deployList := &appsv1.DeploymentList{}
 
-	if err := cli.List(context.TODO(), deployList); err != nil {
+	if err := fnd.List(ctx, deployList); err != nil {
 		return nil, fmt.Errorf("failed to get deployment: %w", err)
 	}
 
@@ -44,14 +44,14 @@ func GetDeploymentByOwnerReference(cli client.Client, uid types.UID) (*appsv1.De
 	return nil, fmt.Errorf("failed to get deployment with uid: %s", uid)
 }
 
-func ByDeployment(cli client.Client, deployment appsv1.Deployment) ([]corev1.Pod, error) {
+func (fnd Finder) ByDeployment(ctx context.Context, deployment appsv1.Deployment) ([]corev1.Pod, error) {
 	podList := &corev1.PodList{}
 	sel, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
 	if err != nil {
 		return nil, err
 	}
 
-	err = cli.List(context.TODO(), podList, &client.ListOptions{Namespace: deployment.Namespace, LabelSelector: sel})
+	err = fnd.List(ctx, podList, &client.ListOptions{Namespace: deployment.Namespace, LabelSelector: sel})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/podlist/find.go
+++ b/internal/podlist/find.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Red Hat, Inc.
+ * Copyright 2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,25 +17,13 @@
 package podlist
 
 import (
-	"context"
-
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (fnd Finder) ByReplicaSet(ctx context.Context, rs appsv1.ReplicaSet) ([]corev1.Pod, error) {
-	podList := &corev1.PodList{}
-	sel, err := metav1.LabelSelectorAsSelector(rs.Spec.Selector)
-	if err != nil {
-		return nil, err
-	}
+type Finder struct {
+	client.Client
+}
 
-	err = fnd.List(ctx, podList, &client.ListOptions{Namespace: rs.Namespace, LabelSelector: sel})
-	if err != nil {
-		return nil, err
-	}
-
-	return podList.Items, nil
+func With(cli client.Client) Finder {
+	return Finder{Client: cli}
 }

--- a/internal/wait/deployment.go
+++ b/internal/wait/deployment.go
@@ -18,20 +18,17 @@ package wait
 
 import (
 	"context"
-	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
+	k8swait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ForDeploymentComplete(cli client.Client, dp *appsv1.Deployment, pollInterval, pollTimeout time.Duration) (*appsv1.Deployment, error) {
+func (wt Waiter) ForDeploymentComplete(ctx context.Context, dp *appsv1.Deployment) (*appsv1.Deployment, error) {
 	key := ObjectKeyFromObject(dp)
 	updatedDp := &appsv1.Deployment{}
-	err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
-		err := cli.Get(context.TODO(), key.AsKey(), updatedDp)
+	err := k8swait.PollImmediate(wt.PollInterval, wt.PollTimeout, func() (bool, error) {
+		err := wt.Cli.Get(ctx, key.AsKey(), updatedDp)
 		if err != nil {
 			klog.Warningf("failed to get the deployment %s: %v", key.String(), err)
 			return false, err
@@ -59,11 +56,11 @@ func IsDeploymentComplete(dp *appsv1.Deployment, newStatus *appsv1.DeploymentSta
 		newStatus.ObservedGeneration >= dp.Generation
 }
 
-func ForDeploymentReplicasCreation(cli client.Client, dp *appsv1.Deployment, expectedReplicas int32, pollInterval, pollTimeout time.Duration) (*appsv1.Deployment, error) {
+func (wt Waiter) ForDeploymentReplicasCreation(ctx context.Context, dp *appsv1.Deployment, expectedReplicas int32) (*appsv1.Deployment, error) {
 	key := ObjectKeyFromObject(dp)
 	updatedDp := &appsv1.Deployment{}
-	err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
-		err := cli.Get(context.TODO(), key.AsKey(), updatedDp)
+	err := k8swait.PollImmediate(wt.PollInterval, wt.PollTimeout, func() (bool, error) {
+		err := wt.Cli.Get(ctx, key.AsKey(), updatedDp)
 		if err != nil {
 			klog.Warningf("failed to get the deployment %s: %v", key.String(), err)
 			return false, err

--- a/internal/wait/machineconfig.go
+++ b/internal/wait/machineconfig.go
@@ -18,41 +18,40 @@ package wait
 
 import (
 	"context"
-	"time"
+
+	"k8s.io/klog/v2"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	k8swait "k8s.io/apimachinery/pkg/util/wait"
 
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
 
-func ForMachineConfigPoolDeleted(cli client.Client, mcp *machineconfigv1.MachineConfigPool, pollInterval, pollTimeout time.Duration) error {
-	err := wait.Poll(pollInterval, pollTimeout, func() (bool, error) {
+func (wt Waiter) ForMachineConfigPoolDeleted(ctx context.Context, mcp *machineconfigv1.MachineConfigPool) error {
+	err := k8swait.Poll(wt.PollInterval, wt.PollTimeout, func() (bool, error) {
 		updatedMcp := machineconfigv1.MachineConfigPool{}
 		key := ObjectKeyFromObject(mcp)
-		err := cli.Get(context.TODO(), key.AsKey(), &updatedMcp)
+		err := wt.Cli.Get(ctx, key.AsKey(), &updatedMcp)
 		return deletionStatusFromError("MachineConfigPool", key, err)
 	})
 	return err
 }
 
-func ForKubeletConfigDeleted(cli client.Client, kc *machineconfigv1.KubeletConfig, pollInterval, pollTimeout time.Duration) error {
-	err := wait.Poll(pollInterval, pollTimeout, func() (bool, error) {
+func (wt Waiter) ForKubeletConfigDeleted(ctx context.Context, kc *machineconfigv1.KubeletConfig) error {
+	err := k8swait.Poll(wt.PollInterval, wt.PollTimeout, func() (bool, error) {
 		updatedKc := machineconfigv1.KubeletConfig{}
 		key := ObjectKeyFromObject(kc)
-		err := cli.Get(context.TODO(), key.AsKey(), &updatedKc)
+		err := wt.Cli.Get(ctx, key.AsKey(), &updatedKc)
 		return deletionStatusFromError("KubeletConfig", key, err)
 	})
 	return err
 }
 
-func ForMachineConfigPoolCondition(cli client.Client, mcp *machineconfigv1.MachineConfigPool, condType machineconfigv1.MachineConfigPoolConditionType, pollInterval, pollTimeout time.Duration) error {
-	err := wait.Poll(pollInterval, pollTimeout, func() (bool, error) {
+func (wt Waiter) ForMachineConfigPoolCondition(ctx context.Context, mcp *machineconfigv1.MachineConfigPool, condType machineconfigv1.MachineConfigPoolConditionType) error {
+	err := k8swait.Poll(wt.PollInterval, wt.PollTimeout, func() (bool, error) {
 		updatedMcp := machineconfigv1.MachineConfigPool{}
 		key := ObjectKeyFromObject(mcp)
-		err := cli.Get(context.TODO(), key.AsKey(), &updatedMcp)
+		err := wt.Cli.Get(ctx, key.AsKey(), &updatedMcp)
 		if err != nil {
 			return false, err
 		}

--- a/internal/wait/replicaset.go
+++ b/internal/wait/replicaset.go
@@ -18,20 +18,17 @@ package wait
 
 import (
 	"context"
-	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
+	k8swait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ForReplicasetComplete(cli client.Client, rs *appsv1.ReplicaSet, pollInterval, pollTimeout time.Duration) (*appsv1.ReplicaSet, error) {
+func (wt Waiter) ForReplicasetComplete(ctx context.Context, rs *appsv1.ReplicaSet) (*appsv1.ReplicaSet, error) {
 	key := ObjectKeyFromObject(rs)
 	updatedRs := &appsv1.ReplicaSet{}
-	err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
-		err := cli.Get(context.TODO(), key.AsKey(), updatedRs)
+	err := k8swait.PollImmediate(wt.PollInterval, wt.PollTimeout, func() (bool, error) {
+		err := wt.Cli.Get(ctx, key.AsKey(), updatedRs)
 		if err != nil {
 			klog.Warningf("failed to get the replicaset %s: %v", key.String(), err)
 			return false, err

--- a/internal/wait/waiter.go
+++ b/internal/wait/waiter.go
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ */
+
+package wait
+
+import (
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	DefaultPollInterval = 1 * time.Second
+	// DefaultPollTimeout was computed by trial and error, not scientifically,
+	// so it may adjusted in the future any time.
+	// Roughly match the time it takes for pods to go running in CI.
+	DefaultPollTimeout = 3 * time.Minute
+)
+
+type ObjectKey struct {
+	Namespace string
+	Name      string
+}
+
+func ObjectKeyFromObject(obj metav1.Object) ObjectKey {
+	return ObjectKey{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+}
+
+func (ok ObjectKey) AsKey() types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: ok.Namespace,
+		Name:      ok.Name,
+	}
+}
+
+func (ok ObjectKey) String() string {
+	return fmt.Sprintf("%s/%s", ok.Namespace, ok.Name)
+}
+
+type Waiter struct {
+	Cli          client.Client
+	PollTimeout  time.Duration
+	PollInterval time.Duration
+	PollSteps    int // alternative to Timeout
+}
+
+func With(cli client.Client) *Waiter {
+	return &Waiter{
+		Cli:          cli,
+		PollTimeout:  DefaultPollTimeout,
+		PollInterval: DefaultPollInterval,
+	}
+}
+
+func (wt *Waiter) Timeout(tt time.Duration) *Waiter {
+	wt.PollTimeout = tt
+	return wt
+}
+
+func (wt *Waiter) Interval(iv time.Duration) *Waiter {
+	wt.PollInterval = iv
+	return wt
+}
+
+func (wt *Waiter) Steps(st int) *Waiter {
+	wt.PollSteps = st
+	return wt
+}

--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -214,7 +214,7 @@ var _ = Describe("[Install] durability", func() {
 			}
 
 			By("waiting for DaemonSet to be ready")
-			ds, err := nrowait.ForDaemonSetReadyByKey(e2eclient.Client, dsKey, 10*time.Second, 3*time.Minute)
+			ds, err := nrowait.With(e2eclient.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(context.TODO(), dsKey)
 			Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
 
 			By("Update RTE image in NRO")
@@ -359,7 +359,7 @@ func deleteNROPSync(cli client.Client, nropObj *nropv1.NUMAResourcesOperator) {
 	var err error
 	err = cli.Delete(context.TODO(), nropObj)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-	err = nrowait.ForNUMAResourcesOperatorDeleted(cli, nropObj, 10*time.Second, 2*time.Minute)
+	err = nrowait.With(cli).Interval(10*time.Second).Timeout(2*time.Minute).ForNUMAResourcesOperatorDeleted(context.TODO(), nropObj)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "NROP %q failed to be deleted", nropObj.Name)
 }
 

--- a/test/e2e/must-gather/must_gather_test.go
+++ b/test/e2e/must-gather/must_gather_test.go
@@ -17,6 +17,7 @@
 package mustgather
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -110,7 +111,7 @@ var _ = ginkgo.Describe("[must-gather] NRO data collected", func() {
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 				ginkgo.By("Looking for namespace in NUMAResourcesOperator")
-				updatedNRO, err := wait.ForDaemonsetInNUMAResourcesOperatorStatus(e2eclient.Client, deployment.NroObj, 5*time.Second, 2*time.Minute)
+				updatedNRO, err := wait.With(e2eclient.Client).Interval(5*time.Second).Timeout(2*time.Minute).ForDaemonsetInNUMAResourcesOperatorStatus(context.TODO(), deployment.NroObj)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				namespace := updatedNRO.Status.DaemonSets[0].Namespace
 

--- a/test/e2e/sched/install/install_test.go
+++ b/test/e2e/sched/install/install_test.go
@@ -79,7 +79,7 @@ var _ = Describe("[Scheduler] install", func() {
 			By("checking the NumaResourcesScheduler Deployment is correctly deployed")
 			deployment := &appsv1.Deployment{}
 			Eventually(func() bool {
-				deployment, err = podlist.GetDeploymentByOwnerReference(e2eclient.Client, nroSchedObj.UID)
+				deployment, err = podlist.With(e2eclient.Client).DeploymentByOwnerReference(context.TODO(), nroSchedObj.UID)
 				if err != nil {
 					klog.Warningf("unable to get deployment by owner reference: %v", err)
 					return false
@@ -93,7 +93,7 @@ var _ = Describe("[Scheduler] install", func() {
 			}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).Should(BeTrue(), "Deployment Status not OK: %v", deployment.Status)
 
 			By("Check secondary scheduler pod is scheduled on a control-plane node")
-			podList, err := podlist.ByDeployment(e2eclient.Client, *deployment)
+			podList, err := podlist.With(e2eclient.Client).ByDeployment(context.TODO(), *deployment)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(podList).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
 

--- a/test/e2e/sched/sched_test.go
+++ b/test/e2e/sched/sched_test.go
@@ -92,7 +92,7 @@ var _ = Describe("[Scheduler] imageReplacement", func() {
 			dp, err := podlist.With(e2eclient.Client).DeploymentByOwnerReference(context.TODO(), nroSchedObj.GetUID())
 			Expect(err).ToNot(HaveOccurred())
 
-			_, err = wait.ForDeploymentComplete(e2eclient.Client, dp, time.Second*30, time.Minute*2)
+			_, err = wait.With(e2eclient.Client).Interval(30*time.Second).Timeout(2*time.Minute).ForDeploymentComplete(context.TODO(), dp)
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/test/e2e/sched/sched_test.go
+++ b/test/e2e/sched/sched_test.go
@@ -65,7 +65,7 @@ var _ = Describe("[Scheduler] imageReplacement", func() {
 
 			Eventually(func() bool {
 				// find deployment by the ownerReference
-				deploy, err := podlist.GetDeploymentByOwnerReference(e2eclient.Client, uid)
+				deploy, err := podlist.With(e2eclient.Client).DeploymentByOwnerReference(context.TODO(), uid)
 				if err != nil {
 					klog.Warningf("%w", err)
 					return false
@@ -89,7 +89,7 @@ var _ = Describe("[Scheduler] imageReplacement", func() {
 			}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(BeTrue())
 
 			// find deployment by the ownerReference
-			dp, err := podlist.GetDeploymentByOwnerReference(e2eclient.Client, nroSchedObj.GetUID())
+			dp, err := podlist.With(e2eclient.Client).DeploymentByOwnerReference(context.TODO(), nroSchedObj.GetUID())
 			Expect(err).ToNot(HaveOccurred())
 
 			_, err = wait.ForDeploymentComplete(e2eclient.Client, dp, time.Second*30, time.Minute*2)
@@ -141,7 +141,7 @@ var _ = Describe("[Scheduler] imageReplacement", func() {
 				return true
 			}).WithTimeout(time.Minute * 2).WithPolling(time.Second * 30).Should(BeTrue())
 
-			dp, err := podlist.GetDeploymentByOwnerReference(e2eclient.Client, nroSchedObj.GetUID())
+			dp, err := podlist.With(e2eclient.Client).DeploymentByOwnerReference(context.TODO(), nroSchedObj.GetUID())
 			Expect(err).ToNot(HaveOccurred())
 
 			initialDP := dp.DeepCopy()

--- a/test/e2e/sched/uninstall/uninstall_test.go
+++ b/test/e2e/sched/uninstall/uninstall_test.go
@@ -47,7 +47,7 @@ var _ = Describe("[Scheduler] uninstall", func() {
 				return
 			}
 
-			deploy, err := podlist.GetDeploymentByOwnerReference(e2eclient.Client, nroSchedObj.GetUID())
+			deploy, err := podlist.With(e2eclient.Client).DeploymentByOwnerReference(context.TODO(), nroSchedObj.GetUID())
 			Expect(err).ToNot(HaveOccurred())
 
 			err = e2eclient.Client.Delete(context.TODO(), nroSchedObj)

--- a/test/e2e/serial/config/infra.go
+++ b/test/e2e/serial/config/infra.go
@@ -107,7 +107,7 @@ func setupNUMACell(fxt *e2efixture.Fixture, nodeGroups []nropv1.NodeGroup, timeo
 			klog.Infof("waiting for daemonset %q to be ready", ds.Name)
 
 			// TODO: what if timeout < period?
-			ds, err := wait.ForDaemonSetReady(fxt.Client, ds, 10*time.Second, timeout)
+			ds, err := wait.With(fxt.Client).Interval(10*time.Second).Timeout(timeout).ForDaemonSetReady(context.TODO(), ds)
 			Expect(err).ToNot(HaveOccurred(), "DaemonSet %q failed to go running", ds.Name)
 		}(ds)
 	}

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -152,7 +152,10 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 					go func(mcpool *machineconfigv1.MachineConfigPool) {
 						defer GinkgoRecover()
 						defer wg.Done()
-						err = wait.ForMachineConfigPoolCondition(fxt.Client, mcpool, machineconfigv1.MachineConfigPoolUpdated, configuration.MachineConfigPoolUpdateInterval, configuration.MachineConfigPoolUpdateTimeout)
+						err = wait.With(fxt.Client).
+							Interval(configuration.MachineConfigPoolUpdateInterval).
+							Timeout(configuration.MachineConfigPoolUpdateTimeout).
+							ForMachineConfigPoolCondition(context.TODO(), mcpool, machineconfigv1.MachineConfigPoolUpdated)
 						Expect(err).ToNot(HaveOccurred())
 					}(mcp)
 				}
@@ -163,7 +166,10 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 				err = fxt.Client.Delete(context.TODO(), testMcp)
 				Expect(err).ToNot(HaveOccurred())
 
-				err = wait.ForMachineConfigPoolDeleted(fxt.Client, testMcp, configuration.MachineConfigPoolUpdateInterval, configuration.MachineConfigPoolUpdateTimeout)
+				err = wait.With(fxt.Client).
+					Interval(configuration.MachineConfigPoolUpdateInterval).
+					Timeout(configuration.MachineConfigPoolUpdateTimeout).
+					ForMachineConfigPoolDeleted(context.TODO(), testMcp)
 				Expect(err).ToNot(HaveOccurred())
 			}() // end of defer
 
@@ -206,7 +212,10 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 				go func(mcpool *machineconfigv1.MachineConfigPool) {
 					defer GinkgoRecover()
 					defer wg.Done()
-					err = wait.ForMachineConfigPoolCondition(fxt.Client, mcpool, machineconfigv1.MachineConfigPoolUpdated, configuration.MachineConfigPoolUpdateInterval, configuration.MachineConfigPoolUpdateTimeout)
+					err = wait.With(fxt.Client).
+						Interval(configuration.MachineConfigPoolUpdateInterval).
+						Timeout(configuration.MachineConfigPoolUpdateTimeout).
+						ForMachineConfigPoolCondition(context.TODO(), mcpool, machineconfigv1.MachineConfigPoolUpdated)
 					Expect(err).ToNot(HaveOccurred())
 				}(mcp)
 			}
@@ -349,7 +358,7 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 			err = fxt.Client.Create(context.TODO(), testPod)
 			Expect(err).ToNot(HaveOccurred())
 
-			updatedPod, err := wait.ForPodPhase(fxt.Client, testPod.Namespace, testPod.Name, corev1.PodRunning, timeout)
+			updatedPod, err := wait.With(fxt.Client).Timeout(timeout).ForPodPhase(context.TODO(), testPod.Namespace, testPod.Name, corev1.PodRunning)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
 			}
@@ -412,7 +421,10 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 				go func(mcpool *machineconfigv1.MachineConfigPool) {
 					defer GinkgoRecover()
 					defer wg.Done()
-					err = wait.ForMachineConfigPoolCondition(fxt.Client, mcpool, machineconfigv1.MachineConfigPoolUpdated, configuration.MachineConfigPoolUpdateInterval, configuration.MachineConfigPoolUpdateTimeout)
+					err = wait.With(fxt.Client).
+						Interval(configuration.MachineConfigPoolUpdateInterval).
+						Timeout(configuration.MachineConfigPoolUpdateTimeout).
+						ForMachineConfigPoolCondition(context.TODO(), mcpool, machineconfigv1.MachineConfigPoolUpdated)
 					Expect(err).ToNot(HaveOccurred())
 				}(mcp)
 			}
@@ -477,7 +489,7 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 			err = fxt.Client.Create(context.TODO(), testPod)
 			Expect(err).ToNot(HaveOccurred())
 
-			testPod, err = wait.ForPodPhase(fxt.Client, testPod.Namespace, testPod.Name, corev1.PodRunning, timeout)
+			testPod, err = wait.With(fxt.Client).Timeout(timeout).ForPodPhase(context.TODO(), testPod.Namespace, testPod.Name, corev1.PodRunning)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, testPod.Namespace, testPod.Name)
 			}
@@ -531,7 +543,10 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 					go func(mcpool *machineconfigv1.MachineConfigPool) {
 						defer GinkgoRecover()
 						defer wg.Done()
-						err = wait.ForMachineConfigPoolCondition(fxt.Client, mcpool, machineconfigv1.MachineConfigPoolUpdated, configuration.MachineConfigPoolUpdateInterval, configuration.MachineConfigPoolUpdateTimeout)
+						err = wait.With(fxt.Client).
+							Interval(configuration.MachineConfigPoolUpdateInterval).
+							Timeout(configuration.MachineConfigPoolUpdateTimeout).
+							ForMachineConfigPoolCondition(context.TODO(), mcpool, machineconfigv1.MachineConfigPoolUpdated)
 						Expect(err).ToNot(HaveOccurred())
 					}(mcp)
 				}

--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -278,7 +278,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			nrtPostCreateDeploymentList, err := e2enrt.GetUpdated(fxt.Client, nrtInitialList, time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 
-			pods, err := podlist.ByDeployment(fxt.Client, *updatedDp)
+			pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *updatedDp)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(pods)).To(Equal(1))
 

--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -172,7 +172,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			err = fxt.Client.Create(context.TODO(), testPod)
 			Expect(err).ToNot(HaveOccurred())
 
-			updatedPod, err := wait.ForPodPhase(fxt.Client, testPod.Namespace, testPod.Name, corev1.PodRunning, timeout)
+			updatedPod, err := wait.With(fxt.Client).Timeout(timeout).ForPodPhase(context.TODO(), testPod.Namespace, testPod.Name, corev1.PodRunning)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
 			}
@@ -272,7 +272,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			err = fxt.Client.Create(context.TODO(), dp)
 			Expect(err).ToNot(HaveOccurred())
 
-			updatedDp, err := wait.ForDeploymentComplete(fxt.Client, dp, time.Second*10, time.Minute)
+			updatedDp, err := wait.With(fxt.Client).Interval(10*time.Second).Timeout(time.Minute).ForDeploymentComplete(context.TODO(), dp)
 			Expect(err).ToNot(HaveOccurred())
 
 			nrtPostCreateDeploymentList, err := e2enrt.GetUpdated(fxt.Client, nrtInitialList, time.Minute)
@@ -408,7 +408,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).NotTo(HaveOccurred(), "unable to create pod %q", pod.Name)
 
 			By("check the pod keeps on pending")
-			err = wait.WhileInPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodPending, 10*time.Second, 3)
+			err = wait.With(fxt.Client).Interval(10*time.Second).Steps(3).WhileInPodPhase(context.TODO(), pod.Namespace, pod.Name, corev1.PodPending)
 			if err != nil {
 				objects.LogEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
 			}

--- a/test/e2e/serial/tests/non_regression_fundamentals.go
+++ b/test/e2e/serial/tests/non_regression_fundamentals.go
@@ -81,7 +81,7 @@ var _ = Describe("[serial][fundamentals][scheduler][nonreg] numaresources fundam
 			Expect(err).ToNot(HaveOccurred())
 
 			By("checking the test pod is removed")
-			err = wait.ForPodDeleted(fxt.Client, testPod.Namespace, testPod.Name, 3*time.Minute)
+			err = wait.With(fxt.Client).Timeout(3*time.Minute).ForPodDeleted(context.TODO(), testPod.Namespace, testPod.Name)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -93,8 +93,7 @@ var _ = Describe("[serial][fundamentals][scheduler][nonreg] numaresources fundam
 			err := fxt.Client.Create(context.TODO(), testPod)
 			Expect(err).ToNot(HaveOccurred())
 
-			timeout := 5 * time.Minute
-			updatedPod, err := wait.ForPodPhase(fxt.Client, testPod.Namespace, testPod.Name, corev1.PodRunning, timeout)
+			updatedPod, err := wait.With(fxt.Client).Timeout(5*time.Minute).ForPodPhase(context.TODO(), testPod.Namespace, testPod.Name, corev1.PodRunning)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
 			}
@@ -117,8 +116,7 @@ var _ = Describe("[serial][fundamentals][scheduler][nonreg] numaresources fundam
 			err := fxt.Client.Create(context.TODO(), testPod)
 			Expect(err).ToNot(HaveOccurred())
 
-			timeout := 5 * time.Minute
-			updatedPod, err := wait.ForPodPhase(fxt.Client, testPod.Namespace, testPod.Name, corev1.PodRunning, timeout)
+			updatedPod, err := wait.With(fxt.Client).Timeout(5*time.Minute).ForPodPhase(context.TODO(), testPod.Namespace, testPod.Name, corev1.PodRunning)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
 			}
@@ -141,8 +139,7 @@ var _ = Describe("[serial][fundamentals][scheduler][nonreg] numaresources fundam
 			err := fxt.Client.Create(context.TODO(), testPod)
 			Expect(err).ToNot(HaveOccurred())
 
-			timeout := 5 * time.Minute
-			updatedPod, err := wait.ForPodPhase(fxt.Client, testPod.Namespace, testPod.Name, corev1.PodRunning, timeout)
+			updatedPod, err := wait.With(fxt.Client).Timeout(5*time.Minute).ForPodPhase(context.TODO(), testPod.Namespace, testPod.Name, corev1.PodRunning)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
 			}
@@ -225,7 +222,7 @@ var _ = Describe("[serial][fundamentals][scheduler][nonreg] numaresources fundam
 					testPods = append(testPods, testPod)
 				}
 
-				failedPods, updatedPods := wait.ForPodListAllRunning(fxt.Client, testPods, timeout)
+				failedPods, updatedPods := wait.With(fxt.Client).Timeout(timeout).ForPodListAllRunning(context.TODO(), testPods)
 
 				for _, failedPod := range failedPods {
 					_ = objects.LogEventsForPod(fxt.K8sClient, failedPod.Namespace, failedPod.Name)
@@ -321,7 +318,7 @@ var _ = Describe("[serial][fundamentals][scheduler][nonreg] numaresources fundam
 					testPods = append(testPods, testPod)
 				}
 
-				failedPods, updatedPods := wait.ForPodListAllRunning(fxt.Client, testPods, timeout)
+				failedPods, updatedPods := wait.With(fxt.Client).Timeout(timeout).ForPodListAllRunning(context.TODO(), testPods)
 
 				for _, failedPod := range failedPods {
 					_ = objects.LogEventsForPod(fxt.K8sClient, failedPod.Namespace, failedPod.Name)

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -246,7 +246,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			// TODO: lacking better ways, let's monitor the pod "long enough" and let's check it stays Pending
 			// if it stays Pending "long enough" it still means little, but OTOH if it goes Running or Failed we
 			// can tell for sure something's wrong
-			err = wait.WhileInPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodPending, 10*time.Second, 3)
+			err = wait.With(fxt.Client).Interval(10*time.Second).Steps(3).WhileInPodPhase(context.TODO(), pod.Namespace, pod.Name, corev1.PodPending)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
 			}
@@ -262,14 +262,14 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(err).ToNot(HaveOccurred())
 
 			By("checking the test pod is removed")
-			err = wait.ForPodDeleted(fxt.Client, targetPaddingPod.Namespace, targetPaddingPod.Name, 3*time.Minute)
+			err = wait.With(fxt.Client).Timeout(3*time.Minute).ForPodDeleted(context.TODO(), targetPaddingPod.Namespace, targetPaddingPod.Name)
 			Expect(err).ToNot(HaveOccurred())
 
 			// the status of the test pod moving from pending to running expected to be fast after new resources are released,
 			// thus it is fragile to verify the NRT before make the pending pod running, so let's check
 			// that after the test pod start running
 			By("waiting for the pod to be scheduled")
-			updatedPod, err := wait.ForPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodRunning, 3*time.Minute)
+			updatedPod, err := wait.With(fxt.Client).Timeout(3*time.Minute).ForPodPhase(context.TODO(), pod.Namespace, pod.Name, corev1.PodRunning)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
 			}
@@ -405,7 +405,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 
 			By("waiting for the pod to be scheduled")
 			// 3 minutes is plenty, should never timeout
-			updatedPod, err := wait.ForPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodRunning, 3*time.Minute)
+			updatedPod, err := wait.With(fxt.Client).Timeout(3*time.Minute).ForPodPhase(context.TODO(), pod.Namespace, pod.Name, corev1.PodRunning)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
 			}
@@ -435,7 +435,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 
 			By("waiting for the pod to be scheduled")
 			// 3 minutes is plenty, should never timeout
-			updatedPod, err := wait.ForPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodRunning, 3*time.Minute)
+			updatedPod, err := wait.With(fxt.Client).Timeout(3*time.Minute).ForPodPhase(context.TODO(), pod.Namespace, pod.Name, corev1.PodRunning)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
 			}
@@ -469,10 +469,8 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(err).NotTo(HaveOccurred(), "unable to create deployment %q", deployment.Name)
 
 			By("waiting for deployment to be up & running")
-			dpRunningTimeout := 1 * time.Minute
-			dpRunningPollInterval := 10 * time.Second
-			_, err = wait.ForDeploymentComplete(fxt.Client, deployment, dpRunningPollInterval, dpRunningTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Deployment %q not up & running after %v", deployment.Name, dpRunningTimeout)
+			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(1*time.Minute).ForDeploymentComplete(context.TODO(), deployment)
+			Expect(err).NotTo(HaveOccurred(), "Deployment %q not up & running after %v", deployment.Name, 1*time.Minute)
 
 			By(fmt.Sprintf("checking deployment pods have been scheduled with the topology aware scheduler %q and in the proper node %q", serialconfig.Config.SchedulerName, targetNodeName))
 			pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *deployment)
@@ -540,7 +538,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 
 			By("waiting for the pod to be scheduled")
 			// 3 minutes is plenty, should never timeout
-			updatedPod, err := wait.ForPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodRunning, 3*time.Minute)
+			updatedPod, err := wait.With(fxt.Client).Timeout(3*time.Minute).ForPodPhase(context.TODO(), pod.Namespace, pod.Name, corev1.PodRunning)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
 			}
@@ -570,7 +568,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 
 			By("waiting for the pod to be scheduled")
 			// 3 minutes is plenty, should never timeout
-			updatedPod, err := wait.ForPodPhase(fxt.Client, podBurstable.Namespace, podBurstable.Name, corev1.PodRunning, 3*time.Minute)
+			updatedPod, err := wait.With(fxt.Client).Timeout(3*time.Minute).ForPodPhase(context.TODO(), podBurstable.Namespace, podBurstable.Name, corev1.PodRunning)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
 			}
@@ -615,7 +613,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 
 			By("check the pod is still pending")
 
-			err = wait.WhileInPodPhase(fxt.Client, podGuanranteed.Namespace, podGuanranteed.Name, corev1.PodPending, 10*time.Second, 3)
+			err = wait.With(fxt.Client).Interval(10*time.Second).Steps(3).WhileInPodPhase(context.TODO(), podGuanranteed.Namespace, podGuanranteed.Name, corev1.PodPending)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, podGuanranteed.Namespace, podGuanranteed.Name)
 			}
@@ -631,7 +629,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 
 			By("waiting for the guaranteed pod to be scheduled")
 			// 3 minutes is plenty, should never timeout
-			updatedPod2, err := wait.ForPodPhase(fxt.Client, podGuanranteed.Namespace, podGuanranteed.Name, corev1.PodRunning, 3*time.Minute)
+			updatedPod2, err := wait.With(fxt.Client).Timeout(3*time.Minute).ForPodPhase(context.TODO(), podGuanranteed.Namespace, podGuanranteed.Name, corev1.PodRunning)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod2.Namespace, updatedPod2.Name)
 			}
@@ -707,11 +705,8 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(err).NotTo(HaveOccurred(), "unable to create daemonset %q", ds.Name)
 
 			By("waiting for daemoneset to be up & running")
-			dsRunningTimeout := 1 * time.Minute
-			dsRunningPollInterval := 10 * time.Second
-
-			_, err = wait.ForDaemonSetReady(fxt.Client, ds, dsRunningPollInterval, dsRunningTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Daemonset %q not up & running after %v", ds.Name, dsRunningTimeout)
+			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(1*time.Minute).ForDaemonSetReady(context.TODO(), ds)
+			Expect(err).NotTo(HaveOccurred(), "Daemonset %q not up & running after %v", ds.Name, 1*time.Minute)
 
 			By(fmt.Sprintf("checking Daemonset pods have been scheduled with the topology aware scheduler %q and in the proper node %q", serialconfig.Config.SchedulerName, targetNodeName))
 			pods, err := podlist.With(fxt.Client).ByDaemonset(context.TODO(), *ds)

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -475,7 +475,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(err).NotTo(HaveOccurred(), "Deployment %q not up & running after %v", deployment.Name, dpRunningTimeout)
 
 			By(fmt.Sprintf("checking deployment pods have been scheduled with the topology aware scheduler %q and in the proper node %q", serialconfig.Config.SchedulerName, targetNodeName))
-			pods, err := podlist.ByDeployment(fxt.Client, *deployment)
+			pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *deployment)
 			Expect(err).NotTo(HaveOccurred(), "Unable to get pods from Deployment %q: %v", deployment.Name, err)
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
 			for _, pod := range pods {
@@ -714,7 +714,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(err).NotTo(HaveOccurred(), "Daemonset %q not up & running after %v", ds.Name, dsRunningTimeout)
 
 			By(fmt.Sprintf("checking Daemonset pods have been scheduled with the topology aware scheduler %q and in the proper node %q", serialconfig.Config.SchedulerName, targetNodeName))
-			pods, err := podlist.ByDaemonset(fxt.Client, *ds)
+			pods, err := podlist.With(fxt.Client).ByDaemonset(context.TODO(), *ds)
 			Expect(err).NotTo(HaveOccurred(), "Unable to get pods from Daemonset %q: %v", ds.Name, err)
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DS %s/%s", ds.Namespace, ds.Name)
 			for _, pod := range pods {

--- a/test/e2e/serial/tests/scheduler_cache.go
+++ b/test/e2e/serial/tests/scheduler_cache.go
@@ -187,7 +187,7 @@ var _ = Describe("[serial][scheduler][cache][tier1] scheduler cache", Label("sch
 
 				// very generous timeout here. It's hard and racy to check we had 2 pods pending (expected phased scheduling),
 				// but that would be the most correct and stricter testing.
-				failedPods, updatedPods := wait.ForPodListAllRunning(fxt.Client, testPods, 180*time.Second)
+				failedPods, updatedPods := wait.With(fxt.Client).Timeout(3*time.Minute).ForPodListAllRunning(context.TODO(), testPods)
 				if len(failedPods) > 0 {
 					nrtListFailed, _ := e2enrt.GetUpdated(fxt.Client, nrtv1alpha2.NodeResourceTopologyList{}, time.Minute)
 					klog.Infof("%s", e2enrtint.ListToString(nrtListFailed.Items, "post failure"))
@@ -295,7 +295,7 @@ var _ = Describe("[serial][scheduler][cache][tier1] scheduler cache", Label("sch
 				// note the cleanup is done automatically once the ns on which we run is deleted - the fixture takes care
 
 				// even more generous timeout here. We need to tolerate more reconciliation time because of the interference
-				failedPods, updatedPods := wait.ForPodListAllRunning(fxt.Client, testPods, 300*time.Second)
+				failedPods, updatedPods := wait.With(fxt.Client).Timeout(5*time.Minute).ForPodListAllRunning(context.TODO(), testPods)
 				if len(failedPods) > 0 {
 					nrtListFailed, _ := e2enrt.GetUpdated(fxt.Client, nrtv1alpha2.NodeResourceTopologyList{}, time.Minute)
 					klog.Infof("%s", e2enrtint.ListToString(nrtListFailed.Items, "post failure"))
@@ -411,7 +411,7 @@ var _ = Describe("[serial][scheduler][cache][tier1] scheduler cache", Label("sch
 				// this is a slight abuse. We want to wait for hostsRequired < desiredPods to be running. Other pod(s) must be pending.
 				// So we wait a bit too much unnecessarily, but wetake this chance to ensure the pod(s) which are supposed to be pending
 				// stay pending at least up until timeout
-				failedPods, updatedPods := wait.ForPodListAllRunning(fxt.Client, testPods, 60*time.Second)
+				failedPods, updatedPods := wait.With(fxt.Client).Timeout(time.Minute).ForPodListAllRunning(context.TODO(), testPods)
 				Expect(len(updatedPods)).To(Equal(hostsRequired))
 				Expect(len(failedPods)).To(Equal(expectedPending))
 				Expect(len(updatedPods) + len(failedPods)).To(Equal(desiredPods))
@@ -532,7 +532,7 @@ var _ = Describe("[serial][scheduler][cache][tier1] scheduler cache", Label("sch
 				// this is a slight abuse. We want to wait for hostsRequired < desiredPods to be running. Other pod(s) must be pending.
 				// So we wait a bit too much unnecessarily, but wetake this chance to ensure the pod(s) which are supposed to be pending
 				// stay pending at least up until timeout
-				failedPods, updatedPods := wait.ForPodListAllRunning(fxt.Client, testPods, 60*time.Second)
+				failedPods, updatedPods := wait.With(fxt.Client).Timeout(time.Minute).ForPodListAllRunning(context.TODO(), testPods)
 				Expect(len(updatedPods)).To(Equal(hostsRequired))
 				Expect(len(failedPods)).To(Equal(expectedPending))
 
@@ -573,13 +573,13 @@ var _ = Describe("[serial][scheduler][cache][tier1] scheduler cache", Label("sch
 				err := fxt.Client.Delete(context.TODO(), targetPod)
 				Expect(err).ToNot(HaveOccurred())
 				// VERY generous timeout, we expect the delete to be much faster
-				err = wait.ForPodDeleted(fxt.Client, targetPod.Namespace, targetPod.Name, 300*time.Second)
+				err = wait.With(fxt.Client).Timeout(5*time.Minute).ForPodDeleted(context.TODO(), targetPod.Namespace, targetPod.Name)
 				Expect(err).ToNot(HaveOccurred())
 
 				// here we really need a quite long timeout. Still 300s is a bit of overshot (expected so).
 				// The reason to be supercareful here is the potentially long interplay between
 				// NRT updater, resync loop, scheduler retry loop.
-				failedPods, updatedPods = wait.ForPodListAllRunning(fxt.Client, expectedRunningPods, 300*time.Second)
+				failedPods, updatedPods = wait.With(fxt.Client).Timeout(5*time.Minute).ForPodListAllRunning(context.TODO(), expectedRunningPods)
 				Expect(len(updatedPods)).To(Equal(hostsRequired))
 				Expect(failedPods).To(BeEmpty())
 			})

--- a/test/e2e/serial/tests/scheduler_removal.go
+++ b/test/e2e/serial/tests/scheduler_removal.go
@@ -184,7 +184,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources scheduler restar
 			nrosched.CheckNROSchedulerAvailable(fxt.Client, nroSchedObj.Name)
 
 			By(fmt.Sprintf("waiting for the test deployment %q to become complete and ready", updatedDp.Name))
-			_, err = wait.ForDeploymentComplete(fxt.Client, updatedDp, 2*time.Second, 30*time.Second)
+			_, err = wait.With(fxt.Client).Interval(2*time.Second).Interval(30*time.Second).ForDeploymentComplete(context.TODO(), updatedDp)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
@@ -226,13 +226,10 @@ func createDeployment(fxt *e2efixture.Fixture, name, schedulerName string) *apps
 }
 
 func createDeploymentSync(fxt *e2efixture.Fixture, name, schedulerName string) *appsv1.Deployment {
-	dpRunningTimeout := time.Minute
-	dpRunningPollInterval := 10 * time.Second
 	dp := createDeployment(fxt, name, schedulerName)
 	By(fmt.Sprintf("waiting for the test deployment %q to be complete and ready", name))
-
-	_, err := wait.ForDeploymentComplete(fxt.Client, dp, dpRunningPollInterval, dpRunningTimeout)
-	Expect(err).ToNot(HaveOccurred(), "Deployment %q is not up & running after %v", dp.Name, dpRunningTimeout)
+	_, err := wait.With(fxt.Client).Interval(10*time.Second).Timeout(time.Minute).ForDeploymentComplete(context.TODO(), dp)
+	Expect(err).ToNot(HaveOccurred(), "Deployment %q is not up & running after %v", dp.Name, time.Minute)
 	return dp
 }
 

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -236,10 +236,8 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				Expect(err).NotTo(HaveOccurred(), "unable to create deployment %q", deployment.Name)
 
 				By("waiting for deployment to be up&running")
-				dpRunningTimeout := 2 * time.Minute
-				dpRunningPollInterval := 10 * time.Second
-				_, err = wait.ForDeploymentComplete(fxt.Client, deployment, dpRunningPollInterval, dpRunningTimeout)
-				Expect(err).NotTo(HaveOccurred(), "Deployment %q not up&running after %v", deployment.Name, dpRunningTimeout)
+				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(2*time.Minute).ForDeploymentComplete(context.TODO(), deployment)
+				Expect(err).NotTo(HaveOccurred(), "Deployment %q not up&running after %v", deployment.Name, 2*time.Minute)
 
 				nrtListPostCreate, err := e2enrt.GetUpdated(fxt.Client, nrtListInitial, 1*time.Minute)
 				Expect(err).ToNot(HaveOccurred())
@@ -423,7 +421,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				Expect(err).NotTo(HaveOccurred(), "unable to create deployment %q", deployment.Name)
 
 				By("wait for the deployment to be up with its pod created")
-				deployment, err = wait.ForDeploymentReplicasCreation(fxt.Client, deployment, replicas, time.Second, time.Minute)
+				deployment, err = wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDeploymentReplicasCreation(context.TODO(), deployment, replicas)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("check the deployment pod is still pending")
@@ -432,7 +430,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
 
 				for _, pod := range pods {
-					err = wait.WhileInPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodPending, 10*time.Second, 3)
+					err = wait.With(fxt.Client).Interval(10*time.Second).Steps(3).WhileInPodPhase(context.TODO(), pod.Namespace, pod.Name, corev1.PodPending)
 					if err != nil {
 						_ = objects.LogEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
 					}

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -245,7 +245,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				Expect(err).ToNot(HaveOccurred())
 
 				By(fmt.Sprintf("checking deployment pods have been scheduled with the topology aware scheduler %q and in the proper node %q", serialconfig.Config.SchedulerName, targetNodeName))
-				pods, err := podlist.ByDeployment(fxt.Client, *deployment)
+				pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *deployment)
 				Expect(err).NotTo(HaveOccurred(), "Unable to get pods from Deployment %q:  %v", deployment.Name, err)
 				Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
 
@@ -427,7 +427,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				Expect(err).NotTo(HaveOccurred())
 
 				By("check the deployment pod is still pending")
-				pods, err := podlist.ByDeployment(fxt.Client, *deployment)
+				pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *deployment)
 				Expect(err).NotTo(HaveOccurred(), "Unable to get pods from Deployment %q:  %v", deployment.Name, err)
 				Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
 

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -215,7 +215,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			err = fxt.Client.Create(context.TODO(), dp)
 			Expect(err).ToNot(HaveOccurred())
 
-			updatedDp, err := wait.ForDeploymentComplete(fxt.Client, dp, time.Second*10, time.Minute)
+			updatedDp, err := wait.With(fxt.Client).Interval(10*time.Second).Timeout(time.Minute).ForDeploymentComplete(context.TODO(), dp)
 			Expect(err).ToNot(HaveOccurred())
 
 			nrtPostCreateDeploymentList, err := e2enrt.GetUpdated(fxt.Client, nrtInitialList, time.Minute)
@@ -272,7 +272,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				return fxt.Client.Update(context.TODO(), updatedDp)
 			}).WithTimeout(2 * time.Minute).WithPolling(10 * time.Second).ShouldNot(HaveOccurred())
 
-			updatedDp, err = wait.ForDeploymentComplete(fxt.Client, dp, time.Second*10, time.Minute)
+			updatedDp, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(time.Minute).ForDeploymentComplete(context.TODO(), dp)
 			Expect(err).ToNot(HaveOccurred())
 
 			namespacedDpName := fmt.Sprintf("%s/%s", updatedDp.Namespace, updatedDp.Name)
@@ -364,7 +364,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				return fxt.Client.Update(context.TODO(), updatedDp)
 			}).WithTimeout(2 * time.Minute).WithPolling(10 * time.Second).ShouldNot(HaveOccurred())
 
-			updatedDp, err = wait.ForDeploymentComplete(fxt.Client, dp, time.Second*10, time.Minute)
+			updatedDp, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(time.Minute).ForDeploymentComplete(context.TODO(), dp)
 			Expect(err).ToNot(HaveOccurred())
 
 			namespacedDpName = fmt.Sprintf("%s/%s", updatedDp.Namespace, updatedDp.Name)
@@ -528,7 +528,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			// TODO: lacking better ways, let's monitor the pod "long enough" and let's check it stays Pending
 			// if it stays Pending "long enough" it still means little, but OTOH if it goes Running or Failed we
 			// can tell for sure something's wrong
-			err = wait.WhileInPodPhase(fxt.Client, pod2.Namespace, pod2.Name, corev1.PodPending, 10*time.Second, 3)
+			err = wait.With(fxt.Client).Interval(10*time.Second).Steps(3).WhileInPodPhase(context.TODO(), pod2.Namespace, pod2.Name, corev1.PodPending)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, pod2.Namespace, pod2.Name)
 			}
@@ -536,7 +536,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			By(fmt.Sprintf("Verify the first pod %s/%s scheduled with TAS scheduler is running", pod.Namespace, pod.Name))
 			// 3 minutes is plenty, should never timeout
-			updatedPod, err := wait.ForPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodRunning, 3*time.Minute)
+			updatedPod, err := wait.With(fxt.Client).Timeout(3*time.Minute).ForPodPhase(context.TODO(), pod.Namespace, pod.Name, corev1.PodRunning)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
 			}
@@ -576,7 +576,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			By(fmt.Sprintf("verify the pod %s/%s is removed", pod2.Namespace, pod2.Name))
-			err = wait.ForPodDeleted(fxt.Client, pod2.Namespace, pod2.Name, 3*time.Minute)
+			err = wait.With(fxt.Client).Timeout(3*time.Minute).ForPodDeleted(context.TODO(), pod2.Namespace, pod2.Name)
 			Expect(err).ToNot(HaveOccurred())
 
 			// the NRT updaters MAY be slow to react for a number of reasons including factors out of our control
@@ -602,7 +602,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			By(fmt.Sprintf("verify the pod %s/%s is removed", updatedPod.Namespace, updatedPod.Name))
-			err = wait.ForPodDeleted(fxt.Client, updatedPod.Namespace, updatedPod.Name, 3*time.Minute)
+			err = wait.With(fxt.Client).Timeout(3*time.Minute).ForPodDeleted(context.TODO(), updatedPod.Namespace, updatedPod.Name)
 			Expect(err).ToNot(HaveOccurred())
 
 			By(fmt.Sprintf("checking the resources are restored as expected on node %q after deleting the running pod %s/%s", updatedPod.Spec.NodeName, updatedPod.Namespace, updatedPod.Name))
@@ -735,7 +735,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			err = fxt.Client.Create(context.TODO(), dp)
 			Expect(err).ToNot(HaveOccurred())
 
-			updatedDp, err := wait.ForDeploymentComplete(fxt.Client, dp, time.Second*10, 2*time.Minute)
+			updatedDp, err := wait.With(fxt.Client).Interval(10*time.Second).Timeout(2*time.Minute).ForDeploymentComplete(context.TODO(), dp)
 			Expect(err).ToNot(HaveOccurred())
 
 			nrtPostCreateDeploymentList, err := e2enrt.GetUpdated(fxt.Client, nrtList, time.Minute)
@@ -793,7 +793,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				return fxt.Client.Update(context.TODO(), updatedDp)
 			}, 10*time.Second, 2*time.Minute).ShouldNot(HaveOccurred())
 
-			updatedDp, err = wait.ForDeploymentComplete(fxt.Client, dp, time.Second*10, time.Minute*2)
+			updatedDp, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(2*time.Minute).ForDeploymentComplete(context.TODO(), dp)
 			Expect(err).ToNot(HaveOccurred())
 
 			namespacedDpName := fmt.Sprintf("%s/%s", updatedDp.Namespace, updatedDp.Name)
@@ -964,7 +964,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			By("wait for replicaset to be up and running with all its replicas")
-			rs, err = wait.ForReplicasetComplete(fxt.Client, rs, time.Second, 2*time.Minute)
+			rs, err = wait.With(fxt.Client).Interval(time.Second).Timeout(2*time.Minute).ForReplicasetComplete(context.TODO(), rs)
 			Expect(err).ToNot(HaveOccurred())
 
 			namespacedRsName := client.ObjectKeyFromObject(rs)
@@ -1037,7 +1037,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			By("verify replicaset's pods are deleted")
 			for _, pod := range pods {
 				klog.Infof("waiting for pod %s/%s to get deleted", pod.Namespace, pod.Name)
-				err := wait.ForPodDeleted(fxt.Client, pod.Namespace, pod.Name, 2*time.Minute)
+				err := wait.With(fxt.Client).Timeout(2*time.Minute).ForPodDeleted(context.TODO(), pod.Namespace, pod.Name)
 				Expect(err).ToNot(HaveOccurred(), "pod %s/%s still exists", pod.Namespace, pod.Name)
 			}
 
@@ -1071,7 +1071,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			By("wait for replicaset to be up and running with all its replicas")
-			rs, err = wait.ForReplicasetComplete(fxt.Client, rs, time.Second, 2*time.Minute)
+			rs, err = wait.With(fxt.Client).Interval(time.Second).Timeout(2*time.Minute).ForReplicasetComplete(context.TODO(), rs)
 			Expect(err).ToNot(HaveOccurred())
 
 			namespacedRsName = client.ObjectKeyFromObject(rs)

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -221,7 +221,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			nrtPostCreateDeploymentList, err := e2enrt.GetUpdated(fxt.Client, nrtInitialList, time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 
-			pods, err := podlist.ByDeployment(fxt.Client, *updatedDp)
+			pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *updatedDp)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(pods)).To(Equal(1))
 
@@ -277,7 +277,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			namespacedDpName := fmt.Sprintf("%s/%s", updatedDp.Namespace, updatedDp.Name)
 			Eventually(func() bool {
-				pods, err = podlist.ByDeployment(fxt.Client, *updatedDp)
+				pods, err = podlist.With(fxt.Client).ByDeployment(context.TODO(), *updatedDp)
 				if err != nil {
 					klog.Warningf("failed to list the pods of deployment: %q error: %v", namespacedDpName, err)
 					return false
@@ -369,7 +369,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			namespacedDpName = fmt.Sprintf("%s/%s", updatedDp.Namespace, updatedDp.Name)
 			Eventually(func() bool {
-				pods, err = podlist.ByDeployment(fxt.Client, *updatedDp)
+				pods, err = podlist.With(fxt.Client).ByDeployment(context.TODO(), *updatedDp)
 				if err != nil {
 					klog.Warningf("failed to list the pods of deployment: %q error: %v", namespacedDpName, err)
 					return false
@@ -741,7 +741,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			nrtPostCreateDeploymentList, err := e2enrt.GetUpdated(fxt.Client, nrtList, time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 
-			pods, err := podlist.ByDeployment(fxt.Client, *updatedDp)
+			pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *updatedDp)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(pods)).To(Equal(2))
 
@@ -798,7 +798,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			namespacedDpName := fmt.Sprintf("%s/%s", updatedDp.Namespace, updatedDp.Name)
 			Eventually(func() bool {
-				pods, err = podlist.ByDeployment(fxt.Client, *updatedDp)
+				pods, err = podlist.With(fxt.Client).ByDeployment(context.TODO(), *updatedDp)
 				if err != nil {
 					klog.Warningf("failed to list the pods of deployment: %q error: %v", namespacedDpName, err)
 					return false
@@ -973,7 +973,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			var pods []corev1.Pod
 			Eventually(func() bool {
-				pods, err = podlist.ByReplicaSet(fxt.Client, *rs)
+				pods, err = podlist.With(fxt.Client).ByReplicaSet(context.TODO(), *rs)
 				if err != nil {
 					klog.Warningf("failed to list the pods of replicaset: %q error: %v", namespacedRsName.String(), err)
 					return false
@@ -1079,7 +1079,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() bool {
-				pods, err = podlist.ByReplicaSet(fxt.Client, *rs)
+				pods, err = podlist.With(fxt.Client).ByReplicaSet(context.TODO(), *rs)
 				if err != nil {
 					klog.Warningf("failed to list the pods of replicaset: %q error: %v", namespacedRsName.String(), err)
 					return false
@@ -1390,12 +1390,12 @@ func logSchedulerPluginLogs(fxt e2efixture.Fixture) {
 		klog.Warningf("error getting the scheduler plugin CR: %v", err)
 		return
 	}
-	schedDp, err := podlist.GetDeploymentByOwnerReference(fxt.Client, nroSchedObj.GetUID())
+	schedDp, err := podlist.With(fxt.Client).DeploymentByOwnerReference(context.TODO(), nroSchedObj.GetUID())
 	if err != nil {
 		klog.Warningf("error getting the scheduler deployment: %v", err)
 		return
 	}
-	schedPods, err := podlist.ByDeployment(fxt.Client, *schedDp)
+	schedPods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *schedDp)
 	if err != nil {
 		klog.Warningf("error getting the scheduler pod: %v", err)
 		return

--- a/test/e2e/serial/tests/workload_placement_nodelabel.go
+++ b/test/e2e/serial/tests/workload_placement_nodelabel.go
@@ -216,7 +216,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).NotTo(HaveOccurred(), "unable to create pod %q", pod.Name)
 
 			By("waiting for pod to be running")
-			updatedPod, err := wait.ForPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodRunning, 1*time.Minute)
+			updatedPod, err := wait.With(fxt.Client).Timeout(time.Minute).ForPodPhase(context.TODO(), pod.Namespace, pod.Name, corev1.PodRunning)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
 			}
@@ -296,10 +296,8 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 					Expect(err).NotTo(HaveOccurred(), "unable to create deployment %q", deployment.Name)
 
 					By("waiting for deployment to be up & running")
-					dpRunningTimeout := 2 * time.Minute
-					dpRunningPollInterval := 10 * time.Second
-					_, err = wait.ForDeploymentComplete(fxt.Client, deployment, dpRunningPollInterval, dpRunningTimeout)
-					Expect(err).NotTo(HaveOccurred(), "Deployment %q not up & running after %v", deployment.Name, dpRunningTimeout)
+					_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(2*time.Minute).ForDeploymentComplete(context.TODO(), deployment)
+					Expect(err).NotTo(HaveOccurred(), "Deployment %q not up & running after %v", deployment.Name, 2*time.Minute)
 
 					By(fmt.Sprintf("checking deployment pods have been scheduled with the topology aware scheduler %q and in the proper node %q", serialconfig.Config.SchedulerName, targetNodeName))
 					pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *deployment)

--- a/test/e2e/serial/tests/workload_placement_nodelabel.go
+++ b/test/e2e/serial/tests/workload_placement_nodelabel.go
@@ -302,7 +302,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 					Expect(err).NotTo(HaveOccurred(), "Deployment %q not up & running after %v", deployment.Name, dpRunningTimeout)
 
 					By(fmt.Sprintf("checking deployment pods have been scheduled with the topology aware scheduler %q and in the proper node %q", serialconfig.Config.SchedulerName, targetNodeName))
-					pods, err := podlist.ByDeployment(fxt.Client, *deployment)
+					pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *deployment)
 					Expect(err).NotTo(HaveOccurred(), "Unable to get pods from Deployment %q: %v", deployment.Name, err)
 					Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
 					for _, pod := range pods {

--- a/test/e2e/serial/tests/workload_placement_resources.go
+++ b/test/e2e/serial/tests/workload_placement_resources.go
@@ -107,12 +107,11 @@ var _ = Describe("[serial][disruptive][scheduler][byres] numaresources workload 
 				Expect(err).NotTo(HaveOccurred(), "unable to create pod %q", pod.Name)
 
 				By("waiting for pod to be up and running")
-				podRunningTimeout := 1 * time.Minute
-				updatedPod, err := wait.ForPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodRunning, podRunningTimeout)
+				updatedPod, err := wait.With(fxt.Client).Timeout(time.Minute).ForPodPhase(context.TODO(), pod.Namespace, pod.Name, corev1.PodRunning)
 				if err != nil {
 					_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
 				}
-				Expect(err).NotTo(HaveOccurred(), "Pod %q not up&running after %v", pod.Name, podRunningTimeout)
+				Expect(err).NotTo(HaveOccurred(), "Pod %q not up&running after %v", pod.Name, time.Minute)
 
 				By("checking the pod has been scheduled in the proper node")
 				Expect(updatedPod.Spec.NodeName).To(Equal(targetNodeName))

--- a/test/e2e/serial/tests/workload_placement_taint.go
+++ b/test/e2e/serial/tests/workload_placement_taint.go
@@ -212,7 +212,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			err = fxt.Client.Create(context.TODO(), testPod)
 			Expect(err).ToNot(HaveOccurred())
 
-			updatedPod, err := wait.ForPodPhase(fxt.Client, testPod.Namespace, testPod.Name, corev1.PodRunning, timeout)
+			updatedPod, err := wait.With(fxt.Client).Timeout(timeout).ForPodPhase(context.TODO(), testPod.Namespace, testPod.Name, corev1.PodRunning)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
 			}
@@ -255,7 +255,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}
 
 			By("checking the test pod is removed")
-			err = wait.ForPodDeleted(fxt.Client, updatedPod.Namespace, testPod.Name, 3*time.Minute)
+			err = wait.With(fxt.Client).Timeout(3*time.Minute).ForPodDeleted(context.TODO(), updatedPod.Namespace, testPod.Name)
 			Expect(err).ToNot(HaveOccurred())
 
 			// the NRT updaters MAY be slow to react for a number of reasons including factors out of our control

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -307,7 +307,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				Expect(err).NotTo(HaveOccurred(), "Deployment %q not up & running after %v", deployment.Name, dpRunningTimeout)
 
 				By(fmt.Sprintf("checking deployment pods have been scheduled with the topology aware scheduler %q and in the proper node %q", serialconfig.Config.SchedulerName, targetNodeName))
-				pods, err := podlist.ByDeployment(fxt.Client, *deployment)
+				pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *deployment)
 				Expect(err).NotTo(HaveOccurred(), "Unable to get pods from Deployment %q:  %v", deployment.Name, err)
 				Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
 

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -189,12 +189,11 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				Expect(err).NotTo(HaveOccurred(), "unable to create pod %q", pod.Name)
 
 				By("waiting for pod to be up & running")
-				podRunningTimeout := 1 * time.Minute
-				updatedPod, err := wait.ForPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodRunning, podRunningTimeout)
+				updatedPod, err := wait.With(fxt.Client).Timeout(time.Minute).ForPodPhase(context.TODO(), pod.Namespace, pod.Name, corev1.PodRunning)
 				if err != nil {
 					_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
 				}
-				Expect(err).NotTo(HaveOccurred(), "Pod %q not up & running after %v", pod.Name, podRunningTimeout)
+				Expect(err).NotTo(HaveOccurred(), "Pod %q not up & running after %v", pod.Name, time.Minute)
 
 				By("checking the pod has been scheduled in the proper node")
 				Expect(updatedPod.Spec.NodeName).To(Equal(targetNodeName))
@@ -301,10 +300,8 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				Expect(err).NotTo(HaveOccurred(), "unable to create deployment %q", deployment.Name)
 
 				By("waiting for deployment to be up & running")
-				dpRunningTimeout := 1 * time.Minute
-				dpRunningPollInterval := 10 * time.Second
-				_, err = wait.ForDeploymentComplete(fxt.Client, deployment, dpRunningPollInterval, dpRunningTimeout)
-				Expect(err).NotTo(HaveOccurred(), "Deployment %q not up & running after %v", deployment.Name, dpRunningTimeout)
+				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(time.Minute).ForDeploymentComplete(context.TODO(), deployment)
+				Expect(err).NotTo(HaveOccurred(), "Deployment %q not up & running after %v", deployment.Name, time.Minute)
 
 				By(fmt.Sprintf("checking deployment pods have been scheduled with the topology aware scheduler %q and in the proper node %q", serialconfig.Config.SchedulerName, targetNodeName))
 				pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *deployment)
@@ -480,7 +477,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			By("waiting for the pod to be scheduled")
-			updatedPod, err := wait.ForPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodRunning, 2*time.Minute)
+			updatedPod, err := wait.With(fxt.Client).Timeout(2*time.Minute).ForPodPhase(context.TODO(), pod.Namespace, pod.Name, corev1.PodRunning)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
 				dumpNRTForNode(fxt.Client, targetNodeName, "target")
@@ -519,7 +516,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			By("checking the test pod is removed")
-			err = wait.ForPodDeleted(fxt.Client, updatedPod.Namespace, updatedPod.Name, 3*time.Minute)
+			err = wait.With(fxt.Client).Timeout(3*time.Minute).ForPodDeleted(context.TODO(), updatedPod.Namespace, updatedPod.Name)
 			Expect(err).ToNot(HaveOccurred())
 
 			// the NRT updaters MAY be slow to react for a number of reasons including factors out of our control
@@ -1398,7 +1395,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			By("verify the pod keep on pending")
-			err = wait.WhileInPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodPending, 10*time.Second, 5)
+			err = wait.With(fxt.Client).Interval(10*time.Second).Steps(5).WhileInPodPhase(context.TODO(), pod.Namespace, pod.Name, corev1.PodPending)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
 				dumpNRTForNode(fxt.Client, targetNodeName, "target")
@@ -1433,7 +1430,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			By("checking the test pod is removed")
-			err = wait.ForPodDeleted(fxt.Client, updatedPod.Namespace, updatedPod.Name, 3*time.Minute)
+			err = wait.With(fxt.Client).Timeout(3*time.Minute).ForPodDeleted(context.TODO(), updatedPod.Namespace, updatedPod.Name)
 			Expect(err).ToNot(HaveOccurred())
 
 			// we don't need to wait for NRT update since we already checked it hasn't changed in prior step

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -203,7 +203,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			err := fxt.Client.Create(context.TODO(), pod)
 			Expect(err).NotTo(HaveOccurred(), "unable to create pod %q", pod.Name)
 
-			err = wait.WhileInPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodPending, 10*time.Second, 3)
+			err = wait.With(fxt.Client).Interval(10*time.Second).Steps(3).WhileInPodPhase(context.TODO(), pod.Namespace, pod.Name, corev1.PodPending)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
 			}
@@ -233,7 +233,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(err).NotTo(HaveOccurred(), "unable to create deployment %q", deployment.Name)
 
 			By("wait for the deployment to be up with its pod created")
-			deployment, err = wait.ForDeploymentReplicasCreation(fxt.Client, deployment, replicas, time.Second, time.Minute)
+			deployment, err = wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDeploymentReplicasCreation(context.TODO(), deployment, replicas)
 			Expect(err).NotTo(HaveOccurred())
 
 			By(fmt.Sprintf("checking deployment pods have been handled by the topology aware scheduler %q but failed to be scheduled on any node", serialconfig.Config.SchedulerName))
@@ -270,7 +270,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(err).NotTo(HaveOccurred(), "unable to create daemonset %q", ds.Name)
 
 			By("wait for the daemonset to be up with its pods created")
-			ds, err = wait.ForDaemonsetPodsCreation(fxt.Client, ds, len(nrtCandidates), time.Second, time.Minute)
+			ds, err = wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDaemonsetPodsCreation(context.TODO(), ds, len(nrtCandidates))
 			Expect(err).NotTo(HaveOccurred())
 
 			By(fmt.Sprintf("checking daemonset pods have been handled by the topology aware scheduler %q but failed to be scheduled on any node", serialconfig.Config.SchedulerName))
@@ -307,7 +307,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(err).NotTo(HaveOccurred(), "unable to create deployment %q", deployment.Name)
 
 			By("wait for the deployment to be up with its pod created")
-			deployment, err = wait.ForDeploymentReplicasCreation(fxt.Client, deployment, replicas, time.Second, time.Minute)
+			deployment, err = wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDeploymentReplicasCreation(context.TODO(), deployment, replicas)
 			Expect(err).NotTo(HaveOccurred())
 
 			By(fmt.Sprintf("checking deployment pods have been handled by the default scheduler %q but failed to be scheduled", corev1.DefaultSchedulerName))
@@ -412,7 +412,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(err).NotTo(HaveOccurred(), "unable to create daemonset %q", ds.Name)
 
 			By("wait for the daemonset to be up with its pods created")
-			ds, err = wait.ForDaemonsetPodsCreation(fxt.Client, ds, len(nrtCandidates), time.Second, time.Minute)
+			ds, err = wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDaemonsetPodsCreation(context.TODO(), ds, len(nrtCandidates))
 			Expect(err).NotTo(HaveOccurred())
 
 			By(fmt.Sprintf("checking daemonset pods have been scheduled with the topology aware scheduler %q ", serialconfig.Config.SchedulerName))
@@ -431,7 +431,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 					Expect(err).ToNot(HaveOccurred())
 					Expect(scheduledWithTAS).To(BeTrue(), "pod %s/%s was NOT scheduled with  %s", pod.Namespace, pod.Name, serialconfig.Config.SchedulerName)
 
-					_, err = wait.ForPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodRunning, podRunningTimeout)
+					_, err = wait.With(fxt.Client).Timeout(podRunningTimeout).ForPodPhase(context.TODO(), pod.Namespace, pod.Name, corev1.PodRunning)
 					Expect(err).ToNot(HaveOccurred(), "unable to get pod %s/%s to be Running after %v", pod.Namespace, pod.Name, podRunningTimeout)
 
 				} else {
@@ -597,7 +597,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 
 			interval := 10 * time.Second
 			By(fmt.Sprintf("Checking pod %q keeps in %q state for at least %v seconds ...", pod.Name, string(corev1.PodPending), interval*3))
-			err = wait.WhileInPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodPending, interval, 3)
+			err = wait.With(fxt.Client).Interval(interval).Steps(3).WhileInPodPhase(context.TODO(), pod.Namespace, pod.Name, corev1.PodPending)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
 			}
@@ -695,7 +695,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			// although the deployment pods will be pending thus the deployment will not be counted as complete,
 			// we need to wait until all the replicas are created despite their status before moving forward with the checks
 			By("wait for the deployment to be up with its pod created")
-			dp, err = wait.ForDeploymentReplicasCreation(fxt.Client, dp, replicas, time.Second, time.Minute)
+			dp, err = wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDeploymentReplicasCreation(context.TODO(), dp, replicas)
 			Expect(err).NotTo(HaveOccurred())
 
 			By(fmt.Sprintf("checking deployment pods failed to be scheduled by %q ", schedulerName))
@@ -904,7 +904,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(err).NotTo(HaveOccurred(), "unable to create pod %q", pod.Name)
 
 			By("check the pod is still pending")
-			err = wait.WhileInPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodPending, 10*time.Second, 3)
+			err = wait.With(fxt.Client).Interval(10*time.Second).Steps(3).WhileInPodPhase(context.TODO(), pod.Namespace, pod.Name, corev1.PodPending)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
 			}
@@ -929,7 +929,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(err).NotTo(HaveOccurred(), "unable to create deployment %q", deployment.Name)
 
 			By("wait for the deployment to be up with its pod created")
-			deployment, err = wait.ForDeploymentReplicasCreation(fxt.Client, deployment, replicas, time.Second, time.Minute)
+			deployment, err = wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDeploymentReplicasCreation(context.TODO(), deployment, replicas)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("check the deployment pod is still pending")
@@ -938,7 +938,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
 
 			for _, pod := range pods {
-				err = wait.WhileInPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodPending, 10*time.Second, 3)
+				err = wait.With(fxt.Client).Interval(10*time.Second).Steps(3).WhileInPodPhase(context.TODO(), pod.Namespace, pod.Name, corev1.PodPending)
 				if err != nil {
 					_ = objects.LogEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
 				}
@@ -965,7 +965,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(err).NotTo(HaveOccurred(), "unable to create daemonset %q", ds.Name)
 
 			By("wait for the daemonset to be up with its pods created")
-			ds, err = wait.ForDaemonsetPodsCreation(fxt.Client, ds, len(nrtCandidates), time.Second, time.Minute)
+			ds, err = wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDaemonsetPodsCreation(context.TODO(), ds, len(nrtCandidates))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("check the daemonset pods are still pending")
@@ -974,7 +974,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DS %s/%s", ds.Namespace, ds.Name)
 
 			for _, pod := range pods {
-				err = wait.WhileInPodPhase(fxt.Client, pod.Namespace, pod.Name, corev1.PodPending, 10*time.Second, 3)
+				err = wait.With(fxt.Client).Interval(10*time.Second).Steps(3).WhileInPodPhase(context.TODO(), pod.Namespace, pod.Name, corev1.PodPending)
 				if err != nil {
 					_ = objects.LogEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
 				}

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -237,7 +237,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(err).NotTo(HaveOccurred())
 
 			By(fmt.Sprintf("checking deployment pods have been handled by the topology aware scheduler %q but failed to be scheduled on any node", serialconfig.Config.SchedulerName))
-			pods, err := podlist.ByDeployment(fxt.Client, *deployment)
+			pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *deployment)
 			Expect(err).ToNot(HaveOccurred(), "Unable to get pods from Deployment %q:  %v", deployment.Name, err)
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
 
@@ -274,7 +274,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(err).NotTo(HaveOccurred())
 
 			By(fmt.Sprintf("checking daemonset pods have been handled by the topology aware scheduler %q but failed to be scheduled on any node", serialconfig.Config.SchedulerName))
-			pods, err := podlist.ByDaemonset(fxt.Client, *ds)
+			pods, err := podlist.With(fxt.Client).ByDaemonset(context.TODO(), *ds)
 			Expect(err).ToNot(HaveOccurred(), "Unable to get pods from daemonset %q:  %v", ds.Name, err)
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DS %s/%s", ds.Namespace, ds.Name)
 
@@ -311,7 +311,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(err).NotTo(HaveOccurred())
 
 			By(fmt.Sprintf("checking deployment pods have been handled by the default scheduler %q but failed to be scheduled", corev1.DefaultSchedulerName))
-			pods, err := podlist.ByDeployment(fxt.Client, *deployment)
+			pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *deployment)
 			Expect(err).ToNot(HaveOccurred(), "Unable to get pods from Deployment %q:  %v", deployment.Name, err)
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
 
@@ -416,7 +416,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(err).NotTo(HaveOccurred())
 
 			By(fmt.Sprintf("checking daemonset pods have been scheduled with the topology aware scheduler %q ", serialconfig.Config.SchedulerName))
-			pods, err := podlist.ByDaemonset(fxt.Client, *ds)
+			pods, err := podlist.With(fxt.Client).ByDaemonset(context.TODO(), *ds)
 			Expect(err).ToNot(HaveOccurred(), "Unable to get pods from daemonset %q:  %v", ds.Name, err)
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DS %s/%s", ds.Namespace, ds.Name)
 
@@ -699,7 +699,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(err).NotTo(HaveOccurred())
 
 			By(fmt.Sprintf("checking deployment pods failed to be scheduled by %q ", schedulerName))
-			pods, err := podlist.ByDeployment(fxt.Client, *dp)
+			pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *dp)
 			Expect(err).ToNot(HaveOccurred(), "unable to get pods from deployment %q:  %v", dp.Name, err)
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", dp.Namespace, dp.Name)
 
@@ -933,7 +933,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(err).NotTo(HaveOccurred())
 
 			By("check the deployment pod is still pending")
-			pods, err := podlist.ByDeployment(fxt.Client, *deployment)
+			pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *deployment)
 			Expect(err).NotTo(HaveOccurred(), "Unable to get pods from Deployment %q:  %v", deployment.Name, err)
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
 
@@ -969,7 +969,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(err).NotTo(HaveOccurred())
 
 			By("check the daemonset pods are still pending")
-			pods, err := podlist.ByDaemonset(fxt.Client, *ds)
+			pods, err := podlist.With(fxt.Client).ByDaemonset(context.TODO(), *ds)
 			Expect(err).ToNot(HaveOccurred(), "Unable to get pods from daemonset %q:  %v", ds.Name, err)
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DS %s/%s", ds.Namespace, ds.Name)
 

--- a/test/utils/deploy/deploy.go
+++ b/test/utils/deploy/deploy.go
@@ -117,7 +117,7 @@ func TeardownDeployment(nrod NroDeployment, timeout time.Duration) {
 			defer GinkgoRecover()
 			defer wg.Done()
 			klog.Infof("waiting for MCP %q to be gone", mcpObj.Name)
-			err := wait.ForMachineConfigPoolDeleted(e2eclient.Client, mcpObj, 10*time.Second, timeout)
+			err := wait.With(e2eclient.Client).Interval(10*time.Second).Timeout(timeout).ForMachineConfigPoolDeleted(context.TODO(), mcpObj)
 			ExpectWithOffset(1, err).ToNot(HaveOccurred(), "MCP %q failed to be deleted", mcpObj.Name)
 		}(nrod.McpObj)
 	}
@@ -131,7 +131,7 @@ func TeardownDeployment(nrod NroDeployment, timeout time.Duration) {
 			defer GinkgoRecover()
 			defer wg.Done()
 			klog.Infof("waiting for KC %q to be gone", kcObj.Name)
-			err := wait.ForKubeletConfigDeleted(e2eclient.Client, kcObj, 10*time.Second, timeout)
+			err := wait.With(e2eclient.Client).Interval(10*time.Second).Timeout(timeout).ForKubeletConfigDeleted(context.TODO(), kcObj)
 			ExpectWithOffset(1, err).ToNot(HaveOccurred(), "KC %q failed to be deleted", kcObj.Name)
 		}(nrod.KcObj)
 	}
@@ -143,7 +143,7 @@ func TeardownDeployment(nrod NroDeployment, timeout time.Duration) {
 		defer GinkgoRecover()
 		defer wg.Done()
 		klog.Infof("waiting for NROP %q to be gone", nropObj.Name)
-		err := wait.ForNUMAResourcesOperatorDeleted(e2eclient.Client, nropObj, 10*time.Second, timeout)
+		err := wait.With(e2eclient.Client).Interval(10*time.Second).Timeout(timeout).ForNUMAResourcesOperatorDeleted(context.TODO(), nropObj)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred(), "NROP %q failed to be deleted", nropObj.Name)
 	}(nrod.NroObj)
 
@@ -259,7 +259,7 @@ func TeardownNROScheduler(nroSched *nropv1.NUMAResourcesScheduler, timeout time.
 		err := e2eclient.Client.Delete(context.TODO(), nroSched)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
-		err = wait.ForNUMAResourcesSchedulerDeleted(e2eclient.Client, nroSched, 10*time.Second, timeout)
+		err = wait.With(e2eclient.Client).Interval(10*time.Second).Timeout(timeout).ForNUMAResourcesSchedulerDeleted(context.TODO(), nroSched)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred(), "NROScheduler %q failed to be deleted", nroSched.Name)
 	}
 }

--- a/test/utils/fixture/wait.go
+++ b/test/utils/fixture/wait.go
@@ -17,6 +17,7 @@
 package fixture
 
 import (
+	"context"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -32,7 +33,7 @@ import (
 // WaitPodsRunning waits for all padding pods to be up and running ( or fail)
 func WaitForPaddingPodsRunning(fxt *Fixture, paddingPods []*corev1.Pod) []string {
 	var failedPodIds []string
-	failedPods, _ := wait.ForPodListAllRunning(fxt.Client, paddingPods, wait.DefaultPodRunningTimeout)
+	failedPods, _ := wait.With(fxt.Client).ForPodListAllRunning(context.TODO(), paddingPods)
 	for _, failedPod := range failedPods {
 		_ = objects.LogEventsForPod(fxt.K8sClient, failedPod.Namespace, failedPod.Name)
 		//note that this test does not use podOverhead thus pod req and lim would be the pod's resources as set upon creating

--- a/test/utils/padder/padder.go
+++ b/test/utils/padder/padder.go
@@ -201,7 +201,7 @@ func (p *Padder) Pad(timeout time.Duration, options PaddingOptions) error {
 		}
 	}
 
-	if failedPods, _ := wait.ForPodListAllRunning(p.Client, pods, wait.DefaultPodRunningTimeout); len(failedPods) > 0 {
+	if failedPods, _ := wait.With(p.Client).ForPodListAllRunning(context.TODO(), pods); len(failedPods) > 0 {
 		var asStrings []string
 		for _, pod := range failedPods {
 			asStrings = append(asStrings, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))
@@ -258,7 +258,7 @@ func (p *Padder) Clean() error {
 			defer wg.Done()
 
 			klog.Infof("waiting for pod %q to get deleted", pod.Name)
-			if err := wait.ForPodDeleted(p.Client, p.namespace, pod.Name, time.Minute); err != nil {
+			if err := wait.With(p.Client).Timeout(time.Minute).ForPodDeleted(context.TODO(), p.namespace, pod.Name); err != nil {
 				errLock.Lock()
 				deletionErrors = append(deletionErrors, err.Error())
 				errLock.Unlock()


### PR DESCRIPTION
Our library code, either for internal or for public use, should never hardcode a `context.TODO()`, which is meant
as placeholder and prevents cancelation propagation.
So add explicit context argument to our library functions
