### PR TITLE
validator: podstatus: use AreaKubelet

### DIFF
--- a/pkg/validator/podstatus.go
+++ b/pkg/validator/podstatus.go
@@ -67,7 +67,7 @@ func ValidatePodStatus(data ValidatorData) ([]deployervalidator.ValidationResult
 	for nodeName, pods := range data.nonRunningPodsByNode {
 		for nname, phase := range pods {
 			ret = append(ret, deployervalidator.ValidationResult{
-				Area:      deployervalidator.AreaCluster,
+				Area:      deployervalidator.AreaKubelet, // TODO use AreaNode when available
 				Component: "pod",
 				Node:      nodeName,
 				Setting:   nname,


### PR DESCRIPTION
In order to make the output clearer and easier to consume, account the non-running pod in the AreaKubelet.
These are node-local issues, not cluster-wide issues.