### PR TITLE
serial(v1beta1): set expected scheduler to empty for default sched

### DIFF
--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -988,7 +988,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			By(fmt.Sprintf("checking the pods were scheduled with scheduler %q", corev1.DefaultSchedulerName))
 			for _, pod := range pods {
-				schedOK, err := nrosched.CheckPODWasScheduledWith(fxt.K8sClient, pod.Namespace, pod.Name, corev1.DefaultSchedulerName)
+				// starting v1beta1, if a pod is scheduled by the default scheduler, the ReportingController is left empty (unset)
+				// thus we pass an empty string as the expected scheduler that took charge of scheduling the workload.
+				schedOK, err := nrosched.CheckPODWasScheduledWith(fxt.K8sClient, pod.Namespace, pod.Name, "")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", pod.Namespace, pod.Name, corev1.DefaultSchedulerName)
 


### PR DESCRIPTION
A test that verifies that a pod scheduled with default scheduler failed because the expected Event.ReportingController is not "default-scheduler". Looking into the issue, it turned out that Event.ReportingController is set only if the scheduler is non-default starting v1beta1, if it is default the field is left empty.

Adopt this update in the test and pass an empty value as the expected scheduler.