### PR TITLE
rte: enable PFP computation considering only pods with exclusive resources assigned

### DIFF
--- a/api/numaresourcesoperator/v1/numaresourcesoperator_defaults.go
+++ b/api/numaresourcesoperator/v1/numaresourcesoperator_defaults.go
@@ -41,7 +41,7 @@ func (ngc *NodeGroupConfig) Default() {
 }
 
 func defaultPodsFingerprinting() *PodsFingerprintingMode {
-	podsFp := PodsFingerprintingEnabled
+	podsFp := PodsFingerprintingEnabledExclusiveResources
 	return &podsFp
 }
 

--- a/api/numaresourcesoperator/v1/numaresourcesoperator_defaults_test.go
+++ b/api/numaresourcesoperator/v1/numaresourcesoperator_defaults_test.go
@@ -66,7 +66,7 @@ func TestNodeGroupConfigDefaultMethod(t *testing.T) {
 }
 
 func TestNodeGroupConfigDefault(t *testing.T) {
-	podsFp := PodsFingerprintingEnabled
+	podsFp := PodsFingerprintingEnabledExclusiveResources
 	refMode := InfoRefreshPeriodicAndEvents
 	period := metav1.Duration{
 		Duration: 10 * time.Second,

--- a/api/numaresourcesoperator/v1/numaresourcesoperator_normalize_test.go
+++ b/api/numaresourcesoperator/v1/numaresourcesoperator_normalize_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestNodeGroupConfigMerge(t *testing.T) {
-	podsFp := PodsFingerprintingEnabled
+	podsFp := PodsFingerprintingEnabledExclusiveResources
 	refMode := InfoRefreshPeriodicAndEvents
 
 	type testCase struct {

--- a/api/numaresourcesoperator/v1/numaresourcesoperator_types.go
+++ b/api/numaresourcesoperator/v1/numaresourcesoperator_types.go
@@ -43,15 +43,18 @@ type NUMAResourcesOperatorSpec struct {
 	PodExcludes []NamespacedName `json:"podExcludes,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=Enabled;Disabled
+// +kubebuilder:validation:Enum=Disabled;Enabled;EnabledExclusiveResources
 type PodsFingerprintingMode string
 
 var (
-	// PodsFingerprintingEnabled is the default.
+	// PodsFingerprintingDisabled disables the pod fingerprinting reporting.
+	PodsFingerprintingDisabled PodsFingerprintingMode = "Disabled"
+
+	// PodsFingerprintingEnabled enables the pod fingerprint considering all the pods running on nodes. It is the default.
 	PodsFingerprintingEnabled PodsFingerprintingMode = "Enabled"
 
-	// PodsFingerprintingDisabled is ...
-	PodsFingerprintingDisabled PodsFingerprintingMode = "Disabled"
+	// PodsFingerprintingEnabledExclusiveResources enables the pod fingerprint considering only pods which have exclusive resources assigned.
+	PodsFingerprintingEnabledExclusiveResources PodsFingerprintingMode = "EnabledExclusiveResources"
 )
 
 // +kubebuilder:validation:Enum=Periodic;Events;PeriodicAndEvents

--- a/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_conversion.go
+++ b/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_conversion.go
@@ -199,6 +199,8 @@ func convertNodeGroupConfigV1ToV1Alpha1(src nropv1.NodeGroupConfig) *NodeGroupCo
 	dst := NodeGroupConfig{}
 	if src.PodsFingerprinting != nil {
 		switch *src.PodsFingerprinting {
+		case nropv1.PodsFingerprintingEnabledExclusiveResources:
+			fallthrough
 		case nropv1.PodsFingerprintingEnabled:
 			dst.PodsFingerprinting = ptrToPodsFingerPrintEnabledV1Alpha1(PodsFingerprintingEnabled)
 		case nropv1.PodsFingerprintingDisabled:

--- a/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_types.go
+++ b/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_types.go
@@ -47,11 +47,11 @@ type NUMAResourcesOperatorSpec struct {
 type PodsFingerprintingMode string
 
 var (
-	// PodsFingerprintingEnabled is the default.
-	PodsFingerprintingEnabled PodsFingerprintingMode = "Enabled"
-
-	// PodsFingerprintingDisabled is ...
+	// PodsFingerprintingDisabled disables the pod fingerprinting reporting.
 	PodsFingerprintingDisabled PodsFingerprintingMode = "Disabled"
+
+	// PodsFingerprintingEnabled enables the pod fingerprint considering all the pods running on nodes. It is the default.
+	PodsFingerprintingEnabled PodsFingerprintingMode = "Enabled"
 )
 
 // +kubebuilder:validation:Enum=Periodic;Events;PeriodicAndEvents

--- a/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -78,8 +78,9 @@ spec:
                             should be reported for the machines belonging to this
                             group
                           enum:
-                          - Enabled
                           - Disabled
+                          - Enabled
+                          - EnabledExclusiveResources
                           type: string
                       type: object
                     machineConfigPoolSelector:
@@ -294,8 +295,9 @@ spec:
                             should be reported for the machines belonging to this
                             group
                           enum:
-                          - Enabled
                           - Disabled
+                          - Enabled
+                          - EnabledExclusiveResources
                           type: string
                       type: object
                     name:

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -79,8 +79,9 @@ spec:
                             should be reported for the machines belonging to this
                             group
                           enum:
-                          - Enabled
                           - Disabled
+                          - Enabled
+                          - EnabledExclusiveResources
                           type: string
                       type: object
                     machineConfigPoolSelector:
@@ -295,8 +296,9 @@ spec:
                             should be reported for the machines belonging to this
                             group
                           enum:
-                          - Enabled
                           - Disabled
+                          - Enabled
+                          - EnabledExclusiveResources
                           type: string
                       type: object
                     name:

--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -207,7 +207,8 @@ func isPodFingerprintEnabled(conf *nropv1.NodeGroupConfig) bool {
 		// not specified -> use defaults
 		conf = &cfg
 	}
-	return *conf.PodsFingerprinting == nropv1.PodsFingerprintingEnabled
+	return (*conf.PodsFingerprinting == nropv1.PodsFingerprintingEnabled ||
+		*conf.PodsFingerprinting == nropv1.PodsFingerprintingEnabledExclusiveResources)
 }
 
 func isNotifyFileEnabled(conf *nropv1.NodeGroupConfig) bool {

--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -19,6 +19,7 @@ package rte
 import (
 	"fmt"
 	"path/filepath"
+	"strconv"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -146,11 +147,12 @@ func DaemonSetArgs(ds *appsv1.DaemonSet, conf nropv1.NodeGroupConfig) error {
 		flags.SetOption("--sleep-interval", refreshPeriod)
 	}
 
-	pfpEnabled := isPodFingerprintEnabled(&conf)
+	pfpEnabled, pfpRestricted := isPodFingerprintEnabled(&conf)
 	klog.V(2).InfoS("DaemonSet update: pod fingerprinting status", "daemonset", ds.Name, "enabled", pfpEnabled)
 	if pfpEnabled {
 		flags.SetToggle("--pods-fingerprint")
 		flags.SetOption("--pods-fingerprint-status-file", filepath.Join(pfpStatusDir, "dump.json"))
+		flags.SetOption("--pods-fingerprint-unrestricted", strconv.FormatBool(!pfpRestricted)) // note the "not"!
 
 		podSpec := &ds.Spec.Template.Spec
 		// TODO: this doesn't really belong here, but OTOH adding the status file without having set
@@ -201,14 +203,14 @@ func FindContainerByName(podSpec *corev1.PodSpec, containerName string) (*corev1
 	return nil, fmt.Errorf("container %q not found - defaulting to the first", containerName)
 }
 
-func isPodFingerprintEnabled(conf *nropv1.NodeGroupConfig) bool {
+func isPodFingerprintEnabled(conf *nropv1.NodeGroupConfig) (bool, bool) {
 	cfg := nropv1.DefaultNodeGroupConfig()
 	if conf == nil || conf.PodsFingerprinting == nil {
 		// not specified -> use defaults
 		conf = &cfg
 	}
-	return (*conf.PodsFingerprinting == nropv1.PodsFingerprintingEnabled ||
-		*conf.PodsFingerprinting == nropv1.PodsFingerprintingEnabledExclusiveResources)
+	isRestricted := (*conf.PodsFingerprinting == nropv1.PodsFingerprintingEnabledExclusiveResources)
+	return (*conf.PodsFingerprinting == nropv1.PodsFingerprintingEnabled || isRestricted), isRestricted
 }
 
 func isNotifyFileEnabled(conf *nropv1.NodeGroupConfig) bool {

--- a/test/e2e/serial/tests/scheduler_cache.go
+++ b/test/e2e/serial/tests/scheduler_cache.go
@@ -90,7 +90,7 @@ var _ = Describe("[serial][scheduler][cache][tier1] scheduler cache", Label("sch
 
 			mcpName = nroOperObj.Status.MachineConfigPools[0].Name
 			conf := nroOperObj.Status.MachineConfigPools[0].Config
-			if conf.PodsFingerprinting == nil || *conf.PodsFingerprinting != nropv1.PodsFingerprintingEnabled {
+			if conf.PodsFingerprinting == nil || (*conf.PodsFingerprinting != nropv1.PodsFingerprintingEnabled || *conf.PodsFingerprinting != nropv1.PodsFingerprintingEnabledExclusiveResources) {
 				e2efixture.Skipf(fxt, "unsupported fingerprint status %v in %q", conf.PodsFingerprinting, mcpName)
 			}
 			if conf.InfoRefreshMode == nil {


### PR DESCRIPTION
Add option (new enum value in `NodeConfig`) to compute the PFP using only pods which have exclusive resources allocated, which are also the only kind of resources which can be accounted per-NUMA.

IOW considering all pods actually create unnecessary noise.
Accounting only exclusive resources is the most correct thing to do.

Note this is meant to (greatly) improve the jobs situation, but not completely solve it.
The kubelet is supposed to return the correct set of pods straight on, so it's likely we have a bug in the kubelet side.