### PR TITLE
serial: fix reboot testcase and properly wait on mcp updates

### DIFF
--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -132,9 +132,9 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 
 				By("reverting the changes under the NUMAResourcesOperator object")
 				// see https://pkg.go.dev/github.com/onsi/gomega#Eventually category 3
+				nroOperObj := &nropv1.NUMAResourcesOperator{}
 				Eventually(func(g Gomega) {
 					// we need that for the current ResourceVersion
-					nroOperObj := &nropv1.NUMAResourcesOperator{}
 					err := fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(initialNroOperObj), nroOperObj)
 					g.Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Running test 47674 was leaving crashed mcp settings on one of the nodes causing the mcp to stuck in updating status forever, hence incompatible env for the next test to run.
    The reason behind this is that the test was not waiting properly for the updates on relevant mcps to start, and then finish updating.
    When updating the NROP label to the new mcp, this triggers an update on the old mcp, which takes time for it to finish. Before this PR, the test was only waiting on the new mcp to get updated while ignoring the old mcp status. The test continues to run the later checks and even tearsdown while the old mcp was still in updating status. One part of the teardown is restoring initial labels on the nodes and at last, delete the new mcp that was created for the test purpose. Added all up: initial mcp is being updated, nodes labels are restored and new mcp is deleted results in a situation of a node searching for not-found mcp causing the initial mcp to stuck in updating because one node is in degraded state. For example:
    
    Node worker-1 is reporting: "machineconfig.machineconfiguration.openshift.io \"rendered-mcp-test-36f40ba3c1038c7ce5ce54f8a840a58f\" not found"

    
  To resolve this, add waiting loops on each mcp like the following:
  once the operator object is updated with the new mcp:
  1. wait on the new mcp to get updated.
  2. wait on the initial mcp to start updating.
  3. wait on the initial mcp to complete updating.
  
  And by the end of the test when restoring initial configuration:
  1. wait on the initial mcp to start updating.
  2. wait on the initial mcp to complete updating.
    