### PR TITLE
nrtcacheck: add option to dump node states

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
 	github.com/drone/envsubst v1.0.3
 	github.com/ghodss/yaml v1.0.0
+	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.8
 	github.com/jaypipes/ghw v0.9.0
 	github.com/jaypipes/pcidb v1.0.0
@@ -33,6 +34,7 @@ require (
 	k8s.io/kubernetes v1.25.4
 	kubevirt.io/qe-tools v0.1.8
 	sigs.k8s.io/controller-runtime v0.13.1
+	sigs.k8s.io/scheduler-plugins v0.24.9
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -65,7 +67,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
-	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
@@ -145,7 +146,6 @@ require (
 	k8s.io/utils v0.0.0-20220823124924-e9cbc92d1a73 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.33 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
-	sigs.k8s.io/scheduler-plugins v0.24.9 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 

--- a/pkg/validator/schedcache.go
+++ b/pkg/validator/schedcache.go
@@ -19,6 +19,7 @@ package validator
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil"
 	deployervalidator "github.com/k8stopologyawareschedwg/deployer/pkg/validator"
 	"github.com/openshift-kni/numaresources-operator/internal/nodes"
@@ -42,7 +43,14 @@ func CollectSchedCache(ctx context.Context, cli client.Client, data *ValidatorDa
 		return err
 	}
 
-	_, unsynced, err := schedcache.HasSynced(ctx, cli, k8sCli, nodes.GetNames(workers))
+	env := schedcache.Env{
+		Ctx:    ctx,
+		Cli:    cli,
+		K8sCli: k8sCli,
+		Log:    logr.Discard(),
+	}
+
+	_, unsynced, err := schedcache.HasSynced(&env, nodes.GetNames(workers))
 	if err != nil {
 		return err
 	}

--- a/vendor/k8s.io/klog/v2/klogr/README.md
+++ b/vendor/k8s.io/klog/v2/klogr/README.md
@@ -1,0 +1,19 @@
+# Minimal Go logging using klog
+
+This package implements the [logr interface](https://github.com/go-logr/logr)
+in terms of Kubernetes' [klog](https://github.com/kubernetes/klog).  This
+provides a relatively minimalist API to logging in Go, backed by a well-proven
+implementation.
+
+Because klogr was implemented before klog itself added supported for
+structured logging, the default in klogr is to serialize key/value
+pairs with JSON and log the result as text messages via klog. This
+does not work well when klog itself forwards output to a structured
+logger.
+
+Therefore the recommended approach is to let klogr pass all log
+messages through to klog and deal with structured logging there. Just
+beware that the output of klog without a structured logger is meant to
+be human-readable, in contrast to the JSON-based traditional format.
+
+This is a BETA grade implementation.

--- a/vendor/k8s.io/klog/v2/klogr/klogr.go
+++ b/vendor/k8s.io/klog/v2/klogr/klogr.go
@@ -1,0 +1,185 @@
+// Package klogr implements github.com/go-logr/logr.Logger in terms of
+// k8s.io/klog.
+package klogr
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/internal/serialize"
+)
+
+// Option is a functional option that reconfigures the logger created with New.
+type Option func(*klogger)
+
+// Format defines how log output is produced.
+type Format string
+
+const (
+	// FormatSerialize tells klogr to turn key/value pairs into text itself
+	// before invoking klog.
+	FormatSerialize Format = "Serialize"
+
+	// FormatKlog tells klogr to pass all text messages and key/value pairs
+	// directly to klog. Klog itself then serializes in a human-readable
+	// format and optionally passes on to a structure logging backend.
+	FormatKlog Format = "Klog"
+)
+
+// WithFormat selects the output format.
+func WithFormat(format Format) Option {
+	return func(l *klogger) {
+		l.format = format
+	}
+}
+
+// New returns a logr.Logger which serializes output itself
+// and writes it via klog.
+func New() logr.Logger {
+	return NewWithOptions(WithFormat(FormatSerialize))
+}
+
+// NewWithOptions returns a logr.Logger which serializes as determined
+// by the WithFormat option and writes via klog. The default is
+// FormatKlog.
+func NewWithOptions(options ...Option) logr.Logger {
+	l := klogger{
+		level:  0,
+		prefix: "",
+		values: nil,
+		format: FormatKlog,
+	}
+	for _, option := range options {
+		option(&l)
+	}
+	return logr.New(&l)
+}
+
+type klogger struct {
+	level     int
+	callDepth int
+	prefix    string
+	values    []interface{}
+	format    Format
+}
+
+func (l *klogger) Init(info logr.RuntimeInfo) {
+	l.callDepth += info.CallDepth
+}
+
+func flatten(kvList ...interface{}) string {
+	keys := make([]string, 0, len(kvList))
+	vals := make(map[string]interface{}, len(kvList))
+	for i := 0; i < len(kvList); i += 2 {
+		k, ok := kvList[i].(string)
+		if !ok {
+			panic(fmt.Sprintf("key is not a string: %s", pretty(kvList[i])))
+		}
+		var v interface{}
+		if i+1 < len(kvList) {
+			v = kvList[i+1]
+		}
+		// Only print each key once...
+		if _, seen := vals[k]; !seen {
+			keys = append(keys, k)
+		}
+		// ... with the latest value.
+		vals[k] = v
+	}
+	sort.Strings(keys)
+	buf := bytes.Buffer{}
+	for i, k := range keys {
+		v := vals[k]
+		if i > 0 {
+			buf.WriteRune(' ')
+		}
+		buf.WriteString(pretty(k))
+		buf.WriteString("=")
+		buf.WriteString(pretty(v))
+	}
+	return buf.String()
+}
+
+func pretty(value interface{}) string {
+	if err, ok := value.(error); ok {
+		if _, ok := value.(json.Marshaler); !ok {
+			value = err.Error()
+		}
+	}
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	encoder.Encode(value)
+	return strings.TrimSpace(string(buffer.Bytes()))
+}
+
+func (l klogger) Info(level int, msg string, kvList ...interface{}) {
+	switch l.format {
+	case FormatSerialize:
+		msgStr := flatten("msg", msg)
+		merged := serialize.MergeKVs(l.values, kvList)
+		kvStr := flatten(merged...)
+		klog.V(klog.Level(level)).InfoDepth(l.callDepth+1, l.prefix, " ", msgStr, " ", kvStr)
+	case FormatKlog:
+		merged := serialize.MergeKVs(l.values, kvList)
+		if l.prefix != "" {
+			msg = l.prefix + ": " + msg
+		}
+		klog.V(klog.Level(level)).InfoSDepth(l.callDepth+1, msg, merged...)
+	}
+}
+
+func (l klogger) Enabled(level int) bool {
+	return klog.V(klog.Level(level)).Enabled()
+}
+
+func (l klogger) Error(err error, msg string, kvList ...interface{}) {
+	msgStr := flatten("msg", msg)
+	var loggableErr interface{}
+	if err != nil {
+		loggableErr = serialize.ErrorToString(err)
+	}
+	switch l.format {
+	case FormatSerialize:
+		errStr := flatten("error", loggableErr)
+		merged := serialize.MergeKVs(l.values, kvList)
+		kvStr := flatten(merged...)
+		klog.ErrorDepth(l.callDepth+1, l.prefix, " ", msgStr, " ", errStr, " ", kvStr)
+	case FormatKlog:
+		merged := serialize.MergeKVs(l.values, kvList)
+		if l.prefix != "" {
+			msg = l.prefix + ": " + msg
+		}
+		klog.ErrorSDepth(l.callDepth+1, err, msg, merged...)
+	}
+}
+
+// WithName returns a new logr.Logger with the specified name appended.  klogr
+// uses '/' characters to separate name elements.  Callers should not pass '/'
+// in the provided name string, but this library does not actually enforce that.
+func (l klogger) WithName(name string) logr.LogSink {
+	if len(l.prefix) > 0 {
+		l.prefix = l.prefix + "/"
+	}
+	l.prefix += name
+	return &l
+}
+
+func (l klogger) WithValues(kvList ...interface{}) logr.LogSink {
+	l.values = serialize.WithValues(l.values, kvList)
+	return &l
+}
+
+func (l klogger) WithCallDepth(depth int) logr.LogSink {
+	l.callDepth += depth
+	return &l
+}
+
+var _ logr.LogSink = &klogger{}
+var _ logr.CallDepthLogSink = &klogger{}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1179,6 +1179,7 @@ k8s.io/klog/v2/internal/clock
 k8s.io/klog/v2/internal/dbg
 k8s.io/klog/v2/internal/serialize
 k8s.io/klog/v2/internal/severity
+k8s.io/klog/v2/klogr
 # k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1
 ## explicit; go 1.18
 k8s.io/kube-openapi/cmd/openapi-gen/args


### PR DESCRIPTION
Add an option to just dump the node status (provided by RTE).
Differently from the scheduler, which dumps the status only if the resync fails, the RTEs always do.

Knowing the state of RTEs comes almost for free, and makes troubleshooting easier.