### PR TITLE
rte: revert to "method=all" PFP by default

### DIFF
--- a/api/numaresourcesoperator/v1/numaresourcesoperator_defaults.go
+++ b/api/numaresourcesoperator/v1/numaresourcesoperator_defaults.go
@@ -41,7 +41,7 @@ func (ngc *NodeGroupConfig) Default() {
 }
 
 func defaultPodsFingerprinting() *PodsFingerprintingMode {
-	podsFp := PodsFingerprintingEnabledExclusiveResources
+	podsFp := PodsFingerprintingEnabled
 	return &podsFp
 }
 

--- a/api/numaresourcesoperator/v1/numaresourcesoperator_defaults_test.go
+++ b/api/numaresourcesoperator/v1/numaresourcesoperator_defaults_test.go
@@ -66,7 +66,7 @@ func TestNodeGroupConfigDefaultMethod(t *testing.T) {
 }
 
 func TestNodeGroupConfigDefault(t *testing.T) {
-	podsFp := PodsFingerprintingEnabledExclusiveResources
+	podsFp := PodsFingerprintingEnabled
 	refMode := InfoRefreshPeriodicAndEvents
 	period := metav1.Duration{
 		Duration: 10 * time.Second,

--- a/api/numaresourcesoperator/v1/numaresourcesoperator_normalize_test.go
+++ b/api/numaresourcesoperator/v1/numaresourcesoperator_normalize_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestNodeGroupConfigMerge(t *testing.T) {
-	podsFp := PodsFingerprintingEnabledExclusiveResources
+	podsFp := PodsFingerprintingEnabled
 	refMode := InfoRefreshPeriodicAndEvents
 
 	type testCase struct {

--- a/pkg/objectupdate/rte/rte_test.go
+++ b/pkg/objectupdate/rte/rte_test.go
@@ -70,6 +70,7 @@ func TestUpdateDaemonSetArgs(t *testing.T) {
 	}
 
 	pfpEnabled := nropv1.PodsFingerprintingEnabled
+	pfpEnabledExclusiveResources := nropv1.PodsFingerprintingEnabledExclusiveResources
 	pfpDisabled := nropv1.PodsFingerprintingDisabled
 
 	refreshEvents := nropv1.InfoRefreshEvents
@@ -80,7 +81,7 @@ func TestUpdateDaemonSetArgs(t *testing.T) {
 			name: "defaults",
 			conf: nropv1.DefaultNodeGroupConfig(),
 			expectedArgs: []string{
-				"--pods-fingerprint", "--pods-fingerprint-unrestricted=false", "--refresh-node-resources", "--sleep-interval=10s", "--notify-file=/run/rte/notify",
+				"--pods-fingerprint", "--pods-fingerprint-unrestricted=true", "--refresh-node-resources", "--sleep-interval=10s", "--notify-file=/run/rte/notify",
 			},
 		},
 		{
@@ -91,7 +92,7 @@ func TestUpdateDaemonSetArgs(t *testing.T) {
 				},
 			},
 			expectedArgs: []string{
-				"--pods-fingerprint", "--pods-fingerprint-unrestricted=false", "--refresh-node-resources", "--sleep-interval=32s", "--notify-file=/run/rte/notify",
+				"--pods-fingerprint", "--pods-fingerprint-unrestricted=true", "--refresh-node-resources", "--sleep-interval=32s", "--notify-file=/run/rte/notify",
 			},
 		},
 		{
@@ -101,6 +102,15 @@ func TestUpdateDaemonSetArgs(t *testing.T) {
 			},
 			expectedArgs: []string{
 				"--pods-fingerprint", "--pods-fingerprint-unrestricted=true", "--refresh-node-resources", "--sleep-interval=10s", "--notify-file=/run/rte/notify",
+			},
+		},
+		{
+			name: "explicitely disable unrestricted fingerprint",
+			conf: nropv1.NodeGroupConfig{
+				PodsFingerprinting: &pfpEnabledExclusiveResources,
+			},
+			expectedArgs: []string{
+				"--pods-fingerprint", "--pods-fingerprint-unrestricted=false", "--refresh-node-resources", "--sleep-interval=10s", "--notify-file=/run/rte/notify",
 			},
 		},
 		{
@@ -118,7 +128,7 @@ func TestUpdateDaemonSetArgs(t *testing.T) {
 				InfoRefreshMode: &refreshEvents,
 			},
 			expectedArgs: []string{
-				"--pods-fingerprint", "--pods-fingerprint-unrestricted=false", "--refresh-node-resources", "--notify-file=/run/rte/notify",
+				"--pods-fingerprint", "--pods-fingerprint-unrestricted=true", "--refresh-node-resources", "--notify-file=/run/rte/notify",
 			},
 		},
 		{
@@ -127,7 +137,7 @@ func TestUpdateDaemonSetArgs(t *testing.T) {
 				InfoRefreshMode: &refreshPeriodic,
 			},
 			expectedArgs: []string{
-				"--pods-fingerprint", "--pods-fingerprint-unrestricted=false", "--refresh-node-resources", "--sleep-interval=10s",
+				"--pods-fingerprint", "--pods-fingerprint-unrestricted=true", "--refresh-node-resources", "--sleep-interval=10s",
 			},
 		},
 	}


### PR DESCRIPTION
the "execlusive-resource" pfp method is not tested well enough yet, it's safer to fall back to the old method for a little more.