### PR TITLE
manifests: drop obsolete node-role labels

### DIFF
--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -489,7 +489,7 @@ spec:
                   requiredDuringSchedulingIgnoredDuringExecution:
                     nodeSelectorTerms:
                     - matchExpressions:
-                      - key: node-role.kubernetes.io/master
+                      - key: node-role.kubernetes.io/control-plane
                         operator: Exists
               containers:
               - args:
@@ -532,6 +532,8 @@ spec:
               serviceAccountName: numaresources-controller-manager
               terminationGracePeriodSeconds: 10
               tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/control-plane
               - effect: NoSchedule
                 key: node-role.kubernetes.io/master
       permissions:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,13 +30,15 @@ spec:
         runAsNonRoot: true
       tolerations:
       - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: node-role.kubernetes.io/master
+              - key: node-role.kubernetes.io/control-plane
                 operator: Exists
       containers:
       - command:

--- a/internal/nodes/nodes.go
+++ b/internal/nodes/nodes.go
@@ -32,20 +32,22 @@ import (
 )
 
 const (
-	LabelRole   = "node-role.kubernetes.io"
-	RoleWorker  = "worker"
-	RoleMCPTest = "mcp-test"
+	LabelRole = "node-role.kubernetes.io"
 
-	// LabelMasterRole contains the key for the role label
-	LabelMasterRole = "node-role.kubernetes.io/master"
+	RoleControlPlane = "control-plane"
+	RoleWorker       = "worker"
+	RoleMCPTest      = "mcp-test"
 
-	// LabelControlPlane contains the key for the control-plane role label
-	LabelControlPlane = "node-role.kubernetes.io/control-plane"
+	// LabelControlPlaneRole contains the key for the control-plane role label
+	LabelControlPlaneRole = "node-role.kubernetes.io/control-plane"
+
+	// LabelWorker contains the key for the worker role label
+	LabelWorkerRole = "node-role.kubernetes.io/worker"
 )
 
 func GetWorkerNodes(cli client.Client, ctx context.Context) ([]corev1.Node, error) {
 	nodes := &corev1.NodeList{}
-	selector, err := labels.Parse(fmt.Sprintf("%s/%s=", LabelRole, RoleWorker))
+	selector, err := labels.Parse(LabelWorkerRole + "=")
 	if err != nil {
 		return nil, err
 	}
@@ -62,11 +64,11 @@ func GetControlPlane(cli client.Client, ctx context.Context, plat platform.Platf
 	nodeList := &corev1.NodeList{}
 	labels := metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			LabelMasterRole: "",
+			LabelControlPlaneRole: "",
 		},
 	}
 	if plat == platform.Kubernetes {
-		labels.MatchLabels[LabelControlPlane] = ""
+		labels.MatchLabels[LabelControlPlaneRole] = ""
 	}
 
 	selNodes, err := metav1.LabelSelectorAsSelector(&labels)

--- a/pkg/numaresourcesscheduler/manifests/yaml/deployment.yaml
+++ b/pkg/numaresourcesscheduler/manifests/yaml/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: node-role.kubernetes.io/master
+                  - key: node-role.kubernetes.io/control-plane
                     operator: Exists
       volumes:
         - name: "etckubernetes"
@@ -58,6 +58,8 @@ spec:
               name: "runpfpstatus"
       serviceAccountName: "secondary-scheduler"
       tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
       volumes:


### PR DESCRIPTION
We can now use the modern node-role labels to identify control plane nodes. No need to use anymore obsolete terms.