### PR TITLE
e2e: serial: resacct improve and generalize expectations

### DIFF
--- a/internal/wait/noderesourcetopologies.go
+++ b/internal/wait/noderesourcetopologies.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wait
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	k8swait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+
+	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+	nrtv1alpha2attr "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper/attribute"
+	"github.com/k8stopologyawareschedwg/podfingerprint"
+)
+
+type PFPCount struct {
+	Value string
+	Count int
+}
+
+func (pc PFPCount) String() string {
+	return fmt.Sprintf("PFP=%s count=%d", pc.Value, pc.Count)
+}
+
+// map nodeName -> PFPCount
+type PFPState map[string]PFPCount
+
+func (ps PFPState) Len() int {
+	return len(ps)
+}
+
+func (ps PFPState) CountReady(threshold int) int {
+	ready := 0
+	for _, count := range ps {
+		if count.Count >= threshold {
+			ready++
+		}
+	}
+	return ready
+}
+
+func (ps PFPState) AllReady(threshold int) bool {
+	for _, count := range ps {
+		if count.Count < threshold {
+			return false
+		}
+	}
+	return true
+}
+
+func (ps PFPState) Observe(nodeName, pfpValue string) int {
+	count, ok := ps[nodeName]
+	if !ok || count.Value != pfpValue {
+		ps[nodeName] = PFPCount{
+			Value: pfpValue,
+			Count: 1,
+		}
+		return 1
+	}
+	count.Count++
+	ps[nodeName] = count
+	return count.Count
+}
+
+func (ps PFPState) String() string {
+	return "TODO"
+}
+
+func (wt Waiter) ForNodeResourceTopologiesSettled(ctx context.Context, threshold int, nodeNames ...string) (*nrtv1alpha2.NodeResourceTopologyList, error) {
+	expectedNodes := sets.NewString(nodeNames...)
+	pfpState := make(PFPState)
+	nrtList := nrtv1alpha2.NodeResourceTopologyList{}
+
+	err := k8swait.PollImmediate(wt.PollInterval, wt.PollTimeout, func() (bool, error) {
+		klog.Infof("waiting for NRT to stabilize; observed nodes=%d ready=%d", pfpState.Len(), pfpState.CountReady(threshold))
+
+		err := wt.Cli.List(context.TODO(), &nrtList)
+		if err != nil {
+			return false, err
+		}
+		for idx := range nrtList.Items {
+			nrt := &nrtList.Items[idx]
+			if expectedNodes.Len() > 0 && !expectedNodes.Has(nrt.Name) {
+				klog.Infof("-> waiting for NRT to stabilize; ignored unwanted node node=%s", nrt.Name)
+				continue
+			}
+
+			attr, ok := nrtv1alpha2attr.Get(nrt.Attributes, podfingerprint.Attribute)
+			if !ok {
+				return false, fmt.Errorf("NRT %s missing PFP attribute", nrt.Name)
+			}
+			cnt := pfpState.Observe(nrt.Name, attr.Value)
+			klog.Infof("-> waiting for NRT to stabilize; node=%s value=%s count=%d threshold=%d", nrt.Name, attr.Value, cnt, threshold)
+		}
+		return pfpState.AllReady(threshold), nil
+	})
+
+	klog.Infof("done waiting for NRT to stabilize; observed nodes=%d ready=%d", pfpState.Len(), pfpState.CountReady(threshold))
+	return &nrtList, err
+}

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -227,6 +227,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
 			// TODO: smarter cooldown
+			By("cooling down")
 			time.Sleep(18 * time.Second)
 			for _, unsuitableNodeName := range unsuitableNodeNames {
 				dumpNRTForNode(fxt.Client, unsuitableNodeName, "unsuitable")
@@ -285,7 +286,10 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(err).ToNot(HaveOccurred())
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 
-			//Check that NRT of the target node reflect correct consumed resources
+			By("Waiting for the NRT data to stabilize")
+			wait.With(fxt.Client).Interval(11*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesSettled(context.TODO(), 3)
+
+			// Check that NRT of the target node reflect correct consumed resources
 			By("Verifying NRT is updated properly when running the test's pod")
 			expectNRTConsumedResources(fxt, *targetNrtBefore, requiredRes, updatedPod)
 		})

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -407,7 +407,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 
 			By("Verifying NRT reflects no updates after scheduling the best-effort pod")
-			expectNrtUnchanged(fxt, targetNrtListInitial, updatedPod.Spec.NodeName)
+			expectNRTRestoredTo(fxt, &targetNrtListInitial, 5*time.Second, 1*time.Minute)
 		})
 
 		It("[test_id:48686][tier1] should properly schedule a burstable pod with no changes in NRTs", func() {
@@ -437,7 +437,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 
 			By("Verifying NRT reflects no updates after scheduling the burstable pod")
-			expectNrtUnchanged(fxt, targetNrtListInitial, updatedPod.Spec.NodeName)
+			expectNRTRestoredTo(fxt, &targetNrtListInitial, 5*time.Second, 1*time.Minute)
 		})
 
 		It("[test_id:47618][tier2] should properly schedule deployment with burstable pod with no changes in NRTs", func() {
@@ -540,7 +540,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 
 			By("Verifying NRT reflects no updates after scheduling the burstable pod")
-			expectNrtUnchanged(fxt, targetNrtListInitial, updatedPod.Spec.NodeName)
+			expectNRTRestoredTo(fxt, &targetNrtListInitial, 5*time.Second, 1*time.Minute)
 		})
 
 		It("[test_id:47620][tier2] should properly schedule a burstable pod with no changes in NRTs followed by a guaranteed pod that stays pending till burstable pod is deleted", func() {
@@ -570,7 +570,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 
 			By("Verifying NRT reflects no updates after scheduling the burstable pod")
-			expectNrtUnchanged(fxt, targetNrtListInitial, updatedPod.Spec.NodeName)
+			expectNRTRestoredTo(fxt, &targetNrtListInitial, 5*time.Second, 1*time.Minute)
 
 			By("create a gu pod")
 
@@ -610,7 +610,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verifying NRT reflects no updates after scheduling the burstable pod")
-			expectNrtUnchanged(fxt, targetNrtListInitial, updatedPod.Spec.NodeName)
+			expectNRTRestoredTo(fxt, &targetNrtListInitial, 5*time.Second, 1*time.Minute)
 
 			By("delete the burstable pod and the guranteed pod should change state from pending to running")
 
@@ -723,21 +723,6 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 
 	})
 })
-
-func expectNrtUnchanged(fxt *e2efixture.Fixture, targetNrtListInitial nrtv1alpha2.NodeResourceTopologyList, nodeName string) {
-	targetNrtListCurrent, err := e2enrt.GetUpdated(fxt.Client, targetNrtListInitial, 1*time.Minute)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-
-	targetNrtInitial, err := e2enrt.FindFromList(targetNrtListInitial.Items, nodeName)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-	targetNrtCurrent, err := e2enrt.FindFromList(targetNrtListCurrent.Items, nodeName)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-	isEqual, err := e2enrt.CheckEqualAvailableResources(*targetNrtInitial, *targetNrtCurrent)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	ExpectWithOffset(1, isEqual).To(BeTrue(), "new resources are accounted on %q in NRT (%s)", nodeName)
-}
 
 // checkNRTConsumedResources returns the updated NRT and the name of the zone on which resources are consumed
 func checkNRTConsumedResources(fxt *e2efixture.Fixture, targetNrtInitial nrtv1alpha2.NodeResourceTopology, requiredRes corev1.ResourceList, updatedPod *corev1.Pod) (nrtv1alpha2.NodeResourceTopology, string) {

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	corev1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 
@@ -215,8 +216,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				failedPodIds := e2efixture.WaitForPaddingPodsRunning(fxt, paddingPods)
 				Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
-				By("checking the resource allocation as the test starts")
-				nrtListInitial, err := e2enrt.GetUpdated(fxt.Client, nrtList, 1*time.Minute)
+				By(fmt.Sprintf("checking the resource allocation on %q as the test starts", targetNodeName))
+				var nrtInitial nrtv1alpha2.NodeResourceTopology
+				err := fxt.Client.Get(context.TODO(), client.ObjectKey{Name: targetNodeName}, &nrtInitial)
 				Expect(err).ToNot(HaveOccurred())
 
 				By(fmt.Sprintf("Scheduling the testing deployment with RuntimeClass=%q", rtClass.Name))
@@ -239,7 +241,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(2*time.Minute).ForDeploymentComplete(context.TODO(), deployment)
 				Expect(err).NotTo(HaveOccurred(), "Deployment %q not up&running after %v", deployment.Name, 2*time.Minute)
 
-				nrtListPostCreate, err := e2enrt.GetUpdated(fxt.Client, nrtListInitial, 1*time.Minute)
+				nrtPostCreate, err := e2enrt.GetUpdatedForNode(fxt.Client, context.TODO(), nrtInitial, 1*time.Minute)
 				Expect(err).ToNot(HaveOccurred())
 
 				By(fmt.Sprintf("checking deployment pods have been scheduled with the topology aware scheduler %q and in the proper node %q", serialconfig.Config.SchedulerName, targetNodeName))
@@ -257,23 +259,17 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 					Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", pod.Namespace, pod.Name, serialconfig.Config.SchedulerName)
 
 					By(fmt.Sprintf("checking the resources are accounted as expected on %q", pod.Spec.NodeName))
-					nrtInitial, err := e2enrt.FindFromList(nrtListInitial.Items, pod.Spec.NodeName)
-					Expect(err).ToNot(HaveOccurred())
-					nrtPostCreate, err := e2enrt.FindFromList(nrtListPostCreate.Items, pod.Spec.NodeName)
-					Expect(err).ToNot(HaveOccurred())
-
-					match, err := e2enrt.CheckZoneConsumedResourcesAtLeast(*nrtInitial, *nrtPostCreate, podResources, corev1qos.GetPodQOS(&pod))
+					match, err := e2enrt.CheckZoneConsumedResourcesAtLeast(nrtInitial, nrtPostCreate, podResources, corev1qos.GetPodQOS(&pod))
 					Expect(err).ToNot(HaveOccurred())
 					// If the pods are running, and they are because we reached this far, then the resources must have been accounted SOMEWHERE!
-					Expect(match).ToNot(Equal(""), "inconsistent accounting: no resources consumed by deployment running")
+					Expect(match).ToNot(BeEmpty(), "inconsistent accounting: no resources consumed by deployment running")
 
-					matchWithOverhead, err := e2enrt.CheckZoneConsumedResourcesAtLeast(*nrtInitial, *nrtPostCreate, podResourcesWithOverhead, corev1qos.GetPodQOS(&pod))
+					matchWithOverhead, err := e2enrt.CheckZoneConsumedResourcesAtLeast(nrtInitial, nrtPostCreate, podResourcesWithOverhead, corev1qos.GetPodQOS(&pod))
 					Expect(err).ToNot(HaveOccurred())
 					// OTOH if we add the overhead no zone is expected to have allocated the EXTRA resources - exactly because the overhead
 					// should not be taken into account!
 					Expect(matchWithOverhead).To(BeEmpty(), "unexpected found resource+overhead allocation accounted to zone %q", matchWithOverhead, match)
 				}
-
 			})
 
 			It("[test_id:53819][tier2][unsched] Pod pending when resources requested + pod overhead don't fit on the target node; NRT objects are not updated", func() {
@@ -448,7 +444,6 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 					Expect(err).ToNot(HaveOccurred())
 					Expect(match).To(BeTrue(), "inconsistent accounting: resources consumed by the updated pods on node %q", initialNrt.Name)
 				}
-
 			})
 		})
 	})

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -271,7 +271,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 					Expect(err).ToNot(HaveOccurred())
 					// OTOH if we add the overhead no zone is expected to have allocated the EXTRA resources - exactly because the overhead
 					// should not be taken into account!
-					Expect(matchWithOverhead).To(Equal(""), "unexpected found resource+overhead allocation accounted to zone %q", matchWithOverhead, match)
+					Expect(matchWithOverhead).To(BeEmpty(), "unexpected found resource+overhead allocation accounted to zone %q", matchWithOverhead, match)
 				}
 
 			})

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -210,6 +210,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			}
 			Expect(err).ToNot(HaveOccurred())
 
+			By("waiting for the NRT data to settle")
+			wait.With(fxt.Client).Interval(11*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesSettled(context.TODO(), 3)
+
 			By(fmt.Sprintf("checking the pod was handled by the topology aware scheduler %q but failed to be scheduled on any node", serialconfig.Config.SchedulerName))
 			isFailed, err := nrosched.CheckPODSchedulingFailedForAlignment(fxt.K8sClient, pod.Namespace, pod.Name, serialconfig.Config.SchedulerName, tmPolicy)
 			Expect(err).ToNot(HaveOccurred())
@@ -241,6 +244,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *deployment)
 			Expect(err).ToNot(HaveOccurred(), "Unable to get pods from Deployment %q:  %v", deployment.Name, err)
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
+
+			By("waiting for the NRT data to settle")
+			wait.With(fxt.Client).Interval(11*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesSettled(context.TODO(), 3)
 
 			for _, pod := range pods {
 				isFailed, err := nrosched.CheckPODSchedulingFailedForAlignment(fxt.K8sClient, pod.Namespace, pod.Name, serialconfig.Config.SchedulerName, tmPolicy)
@@ -278,6 +284,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			pods, err := podlist.With(fxt.Client).ByDaemonset(context.TODO(), *ds)
 			Expect(err).ToNot(HaveOccurred(), "Unable to get pods from daemonset %q:  %v", ds.Name, err)
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DS %s/%s", ds.Namespace, ds.Name)
+
+			By("waiting for the NRT data to settle")
+			wait.With(fxt.Client).Interval(11*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesSettled(context.TODO(), 3)
 
 			for _, pod := range pods {
 				isFailed, err := nrosched.CheckPODSchedulingFailedForAlignment(fxt.K8sClient, pod.Namespace, pod.Name, serialconfig.Config.SchedulerName, tmPolicy)
@@ -420,6 +429,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			pods, err := podlist.With(fxt.Client).ByDaemonset(context.TODO(), *ds)
 			Expect(err).ToNot(HaveOccurred(), "Unable to get pods from daemonset %q:  %v", ds.Name, err)
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DS %s/%s", ds.Namespace, ds.Name)
+
+			By("waiting for the NRT data to settle")
+			wait.With(fxt.Client).Interval(11*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesSettled(context.TODO(), 3)
 
 			By(fmt.Sprintf("checking only daemonset pod in targetNode:%q is up and running", targetNodeName))
 			podRunningTimeout := 3 * time.Minute

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/openshift-kni/numaresources-operator/internal/nodes"
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
-	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
 
@@ -446,19 +445,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			}
 
 			By("check NRT is updated properly when the test's pod is running")
-			targetNrtListAfter, err := e2enrt.GetUpdated(fxt.Client, targetNrtListBefore, 1*time.Minute)
-			Expect(err).ToNot(HaveOccurred())
-			targetNrtAfter, err := e2enrt.FindFromList(targetNrtListAfter.Items, targetNodeName)
-			Expect(err).NotTo(HaveOccurred())
-
-			dataBefore, err := yaml.Marshal(targetNrtBefore)
-			Expect(err).ToNot(HaveOccurred())
-			dataAfter, err := yaml.Marshal(targetNrtAfter)
-			Expect(err).ToNot(HaveOccurred())
-
-			match, err := e2enrt.CheckZoneConsumedResourcesAtLeast(*targetNrtBefore, *targetNrtAfter, requiredRes, corev1qos.GetPodQOS(&(pods[0])))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(match).ToNot(Equal(""), "inconsistent accounting: no resources consumed by the running pod,\nNRT before test's pod: %s \nNRT after: %s \npod resources: %v", dataBefore, dataAfter, e2ereslist.ToString(requiredRes))
+			expectNRTConsumedResources(fxt, *targetNrtBefore, requiredRes, &pods[0])
 		})
 	})
 

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -194,7 +194,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			}
 		})
 
-		It("[test_id:47617][tier2][unsched] workload requests guaranteed pod resources available on one node but not on a single numa", func() {
+		It("[test_id:47617][tier2][unsched][failalign] workload requests guaranteed pod resources available on one node but not on a single numa", Label("unsched", "failalign"), func() {
 
 			By("Scheduling the testing pod")
 			pod := objects.NewTestPodPause(fxt.Namespace.Name, "testpod")
@@ -216,7 +216,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(isFailed).To(BeTrue(), "pod %s/%s with scheduler %s did NOT fail", pod.Namespace, pod.Name, serialconfig.Config.SchedulerName)
 		})
 
-		It("[test_id:48963][tier2][unsched] a deployment with a guaranteed pod resources available on one node but not on a single numa", func() {
+		It("[test_id:48963][tier2][unsched][failalign] a deployment with a guaranteed pod resources available on one node but not on a single numa", Label("unsched", "failalign"), func() {
 
 			By("Scheduling the testing deployment")
 			deploymentName := "test-dp"
@@ -252,7 +252,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			}
 		})
 
-		It("[test_id:48962][tier2][unsched] a daemonset with a guaranteed pod resources available on one node but not on a single numa", func() {
+		It("[test_id:48962][tier2][unsched][failalign] a daemonset with a guaranteed pod resources available on one node but not on a single numa", Label("unsched", "failalign"), func() {
 
 			By("Scheduling the testing daemonset")
 			dsName := "test-ds"
@@ -330,7 +330,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 	})
 
 	Context("with at least two nodes with two numa zones and enough resources in one numa zone", func() {
-		It("[test_id:47592][tier2][unsched] a daemonset with a guaranteed pod resources available on one node/one single numa zone but not in any other node", func() {
+		It("[test_id:47592][tier2][unsched][failalign] a daemonset with a guaranteed pod resources available on one node/one single numa zone but not in any other node", Label("unsched", "failalign"), func() {
 			requiredNUMAZones := 2
 			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", requiredNUMAZones))
 			nrtCandidates := e2enrt.FilterZoneCountEqual(nrts, requiredNUMAZones)
@@ -452,7 +452,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 	})
 
 	Context("with at least one node", func() {
-		It("[test_id:47616][tier2][tmscope:pod] pod with two containers each on one numa zone can NOT be scheduled", func() {
+		It("[test_id:47616][tier2][tmscope:pod][failalign] pod with two containers each on one numa zone can NOT be scheduled", Label("failalign"), func() {
 
 			// Requirements:
 			// Need at least this nodes

--- a/test/utils/noderesourcetopologies/noderesourcetopologies.go
+++ b/test/utils/noderesourcetopologies/noderesourcetopologies.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -64,6 +65,29 @@ func GetUpdated(cli client.Client, ref nrtv1alpha2.NodeResourceTopologyList, tim
 		return updatedNrtList.ListMeta.ResourceVersion != ref.ListMeta.ResourceVersion, nil
 	})
 	return updatedNrtList, err
+}
+
+func GetUpdatedForNode(cli client.Client, ctx context.Context, ref nrtv1alpha2.NodeResourceTopology, timeout time.Duration) (nrtv1alpha2.NodeResourceTopology, error) {
+	var equalZones bool
+	var updatedNrt nrtv1alpha2.NodeResourceTopology
+	klog.Infof("NRT change: reference is %s", e2enrt.ToString(ref))
+	err := wait.PollImmediate(5*time.Second, timeout, func() (bool, error) {
+		err := cli.Get(ctx, client.ObjectKeyFromObject(&ref), &updatedNrt)
+		if err != nil {
+			klog.Errorf("cannot get the updated NRT object %s/%s", ref.Namespace, ref.Name)
+			return false, err
+		}
+		// very cheap test to rule out false negatives
+		if updatedNrt.ObjectMeta.ResourceVersion == ref.ObjectMeta.ResourceVersion {
+			klog.Warningf("NRT for %q resource version didn't change", ref.Name)
+			return false, nil
+		}
+		equalZones = apiequality.Semantic.DeepEqual(ref.Zones, updatedNrt.Zones)
+		klog.Infof("NRT change: updated to %s", e2enrt.ToString(updatedNrt))
+		return !equalZones, nil
+	})
+	klog.Infof("NRT change: finished, equalZones=%v", equalZones)
+	return updatedNrt, err
 }
 
 func CheckEqualAvailableResources(nrtInitial, nrtUpdated nrtv1alpha2.NodeResourceTopology) (bool, error) {
@@ -154,7 +178,7 @@ func accumulateNodeAvailableResources(nrt nrtv1alpha2.NodeResourceTopology, reas
 	if len(resInfoList) < 1 {
 		return resInfoList, fmt.Errorf("failed to accumulate resources for node %q", nrt.Name)
 	}
-	klog.Infof("resInfoList %s: %s", reason, e2enrt.ResourceInfoListToString(resInfoList))
+	klog.Infof("resInfoList available %s: %s", reason, e2enrt.ResourceInfoListToString(resInfoList))
 	return resInfoList, nil
 }
 func SaturateZoneUntilLeft(zone nrtv1alpha2.Zone, requiredRes corev1.ResourceList) (corev1.ResourceList, error) {
@@ -232,17 +256,20 @@ func checkConsumedResourcesAtLeast(resourcesInitial, resourcesUpdated []nrtv1alp
 		if !ok {
 			return false, fmt.Errorf("resource %q not found in the initial set", string(resName))
 		}
+		expectedQty := initialQty.DeepCopy()
+		expectedQty.Sub(resQty)
+
 		updatedQty, ok := FindResourceAvailableByName(resourcesUpdated, string(resName))
 		if !ok {
 			return false, fmt.Errorf("resource %q not found in the updated set", string(resName))
 		}
-		expectedQty := initialQty.DeepCopy()
-		expectedQty.Sub(resQty)
+
 		ret := updatedQty.Cmp(expectedQty)
 		if ret > 0 {
-			klog.Infof("quantity for resource %q is greater than expected. expected=%s actual=%s", resName, expectedQty.String(), updatedQty.String())
+			klog.Infof("available quantity for resource %q is greater than expected. expected=%s actual=%s", resName, expectedQty.String(), updatedQty.String())
 			return false, nil
 		}
+		klog.Infof("+- resource consumption: %s (consumed %s): expected available [%v] updated available [%v]", resName, resQty.String(), expectedQty.String(), updatedQty.String())
 	}
 	return true, nil
 }

--- a/vendor/github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper/attribute/attribute.go
+++ b/vendor/github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper/attribute/attribute.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package attribute
+
+import (
+	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+)
+
+// Get looks for attribute by its name in the provided AtributeList.
+// If found, returns the value of the attribute and an explicit boolean value equals true
+// Otherwise, returns the zero value and explicit boolean value equals false.
+// In case there are duplicates in the attribute list, returns the first attribute from the left
+// found in iteration order, iterating on the attribute list treating it as a golang slice.
+func Get(attributes v1alpha2.AttributeList, name string) (v1alpha2.AttributeInfo, bool) {
+	attr := findAttrByName(attributes, name)
+	if attr == nil {
+		return v1alpha2.AttributeInfo{}, false
+	}
+	return *attr, true
+}
+
+// Insert updates or adds an attribute to the provided AttributeList, preserving the existing order.
+// The attribute name must be non-zero, the value can be zero.
+// If the attribute is already present, its value is overridden with the given one; otherwise
+// adds a new attribute preserving as much as possible the current ordering between attributes.
+// Returns the updated AttributeList.
+func Insert(attributes v1alpha2.AttributeList, attr v1alpha2.AttributeInfo) v1alpha2.AttributeList {
+	if attr.Name == "" {
+		return attributes
+	}
+	attrs := attributes.DeepCopy()
+	existingAttr := findAttrByName(attrs, attr.Name)
+	if existingAttr == nil {
+		return append(attrs, attr)
+	}
+	existingAttr.Value = attr.Value
+	return attrs
+}
+
+// Merge joins `updated` into `existing`, preserving as much as possible the current ordering between attributes.
+// Returns the merged attribute list, which includes the union of the elements from `existing` and `updated`.
+// If an element is present in both lists, takes the value present in `updated`.
+func Merge(existing, updated v1alpha2.AttributeList) v1alpha2.AttributeList {
+	ret := existing.DeepCopy()
+	delta := v1alpha2.AttributeList{}
+	for _, attr := range updated {
+		if existingAttr := findAttrByName(ret, attr.Name); existingAttr != nil {
+			existingAttr.Value = attr.Value
+		} else {
+			delta = append(delta, attr)
+		}
+	}
+	return append(ret, delta...)
+}
+
+// DeleteAll removes from the given AttributeList all the elements whose name matches the given `name`.
+// Returns a new AttributeList with all the attributes removed, preserving as much as possible the current
+// ordering between attributes.
+func DeleteAll(attributes v1alpha2.AttributeList, name string) v1alpha2.AttributeList {
+	ret := make(v1alpha2.AttributeList, 0, len(attributes))
+	for _, attr := range attributes {
+		if attr.Name == name {
+			continue
+		}
+		ret = append(ret, attr)
+	}
+	return ret
+}
+
+func findAttrByName(attributes v1alpha2.AttributeList, name string) *v1alpha2.AttributeInfo {
+	for idx := range attributes {
+		attr := &attributes[idx]
+		if attr.Name == name {
+			return attr
+		}
+	}
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -238,6 +238,7 @@ github.com/k8stopologyawareschedwg/deployer/pkg/validator
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2
+github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper/attribute
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned/scheme
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned/typed/topology/v1alpha1


### PR DESCRIPTION
We should in general very, VERY careful when factorizing code in e2e tests.
We totally DO NOT want to add coupling to tests, and when we factor code we need to make really sure we're factoring code which does so general that a failure or a bug _always_ means a critical failure in the context of tests.

Easy candidates are setup helpers and expectations.

Turns out we check quite some expectations about proper NRT resource accounting, so let's reuse expectations for the
most obvious candidate sites.
Previously, we just checked for _A_ change in the NRT list, which was very crude and caused frequent flakes.
Now we wait for a targeted change in the very NRT object we care about, then we check that change is what we expected.
This is more precise, more correct and, at least in the initial runs, less flaky.