### PR TITLE
e2e: verify nrt data after each test

### DIFF
--- a/test/e2e/serial/README.md
+++ b/test/e2e/serial/README.md
@@ -34,6 +34,7 @@ they found it before they run.
   failed unexpectedly on standard output, alongside (not replacing) the logging of the said events.
 - `E2E_NROP_TARGET_NODE` (accepts string, e.g. `node-0.my-cluster.io`) instructs the suite to always pick the
   node matching the given name when a random node is needed.
+- `E2E_NROP_COOLDOWN_THRESHOLD` (accepts integer, e.g 1, 3) instructs the suite to collect data of resources topology matching to the initial data for the specified threshold count, before considering it settled.
 - `E2E_NROP_TEST_COOLDOWN` (accepts string expressing time unit, e.g. `30s`) instructs the suite to wait
   for the specified amount of time after each spec, to give time to the cluster to settle up.
 - `E2E_NROP_TEST_TEARDOWN` (accepts string expressing time unit, e.g. `30s`) instructs the suite to wait

--- a/test/e2e/serial/config/fixture.go
+++ b/test/e2e/serial/config/fixture.go
@@ -68,7 +68,7 @@ func NewFixtureWithOptions(nsName string, options e2efixture.Options) (*E2EConfi
 		NROSchedObj: &nropv1.NUMAResourcesScheduler{},
 	}
 
-	cfg.Fixture, err = e2efixture.SetupWithOptions(nsName, options)
+	cfg.Fixture, err = e2efixture.SetupWithOptions(nsName, nrtv1alpha2.NodeResourceTopologyList{}, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -71,7 +71,7 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 
 		var err error
-		fxt, err = e2efixture.Setup("e2e-test-configuration")
+		fxt, err = e2efixture.Setup("e2e-test-configuration", serialconfig.Config.NRTList)
 		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
 
 		err = fxt.Client.List(context.TODO(), &nrtList)

--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -63,7 +63,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 
 		var err error
-		fxt, err = e2efixture.Setup("e2e-test-non-regression")
+		fxt, err = e2efixture.Setup("e2e-test-non-regression", serialconfig.Config.NRTList)
 		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
 
 		padder, err = e2epadder.New(fxt.Client, fxt.Namespace.Name)

--- a/test/e2e/serial/tests/non_regression_fundamentals.go
+++ b/test/e2e/serial/tests/non_regression_fundamentals.go
@@ -51,7 +51,7 @@ var _ = Describe("[serial][fundamentals][scheduler][nonreg] numaresources fundam
 		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 
 		var err error
-		fxt, err = e2efixture.Setup("e2e-test-non-regression-fundamentals")
+		fxt, err = e2efixture.Setup("e2e-test-non-regression-fundamentals", serialconfig.Config.NRTList)
 		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
 
 		err = fxt.Client.List(context.TODO(), &nrtList)

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -65,7 +65,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 
 		var err error
-		fxt, err = e2efixture.Setup("e2e-test-resource-accounting")
+		fxt, err = e2efixture.Setup("e2e-test-resource-accounting", serialconfig.Config.NRTList)
 		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
 
 		padder, err = e2epadder.New(fxt.Client, fxt.Namespace.Name)

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -287,8 +287,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 
 			By("Waiting for the NRT data to stabilize")
-			wait.With(fxt.Client).Interval(11*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesSettled(context.TODO(), 3)
-
+			e2efixture.WaitForNRTSettle(fxt)
 			// Check that NRT of the target node reflect correct consumed resources
 			By("Verifying NRT is updated properly when running the test's pod")
 			expectNRTConsumedResources(fxt, *targetNrtBefore, requiredRes, updatedPod)

--- a/test/e2e/serial/tests/scheduler_cache.go
+++ b/test/e2e/serial/tests/scheduler_cache.go
@@ -58,7 +58,7 @@ var _ = Describe("[serial][scheduler][cache][tier1] scheduler cache", Label("sch
 		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 
 		var err error
-		fxt, err = e2efixture.Setup("e2e-test-sched-cache")
+		fxt, err = e2efixture.Setup("e2e-test-sched-cache", serialconfig.Config.NRTList)
 		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
 
 		err = fxt.Client.List(context.TODO(), &nrtList)

--- a/test/e2e/serial/tests/scheduler_cache_stall.go
+++ b/test/e2e/serial/tests/scheduler_cache_stall.go
@@ -137,7 +137,7 @@ var _ = Describe("[serial][scheduler][cache][tier1] scheduler cache stall", Labe
 				Expect(err).ToNot(HaveOccurred())
 
 				// ensure foreign pods are reported
-				_, err = wait.With(fxt.Client).Interval(11*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesSettled(context.TODO(), 3)
+				_, err = e2efixture.WaitForNRTSettle(fxt)
 				Expect(err).ToNot(HaveOccurred())
 			})
 

--- a/test/e2e/serial/tests/scheduler_cache_stall.go
+++ b/test/e2e/serial/tests/scheduler_cache_stall.go
@@ -54,7 +54,7 @@ var _ = Describe("[serial][scheduler][cache][tier1] scheduler cache stall", Labe
 		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 
 		var err error
-		fxt, err = e2efixture.Setup("e2e-test-sched-cache-stall")
+		fxt, err = e2efixture.Setup("e2e-test-sched-cache-stall", serialconfig.Config.NRTList)
 		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
 
 		err = fxt.Client.List(context.TODO(), &nrtList)

--- a/test/e2e/serial/tests/scheduler_removal.go
+++ b/test/e2e/serial/tests/scheduler_removal.go
@@ -49,7 +49,7 @@ var _ = Describe("[serial][disruptive][scheduler][rmsched] numaresources schedul
 		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 
 		var err error
-		fxt, err = e2efixture.Setup("e2e-test-sched-remove")
+		fxt, err = e2efixture.Setup("e2e-test-sched-remove", serialconfig.Config.NRTList)
 		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
 
 		nrosched.CheckNROSchedulerAvailable(fxt.Client, serialconfig.Config.NROSchedObj.Name)
@@ -119,7 +119,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources scheduler restar
 
 	BeforeEach(func() {
 		var err error
-		fxt, err = e2efixture.Setup("e2e-test-sched-remove")
+		fxt, err = e2efixture.Setup("e2e-test-sched-remove", serialconfig.Config.NRTList)
 		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
 
 		nroSchedObj = &nropv1.NUMAResourcesScheduler{}

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -434,7 +434,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				}
 
 				By("waiting for the NRT data to settle")
-				wait.With(fxt.Client).Interval(11*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesSettled(context.TODO(), 3)
+				e2efixture.WaitForNRTSettle(fxt)
 
 				for idx := range nrtListInitial.Items {
 					initialNrt := &nrtListInitial.Items[idx]

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -60,7 +60,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 
 		var err error
-		fxt, err = e2efixture.Setup("e2e-test-workload-overhead")
+		fxt, err = e2efixture.Setup("e2e-test-workload-overhead", serialconfig.Config.NRTList)
 		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
 
 		padder, err = e2epadder.New(fxt.Client, fxt.Namespace.Name)

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -79,7 +79,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 
 		var err error
-		fxt, err = e2efixture.Setup("e2e-test-workload-placement")
+		fxt, err = e2efixture.Setup("e2e-test-workload-placement", serialconfig.Config.NRTList)
 		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
 
 		padder, err = e2epadder.New(fxt.Client, fxt.Namespace.Name)

--- a/test/e2e/serial/tests/workload_placement_nodelabel.go
+++ b/test/e2e/serial/tests/workload_placement_nodelabel.go
@@ -61,7 +61,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 
 		var err error
-		fxt, err = e2efixture.Setup("e2e-test-workload-placement-nodesel")
+		fxt, err = e2efixture.Setup("e2e-test-workload-placement-nodesel", serialconfig.Config.NRTList)
 		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
 
 		padder, err = e2epadder.New(fxt.Client, fxt.Namespace.Name)

--- a/test/e2e/serial/tests/workload_placement_resources.go
+++ b/test/e2e/serial/tests/workload_placement_resources.go
@@ -61,7 +61,7 @@ var _ = Describe("[serial][disruptive][scheduler][byres] numaresources workload 
 		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 
 		var err error
-		fxt, err = e2efixture.Setup("e2e-test-workload-placement-resources")
+		fxt, err = e2efixture.Setup("e2e-test-workload-placement-resources", serialconfig.Config.NRTList)
 		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
 
 		err = fxt.Client.List(context.TODO(), &nrtList)

--- a/test/e2e/serial/tests/workload_placement_taint.go
+++ b/test/e2e/serial/tests/workload_placement_taint.go
@@ -59,7 +59,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 
 		var err error
-		fxt, err = e2efixture.Setup("e2e-test-workload-placement")
+		fxt, err = e2efixture.Setup("e2e-test-workload-placement", serialconfig.Config.NRTList)
 		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
 
 		padder, err = e2epadder.New(fxt.Client, fxt.Namespace.Name)

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -86,7 +86,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 
 		var err error
-		fxt, err = e2efixture.Setup("e2e-test-workload-placement-tmpol")
+		fxt, err = e2efixture.Setup("e2e-test-workload-placement-tmpol", serialconfig.Config.NRTList)
 		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
 
 		err = fxt.Client.List(context.TODO(), &nrtList)

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -60,7 +60,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 		Expect(serialconfig.Config).ToNot(BeNil())
 
 		var err error
-		fxt, err = e2efixture.Setup("e2e-test-workload-unschedulable")
+		fxt, err = e2efixture.Setup("e2e-test-workload-unschedulable", serialconfig.Config.NRTList)
 		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
 
 		padder, err = e2epadder.New(fxt.Client, fxt.Namespace.Name)

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -192,7 +192,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(err).ToNot(HaveOccurred())
 
 			By("waiting for the NRT data to settle")
-			wait.With(fxt.Client).Interval(11*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesSettled(context.TODO(), 3)
+			e2efixture.WaitForNRTSettle(fxt)
 
 			By(fmt.Sprintf("checking the pod was handled by the topology aware scheduler %q but failed to be scheduled on any node", serialconfig.Config.SchedulerName))
 			isFailed, err := nrosched.CheckPODSchedulingFailedForAlignment(fxt.K8sClient, pod.Namespace, pod.Name, serialconfig.Config.SchedulerName, tmPolicy)
@@ -227,7 +227,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
 
 			By("waiting for the NRT data to settle")
-			wait.With(fxt.Client).Interval(11*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesSettled(context.TODO(), 3)
+			e2efixture.WaitForNRTSettle(fxt)
 
 			for _, pod := range pods {
 				isFailed, err := nrosched.CheckPODSchedulingFailedForAlignment(fxt.K8sClient, pod.Namespace, pod.Name, serialconfig.Config.SchedulerName, tmPolicy)
@@ -267,7 +267,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DS %s/%s", ds.Namespace, ds.Name)
 
 			By("waiting for the NRT data to settle")
-			wait.With(fxt.Client).Interval(11*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesSettled(context.TODO(), 3)
+			e2efixture.WaitForNRTSettle(fxt)
 
 			for _, pod := range pods {
 				isFailed, err := nrosched.CheckPODSchedulingFailedForAlignment(fxt.K8sClient, pod.Namespace, pod.Name, serialconfig.Config.SchedulerName, tmPolicy)
@@ -411,7 +411,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DS %s/%s", ds.Namespace, ds.Name)
 
 			By("waiting for the NRT data to settle")
-			wait.With(fxt.Client).Interval(11*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesSettled(context.TODO(), 3)
+			e2efixture.WaitForNRTSettle(fxt)
 
 			By(fmt.Sprintf("checking only daemonset pod in targetNode:%q is up and running", targetNodeName))
 			podRunningTimeout := 3 * time.Minute
@@ -699,7 +699,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(succeededPods).To(BeEmpty(), "some pods are running, but we expect all of them to fail")
 
 			By("Verifying NRTs had no updates because the pods failed to be scheduled on any node")
-			wait.With(fxt.Client).Interval(11*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesSettled(context.TODO(), 3)
+			e2efixture.WaitForNRTSettle(fxt)
 			wait.With(fxt.Client).Interval(5*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesEqualTo(context.TODO(), &nrtInitialList, func(nrt *nrtv1alpha2.NodeResourceTopology) bool {
 				return !nodesNameSet.Has(nrt.Name)
 			})
@@ -826,7 +826,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
 			// TODO: interval proportional to periodic update
-			nrtListInitial, err = wait.With(fxt.Client).Interval(11*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesSettled(context.TODO(), 3)
+			nrtListInitial, err = e2efixture.WaitForNRTSettle(fxt)
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -105,7 +105,6 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 
 	Context("with no suitable node", func() {
 		var requiredRes corev1.ResourceList
-		var nrtListInitial nrtv1alpha2.NodeResourceTopologyList
 		var nrtCandidates []nrtv1alpha2.NodeResourceTopology
 		BeforeEach(func() {
 			neededNodes := 1
@@ -165,14 +164,8 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			failedPodIds := e2efixture.WaitForPaddingPodsRunning(fxt, paddingPods)
 			Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
-			//save initial NRT to compare the data after trying to schedule the workloads
-			var err error
-			nrtListInitial, err = e2enrt.GetUpdated(fxt.Client, nrtList, time.Minute)
+			_, err := e2enrt.GetUpdated(fxt.Client, nrtList, time.Minute)
 			Expect(err).ToNot(HaveOccurred())
-		})
-
-		AfterEach(func() {
-			wait.With(fxt.Client).Interval(5*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesEqualTo(context.TODO(), &nrtListInitial, wait.NRTIgnoreNothing)
 		})
 
 		It("[test_id:47617][tier2][unsched][failalign] workload requests guaranteed pod resources available on one node but not on a single numa", Label("unsched", "failalign"), func() {
@@ -761,7 +754,6 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 	Context("Requesting allocatable resources on the node", func() {
 		var requiredRes corev1.ResourceList
 		var targetNodeName string
-		var nrtListInitial *nrtv1alpha2.NodeResourceTopologyList
 		var nrtCandidates []nrtv1alpha2.NodeResourceTopology
 		var targetNrtInitial nrtv1alpha2.NodeResourceTopology
 		var err error
@@ -826,12 +818,8 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
 			// TODO: interval proportional to periodic update
-			nrtListInitial, err = e2efixture.WaitForNRTSettle(fxt)
+			_, err = e2efixture.WaitForNRTSettle(fxt)
 			Expect(err).ToNot(HaveOccurred())
-		})
-
-		AfterEach(func() {
-			wait.With(fxt.Client).Interval(5*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesEqualTo(context.TODO(), nrtListInitial, wait.NRTIgnoreNothing)
 		})
 
 		It("[test_id:47614][tier3][unsched][pod] workload requests guaranteed pod resources available on one node but not on a single numa", func() {


### PR DESCRIPTION
Following https://github.com/openshift-kni/numaresources-operator/pull/598, https://github.com/openshift-kni/numaresources-operator/pull/608 stabilize the e2e tests even more by verifying after each test that the NRT data is settled to the initial. This will help in troubleshooting failures related to to unclean NRT data and in a meaninful cooldown.

PS: we assume that the cluster is clean before running the suite, as in it doesn't have workloads apart from the system and setup workloads that are needed for executing serial. Also, we assume no sudden interrupts, resources consumptions/releases during the run, which was also the case before this update.