### PR TITLE
e2e: print random seed being used

### DIFF
--- a/test/e2e/rte/rte_e2e_suite_test.go
+++ b/test/e2e/rte/rte_e2e_suite_test.go
@@ -37,6 +37,12 @@ import (
 	_ "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/topology_updater"
 )
 
+var (
+	BinaryPath string
+
+	randomSeed int64
+)
+
 func TestMain(m *testing.M) {
 	config.CopyFlags(config.Flags, flag.CommandLine)
 	framework.RegisterCommonFlags(flag.CommandLine)
@@ -45,7 +51,8 @@ func TestMain(m *testing.M) {
 
 	framework.AfterReadingAllFlags(&framework.TestContext)
 
-	rand.Seed(time.Now().UnixNano())
+	randomSeed = time.Now().UnixNano()
+	rand.Seed(randomSeed)
 	os.Exit(m.Run())
 }
 
@@ -54,9 +61,9 @@ func TestRTE(t *testing.T) {
 	RunSpecs(t, "RTE Test Suite")
 }
 
-var BinaryPath string
-
 var _ = BeforeSuite(func() {
+	By(fmt.Sprintf("Using random seed %v", randomSeed))
+
 	By("Finding the binaries path")
 
 	binPath, err := runtime.FindBinaryPath("exporter")

--- a/test/e2e/serial/e2e_serial_test.go
+++ b/test/e2e/serial/e2e_serial_test.go
@@ -25,6 +25,8 @@ import (
 	ginkgo_reporters "github.com/onsi/ginkgo/v2/reporters"
 	. "github.com/onsi/gomega"
 
+	"k8s.io/klog/v2"
+
 	qe_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
@@ -32,6 +34,8 @@ import (
 )
 
 var afterSuiteReporters = []Reporter{}
+
+var randomSeed int64
 
 func TestSerial(t *testing.T) {
 	if qe_reporters.Polarion.Run {
@@ -44,7 +48,11 @@ func TestSerial(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	// this must be the very first thing
-	rand.Seed(time.Now().UnixNano())
+	randomSeed = time.Now().UnixNano()
+	rand.Seed(randomSeed)
+
+	klog.Infof("using random seed %v", randomSeed)
+
 	serialconfig.Setup()
 })
 


### PR DESCRIPTION
We reset the random seed, so let's make sure we print what we use. Ideally we should integrate with ginkgo and/or make the seed configurable. Let's at least make it explicit the seed we use as starting point.