### PR TITLE
e2e: add missing wait for NRT to settle

### DIFF
--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -277,6 +277,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			nrtInitial, err := e2enrt.FindFromList(nrtInitialList.Items, updatedPod.Spec.NodeName)
 			Expect(err).ToNot(HaveOccurred())
 
+			By("wait for NRT data to settle")
+			e2efixture.WaitForNRTSettle(fxt)
+
 			nrtPostCreate, err := e2enrt.FindFromList(nrtPostCreateDeploymentList.Items, updatedPod.Spec.NodeName)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -391,6 +394,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				objects.LogEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
 			}
 			Expect(err).ToNot(HaveOccurred())
+
+			By("wait for NRT data to settle")
+			e2efixture.WaitForNRTSettle(fxt)
 
 			By("check the NRT has no changes")
 			nrtListPostPodCreate, err := e2enrt.GetUpdated(fxt.Client, targetNrtListInitial, 1*time.Minute)

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -633,6 +633,9 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(err).ToNot(HaveOccurred())
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 
+			By("wait for NRT data to settle")
+			e2efixture.WaitForNRTSettle(fxt)
+
 			nrtPostPodCreateList, err := e2enrt.GetUpdated(fxt.Client, targetNrtListInitial, time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -241,6 +241,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(2*time.Minute).ForDeploymentComplete(context.TODO(), deployment)
 				Expect(err).NotTo(HaveOccurred(), "Deployment %q not up&running after %v", deployment.Name, 2*time.Minute)
 
+				By("wait for NRT data to settle")
+				e2efixture.WaitForNRTSettle(fxt)
+
 				nrtPostCreate, err := e2enrt.GetUpdatedForNode(fxt.Client, context.TODO(), nrtInitial, 1*time.Minute)
 				Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -242,6 +242,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			nrtInitial, err := e2enrt.FindFromList(nrtInitialList.Items, updatedPod.Spec.NodeName)
 			Expect(err).ToNot(HaveOccurred())
 
+			By("wait for NRT data to settle")
+			e2efixture.WaitForNRTSettle(fxt)
+
 			nrtPostCreate, err := e2enrt.FindFromList(nrtPostCreateDeploymentList.Items, updatedPod.Spec.NodeName)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -305,6 +308,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			rl = e2ereslist.FromGuaranteedPod(updatedPod)
 			klog.Infof("post-update pod resource list: spec=[%s] updated=[%s]", e2ereslist.ToString(e2ereslist.FromContainers(podSpec.Containers)), e2ereslist.ToString(rl))
+
+			By("wait for NRT data to settle")
+			e2efixture.WaitForNRTSettle(fxt)
 
 			nrtPostUpdate, err := e2enrt.FindFromList(nrtPostUpdateDeploymentList.Items, updatedPod.Spec.NodeName)
 			Expect(err).ToNot(HaveOccurred())
@@ -404,6 +410,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			nrtReorganized, err := e2enrt.FindFromList(nrtReorganizedList.Items, updatedPod.Spec.NodeName)
 			Expect(err).ToNot(HaveOccurred())
+
+			By("wait for NRT data to settle")
+			e2efixture.WaitForNRTSettle(fxt)
 
 			nrtLastUpdate, err := e2enrt.FindFromList(nrtLastUpdateDeploymentList.Items, updatedPod.Spec.NodeName)
 			Expect(err).ToNot(HaveOccurred())
@@ -557,6 +566,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			rl := e2ereslist.FromGuaranteedPod(*updatedPod)
 			klog.Infof("post-create pod resource list: spec=[%s] updated=[%s]", e2ereslist.ToString(e2ereslist.FromContainers(pod.Spec.Containers)), e2ereslist.ToString(rl))
+
+			By("wait for NRT data to settle")
+			e2efixture.WaitForNRTSettle(fxt)
 
 			nrtPostCreatePod1, err := e2enrt.FindFromList(nrtPostCreatePodList.Items, updatedPod.Spec.NodeName)
 			Expect(err).ToNot(HaveOccurred())
@@ -757,6 +769,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			nrtInitial, err := e2enrt.FindFromList(nrtList.Items, targetNodeName)
 			Expect(err).ToNot(HaveOccurred())
 
+			By("wait for NRT data to settle")
+			e2efixture.WaitForNRTSettle(fxt)
+
 			nrtPostCreate, err := e2enrt.FindFromList(nrtPostCreateDeploymentList.Items, targetNodeName)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -821,6 +836,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			updatedPod1 = pods[1]
 			checkReplica(updatedPod1, targetNodeName, fxt.K8sClient)
 			rl1 = e2ereslist.FromGuaranteedPod(updatedPod1)
+
+			By("wait for NRT data to settle")
+			e2efixture.WaitForNRTSettle(fxt)
 
 			nrtPostUpdate, err := e2enrt.FindFromList(nrtPostCreateDeploymentList.Items, targetNodeName)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/serial/tests/workload_placement_nodelabel.go
+++ b/test/e2e/serial/tests/workload_placement_nodelabel.go
@@ -230,6 +230,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 
+			By("wait for NRT data to settle")
+			e2efixture.WaitForNRTSettle(fxt)
+
 			By("Verifing the NRT statistics are updated")
 			targetNrtListCurrent, err := e2enrt.GetUpdated(fxt.Client, targetNrtListInitial, 1*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
@@ -309,6 +312,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 						Expect(err).ToNot(HaveOccurred())
 						Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", pod.Namespace, pod.Name, serialconfig.Config.SchedulerName)
 					}
+
+					By("wait for NRT data to settle")
+					e2efixture.WaitForNRTSettle(fxt)
 
 					By("Verifing the NRT statistics are updated")
 					targetNrtListCurrent, err := e2enrt.GetUpdated(fxt.Client, targetNrtListInitial, 1*time.Minute)

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -466,6 +466,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 
+			By("wait for NRT data to settle")
+			e2efixture.WaitForNRTSettle(fxt)
+
 			By(fmt.Sprintf("checking the resources are accounted as expected on %q", updatedPod.Spec.NodeName))
 			nrtPostCreate, err := e2enrt.GetUpdatedForNode(fxt.Client, context.TODO(), nrtInitial, 1*time.Minute)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -584,6 +584,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			}
 			Expect(isFailed).To(BeTrue(), "pod %s/%s with scheduler %s did NOT fail", pod.Namespace, pod.Name, serialconfig.Config.SchedulerName)
 
+			By("wait for NRT data to settle")
+			e2efixture.WaitForNRTSettle(fxt)
+
 			By("Verifying NRT reflects no updates")
 			targetNrtListAfter, err := e2enrt.GetUpdated(fxt.Client, targetNrtListBefore, 1*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
@@ -729,6 +732,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 				}
 				return true
 			}).WithTimeout(time.Minute*5).WithPolling(time.Second*30).Should(BeTrue(), "deployment %q failed to have %d running replicas within the defined period", dpKey.String(), expectedReadyReplicas)
+
+			By("wait for NRT data to settle")
+			e2efixture.WaitForNRTSettle(fxt)
 
 			By("checking NRT objects updated accordingly")
 			nrtPostDpCreateList, err := e2enrt.GetUpdated(fxt.Client, nrtInitialList, time.Second*10)


### PR DESCRIPTION
Some tests fail often in CI on inconsistent accounting in NRT data, and pass after rerun. To assure the NRT data is relaible at the checking point, need to wait enough for the data to be settled and only then to compare the outputs.