### PR TITLE
e2e: serial: support kubelet defaults in validation

### DIFF
--- a/test/e2e/serial/config/config.go
+++ b/test/e2e/serial/config/config.go
@@ -155,6 +155,7 @@ func CheckNodesTopology(ctx context.Context) error {
 
 	errorMap := getTopologyConsistencyErrors(kconfigs, nrtList.Items)
 	if len(errorMap) != 0 {
+		klog.Infof("incoeherent NRT/KubeletConfig data: %v", errorMap)
 		prettyMap, err := json.MarshalIndent(errorMap, "", "  ")
 		if err != nil {
 			return fmt.Errorf("Found some nodes with incoherent info in KubeletConfig/NRT data")


### PR DESCRIPTION
The kubelet sets defaults for Topology Manager policy and scope when a value is not explicitely set in the configuration.
Let's support this scenario, copying the kubelet defaults. 
We should get them programmatically and from the right kubelet version, but the saving grace is the values don't change
frequently (if at all).

In addition, starting NRT API v1alpha2, the "topologyPolicies" field is deprecated in favor of Attributes.
Albeit not  needed for the enhancement,  we take the chance to make this code more forward-looking switching to comparing attributes.
