### PR TITLE
serial: fetch CacheResyncPeriod from Status

### DIFF
--- a/test/e2e/serial/tests/non_regression_fundamentals.go
+++ b/test/e2e/serial/tests/non_regression_fundamentals.go
@@ -168,10 +168,10 @@ var _ = Describe("[serial][fundamentals][scheduler][nonreg] numaresources fundam
 				err := fxt.Client.Get(context.TODO(), nroSchedKey, nroSchedObj)
 				Expect(err).ToNot(HaveOccurred())
 
-				if nroSchedObj.Spec.CacheResyncPeriod == nil {
+				if nroSchedObj.Status.CacheResyncPeriod == nil {
 					e2efixture.Skip(fxt, "Scheduler cache not enabled")
 				}
-				timeout := nroSchedObj.Spec.CacheResyncPeriod.Round(time.Second) * 10
+				timeout := nroSchedObj.Status.CacheResyncPeriod.Round(time.Second) * 10
 				klog.Infof("pod running timeout: %v", timeout)
 
 				nrts := e2enrt.FilterZoneCountEqual(nrtList.Items, 2)
@@ -263,10 +263,10 @@ var _ = Describe("[serial][fundamentals][scheduler][nonreg] numaresources fundam
 				err := fxt.Client.Get(context.TODO(), nroSchedKey, nroSchedObj)
 				Expect(err).ToNot(HaveOccurred())
 
-				if nroSchedObj.Spec.CacheResyncPeriod == nil {
+				if nroSchedObj.Status.CacheResyncPeriod == nil {
 					e2efixture.Skip(fxt, "Scheduler cache not enabled")
 				}
-				timeout := nroSchedObj.Spec.CacheResyncPeriod.Round(time.Second) * 10
+				timeout := nroSchedObj.Status.CacheResyncPeriod.Round(time.Second) * 10
 				klog.Infof("pod running timeout: %v", timeout)
 
 				nrts := e2enrt.FilterZoneCountEqual(nrtList.Items, 2)

--- a/test/e2e/serial/tests/scheduler_cache_stall.go
+++ b/test/e2e/serial/tests/scheduler_cache_stall.go
@@ -82,7 +82,7 @@ var _ = Describe("[serial][scheduler][cache][tier1] scheduler cache stall", Labe
 			err = fxt.Client.Get(context.TODO(), nroSchedKey, &nroSchedObj)
 			Expect(err).ToNot(HaveOccurred())
 
-			if nroSchedObj.Spec.CacheResyncPeriod == nil { // should never trigger
+			if nroSchedObj.Status.CacheResyncPeriod == nil { // should never trigger
 				e2efixture.Skip(fxt, "Scheduler cache not enabled")
 			}
 
@@ -99,7 +99,7 @@ var _ = Describe("[serial][scheduler][cache][tier1] scheduler cache stall", Labe
 			mcpName = nroOperObj.Status.MachineConfigPools[0].Name
 			conf := nroOperObj.Status.MachineConfigPools[0].Config
 			if ok, val := isPFPEnabledInConfig(conf); !ok {
-				e2efixture.Skipf(fxt, "unsupported refresh mode %q in %q", val, mcpName)
+				e2efixture.Skipf(fxt, "unsupported pfp mode %q in %q", val, mcpName)
 			}
 			if ok, val := isInfoRefreshModeEqual(conf, nropv1.InfoRefreshPeriodic); !ok {
 				e2efixture.Skipf(fxt, "unsupported refresh mode %q in %q", val, mcpName)
@@ -234,7 +234,7 @@ var _ = Describe("[serial][scheduler][cache][tier1] scheduler cache stall", Labe
 				// like non-regression tests, but with jobs present
 
 				func(setupPod setupPodFunc) {
-					timeout := nroSchedObj.Spec.CacheResyncPeriod.Round(time.Second) * 10
+					timeout := nroSchedObj.Status.CacheResyncPeriod.Round(time.Second) * 10
 					klog.Infof("pod running timeout: %v", timeout)
 
 					nrts := e2enrt.FilterZoneCountEqual(nrtList.Items, 2)


### PR DESCRIPTION
When running the tests on a cluster with default configuration, the default value of scheduler's CacheResyncPeriod is reflected in the object's status and not in spec. The tests do not change this field so they run on default configuration and when fetching it from spec the value is not found hence skipping tests.

Fetch the scheduler's CacheResyncPeriod from its status instead to enable running the tests. This is also true if the value is not default.