### PR TITLE
e2e: run scheduler tests by default

### DIFF
--- a/hack/run-test-e2e.sh
+++ b/hack/run-test-e2e.sh
@@ -2,7 +2,7 @@
 
 source hack/common.sh
 
-ENABLE_SCHED_TESTS="${ENABLE_SCHED_TESTS:-false}"
+ENABLE_SCHED_TESTS="${ENABLE_SCHED_TESTS:-true}"
 NO_TEARDOWN="${NO_TEARDOWN:-false}"
 
 function test_sched() {


### PR DESCRIPTION
In the early days of the operator we disable the scheduler tests by default to keep the CI stable.

Now when the project is mature enough, we should always run those tests for maximum coverage.