### PR TITLE
internal: drop stale v1alpha1 API ref

### DIFF
--- a/internal/schedcache/synced.go
+++ b/internal/schedcache/synced.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/k8stopologyawareschedwg/podfingerprint"
-	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1alpha1"
+	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
 	"github.com/openshift-kni/numaresources-operator/pkg/status"
 


### PR DESCRIPTION
was kept only because incomplete replace