### PR TITLE
Deprecate topology policies

### DIFF
--- a/internal/noderesourcetopology/attributes.go
+++ b/internal/noderesourcetopology/attributes.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package noderesourcetopology
+
+// TopologyManager Attributes Names and values should follow the format
+// documented here
+// https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/pkg/noderesourcetopology/README.md#topology-manager-configuration
+const (
+	TopologyManagerPolicyAttribute = "topologyManagerPolicy"
+	TopologyManagerScopeAttribute  = "topologyManagerScope"
+)
+
+// From https://pkg.go.dev/k8s.io/kubelet@v0.25.11/config/v1beta1#KubeletConfiguration.TopologyManagerPolicy
+//   - `restricted`: kubelet only allows pods with optimal NUMA node alignment for
+//     requested resources;
+//   - `best-effort`: kubelet will favor pods with NUMA alignment of CPU and device
+//     resources;
+//   - `none`: kubelet has no knowledge of NUMA alignment of a pod's CPU and device resources.
+//   - `single-numa-node`: kubelet only allows pods with a single NUMA alignment
+//     of CPU and device resources.
+const (
+	SingleNUMANode = "single-numa-node"
+	Restricted     = "restricted"
+	BestEffort     = "best-effort"
+	None           = "none"
+)
+
+// From https://pkg.go.dev/k8s.io/kubelet@v0.25.11/config/v1beta1#KubeletConfiguration.TopologyManagerScope
+// - `container`: topology policy is applied on a per-container basis.
+// - `pod`: topology policy is applied on a per-pod basis.
+const (
+	Container = "container"
+	Pod       = "pod"
+)

--- a/internal/noderesourcetopology/tostring.go
+++ b/internal/noderesourcetopology/tostring.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper/attribute"
 )
 
 func ResourceInfoToString(resInfo nrtv1alpha2.ResourceInfo) string {
@@ -61,10 +62,16 @@ func ToString(nrt nrtv1alpha2.NodeResourceTopology) string {
 		name = "<MISSING>"
 	}
 	pol := "N/A"
-	if len(nrt.TopologyPolicies) > 0 {
-		pol = nrt.TopologyPolicies[0]
+	tmPolicy, ok := attribute.Get(nrt.Attributes, TopologyManagerPolicyAttribute)
+	if ok {
+		pol = tmPolicy.Value
 	}
-	fmt.Fprintf(&b, "%s policy=%s\n", name, pol)
+	scope := "N/A"
+	tmScope, ok := attribute.Get(nrt.Attributes, TopologyManagerScopeAttribute)
+	if ok {
+		scope = tmScope.Value
+	}
+	fmt.Fprintf(&b, "%s policy=%s, scope=%s\n", name, pol, scope)
 	for idx := range nrt.Zones {
 		fmt.Fprintf(&b, "- zone: %s\n", ZoneToString(nrt.Zones[idx]))
 	}

--- a/internal/noderesourcetopology/tostring_test.go
+++ b/internal/noderesourcetopology/tostring_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 )
@@ -166,48 +165,7 @@ func TestToString(t *testing.T) {
 	}{
 		{
 			name:     "empty",
-			expected: "<MISSING> policy=N/A\n",
-		},
-		{
-			name: "only-one",
-			nrt: nrtv1alpha2.NodeResourceTopology{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-nrt",
-				},
-				TopologyPolicies: []string{
-					"restricted",
-					"ignored-from-the-second-onwards",
-				},
-				Zones: []nrtv1alpha2.Zone{
-					{
-						Name:   "zone-0",
-						Type:   "zoneTypeA",
-						Parent: "will-not-be-stringified",
-						Resources: []nrtv1alpha2.ResourceInfo{
-							{
-								Name:        "dev1",
-								Capacity:    resource.MustParse("10"),
-								Allocatable: resource.MustParse("9"),
-								Available:   resource.MustParse("4"),
-							},
-						},
-					},
-					{
-						Name:   "zone-1",
-						Type:   "zoneTypeA",
-						Parent: "will-not-be-stringified",
-						Resources: []nrtv1alpha2.ResourceInfo{
-							{
-								Name:        "dev1",
-								Capacity:    resource.MustParse("10"),
-								Allocatable: resource.MustParse("10"),
-								Available:   resource.MustParse("8"),
-							},
-						},
-					},
-				},
-			},
-			expected: "test-nrt policy=restricted\n- zone: zone-0 [zoneTypeA]: dev1=10/9/4\n- zone: zone-1 [zoneTypeA]: dev1=10/10/8\n",
+			expected: "<MISSING> policy=N/A, scope=N/A\n",
 		},
 	}
 	for _, tt := range testCases {

--- a/test/e2e/serial/config/config.go
+++ b/test/e2e/serial/config/config.go
@@ -30,6 +30,7 @@ import (
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	nrtv1alpha2attr "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper/attribute"
 
+	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	"github.com/openshift-kni/numaresources-operator/pkg/validator"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
 	e2enrt "github.com/openshift-kni/numaresources-operator/test/utils/noderesourcetopologies"
@@ -164,14 +165,9 @@ func CheckNodesTopology(ctx context.Context) error {
 		return fmt.Errorf("Following nodes have incoherent info in KubeletConfig/NRT data:\n%s\n", string(prettyMap))
 	}
 
-	snnPodLevelNRTs := e2enrt.FilterTopologyManagerPolicy(nrtList.Items, nrtv1alpha2.SingleNUMANodePodLevel)
-	numSnnPodLevelNRTs := len(snnPodLevelNRTs)
-
-	snnContainerLevelNRTs := e2enrt.FilterTopologyManagerPolicy(nrtList.Items, nrtv1alpha2.SingleNUMANodeContainerLevel)
-	numSnnContainerLevelNRTs := len(snnContainerLevelNRTs)
-
-	if numSnnPodLevelNRTs < minNumberOfNodesWithSameTopology && numSnnContainerLevelNRTs < minNumberOfNodesWithSameTopology {
-		return fmt.Errorf("Not enough nodes with either %q topology (found:%d) nor %q topology (found: %d). Need at least %d", nrtv1alpha2.SingleNUMANodePodLevel, numSnnPodLevelNRTs, nrtv1alpha2.SingleNUMANodeContainerLevel, numSnnContainerLevelNRTs, minNumberOfNodesWithSameTopology)
+	singleNUMANodeNRTs := e2enrt.FilterByTopologyManagerPolicy(nrtList.Items, intnrt.SingleNUMANode)
+	if len(singleNUMANodeNRTs) < minNumberOfNodesWithSameTopology {
+		return fmt.Errorf("Not enough nodes with %q topology (found:%d). Need at least %d", intnrt.SingleNUMANode, len(singleNUMANodeNRTs), minNumberOfNodesWithSameTopology)
 	}
 
 	return nil

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -51,6 +51,7 @@ import (
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
 
+	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
 	"github.com/openshift-kni/numaresources-operator/test/utils/configuration"
 	e2efixture "github.com/openshift-kni/numaresources-operator/test/utils/fixture"
@@ -79,11 +80,7 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 
 		// we're ok with any TM policy as long as the updater can handle it,
 		// we use this as proxy for "there is valid NRT data for at least X nodes
-		policies := []nrtv1alpha2.TopologyManagerPolicy{
-			nrtv1alpha2.SingleNUMANodeContainerLevel,
-			nrtv1alpha2.SingleNUMANodePodLevel,
-		}
-		nrts = e2enrt.FilterByPolicies(nrtList.Items, policies)
+		nrts = e2enrt.FilterByTopologyManagerPolicy(nrtList.Items, intnrt.SingleNUMANode)
 		if len(nrts) < 2 {
 			Skip(fmt.Sprintf("not enough nodes with valid policy - found %d", len(nrts)))
 		}

--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -33,12 +33,14 @@ import (
 	corev1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper/attribute"
 
 	"github.com/openshift-kni/numaresources-operator/internal/nodes"
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
 
+	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 	e2efixture "github.com/openshift-kni/numaresources-operator/test/utils/fixture"
 	"github.com/openshift-kni/numaresources-operator/test/utils/images"
@@ -53,9 +55,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 	var nrts []nrtv1alpha2.NodeResourceTopology
-	tmPolicyFuncsHandler := tmPolicyFuncsHandler{
-		nrtv1alpha2.SingleNUMANodePodLevel:       newPodScopeTMPolicyFuncs(),
-		nrtv1alpha2.SingleNUMANodeContainerLevel: newContainerScopeTMPolicyFuncs(),
+	tmSingleNUMANodeFuncsHandler := tmScopeFuncsHandler{
+		intnrt.Pod:       newPodScopeSingleNUMANodeFuncs(),
+		intnrt.Container: newContainerScopeSingleNUMANodeFuncs(),
 	}
 
 	BeforeEach(func() {
@@ -82,11 +84,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 		// we're ok with any TM policy as long as the updater can handle it,
 		// we use this as proxy for "there is valid NRT data for at least X nodes
-		policies := []nrtv1alpha2.TopologyManagerPolicy{
-			nrtv1alpha2.SingleNUMANodeContainerLevel,
-			nrtv1alpha2.SingleNUMANodePodLevel,
-		}
-		nrts = e2enrt.FilterByPolicies(nrtCandidates, policies)
+		nrts = e2enrt.FilterByTopologyManagerPolicy(nrtCandidates, intnrt.SingleNUMANode)
 		if len(nrts) < 2 {
 			e2efixture.Skipf(fxt, "not enough nodes with valid policy - found %d", len(nrts))
 		}
@@ -283,7 +281,10 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			nrtPostCreate, err := e2enrt.FindFromList(nrtPostCreateDeploymentList.Items, updatedPod.Spec.NodeName)
 			Expect(err).ToNot(HaveOccurred())
 
-			policyFuncs := tmPolicyFuncsHandler[nrtv1alpha2.TopologyManagerPolicy(nrtInitial.TopologyPolicies[0])]
+			scope, ok := attribute.Get(nrtInitial.Attributes, intnrt.TopologyManagerScopeAttribute)
+			Expect(ok).To(BeTrue(), fmt.Sprintf("Unable to get required attribute %q from NRT %q", intnrt.TopologyManagerScopeAttribute, nrtInitial.Name))
+
+			policyFuncs := tmSingleNUMANodeFuncsHandler[scope.Value]
 
 			By(fmt.Sprintf("checking post-create NRT for target node %q updated correctly", targetNodeName))
 			dataBefore, err := yaml.Marshal(nrtInitial)

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper/attribute"
 
 	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	"github.com/openshift-kni/numaresources-operator/internal/nodes"
@@ -55,9 +56,9 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 	var nrts []nrtv1alpha2.NodeResourceTopology
-	tmPolicyFuncsHandler := tmPolicyFuncsHandler{
-		nrtv1alpha2.SingleNUMANodePodLevel:       newPodScopeTMPolicyFuncs(),
-		nrtv1alpha2.SingleNUMANodeContainerLevel: newContainerScopeTMPolicyFuncs(),
+	tmSingleNUMANodeFuncsHandler := tmScopeFuncsHandler{
+		intnrt.Pod:       newPodScopeSingleNUMANodeFuncs(),
+		intnrt.Container: newContainerScopeSingleNUMANodeFuncs(),
 	}
 
 	BeforeEach(func() {
@@ -76,11 +77,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 
 		// we're ok with any TM policy as long as the updater can handle it,
 		// we use this as proxy for "there is valid NRT data for at least X nodes
-		policies := []nrtv1alpha2.TopologyManagerPolicy{
-			nrtv1alpha2.SingleNUMANodeContainerLevel,
-			nrtv1alpha2.SingleNUMANodePodLevel,
-		}
-		nrts = e2enrt.FilterByPolicies(nrtList.Items, policies)
+		nrts = e2enrt.FilterByTopologyManagerPolicy(nrtList.Items, intnrt.SingleNUMANode)
 		if len(nrts) < 2 {
 			e2efixture.Skipf(fxt, "not enough nodes with valid policy - found %d", len(nrts))
 		}
@@ -518,7 +515,13 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			pod.Spec.Containers[0].Resources.Limits = reqResPerNUMA[0]
 			// keep the pod QoS as burstable
 			pod.Spec.Containers[1].Resources.Requests = reqResPerNUMA[1]
-			if targetNrtInitial.TopologyPolicies[0] == string(nrtv1alpha2.SingleNUMANodePodLevel) {
+			tmPolicy, ok := attribute.Get(targetNrtInitial.Attributes, intnrt.TopologyManagerPolicyAttribute)
+			Expect(ok).To(BeTrue(), fmt.Sprintf("Unable to get %q attribute", intnrt.TopologyManagerPolicyAttribute))
+
+			tmScope, ok := attribute.Get(targetNrtInitial.Attributes, intnrt.TopologyManagerScopeAttribute)
+			Expect(ok).To(BeTrue(), fmt.Sprintf("Unable to get %q attribute", intnrt.TopologyManagerPolicyAttribute))
+
+			if tmPolicy.Value == intnrt.SingleNUMANode && tmScope.Value == intnrt.Pod {
 				// if both containers should fit into the same zone, we should make the burstable one asking for minimum
 				// resources as possible so the node won't get filtered by the NodeResourceFit plugin
 				pod.Spec.Containers[1].Resources.Requests = corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("5Mi")}
@@ -645,7 +648,10 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			rl := e2ereslist.FromGuaranteedPod(*updatedPod2)
 			klog.Infof("post-create pod resource list: spec=[%s] updated=[%s]", e2ereslist.ToString(e2ereslist.FromContainers(podGuanranteed.Spec.Containers)), e2ereslist.ToString(rl))
 
-			policyFuncs := tmPolicyFuncsHandler[nrtv1alpha2.TopologyManagerPolicy(targetNrtInitial.TopologyPolicies[0])]
+			scope, ok := attribute.Get(targetNrtInitial.Attributes, intnrt.TopologyManagerScopeAttribute)
+			Expect(ok).To(BeTrue(), fmt.Sprintf("Unable to find required attribute %q on NRT %q", intnrt.TopologyManagerScopeAttribute, targetNrtInitial.Name))
+
+			policyFuncs := tmSingleNUMANodeFuncsHandler[scope.Value]
 
 			By(fmt.Sprintf("checking post-update NRT for target node %q updated correctly", targetNodeName))
 			// it's simpler (no resource substraction/difference) to check against initial than compute

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -33,6 +33,7 @@ import (
 
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 
+	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	"github.com/openshift-kni/numaresources-operator/internal/nodes"
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
 	"github.com/openshift-kni/numaresources-operator/internal/resourcelist"
@@ -71,11 +72,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 
 		// we're ok with any TM policy as long as the updater can handle it,
 		// we use this as proxy for "there is valid NRT data for at least X nodes
-		policies := []nrtv1alpha2.TopologyManagerPolicy{
-			nrtv1alpha2.SingleNUMANodeContainerLevel,
-			nrtv1alpha2.SingleNUMANodePodLevel,
-		}
-		nrts = e2enrt.FilterByPolicies(nrtList.Items, policies)
+		nrts = e2enrt.FilterByTopologyManagerPolicy(nrtList.Items, intnrt.SingleNUMANode)
 		if len(nrts) < 2 {
 			e2efixture.Skipf(fxt, "not enough nodes with valid policy - found %d", len(nrts))
 		}

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -41,6 +41,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper/attribute"
 
 	"github.com/openshift-kni/numaresources-operator/pkg/flagcodec"
 	"github.com/openshift-kni/numaresources-operator/pkg/loglevel"
@@ -69,9 +70,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 	var nrts []nrtv1alpha2.NodeResourceTopology
-	tmPolicyFuncsHandler := tmPolicyFuncsHandler{
-		nrtv1alpha2.SingleNUMANodePodLevel:       newPodScopeTMPolicyFuncs(),
-		nrtv1alpha2.SingleNUMANodeContainerLevel: newContainerScopeTMPolicyFuncs(),
+	tmSingleNUMANodeFuncsHandler := tmScopeFuncsHandler{
+		intnrt.Pod:       newPodScopeSingleNUMANodeFuncs(),
+		intnrt.Container: newContainerScopeSingleNUMANodeFuncs(),
 	}
 
 	BeforeEach(func() {
@@ -118,11 +119,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}
 			klog.Infof("Found node with 2 NUMA zones: %d", len(nrtCandidates))
 
-			policies := []nrtv1alpha2.TopologyManagerPolicy{
-				nrtv1alpha2.SingleNUMANodeContainerLevel,
-				nrtv1alpha2.SingleNUMANodePodLevel,
-			}
-			nrts = e2enrt.FilterByPolicies(nrtCandidates, policies)
+			nrts = e2enrt.FilterByTopologyManagerPolicy(nrtCandidates, intnrt.SingleNUMANode)
 			if len(nrts) < hostsRequired {
 				e2efixture.Skipf(fxt, "not enough nodes with valid policy - found %d", len(nrts))
 			}
@@ -248,7 +245,10 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			nrtPostCreate, err := e2enrt.FindFromList(nrtPostCreateDeploymentList.Items, updatedPod.Spec.NodeName)
 			Expect(err).ToNot(HaveOccurred())
 
-			policyFuncs := tmPolicyFuncsHandler[nrtv1alpha2.TopologyManagerPolicy(nrtInitial.TopologyPolicies[0])]
+			scope, ok := attribute.Get(nrtInitial.Attributes, intnrt.TopologyManagerScopeAttribute)
+			Expect(ok).To(BeTrue(), fmt.Sprintf("Unable to find required attribute %q on NRT %q", intnrt.TopologyManagerScopeAttribute, nrtInitial.Name))
+
+			policyFuncs := tmSingleNUMANodeFuncsHandler[scope.Value]
 
 			By(fmt.Sprintf("checking post-create NRT for target node %q updated correctly", targetNodeName))
 			dataBefore, err := yaml.Marshal(nrtInitial)
@@ -490,8 +490,13 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				reqResPerNUMA = append(reqResPerNUMA, numaRes)
 			}
 			//get the topology manager policy + scope of the NRT
-			tmPolicy := nrtv1alpha2.TopologyManagerPolicy(nrtInitial.TopologyPolicies[0])
-			if tmPolicy == nrtv1alpha2.SingleNUMANodePodLevel {
+			tmPolicy, ok := attribute.Get(nrtInitial.Attributes, intnrt.TopologyManagerPolicyAttribute)
+			Expect(ok).To(BeTrue(), fmt.Sprintf("Unable to find required attribute %q", intnrt.TopologyManagerPolicyAttribute))
+
+			tmScope, ok := attribute.Get(nrtInitial.Attributes, intnrt.TopologyManagerScopeAttribute)
+			Expect(ok).To(BeTrue(), fmt.Sprintf("Unable to find required attribute %q", intnrt.TopologyManagerScopeAttribute))
+
+			if tmPolicy.Value == intnrt.SingleNUMANode && tmScope.Value == intnrt.Pod {
 				paddingPodName := "padding-pod-on-target"
 				By("Pad target node to fit only the pod with TAS scheduler")
 				zeroRl := corev1.ResourceList{
@@ -516,7 +521,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			nrtPostTargetPadding, err := e2enrt.FindFromList(nrtPostTargetPaddingList.Items, targetNodeName)
 			Expect(err).ToNot(HaveOccurred())
 
-			pod.Spec = getPodSpec(tmPolicy, reqResPerNUMA)
+			pod.Spec = getPodSpec(tmPolicy.Value, tmScope.Value, reqResPerNUMA)
 			//prepare the second pod with default scheduler name
 			pod2 := objects.NewTestPodPause(fxt.Namespace.Name, "testpod-gu-with-default-sched")
 			pod2.Spec = pod.Spec
@@ -573,7 +578,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			nrtPostCreatePod1, err := e2enrt.FindFromList(nrtPostCreatePodList.Items, updatedPod.Spec.NodeName)
 			Expect(err).ToNot(HaveOccurred())
 
-			policyFuncs := tmPolicyFuncsHandler[tmPolicy]
+			policyFuncs := tmSingleNUMANodeFuncsHandler[tmScope.Value]
 
 			By(fmt.Sprintf("checking post-create NRT for target node %q updated correctly", targetNodeName))
 			dataBeforePod1, err := yaml.Marshal(nrtPostTargetPadding)
@@ -651,11 +656,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}
 			klog.Infof("Found node with 2 NUMA zones: %d", len(nrtCandidates))
 
-			policies := []nrtv1alpha2.TopologyManagerPolicy{
-				nrtv1alpha2.SingleNUMANodeContainerLevel,
-				nrtv1alpha2.SingleNUMANodePodLevel,
-			}
-			nrts = e2enrt.FilterByPolicies(nrtCandidates, policies)
+			nrts = e2enrt.FilterByTopologyManagerPolicy(nrtCandidates, intnrt.SingleNUMANode)
 			if len(nrts) < hostsRequired {
 				e2efixture.Skipf(fxt, "not enough nodes with valid policy - found %d", len(nrts))
 			}
@@ -894,11 +895,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}
 			klog.Infof("Found node with 2 NUMA zones: %d", len(nrtCandidates))
 
-			policies := []nrtv1alpha2.TopologyManagerPolicy{
-				nrtv1alpha2.SingleNUMANodeContainerLevel,
-				nrtv1alpha2.SingleNUMANodePodLevel,
-			}
-			nrts = e2enrt.FilterByPolicies(nrtCandidates, policies)
+			nrts = e2enrt.FilterByTopologyManagerPolicy(nrtCandidates, intnrt.SingleNUMANode)
 			if len(nrts) < hostsRequired {
 				e2efixture.Skipf(fxt, "not enough nodes with valid policy - found %d", len(nrts))
 			}
@@ -1419,7 +1416,7 @@ func checkReplica(pod corev1.Pod, targetNodeName string, K8sClient *kubernetes.C
 	Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", pod.Namespace, pod.Name, serialconfig.Config.SchedulerName)
 }
 
-func getPodSpec(tmPolicy nrtv1alpha2.TopologyManagerPolicy, rlPerNuma []corev1.ResourceList) corev1.PodSpec {
+func getPodSpec(tmPolicy, tmScope string, rlPerNuma []corev1.ResourceList) corev1.PodSpec {
 	podSpec := corev1.PodSpec{
 		SchedulerName: serialconfig.Config.SchedulerName,
 		Containers: []corev1.Container{
@@ -1448,7 +1445,7 @@ func getPodSpec(tmPolicy nrtv1alpha2.TopologyManagerPolicy, rlPerNuma []corev1.R
 		},
 	}
 
-	if tmPolicy == nrtv1alpha2.SingleNUMANodePodLevel {
+	if tmPolicy == intnrt.SingleNUMANode && tmScope == intnrt.Pod {
 		podSpec.Containers = []corev1.Container{
 			{
 				Name:    "testpod-cnt",

--- a/test/e2e/serial/tests/workload_placement_nodelabel.go
+++ b/test/e2e/serial/tests/workload_placement_nodelabel.go
@@ -33,6 +33,7 @@ import (
 	corev1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	"github.com/openshift-kni/numaresources-operator/internal/nodes"
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
@@ -72,11 +73,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 		// we're ok with any TM policy as long as the updater can handle it,
 		// we use this as proxy for "there is valid NRT data for at least X nodes
-		policies := []nrtv1alpha2.TopologyManagerPolicy{
-			nrtv1alpha2.SingleNUMANodeContainerLevel,
-			nrtv1alpha2.SingleNUMANodePodLevel,
-		}
-		nrts = e2enrt.FilterByPolicies(nrtList.Items, policies)
+		nrts = e2enrt.FilterByTopologyManagerPolicy(nrtList.Items, intnrt.SingleNUMANode)
 		if len(nrts) < 2 {
 			e2efixture.Skipf(fxt, "not enough nodes with valid policy - found %d", len(nrts))
 		}

--- a/test/e2e/serial/tests/workload_placement_taint.go
+++ b/test/e2e/serial/tests/workload_placement_taint.go
@@ -35,6 +35,7 @@ import (
 
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 
+	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	"github.com/openshift-kni/numaresources-operator/internal/nodes"
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
@@ -77,11 +78,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 		// we're ok with any TM policy as long as the updater can handle it,
 		// we use this as proxy for "there is valid NRT data for at least X nodes
-		policies := []nrtv1alpha2.TopologyManagerPolicy{
-			nrtv1alpha2.SingleNUMANodeContainerLevel,
-			nrtv1alpha2.SingleNUMANodePodLevel,
-		}
-		nrts = e2enrt.FilterByPolicies(nrtCandidates, policies)
+		nrts = e2enrt.FilterByTopologyManagerPolicy(nrtCandidates, intnrt.SingleNUMANode)
 		if len(nrts) < 2 {
 			e2efixture.Skipf(fxt, "not enough nodes with valid policy - found %d", len(nrts))
 		}

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -64,21 +64,22 @@ type podResourcesRequest struct {
 	appCnt  []corev1.ResourceList
 }
 
-type tmPolicyFuncs struct {
-	name                    func() nrtv1alpha2.TopologyManagerPolicy
+type tmScopeFuncs struct {
+	policyName              func() string
+	scopeName               func() string
 	setupPadding            func(fxt *e2efixture.Fixture, nrtList nrtv1alpha2.NodeResourceTopologyList, padInfo paddingInfo) []*corev1.Pod
 	checkConsumedRes        func(nrtInitial, nrtUpdated nrtv1alpha2.NodeResourceTopology, required corev1.ResourceList, podQoS corev1.PodQOSClass) (string, error)
 	filterMatchingResources func(nrts []nrtv1alpha2.NodeResourceTopology, requests corev1.ResourceList) []nrtv1alpha2.NodeResourceTopology
 }
 
-type tmPolicyFuncsHandler map[nrtv1alpha2.TopologyManagerPolicy]tmPolicyFuncs
+type tmScopeFuncsHandler map[string]tmScopeFuncs
 
 var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement considering TM policy", Serial, func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
-	tmPolicyFuncsHandler := tmPolicyFuncsHandler{
-		nrtv1alpha2.SingleNUMANodePodLevel:       newPodScopeTMPolicyFuncs(),
-		nrtv1alpha2.SingleNUMANodeContainerLevel: newContainerScopeTMPolicyFuncs(),
+	tmSingleNUMANodeFuncsHandler := tmScopeFuncsHandler{
+		intnrt.Pod:       newPodScopeSingleNUMANodeFuncs(),
+		intnrt.Container: newContainerScopeSingleNUMANodeFuncs(),
 	}
 
 	BeforeEach(func() {
@@ -167,10 +168,10 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		// FIXME: this is a slight abuse of DescribeTable, but we need to run
 		// the same code which a different test_id per tmscope
 		DescribeTable("[tier1] a guaranteed pod with one container should be scheduled into one NUMA zone",
-			func(tmPolicy nrtv1alpha2.TopologyManagerPolicy, requiredRes, paddingRes corev1.ResourceList) {
+			func(tmPolicy, tmScope string, requiredRes, paddingRes corev1.ResourceList) {
 				setupCluster(requiredRes, paddingRes)
 
-				nrts := e2enrt.FilterTopologyManagerPolicy(nrtCandidates, tmPolicy)
+				nrts := e2enrt.FilterByTopologyManagerPolicyAndScope(nrtCandidates, tmPolicy, tmScope)
 				if len(nrts) != len(nrtCandidates) {
 					e2efixture.Skipf(fxt, "not enough nodes with policy %q - found %d", string(tmPolicy), len(nrts))
 				}
@@ -206,7 +207,8 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				expectNRTConsumedResources(fxt, targetNrtInitial, requiredRes, updatedPod)
 			},
 			Entry("[test_id:48713][tmscope:cnt] with topology-manager-scope: container",
-				nrtv1alpha2.SingleNUMANodeContainerLevel,
+				intnrt.SingleNUMANode,
+				intnrt.Container,
 				corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("4"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -217,7 +219,8 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				},
 			),
 			Entry("[test_id:50156][tmscope:pod] with topology-manager-scope: pod",
-				nrtv1alpha2.SingleNUMANodePodLevel,
+				intnrt.SingleNUMANode,
+				intnrt.Pod,
 				corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("4"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -228,7 +231,8 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				},
 			),
 			Entry("[test_id:50158][tmscope:cnt][hugepages] with topology-manager-scope: container with hugepages",
-				nrtv1alpha2.SingleNUMANodeContainerLevel,
+				intnrt.SingleNUMANode,
+				intnrt.Container,
 				corev1.ResourceList{
 					corev1.ResourceCPU:                   resource.MustParse("4"),
 					corev1.ResourceMemory:                resource.MustParse("4Gi"),
@@ -241,7 +245,8 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				},
 			),
 			Entry("[test_id:50157][tmscope:pod][hugepages] with topology-manager-scope: pod with hugepages",
-				nrtv1alpha2.SingleNUMANodePodLevel,
+				intnrt.SingleNUMANode,
+				intnrt.Pod,
 				corev1.ResourceList{
 					corev1.ResourceCPU:                   resource.MustParse("4"),
 					corev1.ResourceMemory:                resource.MustParse("4Gi"),
@@ -258,10 +263,10 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		// FIXME: this is a slight abuse of DescribeTable, but we need to run
 		// the same code which a different test_id per tmscope
 		DescribeTable("[tier1] a deployment with a guaranteed pod with one container should be scheduled into one NUMA zone",
-			func(tmPolicy nrtv1alpha2.TopologyManagerPolicy, requiredRes, paddingRes corev1.ResourceList) {
+			func(tmPolicy, tmScope string, requiredRes, paddingRes corev1.ResourceList) {
 				setupCluster(requiredRes, paddingRes)
 
-				nrts := e2enrt.FilterTopologyManagerPolicy(nrtCandidates, tmPolicy)
+				nrts := e2enrt.FilterByTopologyManagerPolicyAndScope(nrtCandidates, tmPolicy, tmScope)
 				if len(nrts) != len(nrtCandidates) {
 					e2efixture.Skipf(fxt, "not enough nodes with policy %q - found %d", string(tmPolicy), len(nrts))
 				}
@@ -305,7 +310,8 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				expectNRTConsumedResources(fxt, targetNrtInitial, requiredRes, &pods[0])
 			},
 			Entry("[test_id:47583][tmscope:cnt] with topology-manager-scope: container",
-				nrtv1alpha2.SingleNUMANodeContainerLevel,
+				intnrt.SingleNUMANode,
+				intnrt.Container,
 				corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("4"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -316,7 +322,8 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				},
 			),
 			Entry("[test_id:50159][tmscope:pod] with topology-manager-scope: pod",
-				nrtv1alpha2.SingleNUMANodePodLevel,
+				intnrt.SingleNUMANode,
+				intnrt.Pod,
 				corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("4"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -327,7 +334,8 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				},
 			),
 			Entry("[test_id:50165][tmscope:cnt][hugepages] with topology-manager-scope: container and with hugepages",
-				nrtv1alpha2.SingleNUMANodeContainerLevel,
+				intnrt.SingleNUMANode,
+				intnrt.Container,
 				corev1.ResourceList{
 					corev1.ResourceCPU:                   resource.MustParse("4"),
 					corev1.ResourceMemory:                resource.MustParse("4Gi"),
@@ -340,7 +348,8 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				},
 			),
 			Entry("[test_id:50182][tmscope:pod][hugepages] with topology-manager-scope: pod and with hugepages",
-				nrtv1alpha2.SingleNUMANodePodLevel,
+				intnrt.SingleNUMANode,
+				intnrt.Pod,
 				corev1.ResourceList{
 					corev1.ResourceCPU:                   resource.MustParse("4"),
 					corev1.ResourceMemory:                resource.MustParse("4Gi"),
@@ -356,13 +365,13 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 	})
 
 	DescribeTable("[placement] cluster with multiple worker nodes suitable",
-		func(policyFuncs tmPolicyFuncs, podRes podResourcesRequest, unsuitableFreeRes, targetFreeResPerNUMA []corev1.ResourceList) {
+		func(policyFuncs tmScopeFuncs, podRes podResourcesRequest, unsuitableFreeRes, targetFreeResPerNUMA []corev1.ResourceList) {
 
 			hostsRequired := 2
 
-			nrts := e2enrt.FilterTopologyManagerPolicy(nrtList.Items, policyFuncs.name())
+			nrts := e2enrt.FilterByTopologyManagerPolicyAndScope(nrtList.Items, policyFuncs.policyName(), policyFuncs.scopeName())
 			if len(nrts) < hostsRequired {
-				e2efixture.Skipf(fxt, "not enough nodes with policy %q - found %d", string(policyFuncs.name()), len(nrts))
+				e2efixture.Skipf(fxt, "not enough nodes with policy %q - found %d", string(policyFuncs.policyName()), len(nrts))
 			}
 
 			Expect(len(unsuitableFreeRes)).To(Equal(hostsRequired), "mismatch unsuitable resource declarations expected %d items, but found %d", hostsRequired, len(unsuitableFreeRes))
@@ -501,7 +510,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		},
 
 		Entry("[test_id:47575][tmscope:cnt][tier1] should make a pod with two gu cnt land on a node with enough resources on a specific NUMA zone, each cnt on a different zone",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodeContainerLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
 					{
@@ -530,7 +539,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			[]corev1.ResourceList{},
 		),
 		Entry("[test_id:47577][tmscope:pod][tier1] should make a pod with two gu cnt land on a node with enough resources on a specific NUMA zone, all cnt on the same zone",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodePodLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
 					{
@@ -565,7 +574,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:50183][tmscope:cnt][hugepages] should make a pod with two gu cnt land on a node with enough resources with hugepages on a specific NUMA zone, each cnt on a different zone",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodeContainerLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
 					{
@@ -597,7 +606,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			[]corev1.ResourceList{},
 		),
 		Entry("[test_id:50184][tmscope:pod][hugepages] should make a pod with two gu cnt land on a node with enough resources with hugepages on a specific NUMA zone, all cnt on the same zone",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodePodLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
 					{
@@ -637,7 +646,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[tier1][testtype4][tmscope:container] should make a pod with three gu cnt land on a node with enough resources, containers should be spread on a different zone",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodeContainerLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
 					{
@@ -680,7 +689,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[tier1][testtype4][tmscope:container][cpu] pod with two gu cnt land on a node with enough resources, containers should be spread on a different zone",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodeContainerLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
 					{
@@ -731,7 +740,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[tier1][testtype4][tmscope:container][memory] pod with two gu cnt land on a node with enough resources, containers should be spread on a different zone",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodeContainerLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
 					{
@@ -782,7 +791,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[tier1][testtype4][tmscope:container][hugepages2Mi] pod with two gu cnt land on a node with enough resources, containers should be spread on a different zone",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodeContainerLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
 					{
@@ -833,7 +842,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[tier1][testtype4][tmscope:container][hugepages1Gi] pod with two gu cnt land on a node with enough resources, containers should be spread on a different zone",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodeContainerLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
 					{
@@ -883,7 +892,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:54021][tier1][testtype4][tmscope:container][devices] pod with two gu cnt land on a node with enough resources, containers should be spread on a different zone",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodeContainerLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
 					{
@@ -932,7 +941,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[tier1][testtype11][tmscope:container] should make a pod with one init cnt and three gu cnt land on a node with enough resources, containers should be spread on a different zone",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodeContainerLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				initCnt: []corev1.ResourceList{
 					{
@@ -981,7 +990,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[tier1][testtype29][tmscope:container] should make a pod with 3 gu cnt and 3 init cnt land on a node with enough resources, when sum of init and app cnt resources are more than node resources",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodeContainerLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				initCnt: []corev1.ResourceList{
 					{
@@ -1038,7 +1047,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:54018][tmscope:cnt][devices] should make a pod with two gu cnt land on a node with enough resources with devices on a specific NUMA zone,  containers should be spread on a different zone",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodeContainerLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
 					{
@@ -1082,7 +1091,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:54016][tmscope:pod][tier1][devices] should make a pod with one gu cnt requesting devices land on a node with enough resources on a specific NUMA zone",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodePodLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
 					{
@@ -1117,7 +1126,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:54025][tmscope:cnt][tier2][devices] should make a besteffort pod requesting devices land on a node with enough resources on a specific NUMA zone, containers should be spread on a different zone",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodeContainerLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
 					{
@@ -1154,7 +1163,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:55431][tmscope:pod][tier1][devices] should make a besteffort pod requesting devices land on a node with enough resources on a specific NUMA zone",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodePodLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
 					{
@@ -1186,7 +1195,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:55450][tmscope:pod][tier2][devices] should make a burstable pod requesting devices land on a node with enough resources on a specific NUMA zone",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodePodLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
 					{
@@ -1219,7 +1228,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:54024][tmscope:cnt][tier2][devices] should make a burstable pod requesting devices land on a node with enough resources on a specific NUMA zone, containers should be spread on a different zone",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodeContainerLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
 					{
@@ -1259,13 +1268,13 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 	)
 
 	DescribeTable("[placement][unsched] cluster with one worker nodes suitable",
-		func(policyFuncs tmPolicyFuncs, errMsg string, podRes podResourcesRequest, unsuitableFreeRes, targetFreeResPerNUMA []corev1.ResourceList) {
+		func(policyFuncs tmScopeFuncs, errMsg string, podRes podResourcesRequest, unsuitableFreeRes, targetFreeResPerNUMA []corev1.ResourceList) {
 
 			hostsRequired := 2
 
-			nrts := e2enrt.FilterTopologyManagerPolicy(nrtList.Items, policyFuncs.name())
+			nrts := e2enrt.FilterByTopologyManagerPolicyAndScope(nrtList.Items, policyFuncs.policyName(), policyFuncs.scopeName())
 			if len(nrts) < hostsRequired {
-				e2efixture.Skipf(fxt, "not enough nodes with policy %q - found %d", string(policyFuncs.name()), len(nrts))
+				e2efixture.Skipf(fxt, "not enough nodes with policy %q - found %d", string(policyFuncs.policyName()), len(nrts))
 			}
 
 			Expect(len(unsuitableFreeRes)).To(Equal(hostsRequired), "mismatch unsuitable resource declarations expected %d items, but found %d", hostsRequired, len(unsuitableFreeRes))
@@ -1403,7 +1412,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		// to see the reason for not scheduling the pod on that target node as "cannot align container: testcnt-1", because the other worker nodes have insufficient
 		// free resources to accommodate the pod thus they will be rejected as candidates at earlier stage
 		Entry("[tier1][unsched][tmscope:container][cpu] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodeContainerLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			nrosched.ErrorCannotAlignContainer,
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -1463,7 +1472,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[tier1][unsched][tmscope:container][memory] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodeContainerLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			nrosched.ErrorCannotAlignContainer,
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -1521,7 +1530,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[tier1][unsched][tmscope:container][hugepages2Mi] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodeContainerLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			nrosched.ErrorCannotAlignContainer,
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -1578,7 +1587,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[tier1][unsched][tmscope:container][hugepages1Gi] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodeContainerLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			nrosched.ErrorCannotAlignContainer,
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -1634,7 +1643,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:54020][tier2][unsched][tmscope:container][devices] pod with two gu cnt requesting multiple device types keep on pending because cannot align the second container to a single numa node",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodeContainerLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			nrosched.ErrorCannotAlignContainer,
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -1686,7 +1695,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:54019][tier1][unsched][tmscope:container][devices] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodeContainerLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			nrosched.ErrorCannotAlignContainer,
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -1730,7 +1739,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:54017][tier1][unsched][tmscope:pod][devices] pod with two gu cnt keep on pending because cannot align the both containers on single numa",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodePodLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			nrosched.ErrorCannotAlignPod,
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -1774,7 +1783,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:55430][tier2][unsched][tmscope:pod][devices] besteffort pod requesting multiple device types keep on pending because cannot align the container to a single numa node",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodePodLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			nrosched.ErrorCannotAlignPod,
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -1819,7 +1828,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:55429][tier2][unsched][tmscope:pod][devices] burstable pod requesting multiple device types keep on pending because cannot align the container to a single numa node",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodePodLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			nrosched.ErrorCannotAlignPod,
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -1869,7 +1878,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:54023][tier2][unsched][tmscope:container][devices] besteffort pod requesting multiple device types keep on pending because cannot align the container to a single numa node",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodeContainerLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			nrosched.ErrorCannotAlignContainer,
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -1915,7 +1924,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:54022][tier2][unsched][tmscope:container][devices] burstable pod requesting multiple device types keep on pending because cannot align the container to a single numa node",
-			tmPolicyFuncsHandler[nrtv1alpha2.SingleNUMANodeContainerLevel],
+			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			nrosched.ErrorCannotAlignContainer,
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -2079,18 +2088,20 @@ func isHugepageNeeded(podRes podResourcesRequest) bool {
 	return false
 }
 
-func newPodScopeTMPolicyFuncs() tmPolicyFuncs {
-	return tmPolicyFuncs{
-		name:                    func() nrtv1alpha2.TopologyManagerPolicy { return nrtv1alpha2.SingleNUMANodePodLevel },
+func newPodScopeSingleNUMANodeFuncs() tmScopeFuncs {
+	return tmScopeFuncs{
+		policyName:              func() string { return intnrt.SingleNUMANode },
+		scopeName:               func() string { return intnrt.Pod },
 		setupPadding:            setupPadding,
 		checkConsumedRes:        e2enrt.CheckZoneConsumedResourcesAtLeast,
 		filterMatchingResources: e2enrt.FilterAnyZoneMatchingResources,
 	}
 }
 
-func newContainerScopeTMPolicyFuncs() tmPolicyFuncs {
-	return tmPolicyFuncs{
-		name:                    func() nrtv1alpha2.TopologyManagerPolicy { return nrtv1alpha2.SingleNUMANodeContainerLevel },
+func newContainerScopeSingleNUMANodeFuncs() tmScopeFuncs {
+	return tmScopeFuncs{
+		policyName:              func() string { return intnrt.SingleNUMANode },
+		scopeName:               func() string { return intnrt.Container },
 		setupPadding:            setupPadding,
 		checkConsumedRes:        e2enrt.CheckNodeConsumedResourcesAtLeast,
 		filterMatchingResources: e2enrt.FilterAnyNodeMatchingResources,

--- a/test/utils/nrosched/nrosched.go
+++ b/test/utils/nrosched/nrosched.go
@@ -33,8 +33,8 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
+	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	"github.com/openshift-kni/numaresources-operator/pkg/status"
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 )
@@ -116,11 +116,12 @@ func CheckPODKubeletRejectWithTopologyAffinityError(k8sCli *kubernetes.Clientset
 	return checkPODEvents(k8sCli, podNamespace, podName, isKubeletRejectForTopologyAffinityError)
 }
 
-func CheckPODSchedulingFailedForAlignment(k8sCli *kubernetes.Clientset, podNamespace, podName, schedulerName, policy string) (bool, error) {
+// This function assumes a TMPolicy of "single-numa-node"
+func CheckPODSchedulingFailedForAlignment(k8sCli *kubernetes.Clientset, podNamespace, podName, schedulerName, scope string) (bool, error) {
 	var alignmentErr string
-	if policy == string(nrtv1alpha2.SingleNUMANodeContainerLevel) {
+	if scope == intnrt.Container {
 		alignmentErr = ErrorCannotAlignContainer
-	} else {
+	} else { //intnrt.Pod
 		alignmentErr = ErrorCannotAlignPod
 	}
 

--- a/test/utils/padder/padder.go
+++ b/test/utils/padder/padder.go
@@ -37,6 +37,7 @@ import (
 
 	numacellapi "github.com/openshift-kni/numaresources-operator/test/deviceplugin/pkg/numacell/api"
 
+	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 
 	"github.com/openshift-kni/numaresources-operator/test/utils/fixture"
@@ -138,7 +139,7 @@ func (p *Padder) Pad(timeout time.Duration, options PaddingOptions) error {
 	// since there is a relation of 1 : 1 between nodes and NRTs we can filter by the nodes` name
 	nrts := filterNrtByNodeName(nrtList.Items, nodeList.Items)
 
-	singleNumaNrt := nrtutil.FilterByPolicies(nrts, []nrtv1alpha2.TopologyManagerPolicy{nrtv1alpha2.SingleNUMANodePodLevel, nrtv1alpha2.SingleNUMANodeContainerLevel})
+	singleNumaNrt := nrtutil.FilterByTopologyManagerPolicy(nrts, intnrt.SingleNUMANode)
 	if p.nNodes > len(singleNumaNrt) {
 		return fmt.Errorf("not enough nodes were found for padding. requested: %d, got: %d", p.nNodes, len(singleNumaNrt))
 	}


### PR DESCRIPTION
`topologyPolicies` field is deprecated and should not be used. 
The new recommended approach is to use the attributes. 
Update our codebase to use an attribute instead of that field.

Fixes #630 