### PR TITLE
e2e: fix RTE lane

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,6 @@ jobs:
     env:
       built_image: "numaresources-operator:ci" # Arbitrary name
       E2E_NAMESPACE_NAME: numaresources
-      E2E_TOPOLOGY_MANAGER_POLICY: SingleNUMANodePodLevel
       LOG_DIR: /tmp/test_e2e_logs
     steps:
     - name: Checkout
@@ -39,7 +38,7 @@ jobs:
 
     - name: build test binary
       run: |
-        make binary-e2e-rte binary-e2e-install binary-e2e-uninstall
+        make build-tools binary-e2e-rte binary-e2e-install binary-e2e-uninstall
 
     - name: Build image
       run: |
@@ -60,7 +59,8 @@ jobs:
     - name: E2E Tests
       run: |
         export KUBECONFIG=${HOME}/.kube/config
-        NO_TEARDOWN=true make test-e2e
+        bin/catkubeletconfigmap --namespace ${E2E_NAMESPACE_NAME} --prefix 'E2E_' >> $GITHUB_ENV
+        make test-e2e
 
     - name: Export E2E Tests logs
       if: ${{ failure() }}

--- a/Makefile
+++ b/Makefile
@@ -363,7 +363,7 @@ goversion:
 	@go version
 
 .PHONY: build-tools
-build-tools: goversion bin/buildhelper bin/envsubst bin/lsplatform
+build-tools: goversion bin/buildhelper bin/envsubst bin/lsplatform bin/catkubeletconfmap
 
 bin/buildhelper:
 	@go build -o bin/buildhelper tools/buildhelper/buildhelper.go
@@ -373,6 +373,9 @@ bin/envsubst:
 
 bin/lsplatform:
 	@go build -o bin/lsplatform tools/lsplatform/lsplatform.go
+
+bin/catkubeletconfmap:
+	@go build -o bin/catkubeletconfmap tools/catkubeletconfmap/catkubeletconfmap.go
 
 verify-generated: bundle generate
 	@echo "Verifying that all code is committed after updating deps and formatting and generating code"

--- a/hack/kind-config-e2e-no-registry.yaml
+++ b/hack/kind-config-e2e-no-registry.yaml
@@ -6,6 +6,7 @@ kubeadmConfigPatches:
   cpuManagerPolicy: "static"
   cpuManagerReconcilePeriod: "5s"
   topologyManagerPolicy: "single-numa-node"
+  topologyManagerScope: "container"
   reservedSystemCPUs: "0"
   featureGates:
     KubeletPodResourcesGetAllocatable: true

--- a/hack/run-test-e2e.sh
+++ b/hack/run-test-e2e.sh
@@ -75,13 +75,15 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Running RTE tests"
-export E2E_TOPOLOGY_MANAGER_POLICY="${E2E_TOPOLOGY_MANAGER_POLICY:-SingleNUMANodePodLevel}"
+export E2E_TOPOLOGY_MANAGER_POLICY="${E2E_TOPOLOGY_MANAGER_POLICY}"
+export E2E_TOPOLOGY_MANAGER_SCOPE="${E2E_TOPOLOGY_MANAGER_SCOPE}"
 # -v: print out the text and location for each spec before running it and flush output to stdout in realtime
 # -timeout: exit the suite after the specified time
 # -r: run suites recursively
 # --fail-fast: ginkgo will stop the suite right after the first spec failure
 # --flake-attempts: rerun the test if it fails
 # -requireSuite: fail if tests are not executed because of missing suite
+echo "TM config policy=[${E2E_TOPOLOGY_MANAGER_POLICY}] scope=[${E2E_TOPOLOGY_MANAGER_SCOPE}]"
 ${BIN_DIR}/e2e-nrop-rte.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.flake-attempts=2 --ginkgo.junit-report=${REPORT_DIR}/e2e.xml --ginkgo.skip='\[Disruptive\]|\[StateDirectories\]|\[NodeRefresh\]|\[local\]' --ginkgo.focus='\[release\]'
 
 

--- a/hack/run-test-e2e.sh
+++ b/hack/run-test-e2e.sh
@@ -1,30 +1,10 @@
 #!/usr/bin/env bash
 
+set -e
+
 source hack/common.sh
 
 ENABLE_SCHED_TESTS="${ENABLE_SCHED_TESTS:-true}"
-NO_TEARDOWN="${NO_TEARDOWN:-false}"
-
-function test_sched() {
-  # Run install test suite
-  echo "Running NROScheduler install test suite"
-  ${BIN_DIR}/e2e-nrop-sched-install.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.junit-report=${REPORT_DIR}/sched-install.xml
-
-  # The install failed, no taste to continue
-  if [ $? -ne 0 ]; then
-      echo "Failed to install NROScheduler"
-      exit 1
-  fi
-
-  echo "Running Functional Tests: ${GINKGO_SUITS}"
-  # -v: print out the text and location for each spec before running it and flush output to stdout in realtime
-  # -timeout: exit the suite after the specified time
-  # -r: run suites recursively
-  # --fail-fast: ginkgo will stop the suite right after the first spec failure
-  # --flake-attempts: rerun the test if it fails
-  # -requireSuite: fail if tests are not executed because of missing suite
-  ${BIN_DIR}/e2e-nrop-sched.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.flake-attempts=2 --ginkgo.junit-report=${REPORT_DIR}/e2e-sched.xml
-}
 
 NO_COLOR=""
 if ! which tput &> /dev/null 2>&1 || [[ $(tput -T$TERM colors) -lt 8 ]]; then
@@ -34,45 +14,16 @@ fi
 
 setupreport
 
-# Make sure that we always properly clean the environment
-trap '{ if [ "${NO_TEARDOWN}" = false ]; then
-          if [ "${ENABLE_SCHED_TESTS}" = true ]; then
-             echo "Running NROScheduler uninstall test suite";
-             ${BIN_DIR}/e2e-nrop-sched-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/sched-uninstall.xml
-          fi
-
-          echo "Undeploying sample devices for RTE tests"
-          rte/hack/undeploy-devices.sh
-
-          echo "Running NRO uninstall test suite";
-	  ${BIN_DIR}/e2e-nrop-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/uninstall.xml
-        fi }' EXIT SIGINT SIGTERM SIGSTOP
-
 # Run install test suite
 echo "Running NRO install test suite"
 ${BIN_DIR}/e2e-nrop-install.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.junit-report=${REPORT_DIR}/install.xml --ginkgo.focus='\[Install\] continuousIntegration'
-
-# The install failed, no reason to continue
-if [ $? -ne 0 ]; then
-    echo "Failed to install NRO"
-    exit 1
-fi
-
 
 echo "Running Functional Tests: ${GINKGO_SUITS}"
 
 echo "Deploying sample devices for RTE tests"
 rte/hack/deploy-devices.sh
-if [ $? -ne 0 ]; then
-    echo "Failed to deploy sample device plugin for RTE tests"
-    exit 2
-fi
 
 rte/hack/check-ds.sh oc sampledevices device-plugin-a-ds
-if [ $? -ne 0 ]; then
-    echo "Failed to verify sample device plugin for RTE tests"
-    exit 4
-fi
 
 echo "Running RTE tests"
 export E2E_TOPOLOGY_MANAGER_POLICY="${E2E_TOPOLOGY_MANAGER_POLICY}"
@@ -86,7 +37,26 @@ export E2E_TOPOLOGY_MANAGER_SCOPE="${E2E_TOPOLOGY_MANAGER_SCOPE}"
 echo "TM config policy=[${E2E_TOPOLOGY_MANAGER_POLICY}] scope=[${E2E_TOPOLOGY_MANAGER_SCOPE}]"
 ${BIN_DIR}/e2e-nrop-rte.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.flake-attempts=2 --ginkgo.junit-report=${REPORT_DIR}/e2e.xml --ginkgo.skip='\[Disruptive\]|\[StateDirectories\]|\[NodeRefresh\]|\[local\]' --ginkgo.focus='\[release\]'
 
-
 if [ "$ENABLE_SCHED_TESTS" = true ]; then
-  test_sched
+  # Run install test suite
+  echo "Running NROScheduler install test suite"
+  ${BIN_DIR}/e2e-nrop-sched-install.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.junit-report=${REPORT_DIR}/sched-install.xml
+
+  echo "Running Functional Tests: ${GINKGO_SUITS}"
+  # -v: print out the text and location for each spec before running it and flush output to stdout in realtime
+  # -timeout: exit the suite after the specified time
+  # -r: run suites recursively
+  # --fail-fast: ginkgo will stop the suite right after the first spec failure
+  # --flake-attempts: rerun the test if it fails
+  # -requireSuite: fail if tests are not executed because of missing suite
+  ${BIN_DIR}/e2e-nrop-sched.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.flake-attempts=2 --ginkgo.junit-report=${REPORT_DIR}/e2e-sched.xml
+
+  echo "Running NROScheduler uninstall test suite";
+  ${BIN_DIR}/e2e-nrop-sched-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/sched-uninstall.xml
 fi
+
+echo "Undeploying sample devices for RTE tests"
+rte/hack/undeploy-devices.sh
+
+echo "Running NRO uninstall test suite";
+${BIN_DIR}/e2e-nrop-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/uninstall.xml

--- a/hack/run-test-e2e.sh
+++ b/hack/run-test-e2e.sh
@@ -63,7 +63,7 @@ export E2E_TOPOLOGY_MANAGER_POLICY="${E2E_TOPOLOGY_MANAGER_POLICY:-SingleNUMANod
 # --fail-fast: ginkgo will stop the suite right after the first spec failure
 # --flake-attempts: rerun the test if it fails
 # -requireSuite: fail if tests are not executed because of missing suite
-${BIN_DIR}/e2e-nrop-rte.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.flake-attempts=2 --ginkgo.junit-report=${REPORT_DIR}/e2e.xml --ginkgo.skip='\[Disruptive\]|\[StateDirectories\]|\[NodeRefresh\]|\[local\]'
+${BIN_DIR}/e2e-nrop-rte.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.flake-attempts=2 --ginkgo.junit-report=${REPORT_DIR}/e2e.xml --ginkgo.skip='\[Disruptive\]|\[StateDirectories\]|\[NodeRefresh\]|\[local\]' --ginkgo.focus='\[release\]'
 
 
 if [ "$ENABLE_SCHED_TESTS" = true ]; then

--- a/rte/hack/deploy-devices.sh
+++ b/rte/hack/deploy-devices.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -ex
+
+DIRNAME="$(dirname "$(readlink -f "$0")")"
+
+oc create -f ${DIRNAME}/manifests/sample-devices/namespace.yaml
+oc create -f ${DIRNAME}/manifests/sample-devices/serviceaccount.yaml
+oc create -f ${DIRNAME}/manifests/sample-devices/role.yaml
+oc create -f ${DIRNAME}/manifests/sample-devices/rolebinding.yaml
+oc create -f ${DIRNAME}/manifests/sample-devices/configmap-dpa.yaml
+oc create -f ${DIRNAME}/manifests/sample-devices/daemonset-dpa.yaml

--- a/rte/hack/manifests/sample-devices/configmap-dpa.yaml
+++ b/rte/hack/manifests/sample-devices/configmap-dpa.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: sampledevices
+  name: device-a-configmap
+data:
+  example_com_deviceA.yaml: |
+    devicename: tty1
+    devices:
+      '*':
+        - id: DevA1
+          healthy: true
+          numanode: 0
+        - id: DevA2
+          healthy: false
+          numanode: 0

--- a/rte/hack/manifests/sample-devices/daemonset-dpa.yaml
+++ b/rte/hack/manifests/sample-devices/daemonset-dpa.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: sampledevices
+  name: dpa-ds
+spec:
+  selector:
+    matchLabels:
+      name: dpa
+  template:
+    metadata:
+      labels:
+        name: dpa
+    spec:
+      serviceAccountName: sampledevices-sa
+      containers:
+        - name: dpa-container
+          securityContext:
+            privileged: true
+          image: quay.io/k8stopologyawareschedwg/sample-device-plugin:v0.1.1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DEVICE_RESOURCE_NAME
+              value: "example.com/deviceA"
+          volumeMounts:
+            - name: kubeletsockets
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: device-a-config-vol
+              mountPath: /etc/devices
+      volumes:
+        - name: kubeletsockets
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+            type: Directory
+        - configMap:
+            name: device-a-configmap
+          name: device-a-config-vol

--- a/rte/hack/manifests/sample-devices/namespace.yaml
+++ b/rte/hack/manifests/sample-devices/namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sampledevices
+  labels:
+    pod-security.kubernetes.io/audit: "privileged"
+    pod-security.kubernetes.io/enforce: "privileged"
+    pod-security.kubernetes.io/warn: "privileged"
+    security.openshift.io/scc.podSecurityLabelSync: "false"

--- a/rte/hack/manifests/sample-devices/role.yaml
+++ b/rte/hack/manifests/sample-devices/role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sampledevices-ro
+  namespace: sampledevices
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/rte/hack/manifests/sample-devices/rolebinding.yaml
+++ b/rte/hack/manifests/sample-devices/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sampledevices-rb
+  namespace: sampledevices
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sampledevices-ro
+subjects:
+- kind: ServiceAccount
+  name: sampledevices-sa
+  namespace: sampledevices

--- a/rte/hack/manifests/sample-devices/serviceaccount.yaml
+++ b/rte/hack/manifests/sample-devices/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sampledevices-sa
+  namespace: sampledevices

--- a/rte/hack/undeploy-devices.sh
+++ b/rte/hack/undeploy-devices.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+DIRNAME="$(dirname "$(readlink -f "$0")")"
+
+oc delete -f ${DIRNAME}/manifests/sample-devices/namespace.yaml
+

--- a/test/e2e/rte/rte_e2e_suite_test.go
+++ b/test/e2e/rte/rte_e2e_suite_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -33,15 +32,12 @@ import (
 
 	e2etestns "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/namespace"
 	"github.com/openshift-kni/numaresources-operator/internal/objects"
-	"github.com/openshift-kni/numaresources-operator/test/utils/runtime"
 
 	_ "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/rte"
 	_ "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/topology_updater"
 )
 
 var (
-	BinaryPath string
-
 	randomSeed int64
 )
 
@@ -68,24 +64,4 @@ func TestRTE(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	By(fmt.Sprintf("Using random seed %v", randomSeed))
-
-	By("Finding the binaries path")
-
-	binPath, err := runtime.FindBinaryPath("exporter")
-	Expect(err).ToNot(HaveOccurred())
-	BinaryPath = binPath
-
-	By(fmt.Sprintf("Using the binary at %q", BinaryPath))
 })
-
-func expectExecutableExists(path string) {
-	cmdline := []string{
-		path,
-		"-h",
-	}
-
-	cmd := exec.Command(cmdline[0], cmdline[1:]...)
-	out, err := cmd.CombinedOutput()
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-	ExpectWithOffset(1, out).ToNot(BeEmpty())
-}

--- a/test/e2e/rte/rte_local_test.go
+++ b/test/e2e/rte/rte_local_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nrtupdater"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcemonitor"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcetopologyexporter"
+
+	"github.com/openshift-kni/numaresources-operator/test/utils/runtime"
 )
 
 type ProgArgs struct {
@@ -36,7 +38,20 @@ type ProgArgs struct {
 	RTE             resourcetopologyexporter.Args
 }
 
+var binaryPath string
+
 var _ = Describe("[rte][local][config] RTE configuration", func() {
+
+	BeforeEach(func() {
+		By("Finding the binaries path")
+
+		binPath, err := runtime.FindBinaryPath("exporter")
+		Expect(err).ToNot(HaveOccurred())
+		binaryPath = binPath
+
+		By(fmt.Sprintf("Using the binary at %q", binaryPath))
+	})
+
 	Context("with the binary available", func() {
 		It("should have any default for TM params", func() {
 			args := runConfig([]string{}, map[string]string{})
@@ -80,7 +95,7 @@ var _ = Describe("[rte][local][config] RTE configuration", func() {
 
 func runConfig(argv []string, env map[string]string) ProgArgs {
 	cmdline := []string{
-		BinaryPath,
+		binaryPath,
 		"--dump-config",
 	}
 	cmdline = append(cmdline, argv...)
@@ -111,4 +126,16 @@ func flattenEnv(env map[string]string) []string {
 		ret = append(ret, strings.TrimSpace(key)+"="+strings.TrimSpace(value))
 	}
 	return ret
+}
+
+func expectExecutableExists(path string) {
+	cmdline := []string{
+		path,
+		"-h",
+	}
+
+	cmd := exec.Command(cmdline[0], cmdline[1:]...)
+	out, err := cmd.CombinedOutput()
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, out).ToNot(BeEmpty())
 }

--- a/tools/catkubeletconfmap/catkubeletconfmap.go
+++ b/tools/catkubeletconfmap/catkubeletconfmap.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil"
+
+	rteconfig "github.com/openshift-kni/numaresources-operator/rte/pkg/config"
+)
+
+func main() {
+	var prefix string
+	var cmNamespace string
+	var cmName string
+	flag.StringVar(&cmNamespace, "namespace", "numaresources", "namespace to look the configmap into")
+	flag.StringVar(&cmName, "name", "numaresourcesoperator-worker", "name of the configmap to look for")
+	flag.StringVar(&prefix, "prefix", "", "prefix for the output")
+	flag.Parse()
+
+	cli, err := clientutil.New()
+	if err != nil {
+		log.Fatalf("error creating a client: %v", err)
+	}
+
+	ctx := context.Background()
+	key := client.ObjectKey{
+		Namespace: cmNamespace,
+		Name:      cmName,
+	}
+	cm := corev1.ConfigMap{}
+	err = cli.Get(ctx, key, &cm)
+	if err != nil {
+		log.Fatalf("error getting the ConfigMap %s/%s: %v", cmNamespace, cmName, err)
+	}
+
+	cmData, err := rteconfig.UnpackConfigMap(&cm)
+	if err != nil {
+		log.Fatalf("error unpacking ConfigMap %s/%s: %v", cmNamespace, cmName, err)
+	}
+
+	conf, err := rteconfig.Unrender(cmData)
+	if err != nil {
+		log.Fatalf("error unrendering ConfigMap %s/%s: %v", cmNamespace, cmName, err)
+	}
+
+	fmt.Printf("%sTOPOLOGY_MANAGER_POLICY=%s\n", prefix, conf.TopologyManagerPolicy)
+	fmt.Printf("%sTOPOLOGY_MANAGER_SCOPE=%s\n", prefix, conf.TopologyManagerScope)
+}


### PR DESCRIPTION
We previously failed to bail out early if the RTE lane was failing.
The runner script ultimately returns the exit code of the last executed command. Problem is: also the latest `if` block
is a command, and the evaluation of the command was successful, swallowing the RTE lane failure (if any).

The test per se seems to be failed because we incorrectly always check for the exporter binary availability. But the exporter binary is not meant to be here, in this lane: it is tested explicitely in the separate RTE local lane.