### PR TITLE
serial: fix nil pointer in log

### DIFF
--- a/test/e2e/serial/config/config.go
+++ b/test/e2e/serial/config/config.go
@@ -98,7 +98,7 @@ func getTopologyConsistencyErrors(kconfigs map[string]*kubeletconfigv1beta1.Kube
 	for nodeName, kconfig := range kconfigs {
 		nrt, err := e2enrt.FindFromList(nrts, nodeName)
 		if err != nil {
-			ret[nodeName] = fmt.Errorf("Unable to find NRT for node %q", nrt.Name)
+			ret[nodeName] = fmt.Errorf("Unable to find NRT for node %q", nodeName)
 			continue
 		}
 


### PR DESCRIPTION
In case NRTs don't exist that will return an error and the node name should be logged based on what's there in kconfig map, because nrt list will be empty, and addressing an item in an empty list will cause the program to panic.