### PR TITLE
base image: ubi8 to ubi9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 # Build
 RUN make binary-all
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/manager /bin/numaresources-operator
 # bundle the operand, and use a backward compatible name for RTE
 COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/exporter /bin/resource-topology-exporter

--- a/Dockerfile.must-gather
+++ b/Dockerfile.must-gather
@@ -1,6 +1,6 @@
 FROM quay.io/openshift/origin-must-gather:4.14.0 AS builder
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 RUN microdnf install -y procps-ng tar rsync
 RUN microdnf clean all
 

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 COPY manager /bin/numaresources-operator
 # bundle the operand, and use a backward compatible name for RTE
 COPY exporter /bin/resource-topology-exporter

--- a/Dockerfile.openshift.rte
+++ b/Dockerfile.openshift.rte
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 COPY exporter /bin/resource-topology-exporter
 RUN mkdir /etc/resource-topology-exporter/ && \
     touch /etc/resource-topology-exporter/config.yaml

--- a/Dockerfile.openshift.tests
+++ b/Dockerfile.openshift.tests
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 COPY e2e-nrop-*.test /usr/local/bin/
 COPY run-e2e-nrop-serial.sh /usr/local/bin
 COPY numacell /bin

--- a/Dockerfile.pause
+++ b/Dockerfile.pause
@@ -5,5 +5,5 @@ COPY . .
 
 RUN make build-pause
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/pause /

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -6,7 +6,7 @@ COPY . .
 RUN make build-e2e-all
 RUN make build-numacell
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/e2e-nrop*.test /usr/local/bin
 COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/run-e2e-nrop-serial.sh /usr/local/bin
 COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/numacell /bin

--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi9/ubi
 
 ENV HOME=/home/ci
 ENV GOROOT=/usr/local/go

--- a/test/deviceplugin/cmd/numacell/Dockerfile
+++ b/test/deviceplugin/cmd/numacell/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 ADD numacell /bin/numacell
 ENTRYPOINT ["/bin/numacell", "-alsologtostderr", "-v", "3"]


### PR DESCRIPTION
For RHAOS 4.14 we should rebase on ubi9 for binary artifacts