### PR TITLE
Dockerfile: tools: drop python2

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -17,7 +17,6 @@ RUN yum --setopt=install_weak_deps=False -y install \
     gettext \
     which \
     findutils \
-    python2 \
     && yum clean all
 
 RUN mkdir -p $HOME && \


### PR DESCRIPTION
The package got renamed in ubi9, and that prompted the question: do we still need it? It seems we don't.