### PR TITLE
Makefile: split test-unit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,13 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
-test-unit: envtest
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./api/... ./controllers/... ./pkg/... ./rte/pkg/... ./internal/...
+test-unit: test-unit-pkgs test-controllers
+
+test-unit-pkgs:
+	go test ./api/... ./pkg/... ./rte/pkg/... ./internal/...
+
+test-controllers: envtest
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./controllers/...
 
 test-e2e: build-e2e-all
 	ENABLE_SCHED_TESTS=true hack/run-test-e2e.sh


### PR DESCRIPTION
add more focused targets:
test-controllers: controllers-only integration tests test-unit-pkgs: pkgs unit tests proper

keep the `test-unit` target with the old semantics for backward compatibility.