### PR TITLE
doc: sched: fix examples

### DIFF
--- a/doc/examples/sched.debug.yaml
+++ b/doc/examples/sched.debug.yaml
@@ -6,5 +6,4 @@ spec:
   imageSpec: "quay.io/fromani/k8s-sched-plugins:v0.0.2023052204"
   logLevel: "Trace"
   schedulerName: "topo-aware-scheduler"
-  cacheResyncPeriod: "5s"
   cacheResyncDebug: "DumpJSONFile"

--- a/doc/examples/sched.nocache.yaml
+++ b/doc/examples/sched.nocache.yaml
@@ -6,3 +6,4 @@ spec:
   imageSpec: "quay.io/openshift-kni/scheduler-plugins:4.12-snapshot"
   logLevel: "Trace"
   schedulerName: topo-aware-scheduler
+  cacheResyncPeriod: "0"

--- a/doc/examples/sched.yaml
+++ b/doc/examples/sched.yaml
@@ -6,4 +6,3 @@ spec:
   imageSpec: "quay.io/openshift-kni/scheduler-plugins:4.14-snapshot"
   logLevel: "Trace"
   schedulerName: topo-aware-scheduler
-  cacheResyncPeriod: "5s"


### PR DESCRIPTION
the `cacheResyncPeriod` is enabled by default since d4be591b