### PR TITLE
e2e:rte: run local test separately

### DIFF
--- a/.github/workflows/e2e-local.yaml
+++ b/.github/workflows/e2e-local.yaml
@@ -43,4 +43,4 @@ jobs:
 
     - name: E2E Tests - not requiring a cluster
       run: |
-        bin/e2e-nrop-rte.test -ginkgo.focus '.*rte.*local.*'
+        bin/e2e-nrop-rte-local.test

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,10 @@ binary-numacell: build-tools
 
 binary-all: binary binary-rte binary-nrovalidate binary-nrtcacheck
 
-binary-e2e-rte:
+binary-e2e-rte-local:
+	go test -c -v -o bin/e2e-nrop-rte-local.test ./test/e2e/rte/local
+
+binary-e2e-rte: binary-e2e-rte-local
 	go test -c -v -o bin/e2e-nrop-rte.test ./test/e2e/rte
 
 binary-e2e-install:

--- a/test/e2e/rte/local/local.go
+++ b/test/e2e/rte/local/local.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package rte
+package local
 
 import (
 	"encoding/json"

--- a/test/e2e/rte/local/local_suite_test.go
+++ b/test/e2e/rte/local/local_suite_test.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package local
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestLocal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "RTE Local Test Suite")
+}

--- a/test/e2e/rte/rte_e2e_suite_test.go
+++ b/test/e2e/rte/rte_e2e_suite_test.go
@@ -35,6 +35,7 @@ import (
 
 	_ "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/rte"
 	_ "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/topology_updater"
+	_ "github.com/openshift-kni/numaresources-operator/test/e2e/rte/local"
 )
 
 var (


### PR DESCRIPTION
The local rte tests are cluster-independent.

Although we're using ginkgo focus for running only the local tests,
the suite still tries to initialize the code in the other tests.

The test passed so far only becuase of the fact that
k8s e2e framework knows how to deal with the absence of kubeconfig file.

Therefore, we should have a sperate suite for the local tests
which doesn't import other tests that are depending on the
presence of a cluster.
