### PR TITLE
e2e: fix flaky test 47591

### DIFF
--- a/internal/podlist/deployment.go
+++ b/internal/podlist/deployment.go
@@ -58,3 +58,18 @@ func (fnd Finder) ByDeployment(ctx context.Context, deployment appsv1.Deployment
 
 	return podList.Items, nil
 }
+
+func (fnd Finder) ReplicaSetByDeployment(ctx context.Context, deployment appsv1.Deployment) ([]appsv1.ReplicaSet, error) {
+	rpList := &appsv1.ReplicaSetList{}
+	sel, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+
+	err = fnd.List(ctx, rpList, &client.ListOptions{Namespace: deployment.Namespace, LabelSelector: sel})
+	if err != nil {
+		return nil, err
+	}
+
+	return rpList.Items, nil
+}

--- a/internal/wait/deployment.go
+++ b/internal/wait/deployment.go
@@ -25,6 +25,10 @@ import (
 )
 
 func (wt Waiter) ForDeploymentComplete(ctx context.Context, dp *appsv1.Deployment) (*appsv1.Deployment, error) {
+	// This function waits for the readiness of the pods under the deployment. The best use of this check is for
+	// completely new deployments. If the deployment exists on the cluster and simply updated, this check is
+	// not enough to guarantee that the deployment is ready with the NEW replica, thus need to cover that by
+	// additional checks as the context requires
 	key := ObjectKeyFromObject(dp)
 	updatedDp := &appsv1.Deployment{}
 	err := k8swait.PollImmediate(wt.PollInterval, wt.PollTimeout, func() (bool, error) {

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -585,7 +585,7 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 			nroSchedKey := objects.NROSchedObjectKey()
 			err = fxt.Client.Get(context.TODO(), nroSchedKey, nroSchedObj)
 			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", nroSchedKey.String())
-			schedulerName := nroSchedObj.Spec.SchedulerName
+			schedulerName := nroSchedObj.Status.SchedulerName
 
 			nrtPreCreatePodList, err := e2enrt.GetUpdated(fxt.Client, initialNrtList, timeout)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -510,6 +510,39 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 			}
 			wg.Wait()
 
+			defer func() {
+				By("reverting kubeletconfig changes")
+				Eventually(func(g Gomega) {
+					err = fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(targetedKC), targetedKC)
+					Expect(err).ToNot(HaveOccurred())
+
+					kcObj, err = kubeletconfig.MCOKubeletConfToKubeletConf(targetedKC)
+					Expect(err).ToNot(HaveOccurred())
+
+					kcObj.TopologyManagerScope = initialTopologyManagerScope
+					err = kubeletconfig.KubeletConfToMCKubeletConf(kcObj, targetedKC)
+					Expect(err).ToNot(HaveOccurred())
+
+					err = fxt.Client.Update(context.TODO(), targetedKC)
+					g.Expect(err).ToNot(HaveOccurred())
+				}).WithTimeout(10 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
+
+				By("waiting for MachineConfigPools to get updated")
+				for _, mcp := range mcps {
+					wg.Add(1)
+					go func(mcpool *machineconfigv1.MachineConfigPool) {
+						defer GinkgoRecover()
+						defer wg.Done()
+						err = wait.With(fxt.Client).
+							Interval(configuration.MachineConfigPoolUpdateInterval).
+							Timeout(configuration.MachineConfigPoolUpdateTimeout).
+							ForMachineConfigPoolCondition(context.TODO(), mcpool, machineconfigv1.MachineConfigPoolUpdated)
+						Expect(err).ToNot(HaveOccurred())
+					}(mcp)
+				}
+				wg.Wait()
+			}()
+
 			By("checking that NUMAResourcesOperator's ConfigMap has changed")
 			cmList := &corev1.ConfigMapList{}
 			err = fxt.Client.List(context.TODO(), cmList)
@@ -588,39 +621,6 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 			By(fmt.Sprintf("checking NRT for target node %q updated correctly", testPod.Spec.NodeName))
 			// TODO: this is only partially correct. We should check with NUMA zone granularity (not with NODE granularity)
 			expectNRTConsumedResources(fxt, *nrtPreCreate, rl, testPod)
-
-			defer func() {
-				By("reverting kubeletconfig changes")
-				Eventually(func(g Gomega) {
-					err = fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(targetedKC), targetedKC)
-					Expect(err).ToNot(HaveOccurred())
-
-					kcObj, err = kubeletconfig.MCOKubeletConfToKubeletConf(targetedKC)
-					Expect(err).ToNot(HaveOccurred())
-
-					kcObj.TopologyManagerScope = initialTopologyManagerScope
-					err = kubeletconfig.KubeletConfToMCKubeletConf(kcObj, targetedKC)
-					Expect(err).ToNot(HaveOccurred())
-
-					err = fxt.Client.Update(context.TODO(), targetedKC)
-					g.Expect(err).ToNot(HaveOccurred())
-				}).WithTimeout(10 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
-
-				By("waiting for MachineConfigPools to get updated")
-				for _, mcp := range mcps {
-					wg.Add(1)
-					go func(mcpool *machineconfigv1.MachineConfigPool) {
-						defer GinkgoRecover()
-						defer wg.Done()
-						err = wait.With(fxt.Client).
-							Interval(configuration.MachineConfigPoolUpdateInterval).
-							Timeout(configuration.MachineConfigPoolUpdateTimeout).
-							ForMachineConfigPoolCondition(context.TODO(), mcpool, machineconfigv1.MachineConfigPoolUpdated)
-						Expect(err).ToNot(HaveOccurred())
-					}(mcp)
-				}
-				wg.Wait()
-			}()
 		})
 
 		It("should report the NodeGroupConfig in the status", func() {


### PR DESCRIPTION
The test fails in CI and passes locally. The test modifies the pod resources under the deployment and do some checks on the new pod. The part that is causing the test to fail is that it doesn't wait "long enough" for the new pod to get created, causing the automation to pick an old pod, hence failing in later node name check.
 Investigating it deeper, even with same oc client the test kept passing locally. Yet managed eventually to reproduce it by running it using an ssh connection to the cluster. Not clear about the root cause at the moment, but it seems that when the automation is connected to the cluster actually matters in terms of how quick the check can be, as via exporting the KC the test had no chance of failing, but via ssh the test continuously failed, possible indicator that ssh connection has a faster reaction than exporting KC.

To fix the flakiness, we add a waiting loop to guarantee we do not move further until the new pod's replicaset gets created.
