### PR TITLE
Fix reboot failed test cases

### DIFF
--- a/internal/noderesourcetopology/equality.go
+++ b/internal/noderesourcetopology/equality.go
@@ -56,10 +56,6 @@ func EqualResourceInfos(resInfosA, resInfosB nrtv1alpha2.ResourceInfoList) (bool
 		resInfoA := resInfosA[idx]
 		resInfoB := resInfosB[idx]
 
-		if resInfoA.Name != resInfoB.Name {
-			return false, fmt.Errorf("mismatched resourceinfo %q vs %q", resInfoA.Name, resInfoB.Name)
-		}
-
 		ok, err := EqualResourceInfo(resInfoA, resInfoB)
 		if !ok || err != nil {
 			return ok, err
@@ -71,16 +67,16 @@ func EqualResourceInfos(resInfosA, resInfosB nrtv1alpha2.ResourceInfoList) (bool
 
 func EqualResourceInfo(resInfoA, resInfoB nrtv1alpha2.ResourceInfo) (bool, error) {
 	if resInfoA.Name != resInfoB.Name {
-		return false, nil
+		return false, fmt.Errorf("mismatched resource name %q vs %q", resInfoA.Name, resInfoB.Name)
 	}
 	if resInfoA.Capacity.Cmp(resInfoB.Capacity) != 0 {
-		return false, nil
+		return false, fmt.Errorf("resource %q: mismatched resource Capacity %q vs %q", resInfoA.Name, resInfoA.Capacity, resInfoB.Capacity)
 	}
 	if resInfoA.Allocatable.Cmp(resInfoB.Allocatable) != 0 {
-		return false, nil
+		return false, fmt.Errorf("resource %q: mismatched resource Allocatable %q vs %q", resInfoA.Name, resInfoA.Allocatable, resInfoB.Allocatable)
 	}
 	if resInfoA.Available.Cmp(resInfoB.Available) != 0 {
-		return false, nil
+		return false, fmt.Errorf("resource %q: mismatched resource Available %q vs %q", resInfoA.Name, resInfoA.Available, resInfoB.Available)
 	}
 	return true, nil
 }

--- a/internal/noderesourcetopology/equality.go
+++ b/internal/noderesourcetopology/equality.go
@@ -18,8 +18,12 @@ package noderesourcetopology
 
 import (
 	"fmt"
+	"strings"
+
+	"github.com/ghodss/yaml"
 
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func EqualZones(zonesA, zonesB nrtv1alpha2.ZoneList) (bool, error) {
@@ -48,6 +52,8 @@ func EqualZones(zonesA, zonesB nrtv1alpha2.ZoneList) (bool, error) {
 }
 
 func EqualResourceInfos(resInfosA, resInfosB nrtv1alpha2.ResourceInfoList) (bool, error) {
+	var memA, memB nrtv1alpha2.ResourceInfoList
+
 	if len(resInfosA) != len(resInfosB) {
 		return false, fmt.Errorf("unequal resourceinfo count")
 	}
@@ -56,12 +62,22 @@ func EqualResourceInfos(resInfosA, resInfosB nrtv1alpha2.ResourceInfoList) (bool
 		resInfoA := resInfosA[idx]
 		resInfoB := resInfosB[idx]
 
+		if strings.Compare(resInfoA.Name, string(corev1.ResourceMemory)) == 0 {
+			infoA := resInfoA.DeepCopy()
+			infoB := resInfoB.DeepCopy()
+			memA = append(memA, *infoA)
+			memB = append(memB, *infoB)
+			continue
+		}
+
 		ok, err := EqualResourceInfo(resInfoA, resInfoB)
 		if !ok || err != nil {
 			return ok, err
 		}
 	}
 
+	//now compare the memory
+	EqualMemoryInfo(memA, memB)
 	return true, nil
 }
 
@@ -70,13 +86,47 @@ func EqualResourceInfo(resInfoA, resInfoB nrtv1alpha2.ResourceInfo) (bool, error
 		return false, fmt.Errorf("mismatched resource name %q vs %q", resInfoA.Name, resInfoB.Name)
 	}
 	if resInfoA.Capacity.Cmp(resInfoB.Capacity) != 0 {
-		return false, fmt.Errorf("resource %q: mismatched resource Capacity %q vs %q", resInfoA.Name, resInfoA.Capacity, resInfoB.Capacity)
+		return false, fmt.Errorf("resource %q: mismatched resource Capacity %v vs %v", resInfoA.Name, resInfoA.Capacity, resInfoB.Capacity)
 	}
 	if resInfoA.Allocatable.Cmp(resInfoB.Allocatable) != 0 {
-		return false, fmt.Errorf("resource %q: mismatched resource Allocatable %q vs %q", resInfoA.Name, resInfoA.Allocatable, resInfoB.Allocatable)
+		return false, fmt.Errorf("resource %q: mismatched resource Allocatable %v vs %v", resInfoA.Name, resInfoA.Allocatable, resInfoB.Allocatable)
 	}
 	if resInfoA.Available.Cmp(resInfoB.Available) != 0 {
-		return false, fmt.Errorf("resource %q: mismatched resource Available %q vs %q", resInfoA.Name, resInfoA.Available, resInfoB.Available)
+		return false, fmt.Errorf("resource %q: mismatched resource Available %v vs %v", resInfoA.Name, resInfoA.Available, resInfoB.Available)
 	}
 	return true, nil
+}
+
+func EqualMemoryInfo(a nrtv1alpha2.ResourceInfoList, b nrtv1alpha2.ResourceInfoList) (bool, error) {
+	if len(a) != len(b) {
+		return false, fmt.Errorf("mismatched memory resources count: %d vs %d", len(a), len(b))
+	}
+
+	for len(a) > 0 {
+		idx := isExist(b, a[0])
+		if idx == -1 {
+			resData, _ := yaml.Marshal(a[0])
+			return false, fmt.Errorf("mismatched memory info: %s is not found in both lists", resData)
+		}
+		if len(a) > 1 {
+			a = remove(a, 0)
+			b = remove(b, idx)
+		}
+	}
+	return true, nil
+}
+
+func isExist(list nrtv1alpha2.ResourceInfoList, res nrtv1alpha2.ResourceInfo) int {
+	for idx := range list {
+		ok, _ := EqualResourceInfo(list[idx], res)
+		if ok {
+			return idx
+		}
+	}
+	return -1
+}
+
+func remove(list nrtv1alpha2.ResourceInfoList, i int) nrtv1alpha2.ResourceInfoList {
+	list[i] = list[len(list)-1]
+	return list[:len(list)-1]
 }

--- a/internal/noderesourcetopology/equality_test.go
+++ b/internal/noderesourcetopology/equality_test.go
@@ -199,6 +199,112 @@ func TestEqualZones(t *testing.T) {
 	}
 }
 
+func TestEqualMemoryInfo(t *testing.T) {
+	testCases := []struct {
+		description string
+		A           nrtv1alpha2.ResourceInfoList
+		B           nrtv1alpha2.ResourceInfoList
+		expected    bool
+	}{
+		{
+			description: "equal",
+			A: nrtv1alpha2.ResourceInfoList{
+				{
+					Name:        "memory",
+					Capacity:    resource.MustParse("2"),
+					Allocatable: resource.MustParse("2"),
+					Available:   resource.MustParse("2"),
+				},
+				{
+					Name:        "memory",
+					Capacity:    resource.MustParse("4"),
+					Allocatable: resource.MustParse("4"),
+					Available:   resource.MustParse("4"),
+				},
+				{
+					Name:        "memory",
+					Capacity:    resource.MustParse("4"),
+					Allocatable: resource.MustParse("4"),
+					Available:   resource.MustParse("4"),
+				},
+			},
+			B: nrtv1alpha2.ResourceInfoList{
+				{
+					Name:        "memory",
+					Capacity:    resource.MustParse("4"),
+					Allocatable: resource.MustParse("4"),
+					Available:   resource.MustParse("4"),
+				},
+				{
+					Name:        "memory",
+					Capacity:    resource.MustParse("2"),
+					Allocatable: resource.MustParse("2"),
+					Available:   resource.MustParse("2"),
+				},
+				{
+					Name:        "memory",
+					Capacity:    resource.MustParse("4"),
+					Allocatable: resource.MustParse("4"),
+					Available:   resource.MustParse("4"),
+				},
+			},
+			expected: true,
+		},
+		{
+			description: "not equal",
+			A: nrtv1alpha2.ResourceInfoList{
+				{
+					Name:        "memory",
+					Capacity:    resource.MustParse("4"),
+					Allocatable: resource.MustParse("4"),
+					Available:   resource.MustParse("4"),
+				},
+				{
+					Name:        "memory",
+					Capacity:    resource.MustParse("4"),
+					Allocatable: resource.MustParse("4"),
+					Available:   resource.MustParse("4"),
+				},
+				{
+					Name:        "memory",
+					Capacity:    resource.MustParse("2"),
+					Allocatable: resource.MustParse("2"),
+					Available:   resource.MustParse("2"),
+				},
+			},
+			B: nrtv1alpha2.ResourceInfoList{
+				{
+					Name:        "memory",
+					Capacity:    resource.MustParse("4"),
+					Allocatable: resource.MustParse("4"),
+					Available:   resource.MustParse("4"),
+				},
+				{
+					Name:        "memory",
+					Capacity:    resource.MustParse("4"),
+					Allocatable: resource.MustParse("4"),
+					Available:   resource.MustParse("4"),
+				},
+				{
+					Name:        "memory",
+					Capacity:    resource.MustParse("4"),
+					Allocatable: resource.MustParse("4"),
+					Available:   resource.MustParse("4"),
+				},
+			},
+			expected: false,
+		},
+	}
+	for _, tt := range testCases {
+		got, _ := EqualMemoryInfo(tt.A, tt.B)
+		if got != tt.expected {
+			t.Errorf("got=%v expected=%v\ndata1=%s\ndata2=%s", got, tt.expected, toJSON(tt.A), toJSON(tt.B))
+		}
+
+	}
+
+}
+
 func toJSON(v any) string {
 	data, err := json.Marshal(v)
 	if err != nil {

--- a/test/utils/fixture/fixture.go
+++ b/test/utils/fixture/fixture.go
@@ -24,7 +24,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/ghodss/yaml"
 	"github.com/onsi/ginkgo/v2"
 
 	corev1 "k8s.io/api/core/v1"
@@ -148,8 +148,12 @@ func Cooldown(ft *Fixture) {
 		ginkgo.By(fmt.Sprintf("cooldown by verifying NRTs data is settled to the initial state (interval=%v timeout=%v)", interval, settleTimeout))
 		currentNrtList, err := intwait.With(ft.Client).Interval(interval).Timeout(settleTimeout).ForNodeResourceTopologiesEqualTo(context.TODO(), &ft.InitialNRTList, intwait.NRTIgnoreNothing)
 		if err != nil {
-			diff := cmp.Diff(ft.InitialNRTList.Items, currentNrtList.Items)
-			klog.Warningf("NRT MISMATCH:\n----\n%s\n---\n", diff)
+			klog.Warning("NRT MISMATCH:\n")
+			a, _ := yaml.Marshal(ft.InitialNRTList.Items)
+			klog.Infof("-----Initial NRT: \n%s\n", a)
+			b, _ := yaml.Marshal(currentNrtList.Items)
+			klog.Infof("-----Current NRT: \n%s\n", b)
+
 			ginkgo.Fail("cooldown failed, the NRT data did not settle back to the initial state")
 		}
 		return


### PR DESCRIPTION
The cooldown is performed at the end of the test and its main goal is to validate that the NRT is reset to the initial value.
    On reboot scenarios, this check always fails because it turned out that the memory distributaion accross the same numa zones of same node is not similar after the reboot, but is always found the same on node level. To illustrate that let's have a simple example:

    NRT before reboot:

    ```
    worker-0:
            numa-0:
                  - allocatable: "130674647040"
                    available: "130674647040"
                    capacity: "135238049792"
                    name: memory
                  - allocatable: "39"
                    available: "39"
                    capacity: "40"
                    name: cpu
            numa-1:
                  - allocatable: "130715820032"
                    available: "130715820032"
                    capacity: "135279222784"
                    name: memory
                  - allocatable: "39"
                    available: "39"
                    capacity: "40"
                    name: cpu

    ```

    NRT after reboot:

    ```
    worker-0:
            numa-0:
                  - allocatable: "130715820032"
                    available: "130715820032"
                    capacity: "135279222784"
                    name: memory
                  - allocatable: "39"
                    available: "39"
                    capacity: "40"
                    name: cpu
            numa-1:
                  - allocatable: "130674647040"
                    available: "130674647040"
                    capacity: "135238049792"
                    name: memory
                  - allocatable: "39"
                    available: "39"
                    capacity: "40"
                    name: cpu
    ```

    As one can see in the above example the node NRT overall is similar between before and after reboot, the only diffirence is that reboot may cause NRT to display switched alignment of the memory resources between both the numas.

To tolerate this behavior, allow to have switched memory amount between the different numa zones of the same node.

Signed-off-by: shajmakh <shajmakh@redhat.com>
@shajmakh
