### PR TITLE
rte manifests: update sample-devices image

### DIFF
--- a/rte/hack/manifests/sample-devices/daemonset-dpa.yaml
+++ b/rte/hack/manifests/sample-devices/daemonset-dpa.yaml
@@ -17,11 +17,16 @@ spec:
         - name: dpa-container
           securityContext:
             privileged: true
-          image: quay.io/k8stopologyawareschedwg/sample-device-plugin:v0.1.1
+          image: quay.io/k8stopologyawareschedwg/sample-device-plugin:v0.2.2
           imagePullPolicy: IfNotPresent
           env:
             - name: DEVICE_RESOURCE_NAME
               value: "example.com/deviceA"
+          command:
+            - /bin/deviceplugin
+          args:
+            - --alsologtostderr
+            - --config-dir=/etc/devices
           volumeMounts:
             - name: kubeletsockets
               mountPath: /var/lib/kubelet/device-plugins


### PR DESCRIPTION
Consume the enhanced sample device plugin image that allows reregistration of the devices in case of kubelet restart.

P.S: there is no failure noted before this change but seems more right to consume the enhanced version.