### PR TITLE
pkg: images: reuse client

### DIFF
--- a/main.go
+++ b/main.go
@@ -196,7 +196,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	imageSpec, pullPolicy, err := images.GetCurrentImage(context.Background())
+	imageSpec, pullPolicy, err := images.GetCurrentImage(context.Background(), mgr.GetClient())
 	if err != nil {
 		// intentionally continue
 		klog.InfoS("unable to find current image, using hardcoded", "error", err)


### PR DESCRIPTION
no need to create a specific k8s client to learn the image details, we can safely reuse the manager builtin client.