### PR TITLE
Add golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,26 @@
+name: CI Linter with golangci-lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Set up golang
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.20.6
+
+    - name: Run Linter
+      run: make golangci-lint

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,36 @@
+run:
+  concurrency: 4
+  timeout: 5m
+  tests: true
+  skip-dirs:
+    - vendor
+    - test
+  modules-download-mode: vendor
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - bodyclose
+    - exportloopref
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nolintlint
+    - nosprintfhostport
+    - staticcheck
+    - tenv
+    - typecheck
+    - unconvert
+    - unused
+    - wastedassign
+    - whitespace
+linters-settings:
+  misspell:
+    locale: US
+    ignore-words:
+      - NRO
+      - nro
+      - numaresource
+      - numa
+      - NUMA

--- a/api/numaresourcesoperator/v1/numaresourcesoperator_types.go
+++ b/api/numaresourcesoperator/v1/numaresourcesoperator_types.go
@@ -94,7 +94,7 @@ type NodeGroup struct {
 	// MachineConfigPoolSelector defines label selector for the machine config pool
 	// +optional
 	MachineConfigPoolSelector *metav1.LabelSelector `json:"machineConfigPoolSelector,omitempty"`
-	// Config defines the RTE behaviour for this NodeGroup
+	// Config defines the RTE behavior for this NodeGroup
 	// +optional
 	Config *NodeGroupConfig `json:"config,omitempty"`
 }

--- a/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_types.go
+++ b/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_types.go
@@ -93,7 +93,7 @@ type NodeGroup struct {
 	// DisablePodsFingerprinting defines if pod fingerprint should be omitted for the machines belonging to this group (DEPRECATED: use Config instead)
 	// +optional
 	DisablePodsFingerprinting *bool `json:"disablePodsFingerprinting,omitempty"`
-	// Config defines the RTE behaviour for this NodeGroup
+	// Config defines the RTE behavior for this NodeGroup
 	// +optional
 	Config *NodeGroupConfig `json:"config,omitempty"`
 }

--- a/api/numaresourcesoperator/v1alpha1/numaresourcesscheduler_conversion.go
+++ b/api/numaresourcesoperator/v1alpha1/numaresourcesscheduler_conversion.go
@@ -84,5 +84,4 @@ func (dst *NUMAResourcesScheduler) ConvertFromV1Rote(src *nropv1.NUMAResourcesSc
 		copy(dst.Status.Conditions, src.Status.Conditions)
 	}
 	return nil
-
 }

--- a/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -59,7 +59,7 @@ spec:
                     by MachineConfigPoolSelector or by NodeSelector
                   properties:
                     config:
-                      description: Config defines the RTE behaviour for this NodeGroup
+                      description: Config defines the RTE behavior for this NodeGroup
                       properties:
                         infoRefreshMode:
                           description: InfoRefreshMode sets the mechanism which will
@@ -380,7 +380,7 @@ spec:
                     by MachineConfigPoolSelector or by NodeSelector
                   properties:
                     config:
-                      description: Config defines the RTE behaviour for this NodeGroup
+                      description: Config defines the RTE behavior for this NodeGroup
                       properties:
                         infoRefreshMode:
                           description: InfoRefreshMode sets the mechanism which will

--- a/cmd/nrovalidate/main.go
+++ b/cmd/nrovalidate/main.go
@@ -62,7 +62,7 @@ type ProgArgs struct {
 	Quiet       bool
 	JSON        bool
 	Labels      string
-	Validations sets.String
+	Validations sets.Set[string]
 }
 
 func main() {
@@ -78,7 +78,7 @@ func main() {
 	}
 
 	if len(parsedArgs.Validations) == 0 || parsedArgs.Validations.Has("help") {
-		fmt.Fprintf(os.Stderr, "available validators: %v\n", strings.Join(nrovalidator.Available().List(), ","))
+		fmt.Fprintf(os.Stderr, "available validators: %v\n", strings.Join(sets.List(nrovalidator.Available()), ","))
 		os.Exit(0)
 	}
 
@@ -121,7 +121,7 @@ func validateCluster(ctx context.Context, args ProgArgs) error {
 	}
 
 	if !args.Quiet {
-		fmt.Fprintf(os.Stderr, "INFO>>>>: enabled validators: %s\n", strings.Join(args.Validations.List(), ","))
+		fmt.Fprintf(os.Stderr, "INFO>>>>: enabled validators: %s\n", strings.Join(sets.List(args.Validations), ","))
 	}
 
 	data, err := nrovalidator.Collect(ctx, cli, args.Labels, args.Validations)

--- a/cmd/nrtcacheck/main.go
+++ b/cmd/nrtcacheck/main.go
@@ -66,7 +66,7 @@ func init() {
 type ProgArgs struct {
 	Version   bool
 	DumpNodes bool
-	NodeNames sets.String
+	NodeNames sets.Set[string]
 }
 
 func main() {
@@ -116,7 +116,7 @@ func main() {
 
 	var nodeNames []string
 	if parsedArgs.NodeNames.Len() > 0 {
-		nodeNames = parsedArgs.NodeNames.List()
+		nodeNames = sets.List(parsedArgs.NodeNames)
 		klog.V(2).Infof("using provided node list with %d items", len(nodeNames))
 	} else {
 		workers, err := nodes.GetWorkerNodes(cli, ctx)
@@ -174,19 +174,19 @@ func main() {
 			continue
 		}
 
-		podsByRTE := sets.String{}
+		podsByRTE := sets.New[string]()
 		for _, nn := range st.Pods {
 			podsByRTE.Insert(nn.String())
 		}
 
 		fmt.Printf("%s: pods on sched, not on RTE: [\n", nodeName)
-		for _, name := range podsBySched.Difference(podsByRTE).List() {
+		for _, name := range sets.List(podsBySched.Difference(podsByRTE)) {
 			fmt.Printf(" - %s\n", name)
 		}
 		fmt.Printf("]\n")
 
 		fmt.Printf("%s: pods on RTE, not on sched: [\n", nodeName)
-		for _, name := range podsByRTE.Difference(podsBySched).List() {
+		for _, name := range sets.List(podsByRTE.Difference(podsBySched)) {
 			fmt.Printf(" - %s\n", name)
 		}
 		fmt.Printf("]\n")
@@ -241,7 +241,7 @@ func parseArgs(args ...string) (ProgArgs, error) {
 
 	klog.InitFlags(flags)
 	err := flags.Parse(args)
-	pArgs.NodeNames = sets.NewString(flags.Args()...)
+	pArgs.NodeNames = sets.New[string](flags.Args()...)
 	return pArgs, err
 }
 

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -60,7 +60,7 @@ spec:
                     by MachineConfigPoolSelector or by NodeSelector
                   properties:
                     config:
-                      description: Config defines the RTE behaviour for this NodeGroup
+                      description: Config defines the RTE behavior for this NodeGroup
                       properties:
                         infoRefreshMode:
                           description: InfoRefreshMode sets the mechanism which will
@@ -381,7 +381,7 @@ spec:
                     by MachineConfigPoolSelector or by NodeSelector
                   properties:
                     config:
-                      description: Config defines the RTE behaviour for this NodeGroup
+                      description: Config defines the RTE behavior for this NodeGroup
                       properties:
                         infoRefreshMode:
                           description: InfoRefreshMode sets the mechanism which will

--- a/controllers/kubeletconfig_controller.go
+++ b/controllers/kubeletconfig_controller.go
@@ -156,7 +156,7 @@ func (r *KubeletConfigReconciler) syncConfigMap(ctx context.Context, mcoKc *mcov
 		klog.ErrorS(err, "rendering config", "namespace", r.Namespace, "name", name)
 		return nil, err
 	}
-	rendered := rteconfig.CreateConfigMap(r.Namespace, name, string(data))
+	rendered := rteconfig.CreateConfigMap(r.Namespace, name, data)
 	cfgManifests := cfgstate.Manifests{
 		Config: rendered,
 	}

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -171,7 +171,6 @@ func (r *NUMAResourcesOperatorReconciler) updateStatus(ctx context.Context, inst
 }
 
 func updateStatus(ctx context.Context, cli client.Client, instance *nropv1.NUMAResourcesOperator, condition string, reason string, message string) (bool, error) {
-
 	conditions, ok := status.GetUpdatedConditions(instance.Status.Conditions, condition, reason, message)
 	if !ok {
 		return false, nil
@@ -444,7 +443,6 @@ func (r *NUMAResourcesOperatorReconciler) deleteUnusedDaemonSets(ctx context.Con
 	for _, ds := range daemonSetList.Items {
 		if !expectedDaemonSetNames.Has(ds.Name) {
 			if isOwnedBy(ds.GetObjectMeta(), instance) {
-
 				if err := r.Client.Delete(ctx, &ds); err != nil {
 					klog.ErrorS(err, "error while deleting daemonset", "DaemonSet", ds.Name)
 					errors = append(errors, err)

--- a/controllers/numaresourcesoperator_controller_test.go
+++ b/controllers/numaresourcesoperator_controller_test.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -931,12 +930,4 @@ func reconcileObjects(nro *nropv1.NUMAResourcesOperator, mcp *machineconfigv1.Ma
 
 	ExpectWithOffset(1, secondLoopResult).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
 	return reconciler
-}
-
-func nodeGroupConfigToString(conf nropv1.NodeGroupConfig) string {
-	data, err := json.Marshal(conf)
-	if err != nil {
-		return "<ERROR>"
-	}
-	return string(data)
 }

--- a/controllers/numaresourcesscheduler_controller.go
+++ b/controllers/numaresourcesscheduler_controller.go
@@ -153,7 +153,6 @@ func (r *NUMAResourcesSchedulerReconciler) reconcileResource(ctx context.Context
 	}
 
 	return ctrl.Result{}, status.ConditionAvailable, nil
-
 }
 
 func (r *NUMAResourcesSchedulerReconciler) getRelatedObjects(dpStatus nropv1.NamespacedName) []configv1.ObjectReference {

--- a/internal/baseload/baseload.go
+++ b/internal/baseload/baseload.go
@@ -78,7 +78,6 @@ func (nl Load) String() string {
 // the parameter in place
 func (nl Load) Apply(res corev1.ResourceList) {
 	resourcelist.AddCoreResources(res, nl.Resources)
-
 }
 
 // Deduct subtract the current node load from the given ResourceList by mutating

--- a/internal/machineconfigpools/machineconfigpools.go
+++ b/internal/machineconfigpools/machineconfigpools.go
@@ -41,7 +41,6 @@ func GetListByNodeGroupsV1(ctx context.Context, cli client.Client, nodeGroups []
 func FindBySelector(mcps []*mcov1.MachineConfigPool, sel *metav1.LabelSelector) (*mcov1.MachineConfigPool, error) {
 	if sel == nil {
 		return nil, fmt.Errorf("no MCP selector for selector %v", sel)
-
 	}
 
 	selector, err := metav1.LabelSelectorAsSelector(sel)

--- a/internal/noderesourcetopology/tostring.go
+++ b/internal/noderesourcetopology/tostring.go
@@ -80,15 +80,15 @@ func ToString(nrt nrtv1alpha2.NodeResourceTopology) string {
 
 func ListToString(nrts []nrtv1alpha2.NodeResourceTopology, tag string) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "NRT BEGIN dump")
+	fmt.Fprint(&b, "NRT BEGIN dump")
 	if len(tag) != 0 {
-		fmt.Fprintf(&b, " %s", tag)
+		fmt.Fprint(&b, tag)
 	}
-	fmt.Fprintf(&b, "\n")
+	fmt.Fprint(&b, "\n")
 	for idx := range nrts {
-		fmt.Fprintf(&b, ToString(nrts[idx]))
+		fmt.Fprint(&b, ToString(nrts[idx]))
 	}
-	fmt.Fprintf(&b, "NRT END dump\n")
+	fmt.Fprint(&b, "NRT END dump\n")
 	return b.String()
 }
 

--- a/internal/noderesourcetopology/tostring_test.go
+++ b/internal/noderesourcetopology/tostring_test.go
@@ -176,5 +176,4 @@ func TestToString(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/internal/remoteexec/command.go
+++ b/internal/remoteexec/command.go
@@ -73,5 +73,4 @@ func CommandOnPodByNames(c kubernetes.Interface, podNamespace, podName, cntName 
 	}
 
 	return outputBuf.Bytes(), errorBuf.Bytes(), nil
-
 }

--- a/internal/remoteexec/command.go
+++ b/internal/remoteexec/command.go
@@ -18,6 +18,7 @@ package remoteexec
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 
@@ -29,11 +30,11 @@ import (
 )
 
 // ExecCommandOnPod runs command in the pod and returns buffer output
-func CommandOnPod(c kubernetes.Interface, pod *corev1.Pod, command ...string) ([]byte, []byte, error) {
-	return CommandOnPodByNames(c, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name, command...)
+func CommandOnPod(ctx context.Context, c kubernetes.Interface, pod *corev1.Pod, command ...string) ([]byte, []byte, error) {
+	return CommandOnPodByNames(ctx, c, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name, command...)
 }
 
-func CommandOnPodByNames(c kubernetes.Interface, podNamespace, podName, cntName string, command ...string) ([]byte, []byte, error) {
+func CommandOnPodByNames(ctx context.Context, c kubernetes.Interface, podNamespace, podName, cntName string, command ...string) ([]byte, []byte, error) {
 	var outputBuf bytes.Buffer
 	var errorBuf bytes.Buffer
 
@@ -62,7 +63,7 @@ func CommandOnPodByNames(c kubernetes.Interface, podNamespace, podName, cntName 
 		return nil, nil, err
 	}
 
-	err = exec.Stream(remotecommand.StreamOptions{
+	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
 		Stdin:  os.Stdin,
 		Stdout: &outputBuf,
 		Stderr: &errorBuf,

--- a/internal/resourcelist/resourcelist.go
+++ b/internal/resourcelist/resourcelist.go
@@ -85,7 +85,7 @@ func AddCoreResources(res, resToAdd corev1.ResourceList) {
 func SubCoreResources(res, resToSub corev1.ResourceList) error {
 	for resName, resQty := range resToSub {
 		if resQty.Cmp(res[resName]) > 0 {
-			return fmt.Errorf("cannot substract resource %q because it is not found in the current resources", resName)
+			return fmt.Errorf("cannot subtract resource %q because it is not found in the current resources", resName)
 		}
 		qty := res[resName]
 		qty.Sub(resQty)

--- a/internal/resourcelist/resourcelist_test.go
+++ b/internal/resourcelist/resourcelist_test.go
@@ -168,7 +168,10 @@ func TestSubCoreResources(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(ToString(tc.expected), func(t *testing.T) {
 			res := tc.res.DeepCopy()
-			SubCoreResources(res, tc.resToSub)
+			err := SubCoreResources(res, tc.resToSub)
+			if err != nil {
+				t.Errorf("Error while calculating resources: %s", err.Error())
+			}
 			// comparing strings it just easier
 			got := ToString(res)
 			expected := ToString(tc.expected)

--- a/internal/schedcache/synced.go
+++ b/internal/schedcache/synced.go
@@ -109,7 +109,7 @@ func ReplicaHasSynced(env *Env, pod *corev1.Pod, nodeNames []string) (map[string
 
 func ReplicaHasSyncedForNode(env *Env, pod *corev1.Pod, nodeName string) (bool, sets.String, error) {
 	detectedPods := make(sets.String)
-	stdout, _, err := remoteexec.CommandOnPod(env.K8sCli, pod, "/bin/cat", filepath.Join(TracingDirectory, nodeNameToFileName(nodeName)+".json"))
+	stdout, _, err := remoteexec.CommandOnPod(env.Ctx, env.K8sCli, pod, "/bin/cat", filepath.Join(TracingDirectory, nodeNameToFileName(nodeName)+".json"))
 	if err != nil {
 		return false, detectedPods, err
 	}
@@ -138,7 +138,7 @@ func ReplicaHasSyncedForNode(env *Env, pod *corev1.Pod, nodeName string) (bool, 
 
 func GetUpdaterFingerprintStatus(env *Env, podNamespace, podName, cntName string) (podfingerprint.Status, error) {
 	var st podfingerprint.Status
-	stdout, _, err := remoteexec.CommandOnPodByNames(env.K8sCli, podNamespace, podName, cntName, "/bin/cat", filepath.Join(TracingDirectory, "dump.json"))
+	stdout, _, err := remoteexec.CommandOnPodByNames(env.Ctx, env.K8sCli, podNamespace, podName, cntName, "/bin/cat", filepath.Join(TracingDirectory, "dump.json"))
 	if err != nil {
 		return st, err
 	}

--- a/internal/wait/job.go
+++ b/internal/wait/job.go
@@ -44,7 +44,6 @@ func (wt Waiter) ForJobCompleted(ctx context.Context, jobNamespace, jobName stri
 		}
 		klog.Infof("%s/%s completed! (succeeded=%d)", jobNamespace, jobName, updatedJob.Status.Succeeded)
 		return true, nil
-
 	})
 	return &updatedJob, err
 }

--- a/main.go
+++ b/main.go
@@ -341,7 +341,11 @@ func renderRTEManifests(rteManifests rtemanifests.Manifests, namespace string, i
 		return mf, err
 	}
 	_ = rteupdate.DaemonSetUserImageSettings(mf.DaemonSet, "", imageSpec, images.NullPolicy)
-	rteupdate.DaemonSetPauseContainerSettings(mf.DaemonSet)
+
+	err = rteupdate.DaemonSetPauseContainerSettings(mf.DaemonSet)
+	if err != nil {
+		return mf, err
+	}
 	if mf.ConfigMap != nil {
 		rteupdate.DaemonSetHashAnnotation(mf.DaemonSet, hash.ConfigMapData(mf.ConfigMap))
 	}

--- a/pkg/flagcodec/flagcodec.go
+++ b/pkg/flagcodec/flagcodec.go
@@ -16,7 +16,7 @@
 
 // flagcodec allows to manipulate foreign command lines following the
 // standard golang conventions. It offeres two-way processing aka
-// parsing/marshalling of flags. It is different from the other, well
+// parsing/marshaling of flags. It is different from the other, well
 // established packages (pflag...) because it aims to manipulate command
 // lines in general, not this program command line.
 
@@ -49,7 +49,7 @@ func ParseArgvKeyValue(args []string) *Flags {
 
 // ParseArgvKeyValue parses a clean (trimmed) argv whose components are
 // either toggles or key=value pairs. IOW, this is a restricted and easier
-// to parse flavour of argv on which option and value are guaranteed to
+// to parse flavor of argv on which option and value are guaranteed to
 // be in the same item.
 // IOW, we expect
 // "--opt=foo"

--- a/pkg/flagcodec/flagcodec_test.go
+++ b/pkg/flagcodec/flagcodec_test.go
@@ -135,7 +135,6 @@ func TestAddFlags(t *testing.T) {
 }
 
 func TestDeleteFlags(t *testing.T) {
-
 	type testCase struct {
 		name     string
 		command  string

--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -63,7 +63,10 @@ func DaemonSetUserImageSettings(ds *appsv1.DaemonSet, userImageSpec, builtinImag
 	cnt.ImagePullPolicy = builtinPullPolicy
 	klog.V(3).InfoS("Exporter image", "reason", "builtin", "pullSpec", builtinImageSpec, "pullPolicy", builtinPullPolicy)
 	// if we run with operator-as-operand, we know we NEED this.
-	DaemonSetRunAsIDs(ds)
+	err = DaemonSetRunAsIDs(ds)
+	if err != nil {
+		return fmt.Errorf("error while changing container priviledges %w", err)
+	}
 
 	return nil
 }

--- a/pkg/objectupdate/rte/rte_test.go
+++ b/pkg/objectupdate/rte/rte_test.go
@@ -105,7 +105,7 @@ func TestUpdateDaemonSetArgs(t *testing.T) {
 			},
 		},
 		{
-			name: "explicitely disable unrestricted fingerprint",
+			name: "explicitly disable unrestricted fingerprint",
 			conf: nropv1.NodeGroupConfig{
 				PodsFingerprinting: &pfpEnabledExclusiveResources,
 			},

--- a/pkg/objectupdate/sched/sched.go
+++ b/pkg/objectupdate/sched/sched.go
@@ -124,7 +124,6 @@ func DeploymentConfigMapSettings(dp *appsv1.Deployment, cmName, cmHash string) {
 		template.Annotations = map[string]string{}
 	}
 	template.Annotations[hash.ConfigMapAnnotation] = cmHash
-
 }
 
 func SchedulerConfig(cm *corev1.ConfigMap, name string, cacheResyncPeriod time.Duration) error {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -38,7 +38,6 @@ const (
 )
 
 func GetUpdatedConditions(currentConditions []metav1.Condition, condition string, reason string, message string) ([]metav1.Condition, bool) {
-
 	conditions := NewConditions(condition, reason, message)
 
 	options := []cmp.Option{

--- a/pkg/validator/kubeletconfig.go
+++ b/pkg/validator/kubeletconfig.go
@@ -50,7 +50,6 @@ func CollectKubeletConfig(ctx context.Context, cli client.Client, data *Validato
 			return err
 		}
 		for _, mcp := range machineConfigPools {
-
 			nodes, err := getNodeListFromMachineConfigPool(ctx, cli, *mcp)
 			if err != nil {
 				return err

--- a/pkg/validator/kubeletconfig.go
+++ b/pkg/validator/kubeletconfig.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -77,7 +78,7 @@ func CollectKubeletConfig(ctx context.Context, cli client.Client, data *Validato
 
 func ValidateKubeletConfig(data ValidatorData) ([]deployervalidator.ValidationResult, error) {
 	var ret []deployervalidator.ValidationResult
-	for _, nodeName := range data.tasEnabledNodeNames.List() {
+	for _, nodeName := range sets.List(data.tasEnabledNodeNames) {
 		kc := data.kConfigs[nodeName]
 		// if a TAS enabled node has no MCO kubelet configuration kc will be nil and ValidateClusterNodeKubeletConfig will fill the proper error
 		res := deployervalidator.ValidateClusterNodeKubeletConfig(nodeName, data.versionInfo, kc)

--- a/pkg/validator/machineconfigpools.go
+++ b/pkg/validator/machineconfigpools.go
@@ -59,7 +59,6 @@ func getMachineConfigPoolListFromMCOKubeletConfig(ctx context.Context, cli clien
 		if sel.Matches(mcpLabels) {
 			result = append(result, mcp)
 		}
-
 	}
 	return result, nil
 }

--- a/pkg/validator/noderesourcetopologies.go
+++ b/pkg/validator/noderesourcetopologies.go
@@ -37,7 +37,6 @@ const (
 )
 
 func CollectNodeResourceTopologies(ctx context.Context, _ client.Client, data *ValidatorData) error {
-
 	cli, err := getTopologyClient()
 	if err != nil {
 		return err

--- a/pkg/validator/noderesourcetopologies_test.go
+++ b/pkg/validator/noderesourcetopologies_test.go
@@ -114,5 +114,4 @@ func TestValidateCRDInconsistentData(t *testing.T) {
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("validation mismatch: got=%#v expected=%#v", got, expected)
 	}
-
 }

--- a/pkg/validator/noderesourcetopologies_test.go
+++ b/pkg/validator/noderesourcetopologies_test.go
@@ -82,7 +82,7 @@ func TestValidateCRDMissingData(t *testing.T) {
 
 func TestValidateCRDInconsistentData(t *testing.T) {
 	vd := ValidatorData{
-		tasEnabledNodeNames: sets.NewString("fake-node-0", "fake-node-1"),
+		tasEnabledNodeNames: sets.New[string]("fake-node-0", "fake-node-1"),
 		nrtList: &nrtv1alpha2.NodeResourceTopologyList{
 			// minimal initialization. Consistency doesn't really matter here
 			Items: []nrtv1alpha2.NodeResourceTopology{

--- a/pkg/validator/podstatus.go
+++ b/pkg/validator/podstatus.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -33,7 +34,7 @@ const (
 
 func CollectPodStatus(ctx context.Context, cli client.Client, data *ValidatorData) error {
 	nonRunningPodsByNode := make(map[string]map[string]corev1.PodPhase)
-	for _, nodeName := range data.tasEnabledNodeNames.List() {
+	for _, nodeName := range sets.List(data.tasEnabledNodeNames) {
 		sel, err := fields.ParseSelector("spec.nodeName=" + nodeName)
 		if err != nil {
 			return err

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func TestRequested(t *testing.T) {
@@ -29,7 +31,7 @@ func TestRequested(t *testing.T) {
 		expectedError error
 	}
 
-	available := strings.Join(Available().List(), ",")
+	available := strings.Join(sets.List(Available()), ",")
 
 	testcases := []testCase{
 		{
@@ -73,7 +75,8 @@ func TestRequested(t *testing.T) {
 				t.Errorf("Requested(%s): got error %v expected %v", tc.what, err, tc.expectedError)
 			}
 
-			gotValue := strings.Join(got.List(), ",")
+			gotValue := strings.Join(sets.List(got), ",")
+
 			if !reflect.DeepEqual(gotValue, tc.expectedValue) {
 				t.Errorf("Requested(%s): got %v expected %v", tc.what, got, tc.expectedValue)
 			}

--- a/rte/main.go
+++ b/rte/main.go
@@ -92,6 +92,7 @@ func main() {
 	if err != nil {
 		klog.Fatalf("failed to start prometheus server: %v", err)
 	}
+	//nolint: errcheck
 	defer cleanup()
 
 	cli = sharedcpuspool.NewFromLister(cli, parsedArgs.RTE.Debug, parsedArgs.RTE.ReferenceContainer)

--- a/rte/pkg/config/config.go
+++ b/rte/pkg/config/config.go
@@ -19,7 +19,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
@@ -44,7 +43,7 @@ type Config struct {
 func ReadFile(configPath string) (Config, error) {
 	conf := Config{}
 	// TODO modernize using os.ReadFile
-	data, err := ioutil.ReadFile(configPath)
+	data, err := os.ReadFile(configPath)
 	if err != nil {
 		// config is optional
 		if errors.Is(err, os.ErrNotExist) {

--- a/rte/pkg/config/config_test.go
+++ b/rte/pkg/config/config_test.go
@@ -17,7 +17,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -41,7 +40,7 @@ func TestReadMalformed(t *testing.T) {
 
 func TestReadValidData(t *testing.T) {
 	content := []byte(testData)
-	tmpfile, err := ioutil.TempFile("", "testrteconfig")
+	tmpfile, err := os.CreateTemp("", "testrteconfig")
 	if err != nil {
 		t.Errorf("creating tempfile: %v", err)
 	}

--- a/test/e2e/rte/rte_test.go
+++ b/test/e2e/rte/rte_test.go
@@ -278,7 +278,7 @@ var _ = ginkgo.Describe("with a running cluster with all the components", func()
 
 				// TODO: hardcoded path. Any smarter option?
 				cmd := []string{"/bin/cat", "/run/pfpstatus/dump.json"}
-				stdout, stderr, err := remoteexec.CommandOnPod(clients.K8sClient, &rtePod, cmd...)
+				stdout, stderr, err := remoteexec.CommandOnPod(context.Background(), clients.K8sClient, &rtePod, cmd...)
 				if err != nil {
 					_ = objects.LogEventsForPod(clients.K8sClient, rtePod.Namespace, rtePod.Name)
 				}


### PR DESCRIPTION
This PR adds a new golangci-lint target to the makefile and sets up a common config along the lines of other openshift operators.

- Address misspell violations
- Address staticheck violations

Signed-off-by: Daniel Mellado [dmellado@redhat.com](mailto:dmellado@redhat.com)
Signed-off-by: Jose Luis Ojosnegros [jojosneg@redhat.com](mailto:jojosneg@redhat.com)

issue: #495 