### PR TITLE
Relax condition on reboot and a cleanup

### DIFF
--- a/internal/noderesourcetopology/equality.go
+++ b/internal/noderesourcetopology/equality.go
@@ -56,10 +56,6 @@ func EqualResourceInfos(resInfosA, resInfosB nrtv1alpha2.ResourceInfoList) (bool
 		resInfoA := resInfosA[idx]
 		resInfoB := resInfosB[idx]
 
-		if resInfoA.Name != resInfoB.Name {
-			return false, fmt.Errorf("mismatched resourceinfo %q vs %q", resInfoA.Name, resInfoB.Name)
-		}
-
 		ok, err := EqualResourceInfo(resInfoA, resInfoB)
 		if !ok || err != nil {
 			return ok, err
@@ -71,16 +67,16 @@ func EqualResourceInfos(resInfosA, resInfosB nrtv1alpha2.ResourceInfoList) (bool
 
 func EqualResourceInfo(resInfoA, resInfoB nrtv1alpha2.ResourceInfo) (bool, error) {
 	if resInfoA.Name != resInfoB.Name {
-		return false, nil
+		return false, fmt.Errorf("mismatched resource name %q vs %q", resInfoA.Name, resInfoB.Name)
 	}
 	if resInfoA.Capacity.Cmp(resInfoB.Capacity) != 0 {
-		return false, nil
+		return false, fmt.Errorf("resource %q: mismatched resource Capacity %v vs %v", resInfoA.Name, resInfoA.Capacity, resInfoB.Capacity)
 	}
 	if resInfoA.Allocatable.Cmp(resInfoB.Allocatable) != 0 {
-		return false, nil
+		return false, fmt.Errorf("resource %q: mismatched resource Allocatable %v vs %v", resInfoA.Name, resInfoA.Allocatable, resInfoB.Allocatable)
 	}
 	if resInfoA.Available.Cmp(resInfoB.Available) != 0 {
-		return false, nil
+		return false, fmt.Errorf("resource %q: mismatched resource Available %v vs %v", resInfoA.Name, resInfoA.Available, resInfoB.Available)
 	}
 	return true, nil
 }

--- a/internal/noderesourcetopology/equality_test.go
+++ b/internal/noderesourcetopology/equality_test.go
@@ -188,10 +188,50 @@ func TestEqualZones(t *testing.T) {
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := EqualZones(tt.data1, tt.data2)
-			if err != nil {
-				t.Errorf("unexpected comparison error: %v", err)
+			got, _ := EqualZones(tt.data1, tt.data2, false)
+			if got != tt.expected {
+				t.Errorf("got=%v expected=%v\ndata1=%s\ndata2=%s", got, tt.expected, toJSON(tt.data1), toJSON(tt.data2))
 			}
+		})
+	}
+}
+
+func TestQuantityAbsCmp(t *testing.T) {
+	dev := resource.MustParse("2")
+	testCases := []struct {
+		name     string
+		data1    resource.Quantity
+		data2    resource.Quantity
+		expected bool
+	}{
+		{
+			name:     "equal with deviation",
+			data1:    resource.MustParse("2"),
+			data2:    resource.MustParse("3"),
+			expected: true,
+		},
+		{
+			name:     "equal",
+			data1:    resource.MustParse("2"),
+			data2:    resource.MustParse("2"),
+			expected: true,
+		},
+		{
+			name:     "not equal despite the deviation",
+			data1:    resource.MustParse("4"),
+			data2:    resource.MustParse("1"),
+			expected: false,
+		},
+		{
+			name:     "not equal despite the deviation",
+			data1:    resource.MustParse("1"),
+			data2:    resource.MustParse("5"),
+			expected: false,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := QuantityAbsCmp(tt.data1, tt.data2, dev)
 			if got != tt.expected {
 				t.Errorf("got=%v expected=%v\ndata1=%s\ndata2=%s", got, tt.expected, toJSON(tt.data1), toJSON(tt.data2))
 			}

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -98,6 +98,7 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 		timeout := 5 * time.Minute
 
 		It("[test_id:47674][reboot_required][slow][images][tier2] should be able to modify the configurable values under the NUMAResourcesOperator CR", func() {
+			fxt.IsRebootTest = true
 			nroOperObj := &nropv1.NUMAResourcesOperator{}
 			nroKey := objects.NROObjectKey()
 			err := fxt.Client.Get(context.TODO(), nroKey, nroOperObj)
@@ -442,6 +443,7 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 		})
 
 		It("[test_id:47585][reboot_required][slow] can change kubeletconfig and controller should adapt", func() {
+			fxt.IsRebootTest = true
 			nroOperObj := &nropv1.NUMAResourcesOperator{}
 			nroKey := objects.NROObjectKey()
 			err := fxt.Client.Get(context.TODO(), nroKey, nroOperObj)

--- a/test/utils/fixture/fixture.go
+++ b/test/utils/fixture/fixture.go
@@ -49,6 +49,7 @@ type Fixture struct {
 	Namespace      corev1.Namespace
 	InitialNRTList nrtv1alpha2.NodeResourceTopologyList
 	Skipped        bool
+	IsRebootTest   bool
 	avoidCooldown  bool
 }
 
@@ -146,7 +147,8 @@ func Cooldown(ft *Fixture) {
 	if len(ft.InitialNRTList.Items) > 0 {
 		interval := 5 * time.Second
 		ginkgo.By(fmt.Sprintf("cooldown by verifying NRTs data is settled to the initial state (interval=%v timeout=%v)", interval, settleTimeout))
-		currentNrtList, err := intwait.With(ft.Client).Interval(interval).Timeout(settleTimeout).ForNodeResourceTopologiesEqualTo(context.TODO(), &ft.InitialNRTList, intwait.NRTIgnoreNothing)
+		currentNrtList, err := intwait.With(ft.Client).Interval(interval).Timeout(settleTimeout).ForNodeResourceTopologiesEqualToPostReboot(context.TODO(), &ft.InitialNRTList, intwait.NRTIgnoreNothing, ft.IsRebootTest)
+		ft.IsRebootTest = false
 		if err != nil {
 			klog.Warning("NRT MISMATCH:\n")
 			a, _ := yaml.Marshal(ft.InitialNRTList.Items)

--- a/test/utils/fixture/fixture.go
+++ b/test/utils/fixture/fixture.go
@@ -24,7 +24,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/ghodss/yaml"
 	"github.com/onsi/ginkgo/v2"
 
 	corev1 "k8s.io/api/core/v1"
@@ -148,8 +148,12 @@ func Cooldown(ft *Fixture) {
 		ginkgo.By(fmt.Sprintf("cooldown by verifying NRTs data is settled to the initial state (interval=%v timeout=%v)", interval, settleTimeout))
 		currentNrtList, err := intwait.With(ft.Client).Interval(interval).Timeout(settleTimeout).ForNodeResourceTopologiesEqualTo(context.TODO(), &ft.InitialNRTList, intwait.NRTIgnoreNothing)
 		if err != nil {
-			diff := cmp.Diff(ft.InitialNRTList.Items, currentNrtList.Items)
-			klog.Warningf("NRT MISMATCH:\n----\n%s\n---\n", diff)
+			klog.Warning("NRT MISMATCH:\n")
+			a, _ := yaml.Marshal(ft.InitialNRTList.Items)
+			klog.Infof("-----Initial NRT: \n%s\n", a)
+			b, _ := yaml.Marshal(currentNrtList.Items)
+			klog.Infof("-----Current NRT: \n%s\n", b)
+
 			ginkgo.Fail("cooldown failed, the NRT data did not settle back to the initial state")
 		}
 		return


### PR DESCRIPTION
The cooldown is performed at the end of the test and its main goal is to validate that the NRT is reset to the initial value.
On reboot scenarios, this check always fails because it turns out that the memory distribution across the same numa zones of the same node is not similar after the reboot, but is always found the same on the node level.After investigation, it turns out that new capacities after reboot are reported as so by the kernel. Since this is a behavior we cannot control, we need to adapt it, and thus here we suggest relaxing the equality check of memory resources. We allow a deviation of 52Mi which should cover these differences.

