### PR TITLE
serial: adjust NRT settle timeout and interval

### DIFF
--- a/test/utils/fixture/fixture.go
+++ b/test/utils/fixture/fixture.go
@@ -56,8 +56,8 @@ type Fixture struct {
 const (
 	defaultTeardownTime      = 180 * time.Second
 	defaultCooldownTime      = 30 * time.Second
-	defaultSettleInterval    = 11 * time.Second
-	defaultSettleTimeout     = 1 * time.Minute
+	defaultSettleInterval    = 9 * time.Second
+	defaultSettleTimeout     = 75 * time.Second
 	defaultCooldownThreshold = 5
 )
 


### PR DESCRIPTION
Several tests (+10) fail when waiting for NRT objects to settle due to timeout. The reason behind that is that the old unsettled values take a while to settle thus leaving insufficient time for the real settled data to count as needed as per the threshold (default 5).

To enhance this we have 3 options:
* increase the default timeout
* decrease the interval time
* lower the threshold to 4 (3 is too risky)

We do not want to lower the threshold count because it might be risky because the failing tests show that unsettled data can get to 3 or 4 count when measuring the threshold. Thus omitting this option. We go with a combination of adjusting the timeout and the interval. As per the tests, it looks like at the first ~25 seconds leftover data can still be there. We want to guarantee that in the remaining time, the test still can get to the real settle data and hit the threshold (5). Thus we set the interval to 9 seconds so that in the fourth iteration n we can see the final real data in NRT, and the 4th iteration is the first count for this data. We adjust the timeout to 75 so we allow
 another 4 iterations + 1 at timeout, for the real data to hit the threshold (5).