### PR TITLE
enable skipped tests & stabilize flaky tests

### DIFF
--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -620,6 +620,9 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 			nrtPreCreate, err := e2enrt.FindFromList(nrtPreCreatePodList.Items, testPod.Spec.NodeName)
 			Expect(err).ToNot(HaveOccurred())
 
+			By("Waiting for the NRT data to stabilize")
+			e2efixture.WaitForNRTSettle(fxt)
+
 			By(fmt.Sprintf("checking NRT for target node %q updated correctly", testPod.Spec.NodeName))
 			// TODO: this is only partially correct. We should check with NUMA zone granularity (not with NODE granularity)
 			expectNRTConsumedResources(fxt, *nrtPreCreate, rl, testPod)

--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -179,6 +179,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(updatedPod.Spec.NodeName).To(Equal(targetNodeName),
 				"node landed on %q instead of on %v", updatedPod.Spec.NodeName, targetNodeName)
 
+			By("Waiting for the NRT data to stabilize")
+			e2efixture.WaitForNRTSettle(fxt)
+
 			By(fmt.Sprintf("checking NRT for target node %q updated correctly", targetNodeName))
 			rl := e2ereslist.FromGuaranteedPod(*updatedPod)
 			nrtPostCreate := expectNRTConsumedResources(fxt, nrtInitial, rl, updatedPod)

--- a/test/e2e/serial/tests/scheduler_cache.go
+++ b/test/e2e/serial/tests/scheduler_cache.go
@@ -337,7 +337,7 @@ var _ = Describe("[serial][scheduler][cache][tier1] scheduler cache", Label("sch
 				klog.Infof("hosts required %d desired pods %d expected pending %d", hostsRequired, desiredPods, expectedPending)
 
 				// so we can't support ATM zones > 2. HW with zones > 2 is rare anyway, so not to big of a deal now.
-				// TOOD: when we support NUMA zones > 2, switch to FilterZoneCountAtLeast
+				// TODO: when we support NUMA zones > 2, switch to FilterZoneCountAtLeast
 				By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", NUMAZonesRequired))
 				nrtCandidates = e2enrt.FilterZoneCountEqual(nrtList.Items, NUMAZonesRequired)
 				if len(nrtCandidates) < hostsRequired {
@@ -620,7 +620,7 @@ func ResourceInfoProvidingAtMost(resources []nrtv1alpha2.ResourceInfo, resName s
 	if zoneQty.Cmp(zeroQty) <= 0 {
 		return false
 	}
-	if zoneQty.Cmp(resQty) > 0 {
+	if zoneQty.Cmp(resQty) < 0 {
 		return false
 	}
 	return true

--- a/test/e2e/serial/tests/scheduler_cache.go
+++ b/test/e2e/serial/tests/scheduler_cache.go
@@ -326,7 +326,7 @@ var _ = Describe("[serial][scheduler][cache][tier1] scheduler cache", Label("sch
 				// In this testcase, having running pods is not good enough: we want to ALSO have pods which keep being
 				// pending "forever". We can't really check "forever", so we just check "long enough".
 
-				deviceName := e2efixture.GetDeviceType1Name()
+				deviceName := e2efixture.GetDeviceType3Name()
 				if deviceName == "" {
 					e2efixture.Skipf(fxt, "missing required device name (device1)")
 				}
@@ -449,7 +449,7 @@ var _ = Describe("[serial][scheduler][cache][tier1] scheduler cache", Label("sch
 				// So we will wait "long enough" to ensure a pod stays pending, and then we delete a random running pod;
 				// eventually, the scheduler must catch up and schedule the pod wherever resources have been freed.
 
-				deviceName := e2efixture.GetDeviceType1Name()
+				deviceName := e2efixture.GetDeviceType3Name()
 				if deviceName == "" {
 					e2efixture.Skipf(fxt, "missing required device name (device1)")
 				}

--- a/test/e2e/serial/tests/workload_placement_taint.go
+++ b/test/e2e/serial/tests/workload_placement_taint.go
@@ -237,6 +237,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 
+			By("Waiting for the NRT data to stabilize")
+			e2efixture.WaitForNRTSettle(fxt)
+
 			rl := e2ereslist.FromGuaranteedPod(*updatedPod)
 			By("Verifying NRT is updated properly when running the test's pod")
 			nrtPostCreate := expectNRTConsumedResources(fxt, nrtInitial, rl, updatedPod)

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -203,6 +203,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				Expect(err).ToNot(HaveOccurred())
 				Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 
+				By("Waiting for the NRT data to stabilize")
+				e2efixture.WaitForNRTSettle(fxt)
+
 				By("Verifying NRT is updated properly when running the test's pod")
 				expectNRTConsumedResources(fxt, targetNrtInitial, requiredRes, updatedPod)
 			},
@@ -300,6 +303,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 					Expect(err).ToNot(HaveOccurred())
 					Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", pod.Namespace, pod.Name, serialconfig.Config.SchedulerName)
 				}
+
+				By("Waiting for the NRT data to stabilize")
+				e2efixture.WaitForNRTSettle(fxt)
 
 				By("Verifying NRT is updated properly when running the test's pod")
 				expectNRTConsumedResources(fxt, targetNrtInitial, requiredRes, &pods[0])


### PR DESCRIPTION
Some tests were skipped for unexpected reasons, fix that and fix the flakiness by waiting enough time for the NRTs to settle. See commits for more details on each change. 