### PR TITLE
[release-4.11] rte: disable metrics

### DIFF
--- a/rte/main.go
+++ b/rte/main.go
@@ -81,7 +81,7 @@ func main() {
 
 	k8sCli, err := podrescli.NewK8SClient(parsedArgs.RTE.PodResourcesSocketPath)
 	if err != nil {
-		klog.Fatalf("failed to start prometheus server: %v", err)
+		klog.Fatalf("failed to create podres client: %v", err)
 	}
 
 	sysCli := k8sCli

--- a/rte/main.go
+++ b/rte/main.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nrtupdater"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podrescli"
-	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/prometheus"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcemonitor"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcetopologyexporter"
 
@@ -93,11 +92,6 @@ func main() {
 	cli, err := podrescli.NewFilteringClientFromLister(sysCli, parsedArgs.RTE.Debug, parsedArgs.RTE.ReferenceContainer)
 	if err != nil {
 		klog.Fatalf("failed to get podresources filtering client: %v", err)
-	}
-
-	err = prometheus.InitPrometheus()
-	if err != nil {
-		klog.Fatalf("failed to start prometheus server: %v", err)
 	}
 
 	// TODO: recycled flag (no big deal, but still)


### PR DESCRIPTION
served insecurely, and approaching EOL.
4.12 still supported and will have metrics re-enabled later.