### PR TITLE
snyk: exclude stretchr testify-related repos

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -10,6 +10,8 @@ exclude:
     - "vendor/github.com/golang/**"
     - "vendor/github.com/google/**"
     - "vendor/github.com/openshift/**"
+    - "vendor/github.com/onsi/gomega**"
+    - "vendor/github.com/onsi/ginkgo/**"
     - "vendor/golang.org/**"
     - "vendor/github.com/stretchr/testify/**"
     - "vendor/github.com/stretchr/objx/**"

--- a/.snyk
+++ b/.snyk
@@ -11,3 +11,5 @@ exclude:
     - "vendor/github.com/google/**"
     - "vendor/github.com/openshift/**"
     - "vendor/golang.org/**"
+    - "vendor/github.com/stretchr/testify/**"
+    - "vendor/github.com/stretchr/objx/**"

--- a/.snyk
+++ b/.snyk
@@ -7,6 +7,7 @@ exclude:
     - "**/*_test.go"
     - "vendor/k8s.io/**"
     - "vendor/sigs.k8s.io/**"
+    - "vendor/github.com/jaypipes/ghw/**"
     - "vendor/github.com/golang/**"
     - "vendor/github.com/google/**"
     - "vendor/github.com/openshift/**"


### PR DESCRIPTION
these deps are pulled indirectly by test code,
used by mocking code.