### PR TITLE
snyk: exclude deployer kubeletconfig package

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -8,6 +8,7 @@ exclude:
     - "vendor/k8s.io/**"
     - "vendor/sigs.k8s.io/**"
     - "vendor/github.com/jaypipes/ghw/**"
+    - "vendor/github.com/k8stopologyawareschedwg/deployer/pkg/kubeletconfig/*"
     - "vendor/github.com/golang/**"
     - "vendor/github.com/google/**"
     - "vendor/github.com/openshift/**"


### PR DESCRIPTION
used only in optional validation tools,
not in the main operator binary