### PR TITLE
[release-4.13][manual] test: e2e: import and use the taints pkg from k8s

### DIFF
--- a/test/e2e/serial/tests/workload_placement_taint.go
+++ b/test/e2e/serial/tests/workload_placement_taint.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/util/taints"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
@@ -40,6 +39,7 @@ import (
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
 
 	e2efixture "github.com/openshift-kni/numaresources-operator/test/utils/fixture"
+	"github.com/openshift-kni/numaresources-operator/test/utils/k8simported/taints"
 	e2enrt "github.com/openshift-kni/numaresources-operator/test/utils/noderesourcetopologies"
 	"github.com/openshift-kni/numaresources-operator/test/utils/nrosched"
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"

--- a/test/utils/k8simported/taints/LICENSE
+++ b/test/utils/k8simported/taints/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/test/utils/k8simported/taints/README.md
+++ b/test/utils/k8simported/taints/README.md
@@ -1,0 +1,3 @@
+this is k/k/pkg/util/taints imported from k8s 1.28.3
+plus the dependency k/k/pkg/apis/core/helper/helpers.go
+inlined in helper.go

--- a/test/utils/k8simported/taints/helper.go
+++ b/test/utils/k8simported/taints/helper.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taints
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// helperSemantic can do semantic deep equality checks for core objects.
+// Example: apiequality.Semantic.DeepEqual(aPod, aPodWithNonNilButEmptyMaps) == true
+var helperSemantic = conversion.EqualitiesOrDie(
+	func(a, b resource.Quantity) bool {
+		// Ignore formatting, only care that numeric value stayed the same.
+		// TODO: if we decide it's important, it should be safe to start comparing the format.
+		//
+		// Uninitialized quantities are equivalent to 0 quantities.
+		return a.Cmp(b) == 0
+	},
+	func(a, b metav1.MicroTime) bool {
+		return a.UTC() == b.UTC()
+	},
+	func(a, b metav1.Time) bool {
+		return a.UTC() == b.UTC()
+	},
+	func(a, b labels.Selector) bool {
+		return a.String() == b.String()
+	},
+	func(a, b fields.Selector) bool {
+		return a.String() == b.String()
+	},
+)

--- a/test/utils/k8simported/taints/taints.go
+++ b/test/utils/k8simported/taints/taints.go
@@ -1,0 +1,288 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// package taints implements utilities for working with taints
+package taints
+
+import (
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+const (
+	MODIFIED  = "modified"
+	TAINTED   = "tainted"
+	UNTAINTED = "untainted"
+)
+
+// parseTaint parses a taint from a string, whose form must be either
+// '<key>=<value>:<effect>', '<key>:<effect>', or '<key>'.
+func parseTaint(st string) (v1.Taint, error) {
+	var taint v1.Taint
+
+	var key string
+	var value string
+	var effect v1.TaintEffect
+
+	parts := strings.Split(st, ":")
+	switch len(parts) {
+	case 1:
+		key = parts[0]
+	case 2:
+		effect = v1.TaintEffect(parts[1])
+		if err := validateTaintEffect(effect); err != nil {
+			return taint, err
+		}
+
+		partsKV := strings.Split(parts[0], "=")
+		if len(partsKV) > 2 {
+			return taint, fmt.Errorf("invalid taint spec: %v", st)
+		}
+		key = partsKV[0]
+		if len(partsKV) == 2 {
+			value = partsKV[1]
+			if errs := validation.IsValidLabelValue(value); len(errs) > 0 {
+				return taint, fmt.Errorf("invalid taint spec: %v, %s", st, strings.Join(errs, "; "))
+			}
+		}
+	default:
+		return taint, fmt.Errorf("invalid taint spec: %v", st)
+	}
+
+	if errs := validation.IsQualifiedName(key); len(errs) > 0 {
+		return taint, fmt.Errorf("invalid taint spec: %v, %s", st, strings.Join(errs, "; "))
+	}
+
+	taint.Key = key
+	taint.Value = value
+	taint.Effect = effect
+
+	return taint, nil
+}
+
+func validateTaintEffect(effect v1.TaintEffect) error {
+	if effect != v1.TaintEffectNoSchedule && effect != v1.TaintEffectPreferNoSchedule && effect != v1.TaintEffectNoExecute {
+		return fmt.Errorf("invalid taint effect: %v, unsupported taint effect", effect)
+	}
+
+	return nil
+}
+
+// ParseTaints takes a spec which is an array and creates slices for new taints to be added, taints to be deleted.
+// It also validates the spec. For example, the form `<key>` may be used to remove a taint, but not to add one.
+func ParseTaints(spec []string) ([]v1.Taint, []v1.Taint, error) {
+	var taints, taintsToRemove []v1.Taint
+	uniqueTaints := map[v1.TaintEffect]sets.String{}
+
+	for _, taintSpec := range spec {
+		if strings.HasSuffix(taintSpec, "-") {
+			taintToRemove, err := parseTaint(strings.TrimSuffix(taintSpec, "-"))
+			if err != nil {
+				return nil, nil, err
+			}
+			taintsToRemove = append(taintsToRemove, v1.Taint{Key: taintToRemove.Key, Effect: taintToRemove.Effect})
+		} else {
+			newTaint, err := parseTaint(taintSpec)
+			if err != nil {
+				return nil, nil, err
+			}
+			// validate that the taint has an effect, which is required to add the taint
+			if len(newTaint.Effect) == 0 {
+				return nil, nil, fmt.Errorf("invalid taint spec: %v", taintSpec)
+			}
+			// validate if taint is unique by <key, effect>
+			if len(uniqueTaints[newTaint.Effect]) > 0 && uniqueTaints[newTaint.Effect].Has(newTaint.Key) {
+				return nil, nil, fmt.Errorf("duplicated taints with the same key and effect: %v", newTaint)
+			}
+			// add taint to existingTaints for uniqueness check
+			if len(uniqueTaints[newTaint.Effect]) == 0 {
+				uniqueTaints[newTaint.Effect] = sets.String{}
+			}
+			uniqueTaints[newTaint.Effect].Insert(newTaint.Key)
+
+			taints = append(taints, newTaint)
+		}
+	}
+	return taints, taintsToRemove, nil
+}
+
+// CheckIfTaintsAlreadyExists checks if the node already has taints that we want to add and returns a string with taint keys.
+func CheckIfTaintsAlreadyExists(oldTaints []v1.Taint, taints []v1.Taint) string {
+	var existingTaintList = make([]string, 0)
+	for _, taint := range taints {
+		for _, oldTaint := range oldTaints {
+			if taint.Key == oldTaint.Key && taint.Effect == oldTaint.Effect {
+				existingTaintList = append(existingTaintList, taint.Key)
+			}
+		}
+	}
+	return strings.Join(existingTaintList, ",")
+}
+
+// DeleteTaintsByKey removes all the taints that have the same key to given taintKey
+func DeleteTaintsByKey(taints []v1.Taint, taintKey string) ([]v1.Taint, bool) {
+	newTaints := []v1.Taint{}
+	deleted := false
+	for i := range taints {
+		if taintKey == taints[i].Key {
+			deleted = true
+			continue
+		}
+		newTaints = append(newTaints, taints[i])
+	}
+	return newTaints, deleted
+}
+
+// DeleteTaint removes all the taints that have the same key and effect to given taintToDelete.
+func DeleteTaint(taints []v1.Taint, taintToDelete *v1.Taint) ([]v1.Taint, bool) {
+	newTaints := []v1.Taint{}
+	deleted := false
+	for i := range taints {
+		if taintToDelete.MatchTaint(&taints[i]) {
+			deleted = true
+			continue
+		}
+		newTaints = append(newTaints, taints[i])
+	}
+	return newTaints, deleted
+}
+
+// RemoveTaint tries to remove a taint from annotations list. Returns a new copy of updated Node and true if something was updated
+// false otherwise.
+func RemoveTaint(node *v1.Node, taint *v1.Taint) (*v1.Node, bool, error) {
+	newNode := node.DeepCopy()
+	nodeTaints := newNode.Spec.Taints
+	if len(nodeTaints) == 0 {
+		return newNode, false, nil
+	}
+
+	if !TaintExists(nodeTaints, taint) {
+		return newNode, false, nil
+	}
+
+	newTaints, _ := DeleteTaint(nodeTaints, taint)
+	newNode.Spec.Taints = newTaints
+	return newNode, true, nil
+}
+
+// AddOrUpdateTaint tries to add a taint to annotations list. Returns a new copy of updated Node and true if something was updated
+// false otherwise.
+func AddOrUpdateTaint(node *v1.Node, taint *v1.Taint) (*v1.Node, bool, error) {
+	newNode := node.DeepCopy()
+	nodeTaints := newNode.Spec.Taints
+
+	var newTaints []v1.Taint
+	updated := false
+	for i := range nodeTaints {
+		if taint.MatchTaint(&nodeTaints[i]) {
+			if helperSemantic.DeepEqual(*taint, nodeTaints[i]) {
+				return newNode, false, nil
+			}
+			newTaints = append(newTaints, *taint)
+			updated = true
+			continue
+		}
+
+		newTaints = append(newTaints, nodeTaints[i])
+	}
+
+	if !updated {
+		newTaints = append(newTaints, *taint)
+	}
+
+	newNode.Spec.Taints = newTaints
+	return newNode, true, nil
+}
+
+// TaintExists checks if the given taint exists in list of taints. Returns true if exists false otherwise.
+func TaintExists(taints []v1.Taint, taintToFind *v1.Taint) bool {
+	for _, taint := range taints {
+		if taint.MatchTaint(taintToFind) {
+			return true
+		}
+	}
+	return false
+}
+
+// TaintKeyExists checks if the given taint key exists in list of taints. Returns true if exists false otherwise.
+func TaintKeyExists(taints []v1.Taint, taintKeyToMatch string) bool {
+	for _, taint := range taints {
+		if taint.Key == taintKeyToMatch {
+			return true
+		}
+	}
+	return false
+}
+
+// TaintSetDiff finds the difference between two taint slices and
+// returns all new and removed elements of the new slice relative to the old slice.
+// for example:
+// input: taintsNew=[a b] taintsOld=[a c]
+// output: taintsToAdd=[b] taintsToRemove=[c]
+func TaintSetDiff(taintsNew, taintsOld []v1.Taint) (taintsToAdd []*v1.Taint, taintsToRemove []*v1.Taint) {
+	for _, taint := range taintsNew {
+		if !TaintExists(taintsOld, &taint) {
+			t := taint
+			taintsToAdd = append(taintsToAdd, &t)
+		}
+	}
+
+	for _, taint := range taintsOld {
+		if !TaintExists(taintsNew, &taint) {
+			t := taint
+			taintsToRemove = append(taintsToRemove, &t)
+		}
+	}
+
+	return
+}
+
+// TaintSetFilter filters from the taint slice according to the passed fn function to get the filtered taint slice.
+func TaintSetFilter(taints []v1.Taint, fn func(*v1.Taint) bool) []v1.Taint {
+	res := []v1.Taint{}
+
+	for _, taint := range taints {
+		if fn(&taint) {
+			res = append(res, taint)
+		}
+	}
+
+	return res
+}
+
+// CheckTaintValidation checks if the given taint is valid.
+// Returns error if the given taint is invalid.
+func CheckTaintValidation(taint v1.Taint) error {
+	if errs := validation.IsQualifiedName(taint.Key); len(errs) > 0 {
+		return fmt.Errorf("invalid taint key: %s", strings.Join(errs, "; "))
+	}
+	if taint.Value != "" {
+		if errs := validation.IsValidLabelValue(taint.Value); len(errs) > 0 {
+			return fmt.Errorf("invalid taint value: %s", strings.Join(errs, "; "))
+		}
+	}
+	if taint.Effect != "" {
+		if err := validateTaintEffect(taint.Effect); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/test/utils/k8simported/taints/taints_test.go
+++ b/test/utils/k8simported/taints/taints_test.go
@@ -1,0 +1,985 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taints
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestAddOrUpdateTaint(t *testing.T) {
+	taint := v1.Taint{
+		Key:    "foo",
+		Value:  "bar",
+		Effect: v1.TaintEffectNoSchedule,
+	}
+
+	taintNew := v1.Taint{
+		Key:    "foo_1",
+		Value:  "bar_1",
+		Effect: v1.TaintEffectNoSchedule,
+	}
+
+	taintUpdateValue := taint
+	taintUpdateValue.Value = "bar_1"
+
+	testcases := []struct {
+		name           string
+		node           *v1.Node
+		taint          *v1.Taint
+		expectedUpdate bool
+		expectedTaints []v1.Taint
+	}{
+		{
+			name:           "add a new taint",
+			node:           &v1.Node{},
+			taint:          &taint,
+			expectedUpdate: true,
+			expectedTaints: []v1.Taint{taint},
+		},
+		{
+			name: "add a unique taint",
+			node: &v1.Node{
+				Spec: v1.NodeSpec{Taints: []v1.Taint{taint}},
+			},
+			taint:          &taintNew,
+			expectedUpdate: true,
+			expectedTaints: []v1.Taint{taint, taintNew},
+		},
+		{
+			name: "add duplicate taint",
+			node: &v1.Node{
+				Spec: v1.NodeSpec{Taints: []v1.Taint{taint}},
+			},
+			taint:          &taint,
+			expectedUpdate: false,
+			expectedTaints: []v1.Taint{taint},
+		},
+		{
+			name: "update taint value",
+			node: &v1.Node{
+				Spec: v1.NodeSpec{Taints: []v1.Taint{taint}},
+			},
+			taint:          &taintUpdateValue,
+			expectedUpdate: true,
+			expectedTaints: []v1.Taint{taintUpdateValue},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			newNode, updated, err := AddOrUpdateTaint(tc.node, tc.taint)
+			if err != nil {
+				t.Errorf("[%s] should not raise error but got %v", tc.name, err)
+			}
+			if updated != tc.expectedUpdate {
+				t.Errorf("[%s] expected taints to not be updated", tc.name)
+			}
+			if diff := cmp.Diff(newNode.Spec.Taints, tc.expectedTaints); diff != "" {
+				t.Errorf("Unexpected result (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestTaintExists(t *testing.T) {
+	testingTaints := []v1.Taint{
+		{
+			Key:    "foo_1",
+			Value:  "bar_1",
+			Effect: v1.TaintEffectNoExecute,
+		},
+		{
+			Key:    "foo_2",
+			Value:  "bar_2",
+			Effect: v1.TaintEffectNoSchedule,
+		},
+	}
+
+	cases := []struct {
+		name           string
+		taintToFind    *v1.Taint
+		expectedResult bool
+	}{
+		{
+			name:           "taint exists",
+			taintToFind:    &v1.Taint{Key: "foo_1", Value: "bar_1", Effect: v1.TaintEffectNoExecute},
+			expectedResult: true,
+		},
+		{
+			name:           "different key",
+			taintToFind:    &v1.Taint{Key: "no_such_key", Value: "bar_1", Effect: v1.TaintEffectNoExecute},
+			expectedResult: false,
+		},
+		{
+			name:           "different effect",
+			taintToFind:    &v1.Taint{Key: "foo_1", Value: "bar_1", Effect: v1.TaintEffectNoSchedule},
+			expectedResult: false,
+		},
+	}
+
+	for _, c := range cases {
+		result := TaintExists(testingTaints, c.taintToFind)
+
+		if result != c.expectedResult {
+			t.Errorf("[%s] unexpected results: %v", c.name, result)
+			continue
+		}
+	}
+}
+
+func TestTaintKeyExists(t *testing.T) {
+	testingTaints := []v1.Taint{
+		{
+			Key:    "foo_1",
+			Value:  "bar_1",
+			Effect: v1.TaintEffectNoExecute,
+		},
+		{
+			Key:    "foo_2",
+			Value:  "bar_2",
+			Effect: v1.TaintEffectNoSchedule,
+		},
+	}
+
+	cases := []struct {
+		name            string
+		taintKeyToMatch string
+		expectedResult  bool
+	}{
+		{
+			name:            "taint key exists",
+			taintKeyToMatch: "foo_1",
+			expectedResult:  true,
+		},
+		{
+			name:            "taint key does not exist",
+			taintKeyToMatch: "foo_3",
+			expectedResult:  false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := TaintKeyExists(testingTaints, c.taintKeyToMatch)
+
+			if result != c.expectedResult {
+				t.Errorf("[%s] unexpected results: %v", c.name, result)
+			}
+		})
+	}
+}
+
+func TestTaintSetFilter(t *testing.T) {
+	testTaint1 := v1.Taint{
+		Key:    "foo_1",
+		Value:  "bar_1",
+		Effect: v1.TaintEffectNoExecute,
+	}
+	testTaint2 := v1.Taint{
+		Key:    "foo_2",
+		Value:  "bar_2",
+		Effect: v1.TaintEffectNoSchedule,
+	}
+
+	testTaint3 := v1.Taint{
+		Key:    "foo_3",
+		Value:  "bar_3",
+		Effect: v1.TaintEffectNoSchedule,
+	}
+	testTaints := []v1.Taint{testTaint1, testTaint2, testTaint3}
+
+	testcases := []struct {
+		name           string
+		fn             func(t *v1.Taint) bool
+		expectedTaints []v1.Taint
+	}{
+		{
+			name: "Filter out nothing",
+			fn: func(t *v1.Taint) bool {
+				if t.Key == v1.TaintNodeUnschedulable {
+					return true
+				}
+				return false
+			},
+			expectedTaints: []v1.Taint{},
+		},
+		{
+			name: "Filter out a subset",
+			fn: func(t *v1.Taint) bool {
+				if t.Effect == v1.TaintEffectNoExecute {
+					return true
+				}
+				return false
+			},
+			expectedTaints: []v1.Taint{testTaint1},
+		},
+		{
+			name:           "Filter out everything",
+			fn:             func(t *v1.Taint) bool { return true },
+			expectedTaints: []v1.Taint{testTaint1, testTaint2, testTaint3},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			taintsAfterFilter := TaintSetFilter(testTaints, tc.fn)
+			if diff := cmp.Diff(tc.expectedTaints, taintsAfterFilter); diff != "" {
+				t.Errorf("Unexpected postFilterResult (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRemoveTaint(t *testing.T) {
+	cases := []struct {
+		name           string
+		node           *v1.Node
+		taintToRemove  *v1.Taint
+		expectedTaints []v1.Taint
+		expectedResult bool
+	}{
+		{
+			name: "remove taint unsuccessfully",
+			node: &v1.Node{
+				Spec: v1.NodeSpec{
+					Taints: []v1.Taint{
+						{
+							Key:    "foo",
+							Effect: v1.TaintEffectNoSchedule,
+						},
+					},
+				},
+			},
+			taintToRemove: &v1.Taint{
+				Key:    "foo_1",
+				Effect: v1.TaintEffectNoSchedule,
+			},
+			expectedTaints: []v1.Taint{
+				{
+					Key:    "foo",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "remove taint successfully",
+			node: &v1.Node{
+				Spec: v1.NodeSpec{
+					Taints: []v1.Taint{
+						{
+							Key:    "foo",
+							Effect: v1.TaintEffectNoSchedule,
+						},
+					},
+				},
+			},
+			taintToRemove: &v1.Taint{
+				Key:    "foo",
+				Effect: v1.TaintEffectNoSchedule,
+			},
+			expectedTaints: []v1.Taint{},
+			expectedResult: true,
+		},
+		{
+			name: "remove taint from node with no taint",
+			node: &v1.Node{
+				Spec: v1.NodeSpec{
+					Taints: []v1.Taint{},
+				},
+			},
+			taintToRemove: &v1.Taint{
+				Key:    "foo",
+				Effect: v1.TaintEffectNoSchedule,
+			},
+			expectedTaints: []v1.Taint{},
+			expectedResult: false,
+		},
+	}
+
+	for _, c := range cases {
+		newNode, result, err := RemoveTaint(c.node, c.taintToRemove)
+		if err != nil {
+			t.Errorf("[%s] should not raise error but got: %v", c.name, err)
+		}
+		if result != c.expectedResult {
+			t.Errorf("[%s] should return %t, but got: %t", c.name, c.expectedResult, result)
+		}
+		if !reflect.DeepEqual(newNode.Spec.Taints, c.expectedTaints) {
+			t.Errorf("[%s] the new node object should have taints %v, but got: %v", c.name, c.expectedTaints, newNode.Spec.Taints)
+		}
+	}
+}
+
+func TestDeleteTaint(t *testing.T) {
+	cases := []struct {
+		name           string
+		taints         []v1.Taint
+		taintToDelete  *v1.Taint
+		expectedTaints []v1.Taint
+		expectedResult bool
+	}{
+		{
+			name: "delete taint with different name",
+			taints: []v1.Taint{
+				{
+					Key:    "foo",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			taintToDelete: &v1.Taint{Key: "foo_1", Effect: v1.TaintEffectNoSchedule},
+			expectedTaints: []v1.Taint{
+				{
+					Key:    "foo",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "delete taint with different effect",
+			taints: []v1.Taint{
+				{
+					Key:    "foo",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			taintToDelete: &v1.Taint{Key: "foo", Effect: v1.TaintEffectNoExecute},
+			expectedTaints: []v1.Taint{
+				{
+					Key:    "foo",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "delete taint successfully",
+			taints: []v1.Taint{
+				{
+					Key:    "foo",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			taintToDelete:  &v1.Taint{Key: "foo", Effect: v1.TaintEffectNoSchedule},
+			expectedTaints: []v1.Taint{},
+			expectedResult: true,
+		},
+		{
+			name:           "delete taint from empty taint array",
+			taints:         []v1.Taint{},
+			taintToDelete:  &v1.Taint{Key: "foo", Effect: v1.TaintEffectNoSchedule},
+			expectedTaints: []v1.Taint{},
+			expectedResult: false,
+		},
+	}
+
+	for _, c := range cases {
+		taints, result := DeleteTaint(c.taints, c.taintToDelete)
+		if result != c.expectedResult {
+			t.Errorf("[%s] should return %t, but got: %t", c.name, c.expectedResult, result)
+		}
+		if !reflect.DeepEqual(taints, c.expectedTaints) {
+			t.Errorf("[%s] the result taints should be %v, but got: %v", c.name, c.expectedTaints, taints)
+		}
+	}
+}
+
+func TestDeleteTaintByKey(t *testing.T) {
+	cases := []struct {
+		name           string
+		taints         []v1.Taint
+		taintKey       string
+		expectedTaints []v1.Taint
+		expectedResult bool
+	}{
+		{
+			name: "delete taint unsuccessfully",
+			taints: []v1.Taint{
+				{
+					Key:    "foo",
+					Value:  "bar",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			taintKey: "foo_1",
+			expectedTaints: []v1.Taint{
+				{
+					Key:    "foo",
+					Value:  "bar",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "delete taint successfully",
+			taints: []v1.Taint{
+				{
+					Key:    "foo",
+					Value:  "bar",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			taintKey:       "foo",
+			expectedTaints: []v1.Taint{},
+			expectedResult: true,
+		},
+		{
+			name:           "delete taint from empty taint array",
+			taints:         []v1.Taint{},
+			taintKey:       "foo",
+			expectedTaints: []v1.Taint{},
+			expectedResult: false,
+		},
+	}
+
+	for _, c := range cases {
+		taints, result := DeleteTaintsByKey(c.taints, c.taintKey)
+		if result != c.expectedResult {
+			t.Errorf("[%s] should return %t, but got: %t", c.name, c.expectedResult, result)
+		}
+		if !reflect.DeepEqual(c.expectedTaints, taints) {
+			t.Errorf("[%s] the result taints should be %v, but got: %v", c.name, c.expectedTaints, taints)
+		}
+	}
+}
+
+func TestCheckIfTaintsAlreadyExists(t *testing.T) {
+	oldTaints := []v1.Taint{
+		{
+			Key:    "foo_1",
+			Value:  "bar",
+			Effect: v1.TaintEffectNoSchedule,
+		},
+		{
+			Key:    "foo_2",
+			Value:  "bar",
+			Effect: v1.TaintEffectNoSchedule,
+		},
+		{
+			Key:    "foo_3",
+			Value:  "bar",
+			Effect: v1.TaintEffectNoSchedule,
+		},
+	}
+
+	cases := []struct {
+		name           string
+		taintsToCheck  []v1.Taint
+		expectedResult string
+	}{
+		{
+			name:           "empty array",
+			taintsToCheck:  []v1.Taint{},
+			expectedResult: "",
+		},
+		{
+			name: "no match",
+			taintsToCheck: []v1.Taint{
+				{
+					Key:    "foo_1",
+					Effect: v1.TaintEffectNoExecute,
+				},
+			},
+			expectedResult: "",
+		},
+		{
+			name: "match one taint",
+			taintsToCheck: []v1.Taint{
+				{
+					Key:    "foo_2",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			expectedResult: "foo_2",
+		},
+		{
+			name: "match two taints",
+			taintsToCheck: []v1.Taint{
+				{
+					Key:    "foo_2",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "foo_3",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			expectedResult: "foo_2,foo_3",
+		},
+	}
+
+	for _, c := range cases {
+		result := CheckIfTaintsAlreadyExists(oldTaints, c.taintsToCheck)
+		if result != c.expectedResult {
+			t.Errorf("[%s] should return '%s', but got: '%s'", c.name, c.expectedResult, result)
+		}
+	}
+}
+
+func TestParseTaints(t *testing.T) {
+	cases := []struct {
+		name                   string
+		spec                   []string
+		expectedTaints         []v1.Taint
+		expectedTaintsToRemove []v1.Taint
+		expectedErr            bool
+	}{
+		{
+			name:        "invalid empty spec format",
+			spec:        []string{""},
+			expectedErr: true,
+		},
+		// taint spec format without the suffix '-' must be either '<key>=<value>:<effect>', '<key>:<effect>', or '<key>'
+		{
+			name:        "invalid spec format without effect",
+			spec:        []string{"foo=abc"},
+			expectedErr: true,
+		},
+		{
+			name:        "invalid spec format with multiple '=' separators",
+			spec:        []string{"foo=abc=xyz:NoSchedule"},
+			expectedErr: true,
+		},
+		{
+			name:        "invalid spec format with multiple ':' separators",
+			spec:        []string{"foo=abc:xyz:NoSchedule"},
+			expectedErr: true,
+		},
+		{
+			name:        "invalid spec taint value without separator",
+			spec:        []string{"foo"},
+			expectedErr: true,
+		},
+		// taint spec must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character.
+		{
+			name:        "invalid spec taint value with special chars '%^@'",
+			spec:        []string{"foo=nospecialchars%^@:NoSchedule"},
+			expectedErr: true,
+		},
+		{
+			name:        "invalid spec taint value with non-alphanumeric characters",
+			spec:        []string{"foo=Tama-nui-te-rā.is.Māori.sun:NoSchedule"},
+			expectedErr: true,
+		},
+		{
+			name:        "invalid spec taint value with special chars '\\'",
+			spec:        []string{"foo=\\backslashes\\are\\bad:NoSchedule"},
+			expectedErr: true,
+		},
+		{
+			name:        "invalid spec taint value with start with an non-alphanumeric character '-'",
+			spec:        []string{"foo=-starts-with-dash:NoSchedule"},
+			expectedErr: true,
+		},
+		{
+			name:        "invalid spec taint value with end with an non-alphanumeric character '-'",
+			spec:        []string{"foo=ends-with-dash-:NoSchedule"},
+			expectedErr: true,
+		},
+		{
+			name:        "invalid spec taint value with start with an non-alphanumeric character '.'",
+			spec:        []string{"foo=.starts.with.dot:NoSchedule"},
+			expectedErr: true,
+		},
+		{
+			name:        "invalid spec taint value with end with an non-alphanumeric character '.'",
+			spec:        []string{"foo=ends.with.dot.:NoSchedule"},
+			expectedErr: true,
+		},
+		// The value range of taint effect is "NoSchedule", "PreferNoSchedule", "NoExecute"
+		{
+			name:        "invalid spec effect for adding taint",
+			spec:        []string{"foo=abc:invalid_effect"},
+			expectedErr: true,
+		},
+		{
+			name:        "invalid spec effect for deleting taint",
+			spec:        []string{"foo:invalid_effect-"},
+			expectedErr: true,
+		},
+		{
+			name:        "duplicated taints with the same key and effect",
+			spec:        []string{"foo=abc:NoSchedule", "foo=abc:NoSchedule"},
+			expectedErr: true,
+		},
+		{
+			name:        "invalid spec taint value exceeding the limit",
+			spec:        []string{strings.Repeat("a", 64)},
+			expectedErr: true,
+		},
+		{
+			name: "add new taints with no special chars",
+			spec: []string{"foo=abc:NoSchedule", "bar=abc:NoSchedule", "baz:NoSchedule", "qux:NoSchedule", "foobar=:NoSchedule"},
+			expectedTaints: []v1.Taint{
+				{
+					Key:    "foo",
+					Value:  "abc",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "bar",
+					Value:  "abc",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "baz",
+					Value:  "",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "qux",
+					Value:  "",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "foobar",
+					Value:  "",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "delete taints with no special chars",
+			spec: []string{"foo:NoSchedule-", "bar:NoSchedule-", "qux=:NoSchedule-", "dedicated-"},
+			expectedTaintsToRemove: []v1.Taint{
+				{
+					Key:    "foo",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "bar",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "qux",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key: "dedicated",
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "add taints and delete taints with no special chars",
+			spec: []string{"foo=abc:NoSchedule", "bar=abc:NoSchedule", "baz:NoSchedule", "qux:NoSchedule", "foobar=:NoSchedule", "foo:NoSchedule-", "bar:NoSchedule-", "baz=:NoSchedule-"},
+			expectedTaints: []v1.Taint{
+				{
+					Key:    "foo",
+					Value:  "abc",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "bar",
+					Value:  "abc",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "baz",
+					Value:  "",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "qux",
+					Value:  "",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "foobar",
+					Value:  "",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			expectedTaintsToRemove: []v1.Taint{
+				{
+					Key:    "foo",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "bar",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "baz",
+					Value:  "",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			expectedErr: false,
+		},
+	}
+
+	for _, c := range cases {
+		taints, taintsToRemove, err := ParseTaints(c.spec)
+		if c.expectedErr && err == nil {
+			t.Errorf("[%s] expected error for spec %s, but got nothing", c.name, c.spec)
+		}
+		if !c.expectedErr && err != nil {
+			t.Errorf("[%s] expected no error for spec %s, but got: %v", c.name, c.spec, err)
+		}
+		if !reflect.DeepEqual(c.expectedTaints, taints) {
+			t.Errorf("[%s] expected returen taints as %v, but got: %v", c.name, c.expectedTaints, taints)
+		}
+		if !reflect.DeepEqual(c.expectedTaintsToRemove, taintsToRemove) {
+			t.Errorf("[%s] expected return taints to be removed as %v, but got: %v", c.name, c.expectedTaintsToRemove, taintsToRemove)
+		}
+	}
+}
+
+func TestValidateTaint(t *testing.T) {
+	cases := []struct {
+		name          string
+		taintsToCheck v1.Taint
+		expectedErr   bool
+	}{
+		{
+			name:          "taint invalid key",
+			taintsToCheck: v1.Taint{Key: "", Value: "bar_1", Effect: v1.TaintEffectNoExecute},
+			expectedErr:   true,
+		},
+		{
+			name:          "taint invalid value",
+			taintsToCheck: v1.Taint{Key: "foo_1", Value: strings.Repeat("a", 64), Effect: v1.TaintEffectNoExecute},
+			expectedErr:   true,
+		},
+		{
+			name:          "taint invalid effect",
+			taintsToCheck: v1.Taint{Key: "foo_2", Value: "bar_2", Effect: "no_such_effect"},
+			expectedErr:   true,
+		},
+		{
+			name:          "valid taint",
+			taintsToCheck: v1.Taint{Key: "foo_3", Value: "bar_3", Effect: v1.TaintEffectNoExecute},
+			expectedErr:   false,
+		},
+		{
+			name:          "valid taint",
+			taintsToCheck: v1.Taint{Key: "foo_4", Effect: v1.TaintEffectNoExecute},
+			expectedErr:   false,
+		},
+		{
+			name:          "valid taint",
+			taintsToCheck: v1.Taint{Key: "foo_5", Value: "bar_5"},
+			expectedErr:   false,
+		},
+	}
+
+	for _, c := range cases {
+		err := CheckTaintValidation(c.taintsToCheck)
+
+		if c.expectedErr && err == nil {
+			t.Errorf("[%s] expected error for spec %+v, but got nothing", c.name, c.taintsToCheck)
+		}
+	}
+}
+
+func TestTaintSetDiff(t *testing.T) {
+	cases := []struct {
+		name                   string
+		t1                     []v1.Taint
+		t2                     []v1.Taint
+		expectedTaintsToAdd    []*v1.Taint
+		expectedTaintsToRemove []*v1.Taint
+	}{
+		{
+			name:                   "two_taints_are_nil",
+			expectedTaintsToAdd:    nil,
+			expectedTaintsToRemove: nil,
+		},
+		{
+			name: "one_taint_is_nil_and_the_other_is_not_nil",
+			t1: []v1.Taint{
+				{
+					Key:    "foo_1",
+					Value:  "bar_1",
+					Effect: v1.TaintEffectNoExecute,
+				},
+				{
+					Key:    "foo_2",
+					Value:  "bar_2",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			expectedTaintsToAdd: []*v1.Taint{
+				{
+					Key:    "foo_1",
+					Value:  "bar_1",
+					Effect: v1.TaintEffectNoExecute,
+				},
+				{
+					Key:    "foo_2",
+					Value:  "bar_2",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			expectedTaintsToRemove: nil,
+		},
+		{
+			name: "shared_taints_with_the_same_key_value_effect",
+			t1: []v1.Taint{
+				{
+					Key:    "foo_1",
+					Value:  "bar_1",
+					Effect: v1.TaintEffectNoExecute,
+				},
+				{
+					Key:    "foo_2",
+					Value:  "bar_2",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			t2: []v1.Taint{
+				{
+					Key:    "foo_3",
+					Value:  "bar_3",
+					Effect: v1.TaintEffectNoExecute,
+				},
+				{
+					Key:    "foo_2",
+					Value:  "bar_2",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			expectedTaintsToAdd: []*v1.Taint{
+				{
+					Key:    "foo_1",
+					Value:  "bar_1",
+					Effect: v1.TaintEffectNoExecute,
+				},
+			},
+			expectedTaintsToRemove: []*v1.Taint{
+				{
+					Key:    "foo_3",
+					Value:  "bar_3",
+					Effect: v1.TaintEffectNoExecute,
+				},
+			},
+		},
+		{
+			name: "shared_taints_with_the_same_key_effect_different_value",
+			t1: []v1.Taint{
+				{
+					Key:    "foo_1",
+					Value:  "bar_1",
+					Effect: v1.TaintEffectNoExecute,
+				},
+				{
+					Key:    "foo_2",
+					Value:  "different-value",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			t2: []v1.Taint{
+				{
+					Key:    "foo_3",
+					Value:  "bar_3",
+					Effect: v1.TaintEffectNoExecute,
+				},
+				{
+					Key:    "foo_2",
+					Value:  "bar_2",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			expectedTaintsToAdd: []*v1.Taint{
+				{
+					Key:    "foo_1",
+					Value:  "bar_1",
+					Effect: v1.TaintEffectNoExecute,
+				},
+			},
+			expectedTaintsToRemove: []*v1.Taint{
+				{
+					Key:    "foo_3",
+					Value:  "bar_3",
+					Effect: v1.TaintEffectNoExecute,
+				},
+			},
+		},
+		{
+			name: "shared_taints_with_the_same_key_different_value_effect",
+			t1: []v1.Taint{
+				{
+					Key:    "foo_1",
+					Value:  "bar_1",
+					Effect: v1.TaintEffectNoExecute,
+				},
+				{
+					Key:    "foo_2",
+					Value:  "different-value",
+					Effect: v1.TaintEffectNoExecute,
+				},
+			},
+			t2: []v1.Taint{
+				{
+					Key:    "foo_3",
+					Value:  "bar_3",
+					Effect: v1.TaintEffectNoExecute,
+				},
+				{
+					Key:    "foo_2",
+					Value:  "bar_2",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			expectedTaintsToAdd: []*v1.Taint{
+				{
+					Key:    "foo_1",
+					Value:  "bar_1",
+					Effect: v1.TaintEffectNoExecute,
+				},
+				{
+					Key:    "foo_2",
+					Value:  "different-value",
+					Effect: v1.TaintEffectNoExecute,
+				},
+			},
+			expectedTaintsToRemove: []*v1.Taint{
+				{
+					Key:    "foo_3",
+					Value:  "bar_3",
+					Effect: v1.TaintEffectNoExecute,
+				},
+				{
+					Key:    "foo_2",
+					Value:  "bar_2",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			add, remove := TaintSetDiff(tt.t1, tt.t2)
+			if !reflect.DeepEqual(add, tt.expectedTaintsToAdd) {
+				t.Errorf("taintsToAdd: %v should equal %v, but get unexpected results", add, tt.expectedTaintsToAdd)
+			}
+			if !reflect.DeepEqual(remove, tt.expectedTaintsToRemove) {
+				t.Errorf("taintsToRemove: %v should equal %v, but get unexpected results", remove, tt.expectedTaintsToRemove)
+			}
+		})
+	}
+}


### PR DESCRIPTION
to remove the last dependency from k8s.io/kubernetes, we import (soft-fork) the taints package, and we fix our imports to use the bundled version.

backport notice: more backport is needed to be able to fully remove the `k8s.io/kubernetes` dependency