### PR TITLE
lint: e2e: e2e tests should be linted

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,7 +4,7 @@ run:
   tests: true
   skip-dirs:
     - vendor
-    - test
+    - test/utils/k8simported
   modules-download-mode: vendor
 linters:
   disable-all: true


### PR DESCRIPTION
let's exclude only code pseudo-vendored from k8s