### PR TITLE
controller: minimize related object list

### DIFF
--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -611,14 +611,6 @@ func (r *NUMAResourcesOperatorReconciler) getRelatedObjects(dsStatuses []nropv1.
 			Group:    "topology.node.k8s.io",
 			Resource: "noderesourcetopologies",
 		},
-		{
-			Group:    "nfd.k8s-sig.io",
-			Resource: "nodefeaturerules",
-		},
-		{
-			Group:    "nfd.k8s-sig.io",
-			Resource: "nodefeatures",
-		},
 	}
 
 	for _, dsStatus := range dsStatuses {

--- a/controllers/numaresourcesoperator_controller_test.go
+++ b/controllers/numaresourcesoperator_controller_test.go
@@ -520,14 +520,6 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 									Group:    "topology.node.k8s.io",
 									Resource: "noderesourcetopologies",
 								},
-								{
-									Group:    "nfd.k8s-sig.io",
-									Resource: "nodefeaturerules",
-								},
-								{
-									Group:    "nfd.k8s-sig.io",
-									Resource: "nodefeatures",
-								},
 							}
 							// ... and one for each DaemonSet
 							for _, ds := range nroUpdated.Status.DaemonSets {


### PR DESCRIPTION
the `oc adm inspect` machinery tries first to gather the related objects, then gathers the object itself: https://github.com/openshift/oc/blob/release-4.15/pkg/cli/admin/inspect/resource.go#L188 Thus, if any of the the related objects can't be collected, neither can the parent object.

In our case, the nfs object were meant as forward-looking extra, but our attempt backfired. Let's remove them from the list, focusing only on what the operator is guaranteed to provide.