### PR TITLE
e2e: serial: rewrite deployment wait

### DIFF
--- a/test/e2e/serial/tests/scheduler_removal.go
+++ b/test/e2e/serial/tests/scheduler_removal.go
@@ -25,10 +25,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	appsv1 "k8s.io/api/apps/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/klogr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	depwait "github.com/k8stopologyawareschedwg/deployer/pkg/deployer/wait"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
@@ -142,28 +143,18 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources scheduler restar
 		It("[case:1][test_id:48069][tier2] should schedule any pending workloads submitted while the scheduler was unavailable", func() {
 			var err error
 
-			dps, err := getDPOwnedBy(fxt.Client, nroSchedObj.ObjectMeta)
-			Expect(err).ToNot(HaveOccurred())
+			dpNName := nroSchedObj.Status.Deployment // shortcut
+			if dpNName.Namespace == "" || dpNName.Name == "" {
+				Fail(fmt.Sprintf("scheduler deployment missing: %q", dpNName.String()))
+			}
 
 			By(fmt.Sprintf("deleting the NRO Scheduler object: %s", nroSchedObj.Name))
 			err = fxt.Client.Delete(context.TODO(), nroSchedObj)
 			Expect(err).ToNot(HaveOccurred())
 
 			// make sure scheduler deployment is gone
-			Eventually(func() bool {
-				for _, dp := range dps {
-					if err := fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(dp), dp); err != nil {
-						if apierrors.IsNotFound(err) {
-							return true
-						}
-						klog.Warningf("failed to get Deployment %s/%s; err: %v", dp.Namespace, dp.Name, err)
-						return false
-					}
-					klog.Warningf("Deployment %s/%s is still exists", dp.Namespace, dp.Name)
-					return false
-				}
-				return true
-			}, time.Minute, time.Second*10).Should(BeTrue())
+			err = depwait.With(fxt.Client, klogr.New()).Interval(10*time.Second).Timeout(time.Minute).ForDeploymentDeleted(context.TODO(), dpNName.Namespace, dpNName.Name)
+			Expect(err).ToNot(HaveOccurred())
 
 			dp := createDeployment(fxt, "testdp", schedulerName)
 
@@ -231,19 +222,4 @@ func createDeploymentSync(fxt *e2efixture.Fixture, name, schedulerName string) *
 	_, err := wait.With(fxt.Client).Interval(10*time.Second).Timeout(time.Minute).ForDeploymentComplete(context.TODO(), dp)
 	Expect(err).ToNot(HaveOccurred(), "Deployment %q is not up & running after %v", dp.Name, time.Minute)
 	return dp
-}
-
-func getDPOwnedBy(cli client.Client, objMeta metav1.ObjectMeta) ([]*appsv1.Deployment, error) {
-	dpList := &appsv1.DeploymentList{}
-	if err := cli.List(context.TODO(), dpList); err != nil {
-		return nil, err
-	}
-
-	var dps []*appsv1.Deployment
-	for i := range dpList.Items {
-		if objects.IsOwnedBy(dpList.Items[i].ObjectMeta, objMeta) {
-			dps = append(dps, &dpList.Items[i])
-		}
-	}
-	return dps, nil
 }

--- a/vendor/github.com/k8stopologyawareschedwg/deployer/pkg/deployer/wait/daemonset.go
+++ b/vendor/github.com/k8stopologyawareschedwg/deployer/pkg/deployer/wait/daemonset.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wait
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	k8swait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+func (wt Waiter) ForDaemonSetReadyByKey(ctx context.Context, key ObjectKey) (*appsv1.DaemonSet, error) {
+	updatedDs := &appsv1.DaemonSet{}
+	err := k8swait.PollImmediate(wt.PollInterval, wt.PollTimeout, func() (bool, error) {
+		err := wt.Cli.Get(ctx, key.AsKey(), updatedDs)
+		if err != nil {
+			wt.Log.Info("failed to get the daemonset", "key", key.String(), "error", err)
+			return false, err
+		}
+
+		if !AreDaemonSetPodsReady(&updatedDs.Status) {
+			wt.Log.Info("daemonset not ready",
+				"key", key.String(),
+				"desired", updatedDs.Status.DesiredNumberScheduled,
+				"current", updatedDs.Status.CurrentNumberScheduled,
+				"ready", updatedDs.Status.NumberReady)
+			return false, nil
+		}
+
+		wt.Log.Info("daemonset ready", "key", key.String())
+		return true, nil
+	})
+	return updatedDs, err
+}
+
+func (wt Waiter) ForDaemonSetReady(ctx context.Context, ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
+	return wt.ForDaemonSetReadyByKey(ctx, ObjectKeyFromObject(ds))
+}
+
+func AreDaemonSetPodsReady(newStatus *appsv1.DaemonSetStatus) bool {
+	return newStatus.DesiredNumberScheduled > 0 &&
+		newStatus.DesiredNumberScheduled == newStatus.NumberReady
+}
+
+func (wt Waiter) ForDaemonSetDeleted(ctx context.Context, namespace, name string) error {
+	return k8swait.PollImmediate(wt.PollInterval, wt.PollTimeout, func() (bool, error) {
+		obj := appsv1.DaemonSet{}
+		key := ObjectKey{Name: name, Namespace: namespace}
+		err := wt.Cli.Get(ctx, key.AsKey(), &obj)
+		return deletionStatusFromError(wt.Log, "DaemonSet", key, err)
+	})
+}

--- a/vendor/github.com/k8stopologyawareschedwg/deployer/pkg/deployer/wait/deployment.go
+++ b/vendor/github.com/k8stopologyawareschedwg/deployer/pkg/deployer/wait/deployment.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wait
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	k8swait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+func (wt Waiter) ForDeploymentCompleteByKey(ctx context.Context, key ObjectKey, replicas int32) (*appsv1.Deployment, error) {
+	updatedDp := &appsv1.Deployment{}
+	err := k8swait.PollImmediate(wt.PollInterval, wt.PollTimeout, func() (bool, error) {
+		err := wt.Cli.Get(ctx, key.AsKey(), updatedDp)
+		if err != nil {
+			wt.Log.Info("failed to get the deployment", "key", key.String(), "error", err)
+			return false, err
+		}
+
+		if !areDeploymentReplicasAvailable(&updatedDp.Status, replicas) {
+			wt.Log.Info("deployment not complete",
+				"key", key.String(),
+				"replicas", updatedDp.Status.Replicas,
+				"updated", updatedDp.Status.UpdatedReplicas,
+				"available", updatedDp.Status.AvailableReplicas)
+			return false, nil
+		}
+
+		wt.Log.Info("deployment complete", "key", key.String())
+		return true, nil
+	})
+	return updatedDp, err
+}
+
+func (wt Waiter) ForDeploymentComplete(ctx context.Context, dp *appsv1.Deployment) (*appsv1.Deployment, error) {
+	if dp.Spec.Replicas == nil {
+		return nil, fmt.Errorf("unspecified replicas in %s/%s", dp.Namespace, dp.Name)
+	}
+	return wt.ForDeploymentCompleteByKey(ctx, ObjectKeyFromObject(dp), *dp.Spec.Replicas)
+}
+
+func areDeploymentReplicasAvailable(newStatus *appsv1.DeploymentStatus, replicas int32) bool {
+	return newStatus.UpdatedReplicas == replicas &&
+		newStatus.Replicas == replicas &&
+		newStatus.AvailableReplicas == replicas
+}
+
+func (wt Waiter) ForDeploymentDeleted(ctx context.Context, namespace, name string) error {
+	return k8swait.PollImmediate(wt.PollInterval, wt.PollTimeout, func() (bool, error) {
+		obj := appsv1.Deployment{}
+		key := ObjectKey{Name: name, Namespace: namespace}
+		err := wt.Cli.Get(ctx, key.AsKey(), &obj)
+		return deletionStatusFromError(wt.Log, "Deployment", key, err)
+	})
+}

--- a/vendor/github.com/k8stopologyawareschedwg/deployer/pkg/deployer/wait/wait.go
+++ b/vendor/github.com/k8stopologyawareschedwg/deployer/pkg/deployer/wait/wait.go
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ */
+
+package wait
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8swait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	// found by trial and error, no hard math behind, can change anytime
+	DefaultPollInterval = 2 * time.Second
+	DefaultPollTimeout  = 2 * time.Minute
+)
+
+var (
+	basePollInterval = DefaultPollInterval
+	basePollTimeout  = DefaultPollTimeout
+)
+
+func SetBaseValues(interval, timeout time.Duration) {
+	basePollInterval = interval
+	basePollTimeout = timeout
+}
+
+type ObjectKey struct {
+	Namespace string
+	Name      string
+}
+
+func ObjectKeyFromObject(obj metav1.Object) ObjectKey {
+	return ObjectKey{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+}
+
+func (ok ObjectKey) AsKey() types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: ok.Namespace,
+		Name:      ok.Name,
+	}
+}
+
+func (ok ObjectKey) String() string {
+	return fmt.Sprintf("%s/%s", ok.Namespace, ok.Name)
+}
+
+type Waiter struct {
+	Cli          client.Client
+	Log          logr.Logger
+	PollTimeout  time.Duration
+	PollInterval time.Duration
+}
+
+func With(cli client.Client, log logr.Logger) *Waiter {
+	return &Waiter{
+		Cli:          cli,
+		Log:          log,
+		PollTimeout:  basePollTimeout,
+		PollInterval: basePollInterval,
+	}
+}
+
+func (wt *Waiter) String() string {
+	return fmt.Sprintf("wait every %v up to %v", wt.PollInterval, wt.PollTimeout)
+}
+
+func (wt *Waiter) Timeout(tt time.Duration) *Waiter {
+	wt.PollTimeout = tt
+	return wt
+}
+
+func (wt *Waiter) Interval(iv time.Duration) *Waiter {
+	wt.PollInterval = iv
+	return wt
+}
+
+func (wt Waiter) ForNamespaceDeleted(ctx context.Context, namespace string) error {
+	log := wt.Log.WithValues("namespace", namespace)
+	log.Info("wait for the namespace to be gone")
+	return k8swait.PollImmediate(wt.PollInterval, wt.PollTimeout, func() (bool, error) {
+		nsKey := ObjectKey{Name: namespace}
+		ns := corev1.Namespace{} // unused
+		err := wt.Cli.Get(ctx, nsKey.AsKey(), &ns)
+		return deletionStatusFromError(wt.Log, "Namespace", nsKey, err)
+	})
+}
+
+func deletionStatusFromError(logger logr.Logger, kind string, key ObjectKey, err error) (bool, error) {
+	if err == nil {
+		logger.Info("object still present", "kind", kind, "key", key.String())
+		return false, nil
+	}
+	if k8serrors.IsNotFound(err) {
+		logger.Info("object is gone", "kind", kind, "key", key.String())
+		return true, nil
+	}
+	logger.Info("failed to get object", "kind", kind, "key", key.String(), "error", err)
+	return false, err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -181,6 +181,7 @@ github.com/k8stopologyawareschedwg/deployer/pkg/assets/selinux
 github.com/k8stopologyawareschedwg/deployer/pkg/clientutil
 github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform
 github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform/detect
+github.com/k8stopologyawareschedwg/deployer/pkg/deployer/wait
 github.com/k8stopologyawareschedwg/deployer/pkg/flagcodec
 github.com/k8stopologyawareschedwg/deployer/pkg/images
 github.com/k8stopologyawareschedwg/deployer/pkg/kubeletconfig


### PR DESCRIPTION
the linter complains about code in this tests; rather than add a trivial patch, we take the chance to rewrite the wait loop using facilities gained by libs since the test was first introduced.
No intended change in behavior.