### PR TITLE
e2e: serial: remove half-baked randomSeed

### DIFF
--- a/test/e2e/serial/e2e_serial_test.go
+++ b/test/e2e/serial/e2e_serial_test.go
@@ -18,15 +18,11 @@ package serial
 
 import (
 	"context"
-	"math/rand"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	ginkgo_reporters "github.com/onsi/ginkgo/v2/reporters"
 	. "github.com/onsi/gomega"
-
-	"k8s.io/klog/v2"
 
 	qe_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 
@@ -36,8 +32,6 @@ import (
 
 var afterSuiteReporters = []Reporter{}
 var setupExecuted = false
-
-var randomSeed int64
 
 func TestSerial(t *testing.T) {
 	if qe_reporters.Polarion.Run {
@@ -49,12 +43,6 @@ func TestSerial(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	// this must be the very first thing
-	randomSeed = time.Now().UnixNano()
-	rand.Seed(randomSeed)
-
-	klog.Infof("using random seed %v", randomSeed)
-
 	Expect(serialconfig.CheckNodesTopology(context.TODO())).Should(Succeed())
 	serialconfig.Setup()
 	setupExecuted = true


### PR DESCRIPTION
We tried to make serial suite runs reproducible,
but the effort was half baked:
- we emit the seed WE configure, but we don't allow to set it
- there's no way to ensure any other package resets the global seed

turns out this code is more harmful than useful, so we remove it and we reset to a clean slate.