### PR TITLE
serial: remove ReporterAfterSuite to fix linter

### DIFF
--- a/test/e2e/serial/e2e_serial_test.go
+++ b/test/e2e/serial/e2e_serial_test.go
@@ -21,23 +21,15 @@ import (
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
-	ginkgo_reporters "github.com/onsi/ginkgo/v2/reporters"
 	. "github.com/onsi/gomega"
-
-	qe_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 	_ "github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests"
 )
 
-var afterSuiteReporters = []Reporter{}
 var setupExecuted = false
 
 func TestSerial(t *testing.T) {
-	if qe_reporters.Polarion.Run {
-		afterSuiteReporters = append(afterSuiteReporters, &qe_reporters.Polarion)
-	}
-
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "NUMAResources serial e2e tests")
 }
@@ -53,10 +45,4 @@ var _ = AfterSuite(func() {
 		serialconfig.Teardown()
 	}
 
-})
-
-var _ = ReportAfterSuite("TestTests", func(report Report) {
-	for _, reporter := range afterSuiteReporters {
-		ginkgo_reporters.ReportViaDeprecatedReporter(reporter, report)
-	}
 })


### PR DESCRIPTION
Linter is warning about using depricated ginkgo reporter code to create polarion report. Looking deeper the reporter is not used while publishing the tests report, as we use the junit file which has its own autogenerated ReporterAfterSuite.Thus removing the related code which cuase the noise in linter check.