### PR TITLE
[release-4.13][manual] Deprecate TopologyPolicies field

### DIFF
--- a/internal/noderesourcetopology/attributes.go
+++ b/internal/noderesourcetopology/attributes.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package noderesourcetopology
+
+// TopologyManager Attributes Names and values should follow the format
+// documented here
+// https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/pkg/noderesourcetopology/README.md#topology-manager-configuration
+const (
+	TopologyManagerPolicyAttribute = "topologyManagerPolicy"
+	TopologyManagerScopeAttribute  = "topologyManagerScope"
+)
+
+// From https://pkg.go.dev/k8s.io/kubelet@v0.25.11/config/v1beta1#KubeletConfiguration.TopologyManagerPolicy
+//   - `restricted`: kubelet only allows pods with optimal NUMA node alignment for
+//     requested resources;
+//   - `best-effort`: kubelet will favor pods with NUMA alignment of CPU and device
+//     resources;
+//   - `none`: kubelet has no knowledge of NUMA alignment of a pod's CPU and device resources.
+//   - `single-numa-node`: kubelet only allows pods with a single NUMA alignment
+//     of CPU and device resources.
+const (
+	SingleNUMANode = "single-numa-node"
+	Restricted     = "restricted"
+	BestEffort     = "best-effort"
+	None           = "none"
+)
+
+// From https://pkg.go.dev/k8s.io/kubelet@v0.25.11/config/v1beta1#KubeletConfiguration.TopologyManagerScope
+// - `container`: topology policy is applied on a per-container basis.
+// - `pod`: topology policy is applied on a per-pod basis.
+const (
+	Container = "container"
+	Pod       = "pod"
+)

--- a/internal/noderesourcetopology/tostring.go
+++ b/internal/noderesourcetopology/tostring.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper/attribute"
 )
 
 func ResourceInfoToString(resInfo nrtv1alpha2.ResourceInfo) string {
@@ -61,10 +62,16 @@ func ToString(nrt nrtv1alpha2.NodeResourceTopology) string {
 		name = "<MISSING>"
 	}
 	pol := "N/A"
-	if len(nrt.TopologyPolicies) > 0 {
-		pol = nrt.TopologyPolicies[0]
+	tmPolicy, ok := attribute.Get(nrt.Attributes, TopologyManagerPolicyAttribute)
+	if ok {
+		pol = tmPolicy.Value
 	}
-	fmt.Fprintf(&b, "%s policy=%s\n", name, pol)
+	scope := "N/A"
+	tmScope, ok := attribute.Get(nrt.Attributes, TopologyManagerScopeAttribute)
+	if ok {
+		scope = tmScope.Value
+	}
+	fmt.Fprintf(&b, "%s policy=%s, scope=%s\n", name, pol, scope)
 	for idx := range nrt.Zones {
 		fmt.Fprintf(&b, "- zone: %s\n", ZoneToString(nrt.Zones[idx]))
 	}

--- a/internal/noderesourcetopology/tostring_test.go
+++ b/internal/noderesourcetopology/tostring_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 )
@@ -166,48 +165,7 @@ func TestToString(t *testing.T) {
 	}{
 		{
 			name:     "empty",
-			expected: "<MISSING> policy=N/A\n",
-		},
-		{
-			name: "only-one",
-			nrt: nrtv1alpha2.NodeResourceTopology{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-nrt",
-				},
-				TopologyPolicies: []string{
-					"restricted",
-					"ignored-from-the-second-onwards",
-				},
-				Zones: []nrtv1alpha2.Zone{
-					{
-						Name:   "zone-0",
-						Type:   "zoneTypeA",
-						Parent: "will-not-be-stringified",
-						Resources: []nrtv1alpha2.ResourceInfo{
-							{
-								Name:        "dev1",
-								Capacity:    resource.MustParse("10"),
-								Allocatable: resource.MustParse("9"),
-								Available:   resource.MustParse("4"),
-							},
-						},
-					},
-					{
-						Name:   "zone-1",
-						Type:   "zoneTypeA",
-						Parent: "will-not-be-stringified",
-						Resources: []nrtv1alpha2.ResourceInfo{
-							{
-								Name:        "dev1",
-								Capacity:    resource.MustParse("10"),
-								Allocatable: resource.MustParse("10"),
-								Available:   resource.MustParse("8"),
-							},
-						},
-					},
-				},
-			},
-			expected: "test-nrt policy=restricted\n- zone: zone-0 [zoneTypeA]: dev1=10/9/4\n- zone: zone-1 [zoneTypeA]: dev1=10/10/8\n",
+			expected: "<MISSING> policy=N/A, scope=N/A\n",
 		},
 	}
 	for _, tt := range testCases {

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -51,6 +51,7 @@ import (
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
 
+	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
 	"github.com/openshift-kni/numaresources-operator/test/utils/configuration"
 	e2efixture "github.com/openshift-kni/numaresources-operator/test/utils/fixture"
@@ -79,11 +80,7 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 
 		// we're ok with any TM policy as long as the updater can handle it,
 		// we use this as proxy for "there is valid NRT data for at least X nodes
-		policies := []nrtv1alpha2.TopologyManagerPolicy{
-			nrtv1alpha2.SingleNUMANodeContainerLevel,
-			nrtv1alpha2.SingleNUMANodePodLevel,
-		}
-		nrts = e2enrt.FilterByPolicies(nrtList.Items, policies)
+		nrts = e2enrt.FilterByTopologyManagerPolicy(nrtList.Items, intnrt.SingleNUMANode)
 		if len(nrts) < 2 {
 			Skip(fmt.Sprintf("not enough nodes with valid policy - found %d", len(nrts)))
 		}

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -34,6 +34,7 @@ import (
 
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 
+	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	"github.com/openshift-kni/numaresources-operator/internal/nodes"
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
 	"github.com/openshift-kni/numaresources-operator/internal/resourcelist"
@@ -72,11 +73,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 
 		// we're ok with any TM policy as long as the updater can handle it,
 		// we use this as proxy for "there is valid NRT data for at least X nodes
-		policies := []nrtv1alpha2.TopologyManagerPolicy{
-			nrtv1alpha2.SingleNUMANodeContainerLevel,
-			nrtv1alpha2.SingleNUMANodePodLevel,
-		}
-		nrts = e2enrt.FilterByPolicies(nrtList.Items, policies)
+		nrts = e2enrt.FilterByTopologyManagerPolicy(nrtList.Items, intnrt.SingleNUMANode)
 		if len(nrts) < 2 {
 			e2efixture.Skipf(fxt, "not enough nodes with valid policy - found %d", len(nrts))
 		}

--- a/test/e2e/serial/tests/workload_placement_nodelabel.go
+++ b/test/e2e/serial/tests/workload_placement_nodelabel.go
@@ -34,6 +34,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	"github.com/openshift-kni/numaresources-operator/internal/nodes"
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
@@ -73,11 +74,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 		// we're ok with any TM policy as long as the updater can handle it,
 		// we use this as proxy for "there is valid NRT data for at least X nodes
-		policies := []nrtv1alpha2.TopologyManagerPolicy{
-			nrtv1alpha2.SingleNUMANodeContainerLevel,
-			nrtv1alpha2.SingleNUMANodePodLevel,
-		}
-		nrts = e2enrt.FilterByPolicies(nrtList.Items, policies)
+		nrts = e2enrt.FilterByTopologyManagerPolicy(nrtList.Items, intnrt.SingleNUMANode)
 		if len(nrts) < 2 {
 			e2efixture.Skipf(fxt, "not enough nodes with valid policy - found %d", len(nrts))
 		}

--- a/test/e2e/serial/tests/workload_placement_taint.go
+++ b/test/e2e/serial/tests/workload_placement_taint.go
@@ -34,6 +34,7 @@ import (
 
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 
+	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	"github.com/openshift-kni/numaresources-operator/internal/nodes"
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
@@ -77,11 +78,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 		// we're ok with any TM policy as long as the updater can handle it,
 		// we use this as proxy for "there is valid NRT data for at least X nodes
-		policies := []nrtv1alpha2.TopologyManagerPolicy{
-			nrtv1alpha2.SingleNUMANodeContainerLevel,
-			nrtv1alpha2.SingleNUMANodePodLevel,
-		}
-		nrts = e2enrt.FilterByPolicies(nrtCandidates, policies)
+		nrts = e2enrt.FilterByTopologyManagerPolicy(nrtCandidates, intnrt.SingleNUMANode)
 		if len(nrts) < 2 {
 			e2efixture.Skipf(fxt, "not enough nodes with valid policy - found %d", len(nrts))
 		}

--- a/test/utils/nrosched/nrosched.go
+++ b/test/utils/nrosched/nrosched.go
@@ -31,8 +31,8 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
+	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	"github.com/openshift-kni/numaresources-operator/pkg/status"
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 )
@@ -109,11 +109,12 @@ func CheckPODKubeletRejectWithTopologyAffinityError(k8sCli *kubernetes.Clientset
 	return checkPODEvents(k8sCli, podNamespace, podName, isKubeletRejectForTopologyAffinityError)
 }
 
-func CheckPODSchedulingFailedForAlignment(k8sCli *kubernetes.Clientset, podNamespace, podName, schedulerName, policy string) (bool, error) {
+// This function assumes a TMPolicy of "single-numa-node"
+func CheckPODSchedulingFailedForAlignment(k8sCli *kubernetes.Clientset, podNamespace, podName, schedulerName, scope string) (bool, error) {
 	var alignmentErr string
-	if policy == string(nrtv1alpha2.SingleNUMANodeContainerLevel) {
+	if scope == intnrt.Container {
 		alignmentErr = ErrorCannotAlignContainer
-	} else {
+	} else { //intnrt.Pod
 		alignmentErr = ErrorCannotAlignPod
 	}
 

--- a/test/utils/padder/padder.go
+++ b/test/utils/padder/padder.go
@@ -37,6 +37,7 @@ import (
 
 	numacellapi "github.com/openshift-kni/numaresources-operator/test/deviceplugin/pkg/numacell/api"
 
+	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 
 	"github.com/openshift-kni/numaresources-operator/test/utils/fixture"
@@ -138,7 +139,7 @@ func (p *Padder) Pad(timeout time.Duration, options PaddingOptions) error {
 	// since there is a relation of 1 : 1 between nodes and NRTs we can filter by the nodes` name
 	nrts := filterNrtByNodeName(nrtList.Items, nodeList.Items)
 
-	singleNumaNrt := nrtutil.FilterByPolicies(nrts, []nrtv1alpha2.TopologyManagerPolicy{nrtv1alpha2.SingleNUMANodePodLevel, nrtv1alpha2.SingleNUMANodeContainerLevel})
+	singleNumaNrt := nrtutil.FilterByTopologyManagerPolicy(nrts, intnrt.SingleNUMANode)
 	if p.nNodes > len(singleNumaNrt) {
 		return fmt.Errorf("not enough nodes were found for padding. requested: %d, got: %d", p.nNodes, len(singleNumaNrt))
 	}


### PR DESCRIPTION
topologyPolicies field is deprecated and should not be used. The new recommended approach is to use the attributes.

Added two new attributes to handle policy and scope.

manual backport of #652 