### PR TITLE
[release-4.13][manual] e2e: rte: backport local tests

### DIFF
--- a/hack/run-test-e2e.sh
+++ b/hack/run-test-e2e.sh
@@ -63,7 +63,7 @@ export E2E_TOPOLOGY_MANAGER_POLICY="${E2E_TOPOLOGY_MANAGER_POLICY:-SingleNUMANod
 # --fail-fast: ginkgo will stop the suite right after the first spec failure
 # --flake-attempts: rerun the test if it fails
 # -requireSuite: fail if tests are not executed because of missing suite
-${BIN_DIR}/e2e-nrop-rte.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.flake-attempts=2 --ginkgo.junit-report=${REPORT_DIR}/e2e.xml --ginkgo.skip='\[Disruptive\]|\[StateDirectories\]|\[NodeRefresh\]|\[local\]'
+${BIN_DIR}/e2e-nrop-rte.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.flake-attempts=2 --ginkgo.junit-report=${REPORT_DIR}/e2e.xml --ginkgo.skip='\[Disruptive\]|\[StateDirectories\]|\[NodeRefresh\]|\[local\]' --ginkgo.focus='\[release\]'
 
 
 if [ "$ENABLE_SCHED_TESTS" = true ]; then

--- a/test/e2e/rte/local/local.go
+++ b/test/e2e/rte/local/local.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package rte
+package local
 
 import (
 	"encoding/json"

--- a/test/e2e/rte/local/local_suite_test.go
+++ b/test/e2e/rte/local/local_suite_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Red Hat, Inc.
+ * Copyright 2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,29 +14,16 @@
  * limitations under the License.
  */
 
-package rte
+package local
 
 import (
-	"fmt"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	_ "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/rte"
-	_ "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/topology_updater"
-	_ "github.com/openshift-kni/numaresources-operator/test/e2e/rte/local"
 )
 
-var (
-	randomSeed int64
-)
-
-func TestRTE(t *testing.T) {
+func TestLocal(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "RTE Test Suite")
+	RunSpecs(t, "RTE Local Test Suite")
 }
-
-var _ = BeforeSuite(func() {
-	By(fmt.Sprintf("Using random seed %v", randomSeed))
-})

--- a/test/e2e/rte/rte_e2e_suite_test.go
+++ b/test/e2e/rte/rte_e2e_suite_test.go
@@ -18,21 +18,16 @@ package rte
 
 import (
 	"fmt"
-	"os/exec"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/openshift-kni/numaresources-operator/test/utils/runtime"
 
 	_ "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/rte"
 	_ "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/topology_updater"
 )
 
 var (
-	BinaryPath string
-
 	randomSeed int64
 )
 
@@ -43,24 +38,4 @@ func TestRTE(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	By(fmt.Sprintf("Using random seed %v", randomSeed))
-
-	By("Finding the binaries path")
-
-	binPath, err := runtime.FindBinaryPath("exporter")
-	Expect(err).ToNot(HaveOccurred())
-	BinaryPath = binPath
-
-	By(fmt.Sprintf("Using the binary at %q", BinaryPath))
 })
-
-func expectExecutableExists(path string) {
-	cmdline := []string{
-		path,
-		"-h",
-	}
-
-	cmd := exec.Command(cmdline[0], cmdline[1:]...)
-	out, err := cmd.CombinedOutput()
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-	ExpectWithOffset(1, out).ToNot(BeEmpty())
-}

--- a/test/e2e/rte/rte_local_test.go
+++ b/test/e2e/rte/rte_local_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nrtupdater"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcemonitor"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcetopologyexporter"
+
+	"github.com/openshift-kni/numaresources-operator/test/utils/runtime"
 )
 
 type ProgArgs struct {
@@ -36,7 +38,20 @@ type ProgArgs struct {
 	RTE             resourcetopologyexporter.Args
 }
 
+var binaryPath string
+
 var _ = Describe("[rte][local][config] RTE configuration", func() {
+
+	BeforeEach(func() {
+		By("Finding the binaries path")
+
+		binPath, err := runtime.FindBinaryPath("exporter")
+		Expect(err).ToNot(HaveOccurred())
+		binaryPath = binPath
+
+		By(fmt.Sprintf("Using the binary at %q", binaryPath))
+	})
+
 	Context("with the binary available", func() {
 		It("should have any default for TM params", func() {
 			args := runConfig([]string{}, map[string]string{})
@@ -80,7 +95,7 @@ var _ = Describe("[rte][local][config] RTE configuration", func() {
 
 func runConfig(argv []string, env map[string]string) ProgArgs {
 	cmdline := []string{
-		BinaryPath,
+		binaryPath,
 		"--dump-config",
 	}
 	cmdline = append(cmdline, argv...)
@@ -111,4 +126,16 @@ func flattenEnv(env map[string]string) []string {
 		ret = append(ret, strings.TrimSpace(key)+"="+strings.TrimSpace(value))
 	}
 	return ret
+}
+
+func expectExecutableExists(path string) {
+	cmdline := []string{
+		path,
+		"-h",
+	}
+
+	cmd := exec.Command(cmdline[0], cmdline[1:]...)
+	out, err := cmd.CombinedOutput()
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, out).ToNot(BeEmpty())
 }


### PR DESCRIPTION
move local exoporter tests in their own suite, backporting from 4.14

partial backport of #653 