### PR TITLE
controller: test: relax condition

### DIFF
--- a/controllers/numaresourcesoperator_controller_test.go
+++ b/controllers/numaresourcesoperator_controller_test.go
@@ -500,8 +500,6 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 							nroUpdated := &nropv1.NUMAResourcesOperator{}
 							Expect(reconciler.Client.Get(context.TODO(), key, nroUpdated)).ToNot(HaveOccurred())
 
-							Expect(nroUpdated.Status.DaemonSets).ToNot(BeEmpty())
-
 							//Should have this object references ...
 							expected := []configv1.ObjectReference{
 								{


### PR DESCRIPTION
since e8432043 we have e2e test coverage, so we can relax this condition and tolerate the case on which we miss daemonsets.