### PR TITLE
sched: manifests: move to v1beta3 for the config

### DIFF
--- a/pkg/numaresourcesscheduler/manifests/yaml/configmap.nrt.yaml
+++ b/pkg/numaresourcesscheduler/manifests/yaml/configmap.nrt.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: placeholder
 data:
   "config.yaml": |
-    apiVersion: kubescheduler.config.k8s.io/v1beta2
+    apiVersion: kubescheduler.config.k8s.io/v1beta3
     kind: KubeSchedulerConfiguration
     leaderElection:
       leaderElect: false
@@ -43,7 +43,7 @@ data:
         pluginConfig:
         - name: NodeResourceTopologyMatch
           args:
-            apiVersion: kubescheduler.config.k8s.io/v1beta2
+            apiVersion: kubescheduler.config.k8s.io/v1beta3
             kind: NodeResourceTopologyMatchArgs
             scoringStrategy:
               type: LeastAllocated

--- a/pkg/numaresourcesscheduler/objectstate/sched/sched_test.go
+++ b/pkg/numaresourcesscheduler/objectstate/sched/sched_test.go
@@ -61,13 +61,13 @@ func TestDeploymentNamespacedNameFromObject(t *testing.T) {
 }
 
 const (
-	schedConfigNoProfiles = `apiVersion: kubescheduler.config.k8s.io/v1beta2
+	schedConfigNoProfiles = `apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
 profiles: []`
 
-	schedConfigOK = `apiVersion: kubescheduler.config.k8s.io/v1beta2
+	schedConfigOK = `apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false

--- a/pkg/objectupdate/sched/fakeconfs.go
+++ b/pkg/objectupdate/sched/fakeconfs.go
@@ -24,14 +24,14 @@ import (
 )
 
 const (
-	schedConfig = `apiVersion: kubescheduler.config.k8s.io/v1beta2
+	schedConfig = `apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
 profiles:
 - pluginConfig:
   - args:
-      apiVersion: kubescheduler.config.k8s.io/v1beta2
+      apiVersion: kubescheduler.config.k8s.io/v1beta3
       cacheResyncPeriodSeconds: 3
       kind: NodeResourceTopologyMatchArgs
       scoringStrategy:
@@ -54,14 +54,14 @@ profiles:
       - name: NodeResourceTopologyMatch
   schedulerName: test-topo-aware-sched`
 
-	schedConfigWithPeriod = `apiVersion: kubescheduler.config.k8s.io/v1beta2
+	schedConfigWithPeriod = `apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
 profiles:
   - pluginConfig:
     - args:
-        apiVersion: kubescheduler.config.k8s.io/v1beta2
+        apiVersion: kubescheduler.config.k8s.io/v1beta3
         cacheResyncPeriodSeconds: 3
         kind: NodeResourceTopologyMatchArgs
         scoringStrategy:
@@ -86,14 +86,14 @@ profiles:
 )
 
 const (
-	expectedYAMLWithReconcilePeriod = `apiVersion: kubescheduler.config.k8s.io/v1beta2
+	expectedYAMLWithReconcilePeriod = `apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
 profiles:
 - pluginConfig:
   - args:
-      apiVersion: kubescheduler.config.k8s.io/v1beta2
+      apiVersion: kubescheduler.config.k8s.io/v1beta3
       cacheResyncPeriodSeconds: 3
       kind: NodeResourceTopologyMatchArgs
       scoringStrategy:
@@ -117,14 +117,14 @@ profiles:
   schedulerName: test-topo-aware-sched
 `
 
-	expectedYAMLWithoutReconcile = `apiVersion: kubescheduler.config.k8s.io/v1beta2
+	expectedYAMLWithoutReconcile = `apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
 profiles:
 - pluginConfig:
   - args:
-      apiVersion: kubescheduler.config.k8s.io/v1beta2
+      apiVersion: kubescheduler.config.k8s.io/v1beta3
       kind: NodeResourceTopologyMatchArgs
       scoringStrategy:
         resources:


### PR DESCRIPTION
upstream is about to remove v1beta2, let's do the long-due upgrade to v1beta3.

No intended changes in behavior.