### PR TITLE
e2e: serial: resource accounting: take cluster snapshot post padding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/k8stopologyawareschedwg/deployer v0.18.2
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.1
 	github.com/k8stopologyawareschedwg/podfingerprint v0.2.2
-	github.com/k8stopologyawareschedwg/resource-topology-exporter v0.16.0
+	github.com/k8stopologyawareschedwg/resource-topology-exporter v0.16.1-0.20231211140359-6dba655b8b2a
 	github.com/kubevirt/device-plugin-manager v1.19.4
 	github.com/mdomke/git-semver v1.0.0
 	github.com/onsi/ginkgo/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -1097,8 +1097,8 @@ github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.1 h1:BI3L7hNqRv
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.1/go.mod h1:AkACMQGiTgCt0lQw3m7TTU8PLH9lYKNK5e9DqFf5VuM=
 github.com/k8stopologyawareschedwg/podfingerprint v0.2.2 h1:iFHPfZInM9pz2neye5RdmORMp1hPmte1EGJYpOOzZVg=
 github.com/k8stopologyawareschedwg/podfingerprint v0.2.2/go.mod h1:C23pM15t06dXg/OihGlqBvnYzLr+MXDXJ7zMfbNAyXI=
-github.com/k8stopologyawareschedwg/resource-topology-exporter v0.16.0 h1:BrGZXVDQdDrQdxSyxX+dmDzIQqCDq3roeIU7LxyhnLs=
-github.com/k8stopologyawareschedwg/resource-topology-exporter v0.16.0/go.mod h1:sDgwGXVhjm+sRHouO8yHlFsCJcqVnD4Yg/rl1mvAwf8=
+github.com/k8stopologyawareschedwg/resource-topology-exporter v0.16.1-0.20231211140359-6dba655b8b2a h1:b10VBRUSkuFgcKl2IoVpuyamC7xGl7gxx1UiW57hCC8=
+github.com/k8stopologyawareschedwg/resource-topology-exporter v0.16.1-0.20231211140359-6dba655b8b2a/go.mod h1:sDgwGXVhjm+sRHouO8yHlFsCJcqVnD4Yg/rl1mvAwf8=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/internal/noderesourcetopology/equality.go
+++ b/internal/noderesourcetopology/equality.go
@@ -39,7 +39,7 @@ func EqualZones(zonesA, zonesB nrtv1alpha2.ZoneList, isRebootTest bool) (bool, e
 		zoneB := &zB[idx]
 
 		if zoneA.Name != zoneB.Name {
-			return false, fmt.Errorf("mismatched zones %q vs %q", zoneA.Name, zoneB.Name)
+			return false, fmt.Errorf("mismatched zones initial=%q vs updated=%q", zoneA.Name, zoneB.Name)
 		}
 
 		ok, err := EqualResourceInfos(SortedResourceInfoList(zoneA.Resources), SortedResourceInfoList(zoneB.Resources), isRebootTest)
@@ -75,16 +75,16 @@ func EqualResourceInfo(resInfoA, resInfoB nrtv1alpha2.ResourceInfo, isRebootTest
 	}
 
 	if resInfoA.Name != resInfoB.Name {
-		return false, fmt.Errorf("mismatched resource name %q vs %q", resInfoA.Name, resInfoB.Name)
+		return false, fmt.Errorf("mismatched resource name initial=%q vs updated=%q", resInfoA.Name, resInfoB.Name)
 	}
 	if resInfoA.Capacity.Cmp(resInfoB.Capacity) != 0 {
-		return false, fmt.Errorf("resource %q: mismatched resource Capacity %v vs %v", resInfoA.Name, resInfoA.Capacity, resInfoB.Capacity)
+		return false, fmt.Errorf("mismatched resource Capacity initial=%v vs updated=%v", ResourceInfoToString(resInfoA), ResourceInfoToString(resInfoB))
 	}
 	if resInfoA.Allocatable.Cmp(resInfoB.Allocatable) != 0 {
-		return false, fmt.Errorf("resource %q: mismatched resource Allocatable %v vs %v", resInfoA.Name, resInfoA.Allocatable, resInfoB.Allocatable)
+		return false, fmt.Errorf("mismatched resource Allocatable initial=%v vs updated=%v", ResourceInfoToString(resInfoA), ResourceInfoToString(resInfoB))
 	}
 	if resInfoA.Available.Cmp(resInfoB.Available) != 0 {
-		return false, fmt.Errorf("resource %q: mismatched resource Available %v vs %v", resInfoA.Name, resInfoA.Available, resInfoB.Available)
+		return false, fmt.Errorf("mismatched resource Available initial=%v vs updated=%v", ResourceInfoToString(resInfoA), ResourceInfoToString(resInfoB))
 	}
 	return true, nil
 }
@@ -103,16 +103,16 @@ func EqualResourceInfoWithDeviation(resInfoA, resInfoB nrtv1alpha2.ResourceInfo)
 	dev, _ := resource.ParseQuantity("54525952") //52 Mi
 
 	if resInfoA.Name != resInfoB.Name {
-		return false, fmt.Errorf("mismatched resource name %q vs %q", resInfoA.Name, resInfoB.Name)
+		return false, fmt.Errorf("mismatched resource name initial=%q vs updated=%q", resInfoA.Name, resInfoB.Name)
 	}
 	if !QuantityAbsCmp(resInfoA.Capacity, resInfoB.Capacity, dev) {
-		return false, fmt.Errorf("resource %q: mismatched resource Capacity %v vs %v", resInfoA.Name, resInfoA.Capacity, resInfoB.Capacity)
+		return false, fmt.Errorf("resource %q: mismatched resource Capacity initial=%v vs updated=%v", resInfoA.Name, resInfoA.Capacity, resInfoB.Capacity)
 	}
 	if !QuantityAbsCmp(resInfoA.Allocatable, resInfoB.Allocatable, dev) {
-		return false, fmt.Errorf("resource %q: mismatched resource Allocatable %v vs %v", resInfoA.Name, resInfoA.Allocatable, resInfoB.Allocatable)
+		return false, fmt.Errorf("resource %q: mismatched resource Allocatable initial=%v vs updated=%v", resInfoA.Name, resInfoA.Allocatable, resInfoB.Allocatable)
 	}
 	if !QuantityAbsCmp(resInfoA.Available, resInfoB.Available, dev) {
-		return false, fmt.Errorf("resource %q: mismatched resource Available %v vs %v", resInfoA.Name, resInfoA.Available, resInfoB.Available)
+		return false, fmt.Errorf("resource %q: mismatched resource Available initial=%v vs updated=%v", resInfoA.Name, resInfoA.Available, resInfoB.Available)
 	}
 	return true, nil
 }

--- a/internal/wait/noderesourcetopologies.go
+++ b/internal/wait/noderesourcetopologies.go
@@ -132,6 +132,9 @@ func (wt Waiter) ForNodeResourceTopologiesEqualToPostReboot(ctx context.Context,
 			klog.Errorf("cannot get the NRT List: %v", err)
 			return false, err
 		}
+
+		klog.Infof("checking %s", intnrt.ListToString(updatedNrtList.Items, " current nrt list"))
+
 		for idx := range nrtListReference.Items {
 			referenceNrt := &nrtListReference.Items[idx]
 

--- a/test/e2e/serial/config/fixture.go
+++ b/test/e2e/serial/config/fixture.go
@@ -58,7 +58,7 @@ func (cfg *E2EConfig) RecordNRTReference() error {
 	if err != nil {
 		return err
 	}
-	klog.Infof("recorded reference NRT data:\n%s", intnrt.ListToString(cfg.NRTList.Items, "reference"))
+	klog.Infof("recorded reference NRT data:\n%s", intnrt.ListToString(cfg.NRTList.Items, " reference"))
 	return nil
 }
 

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -327,10 +327,14 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(ok).To(BeTrue(), "cannot select a node among %#v", e2efixture.ListNodeNames(nrtCandidateNames))
 			By(fmt.Sprintf("selecting node to schedule the test pod: %q", targetNodeName))
 
-			targetNrtListInitial, err = e2enrt.GetUpdated(fxt.Client, nrtList, 1*time.Minute)
+			// TODO: just use nrtList?
+			err = fxt.Client.List(context.TODO(), &targetNrtListInitial)
 			Expect(err).ToNot(HaveOccurred())
+			klog.Infof("initial NRT List: %s", intnrt.ListToString(targetNrtListInitial.Items, " initial list"))
+
 			targetNrtInitial, err = e2enrt.FindFromList(targetNrtListInitial.Items, targetNodeName)
 			Expect(err).NotTo(HaveOccurred())
+			klog.Infof("initial NRT target: %s", intnrt.ToString(*targetNrtInitial))
 
 			//calculate base load on the target node
 			baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), targetNodeName)

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -200,6 +200,9 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			failedPodIds = e2efixture.WaitForPaddingPodsRunning(fxt, targetPaddingPods)
 			Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
+			By("waiting for the NRT data to settle")
+			e2efixture.MustSettleNRT(fxt)
+
 			By("saturating nodes we want to be unsuitable")
 			for idx, unsuitableNodeName := range unsuitableNodeNames {
 				nrtInfo, err := e2enrt.FindFromList(nrtList.Items, unsuitableNodeName)
@@ -227,9 +230,9 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			failedPodIds = e2efixture.WaitForPaddingPodsRunning(fxt, allPaddingPods)
 			Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
-			// TODO: smarter cooldown
-			By("cooling down")
-			time.Sleep(18 * time.Second)
+			By("waiting for the NRT data to settle")
+			e2efixture.MustSettleNRT(fxt)
+
 			for _, unsuitableNodeName := range unsuitableNodeNames {
 				dumpNRTForNode(fxt.Client, unsuitableNodeName, "unsuitable")
 			}
@@ -301,6 +304,8 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 		var targetNodeName string
 		var targetNrtInitial *nrtv1alpha2.NodeResourceTopology
 		var targetNrtListInitial nrtv1alpha2.NodeResourceTopologyList
+		var targetNrtReference *nrtv1alpha2.NodeResourceTopology
+		var targetNrtListReference nrtv1alpha2.NodeResourceTopologyList
 		var deployment *appsv1.Deployment
 		var reqResources corev1.ResourceList
 		var err error
@@ -389,6 +394,18 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			By("Waiting for padding pods to be ready")
 			failedPodIds := e2efixture.WaitForPaddingPodsRunning(fxt, paddingPods)
 			Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
+
+			By("waiting for the NRT data to settle")
+			e2efixture.MustSettleNRT(fxt)
+
+			By("Getting the reference NRT list post padding")
+			targetNrtListReference, err = e2enrt.GetUpdated(fxt.Client, targetNrtListInitial, 1*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+			klog.Infof("reference NRT List: %s", intnrt.ListToString(targetNrtListReference.Items, " reference list"))
+
+			targetNrtReference, err = e2enrt.FindFromList(targetNrtListReference.Items, targetNodeName)
+			Expect(err).NotTo(HaveOccurred())
+			klog.Infof("reference NRT target: %s", intnrt.ToString(*targetNrtReference))
 		})
 
 		It("[test_id:48685][tier1] should properly schedule a best-effort pod with no changes in NRTs", func() {
@@ -416,7 +433,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 
 			By("Verifying NRT reflects no updates after scheduling the best-effort pod")
-			_, err = wait.With(fxt.Client).Interval(5*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesEqualTo(context.TODO(), &targetNrtListInitial, wait.NRTIgnoreNothing)
+			_, err = wait.With(fxt.Client).Interval(5*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesEqualTo(context.TODO(), &targetNrtListReference, wait.NRTIgnoreNothing)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -447,7 +464,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 
 			By("Verifying NRT reflects no updates after scheduling the burstable pod")
-			_, err = wait.With(fxt.Client).Interval(5*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesEqualTo(context.TODO(), &targetNrtListInitial, wait.NRTIgnoreNothing)
+			_, err = wait.With(fxt.Client).Interval(5*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesEqualTo(context.TODO(), &targetNrtListReference, wait.NRTIgnoreNothing)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -485,11 +502,11 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			}
 
 			By("Verifying NRT reflects no updates after scheduling the burstable pod")
-			targetNrtListCurrent, err := e2enrt.GetUpdated(fxt.Client, targetNrtListInitial, 1*time.Minute)
+			targetNrtListCurrent, err := e2enrt.GetUpdated(fxt.Client, targetNrtListReference, 1*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 			targetNrtCurrent, err := e2enrt.FindFromList(targetNrtListCurrent.Items, targetNodeName)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(e2enrt.CheckEqualAvailableResources(*targetNrtInitial, *targetNrtCurrent)).To(BeTrue(), "new resources are accounted in NRT although scheduling burstable pod")
+			Expect(e2enrt.CheckEqualAvailableResources(*targetNrtReference, *targetNrtCurrent)).To(BeTrue(), "new resources are accounted in NRT although scheduling burstable pod")
 		})
 
 		It("[tier2] should properly schedule a burstable pod when one of the containers is asking for requests=limits, with no changes in NRTs", func() {
@@ -558,7 +575,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 
 			By("Verifying NRT reflects no updates after scheduling the burstable pod")
-			_, err = wait.With(fxt.Client).Interval(5*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesEqualTo(context.TODO(), &targetNrtListInitial, wait.NRTIgnoreNothing)
+			_, err = wait.With(fxt.Client).Interval(5*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesEqualTo(context.TODO(), &targetNrtListReference, wait.NRTIgnoreNothing)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -589,7 +606,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 
 			By("Verifying NRT reflects no updates after scheduling the burstable pod")
-			_, err = wait.With(fxt.Client).Interval(5*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesEqualTo(context.TODO(), &targetNrtListInitial, wait.NRTIgnoreNothing)
+			_, err = wait.With(fxt.Client).Interval(5*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesEqualTo(context.TODO(), &targetNrtListReference, wait.NRTIgnoreNothing)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("create a gu pod")
@@ -630,7 +647,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verifying NRT reflects no updates after scheduling the burstable pod")
-			_, err = wait.With(fxt.Client).Interval(5*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesEqualTo(context.TODO(), &targetNrtListInitial, wait.NRTIgnoreNothing)
+			_, err = wait.With(fxt.Client).Interval(5*time.Second).Timeout(1*time.Minute).ForNodeResourceTopologiesEqualTo(context.TODO(), &targetNrtListReference, wait.NRTIgnoreNothing)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("delete the burstable pod and the guaranteed pod should change state from pending to running")
@@ -654,7 +671,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			By("wait for NRT data to settle")
 			e2efixture.MustSettleNRT(fxt)
 
-			nrtPostPodCreateList, err := e2enrt.GetUpdated(fxt.Client, targetNrtListInitial, time.Minute)
+			nrtPostPodCreateList, err := e2enrt.GetUpdated(fxt.Client, targetNrtListReference, time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 
 			nrtPostCreate, err := e2enrt.FindFromList(nrtPostPodCreateList.Items, updatedPod.Spec.NodeName)
@@ -737,11 +754,11 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			}
 
 			By("Verifying NRT reflects no updates after scheduling the burstable pod")
-			targetNrtListCurrent, err := e2enrt.GetUpdated(fxt.Client, targetNrtListInitial, 1*time.Minute)
+			targetNrtListCurrent, err := e2enrt.GetUpdated(fxt.Client, targetNrtListReference, 1*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 			targetNrtCurrent, err := e2enrt.FindFromList(targetNrtListCurrent.Items, targetNodeName)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(e2enrt.CheckEqualAvailableResources(*targetNrtInitial, *targetNrtCurrent)).To(BeTrue(), "new resources are accounted in NRT although scheduling burstable pod")
+			Expect(e2enrt.CheckEqualAvailableResources(*targetNrtReference, *targetNrtCurrent)).To(BeTrue(), "new resources are accounted in NRT although scheduling burstable pod")
 
 			By("deleting the daemonset")
 			err = fxt.Client.Delete(context.TODO(), ds)

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -308,7 +308,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 		/*
 		 1. choose a target node on which the test's burstable pod will run
 		 2. fully pad the non-target nodes
-		 3. test step: create a workload with burstable pod and check which scheduler took charge and NRT
+		 3. test step: create a workload with burstable pod and check which scheduler took charge and NRT was _not_ affected
 		*/
 		BeforeEach(func() {
 			const requiredNUMAZones = 2
@@ -487,7 +487,8 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(err).NotTo(HaveOccurred())
 			Expect(e2enrt.CheckEqualAvailableResources(*targetNrtInitial, *targetNrtCurrent)).To(BeTrue(), "new resources are accounted in NRT although scheduling burstable pod")
 		})
-		It("should properly schedule a burstable pod when one of the containers is asking for requests=limits, with no changes in NRTs", func() {
+
+		It("[tier2] should properly schedule a burstable pod when one of the containers is asking for requests=limits, with no changes in NRTs", func() {
 			By("create a burstable pod")
 			pod := objects.NewTestPodPause(fxt.Namespace.Name, "testpod-bu")
 			pod.Spec.SchedulerName = serialconfig.Config.SchedulerName

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -537,7 +537,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 
 			err = fxt.Client.Create(context.TODO(), pod)
 			Expect(err).ToNot(HaveOccurred())
-			klog.Infof("create the busrtable test pod with requests %s", e2ereslist.ToString(reqResources))
+			klog.Infof("create the burstable test pod with requests %s", e2ereslist.ToString(reqResources))
 
 			By("waiting for the pod to be scheduled")
 			// 3 minutes is plenty, should never timeout

--- a/test/utils/fixture/fixture.go
+++ b/test/utils/fixture/fixture.go
@@ -36,6 +36,7 @@ import (
 
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 
+	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	"github.com/openshift-kni/numaresources-operator/internal/objects"
 	intwait "github.com/openshift-kni/numaresources-operator/internal/wait"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
@@ -98,6 +99,9 @@ func SetupWithOptions(name string, nrtList nrtv1alpha2.NodeResourceTopologyList,
 		return nil, err
 	}
 	ginkgo.By(fmt.Sprintf("set up the test namespace %q", ns.Name))
+
+	klog.Infof("set up the fixture reference NRT List: %s", intnrt.ListToString(nrtList.Items, " fixture initial"))
+
 	return &Fixture{
 		Client:         e2eclient.Client,
 		K8sClient:      e2eclient.K8sClient,

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/sysinfo/memory.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/sysinfo/memory.go
@@ -18,8 +18,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-
-	"k8s.io/klog/v2"
 )
 
 func GetMemory(hnd Handle) (map[int]int64, error) {
@@ -34,13 +32,11 @@ func GetMemory(hnd Handle) (map[int]int64, error) {
 		if entry.IsDir() && strings.HasPrefix(entryName, "node") {
 			nodeID, err := strconv.Atoi(entryName[4:])
 			if err != nil {
-				klog.Warningf("cannot detect the node ID for %q", entryName)
-				continue
+				return memory, fmt.Errorf("cannot detect the node ID for %q", entryName)
 			}
 			nodeMemory, err := MemoryForNode(hnd, nodeID)
 			if err != nil {
-				klog.Warningf("cannot find the memory on NUMA node %d: %v", nodeID, err)
-				continue
+				return memory, fmt.Errorf("cannot find the memory on NUMA node %d: %w", nodeID, err)
 			}
 			memory[nodeID] = nodeMemory
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -205,7 +205,7 @@ github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/client
 # github.com/k8stopologyawareschedwg/podfingerprint v0.2.2
 ## explicit; go 1.17
 github.com/k8stopologyawareschedwg/podfingerprint
-# github.com/k8stopologyawareschedwg/resource-topology-exporter v0.16.0
+# github.com/k8stopologyawareschedwg/resource-topology-exporter v0.16.1-0.20231211140359-6dba655b8b2a
 ## explicit; go 1.20
 github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/dump
 github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/k8sannotations


### PR DESCRIPTION
Previously, the test fixture took its NRT snapshot before padding.
But padding is an essential component of testing, and requires guaranteed class pods to actually consume numa-local resources.

If we later check that conditions match, we will never ever converge because padding pods will be (correctly) counted to assess the node resource consumption.

The correct approach is then to take the expected state AFTER padding, considering padding pods as part of the cluster state, and right before any test-specific pod is scheduled.

Or, alternatively, to check the state excluding the padding pods which will make the test more complex (and thus fragile), and/or of questionable value.

The only remaining question is why this failure was gone unnoticed up until now.