### PR TITLE
 flagcodec: always use flag normalization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-logr/logr v1.2.4
 	github.com/google/go-cmp v0.5.9
 	github.com/jaypipes/ghw v0.9.0
-	github.com/k8stopologyawareschedwg/deployer v0.18.0
+	github.com/k8stopologyawareschedwg/deployer v0.18.2
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.1
 	github.com/k8stopologyawareschedwg/podfingerprint v0.2.2
 	github.com/k8stopologyawareschedwg/resource-topology-exporter v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -1091,8 +1091,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/k8stopologyawareschedwg/deployer v0.18.0 h1:Ke7a+7v4jnbX+pStbfA2i1jkQvW0ADZkhvrlVoNJT8U=
-github.com/k8stopologyawareschedwg/deployer v0.18.0/go.mod h1:IMlcFrSMaZFgskzbWg0lskT9zZ3YagTU7DbM9nTWw5k=
+github.com/k8stopologyawareschedwg/deployer v0.18.2 h1:W9MwJqoAmvyD18SGzcY2UEC72t0DYAUwmlhsOyyMdOA=
+github.com/k8stopologyawareschedwg/deployer v0.18.2/go.mod h1:IMlcFrSMaZFgskzbWg0lskT9zZ3YagTU7DbM9nTWw5k=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.1 h1:BI3L7hNqRvXtB42FO4NI/0ZjDDVRPOMBDFLShhFtf28=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.1/go.mod h1:AkACMQGiTgCt0lQw3m7TTU8PLH9lYKNK5e9DqFf5VuM=
 github.com/k8stopologyawareschedwg/podfingerprint v0.2.2 h1:iFHPfZInM9pz2neye5RdmORMp1hPmte1EGJYpOOzZVg=

--- a/pkg/loglevel/loglevel.go
+++ b/pkg/loglevel/loglevel.go
@@ -50,12 +50,12 @@ func UpdatePodSpec(podSpec *corev1.PodSpec, level operatorv1.LogLevel) error {
 	// TODO: better match by name than assume container#0 is the right one
 	cnt := &podSpec.Containers[0]
 	kLog := ToKlog(level)
-	flags := flagcodec.ParseArgvKeyValue(cnt.Args)
+	flags := flagcodec.ParseArgvKeyValue(cnt.Args, flagcodec.WithFlagNormalization)
 	if flags == nil {
 		return fmt.Errorf("cannot modify the arguments for container %s", cnt.Name)
 	}
 	flags.SetOption("--v", kLog.String())
-	klog.InfoS("container klog level", "container", cnt.Name, "--v", kLog.String())
+	klog.InfoS("container klog level", "container", cnt.Name, "-v", kLog.String())
 	cnt.Args = flags.Argv()
 	return nil
 }

--- a/pkg/loglevel/loglevel_test.go
+++ b/pkg/loglevel/loglevel_test.go
@@ -81,19 +81,19 @@ func TestUpdatePodSpec(t *testing.T) {
 	}{
 		{
 			in:           operatorv1.Normal,
-			expectedArgs: append(getArgsCopy(args), "--v=2"),
+			expectedArgs: append(getArgsCopy(args), "-v=2"),
 		},
 		{
 			in:           operatorv1.Debug,
-			expectedArgs: append(getArgsCopy(args), "--v=4"),
+			expectedArgs: append(getArgsCopy(args), "-v=4"),
 		},
 		{
 			in:           operatorv1.Trace,
-			expectedArgs: append(getArgsCopy(args), "--v=6"),
+			expectedArgs: append(getArgsCopy(args), "-v=6"),
 		},
 		{
 			in:           operatorv1.TraceAll,
-			expectedArgs: append(getArgsCopy(args), "--v=8"),
+			expectedArgs: append(getArgsCopy(args), "-v=8"),
 		},
 	}
 

--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -131,7 +131,7 @@ func DaemonSetArgs(ds *appsv1.DaemonSet, conf nropv1.NodeGroupConfig) error {
 	if cnt == nil {
 		return fmt.Errorf("cannot find container data for %q", MainContainerName)
 	}
-	flags := flagcodec.ParseArgvKeyValue(cnt.Args)
+	flags := flagcodec.ParseArgvKeyValue(cnt.Args, flagcodec.WithFlagNormalization)
 	if flags == nil {
 		return fmt.Errorf("cannot modify the arguments for container %s", cnt.Name)
 	}

--- a/test/e2e/rte/rte_test.go
+++ b/test/e2e/rte/rte_test.go
@@ -317,10 +317,10 @@ func getOwnedDss(cs kubernetes.Interface, owner metav1.ObjectMeta) ([]appsv1.Dae
 }
 
 func matchLogLevelToKlog(cnt *corev1.Container, level operatorv1.LogLevel) (bool, bool) {
-	rteFlags := flagcodec.ParseArgvKeyValue(cnt.Args)
+	rteFlags := flagcodec.ParseArgvKeyValue(cnt.Args, flagcodec.WithFlagNormalization)
 	kLvl := loglevel.ToKlog(level)
 
-	val, found := rteFlags.GetFlag("--v")
+	val, found := rteFlags.GetFlag("--")
 	return found, val.Data == kLvl.String()
 }
 

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -1227,10 +1227,10 @@ func getLeastAvailableResourceQty(res resource.Quantity, zones nrtv1alpha2.ZoneL
 }
 
 func matchLogLevelToKlog(cnt *corev1.Container, level operatorv1.LogLevel) (bool, bool) {
-	rteFlags := flagcodec.ParseArgvKeyValue(cnt.Args)
+	rteFlags := flagcodec.ParseArgvKeyValue(cnt.Args, flagcodec.WithFlagNormalization)
 	kLvl := loglevel.ToKlog(level)
 
-	val, found := rteFlags.GetFlag("--v")
+	val, found := rteFlags.GetFlag("-v")
 	return found, val.Data == kLvl.String()
 }
 

--- a/vendor/github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate/sched/render.go
+++ b/vendor/github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate/sched/render.go
@@ -167,7 +167,61 @@ func updateArgs(args map[string]interface{}, params *manifests.ConfigParams) (bo
 			updated++
 		}
 	}
+
+	cacheArgs, ok, err := unstructured.NestedMap(args, "cache")
+	if !ok {
+		cacheArgs = make(map[string]interface{})
+	}
+	if err != nil {
+		return updated > 0, err
+	}
+
+	cacheArgsUpdated, err := updateCacheArgs(cacheArgs, params)
+	if err != nil {
+		return updated > 0, err
+	}
+	updated += cacheArgsUpdated
+
+	if cacheArgsUpdated > 0 {
+		if err := unstructured.SetNestedMap(args, cacheArgs, "cache"); err != nil {
+			return updated > 0, err
+		}
+	}
 	return updated > 0, ensureBackwardCompatibility(args)
+}
+
+func updateCacheArgs(args map[string]interface{}, params *manifests.ConfigParams) (int, error) {
+	var updated int
+	var err error
+
+	if params.Cache != nil {
+		if params.Cache.ResyncMethod != nil {
+			resyncMethod := *params.Cache.ResyncMethod // shortcut
+			err = manifests.ValidateCacheResyncMethod(resyncMethod)
+			if err != nil {
+				return updated, err
+			}
+			err = unstructured.SetNestedField(args, resyncMethod, "resyncMethod")
+			if err != nil {
+				return updated, err
+			}
+			updated++
+		}
+		if params.Cache.ForeignPodsDetectMode != nil {
+			foreignPodsMode := *params.Cache.ForeignPodsDetectMode // shortcut
+			err = manifests.ValidateForeignPodsDetectMode(foreignPodsMode)
+			if err != nil {
+				return updated, err
+			}
+			err = unstructured.SetNestedField(args, foreignPodsMode, "foreignPodsDetect")
+			if err != nil {
+				return updated, err
+			}
+			updated++
+		}
+	}
+
+	return updated, nil
 }
 
 func ensureBackwardCompatibility(args map[string]interface{}) error {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -172,7 +172,7 @@ github.com/josharian/intern
 # github.com/json-iterator/go v1.1.12
 ## explicit; go 1.12
 github.com/json-iterator/go
-# github.com/k8stopologyawareschedwg/deployer v0.18.0
+# github.com/k8stopologyawareschedwg/deployer v0.18.2
 ## explicit; go 1.19
 github.com/k8stopologyawareschedwg/deployer/pkg/assets/rte
 github.com/k8stopologyawareschedwg/deployer/pkg/assets/selinux


### PR DESCRIPTION
this enables us to remove a longstanding ambiguity about `--v` vs `-v` and to fix a silent bug on which we BOTH set `--v` and `-v`, with the latter winning, opening the door for surprising bugs.