### PR TITLE
support error reporting & increae default cooldown timeout

### DIFF
--- a/test/utils/fixture/fixture.go
+++ b/test/utils/fixture/fixture.go
@@ -167,7 +167,7 @@ func Cooldown(ft *Fixture) {
 
 func MustSettleNRT(fxt *Fixture) {
 	_, err := WaitForNRTSettle(fxt)
-	gomega.ExpectWithOffset(1, err).ToNot(gomega.HaveOccurred())
+	gomega.ExpectWithOffset(1, err).ToNot(gomega.HaveOccurred(), "NRTs have not settled during the provided cooldown time: %v", err)
 }
 
 func WaitForNRTSettle(fxt *Fixture) (*nrtv1alpha2.NodeResourceTopologyList, error) {

--- a/test/utils/fixture/fixture.go
+++ b/test/utils/fixture/fixture.go
@@ -58,7 +58,7 @@ const (
 	defaultTeardownTime      = 180 * time.Second
 	defaultCooldownTime      = 30 * time.Second
 	defaultSettleInterval    = 9 * time.Second
-	defaultSettleTimeout     = 75 * time.Second
+	defaultSettleTimeout     = 2 * time.Minute // increased twice
 	defaultCooldownThreshold = 5
 )
 


### PR DESCRIPTION
Before this, if NRTs were failing to settle in the provided cooldown
time, we were hitting context.deadlineExceededError following the
updates done in
https://github.com/openshift-kni/numaresources-operator/commit/14c6bcb10c24aa6783b5293927eedd4b5baf27cb.
Clarify the failure to help better understand the issue, by providing
error reporting.

Additionally, increase the default cooldown timeout to allow the NRTs a proper stabilization time. 
see commits for more details.