### PR TITLE
OCPBUGS-25763: Set base CSV replaces field

### DIFF
--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -599,4 +599,5 @@ spec:
   minKubeVersion: 1.23.0
   provider:
     name: Red Hat
+  replaces: numaresources-operator.v4.14.999-snapshot
   version: 4.15.999-snapshot

--- a/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
@@ -264,4 +264,5 @@ spec:
   minKubeVersion: 1.23.0
   provider:
     name: Red Hat
+  replaces: numaresources-operator.v4.14.999-snapshot
   version: 4.15.0


### PR DESCRIPTION
If we release our newer operator version without the correct metadata, it will release that new version just fine but at the same time it will unpublish all earlier versions in the channel, making the new version effectively the only entry in that channel.

This happens when a new operator bundle ships with a "skipRange" annotation but without the "replaces" property in the operators OLM metadata (CSV)

This PR adds the "replaces" property in addition to the "skipRange" property.