### PR TITLE
RFE-5013: RTE: add support to add extra tolerations

### DIFF
--- a/api/numaresourcesoperator/v1/numaresourcesoperator_normalize.go
+++ b/api/numaresourcesoperator/v1/numaresourcesoperator_normalize.go
@@ -16,13 +16,19 @@
 
 package v1
 
+import corev1 "k8s.io/api/core/v1"
+
 func (nodeGroup NodeGroup) NormalizeConfig() NodeGroupConfig {
 	conf := DefaultNodeGroupConfig()
-	if nodeGroup.Config != nil {
-		conf = conf.Merge(*nodeGroup.Config)
+	if nodeGroup.Config == nil {
+		// nothing to do
+		return conf
 	}
-	return conf
+	// always pass through tolerations
+	conf.Tolerations = CloneTolerations(nodeGroup.Config.Tolerations)
+	return conf.Merge(*nodeGroup.Config)
 }
+
 func (current NodeGroupConfig) Merge(updated NodeGroupConfig) NodeGroupConfig {
 	conf := NodeGroupConfig{}
 	current.DeepCopyInto(&conf)
@@ -40,4 +46,12 @@ func (current NodeGroupConfig) Merge(updated NodeGroupConfig) NodeGroupConfig {
 		conf.InfoRefreshPause = updated.InfoRefreshPause
 	}
 	return conf
+}
+
+func CloneTolerations(tols []corev1.Toleration) []corev1.Toleration {
+	ret := make([]corev1.Toleration, 0, len(tols))
+	for _, tol := range tols {
+		ret = append(ret, *tol.DeepCopy())
+	}
+	return ret
 }

--- a/api/numaresourcesoperator/v1/numaresourcesoperator_normalize_test.go
+++ b/api/numaresourcesoperator/v1/numaresourcesoperator_normalize_test.go
@@ -21,8 +21,30 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestNodeGroupNormalizeConfigKeepsTolerations(t *testing.T) {
+	expectedTols := []corev1.Toleration{
+		{
+			Key:    "foo",
+			Value:  "1",
+			Effect: corev1.TaintEffectNoSchedule,
+		},
+	}
+
+	ng := NodeGroup{
+		Config: &NodeGroupConfig{
+			Tolerations: CloneTolerations(expectedTols),
+		},
+	}
+
+	ngConf := ng.NormalizeConfig()
+	if !reflect.DeepEqual(expectedTols, ngConf.Tolerations) {
+		t.Fatalf("tolerations lost: from=%+v to=%+v", expectedTols, ngConf.Tolerations)
+	}
+}
 
 func TestNodeGroupConfigMerge(t *testing.T) {
 	podsFp := PodsFingerprintingEnabledExclusiveResources

--- a/api/numaresourcesoperator/v1/numaresourcesoperator_types.go
+++ b/api/numaresourcesoperator/v1/numaresourcesoperator_types.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -103,6 +104,11 @@ type NodeGroupConfig struct {
 	// +optional
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable or disable the RTE pause setting",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	InfoRefreshPause *InfoRefreshPauseMode `json:"infoRefreshPause,omitempty"`
+	// Tolerations overrides tolerations to be set into RTE daemonsets for this NodeGroup. If not empty, the tolerations will be the one set here.
+	// Leave empty to make the system use the default tolerations.
+	// +optional
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Extra tolerations for the topology updater daemonset",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 
 // NodeGroup defines group of nodes that will run resource topology exporter daemon set

--- a/api/numaresourcesoperator/v1/zz_generated.deepcopy.go
+++ b/api/numaresourcesoperator/v1/zz_generated.deepcopy.go
@@ -24,6 +24,7 @@ package v1
 import (
 	configv1 "github.com/openshift/api/config/v1"
 	machineconfiguration_openshift_iov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -374,6 +375,13 @@ func (in *NodeGroupConfig) DeepCopyInto(out *NodeGroupConfig) {
 		in, out := &in.InfoRefreshPause, &out.InfoRefreshPause
 		*out = new(InfoRefreshPauseMode)
 		**out = **in
+	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]corev1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 

--- a/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_conversion.go
+++ b/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_conversion.go
@@ -192,6 +192,7 @@ func convertNodeGroupConfigV1Alpha1ToV1(src NodeGroupConfig) *nropv1.NodeGroupCo
 	if src.InfoRefreshPeriod != nil {
 		dst.InfoRefreshPeriod = src.InfoRefreshPeriod.DeepCopy()
 	}
+	// v1alpha1 does not have tolerations, so nothing to do
 	return &dst
 }
 
@@ -220,6 +221,7 @@ func convertNodeGroupConfigV1ToV1Alpha1(src nropv1.NodeGroupConfig) *NodeGroupCo
 	if src.InfoRefreshPeriod != nil {
 		dst.InfoRefreshPeriod = src.InfoRefreshPeriod.DeepCopy()
 	}
+	// v1alpha1 does not have tolerations, so nothing to do
 	return &dst
 }
 

--- a/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -89,6 +89,52 @@ spec:
                           - Enabled
                           - EnabledExclusiveResources
                           type: string
+                        tolerations:
+                          description: Tolerations overrides tolerations to be set
+                            into RTE daemonsets for this NodeGroup. If not empty,
+                            the tolerations will be the one set here. Leave empty
+                            to make the system use the default tolerations.
+                          items:
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect>
+                              using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to
+                                  match. Empty means match all taint effects. When
+                                  specified, allowed values are NoSchedule, PreferNoSchedule
+                                  and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If
+                                  the key is empty, operator must be Exists; this
+                                  combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints
+                                  of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect
+                                  NoExecute, otherwise this field is ignored) tolerates
+                                  the taint. By default, it is not set, which means
+                                  tolerate the taint forever (do not evict). Zero
+                                  and negative values will be treated as 0 (evict
+                                  immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value
+                                  should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
                       type: object
                     machineConfigPoolSelector:
                       description: MachineConfigPoolSelector defines label selector
@@ -313,6 +359,52 @@ spec:
                           - Enabled
                           - EnabledExclusiveResources
                           type: string
+                        tolerations:
+                          description: Tolerations overrides tolerations to be set
+                            into RTE daemonsets for this NodeGroup. If not empty,
+                            the tolerations will be the one set here. Leave empty
+                            to make the system use the default tolerations.
+                          items:
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect>
+                              using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to
+                                  match. Empty means match all taint effects. When
+                                  specified, allowed values are NoSchedule, PreferNoSchedule
+                                  and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If
+                                  the key is empty, operator must be Exists; this
+                                  combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints
+                                  of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect
+                                  NoExecute, otherwise this field is ignored) tolerates
+                                  the taint. By default, it is not set, which means
+                                  tolerate the taint forever (do not evict). Zero
+                                  and negative values will be treated as 0 (evict
+                                  immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value
+                                  should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
                       type: object
                     name:
                       description: Name the name of the machine config pool

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -117,6 +117,13 @@ spec:
         path: nodeGroups[0].config.podsFingerprinting
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tolerations overrides tolerations to be set into RTE daemonsets
+          for this NodeGroup. If not empty, the tolerations will be the one set here.
+          Leave empty to make the system use the default tolerations.
+        displayName: Extra tolerations for the topology updater daemonset
+        path: nodeGroups[0].config.tolerations
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Optional Namespace/Name glob patterns of pod to ignore at node
           level
         displayName: Optional ignore pod namespace/name glob patterns

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -90,6 +90,52 @@ spec:
                           - Enabled
                           - EnabledExclusiveResources
                           type: string
+                        tolerations:
+                          description: Tolerations overrides tolerations to be set
+                            into RTE daemonsets for this NodeGroup. If not empty,
+                            the tolerations will be the one set here. Leave empty
+                            to make the system use the default tolerations.
+                          items:
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect>
+                              using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to
+                                  match. Empty means match all taint effects. When
+                                  specified, allowed values are NoSchedule, PreferNoSchedule
+                                  and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If
+                                  the key is empty, operator must be Exists; this
+                                  combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints
+                                  of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect
+                                  NoExecute, otherwise this field is ignored) tolerates
+                                  the taint. By default, it is not set, which means
+                                  tolerate the taint forever (do not evict). Zero
+                                  and negative values will be treated as 0 (evict
+                                  immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value
+                                  should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
                       type: object
                     machineConfigPoolSelector:
                       description: MachineConfigPoolSelector defines label selector
@@ -314,6 +360,52 @@ spec:
                           - Enabled
                           - EnabledExclusiveResources
                           type: string
+                        tolerations:
+                          description: Tolerations overrides tolerations to be set
+                            into RTE daemonsets for this NodeGroup. If not empty,
+                            the tolerations will be the one set here. Leave empty
+                            to make the system use the default tolerations.
+                          items:
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect>
+                              using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to
+                                  match. Empty means match all taint effects. When
+                                  specified, allowed values are NoSchedule, PreferNoSchedule
+                                  and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If
+                                  the key is empty, operator must be Exists; this
+                                  combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints
+                                  of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect
+                                  NoExecute, otherwise this field is ignored) tolerates
+                                  the taint. By default, it is not set, which means
+                                  tolerate the taint forever (do not evict). Zero
+                                  and negative values will be treated as 0 (evict
+                                  immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value
+                                  should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
                       type: object
                     name:
                       description: Name the name of the machine config pool

--- a/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
@@ -57,6 +57,13 @@ spec:
         path: nodeGroups[0].config.podsFingerprinting
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tolerations overrides tolerations to be set into RTE daemonsets
+          for this NodeGroup. If not empty, the tolerations will be the one set here.
+          Leave empty to make the system use the default tolerations.
+        displayName: Extra tolerations for the topology updater daemonset
+        path: nodeGroups[0].config.tolerations
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Optional Namespace/Name glob patterns of pod to ignore at node
           level
         displayName: Optional ignore pod namespace/name glob patterns

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -701,7 +701,14 @@ func daemonsetUpdater(mcpName string, gdm *rtestate.GeneratedDesiredManifest) er
 		return err
 	}
 
-	return rteupdate.DaemonSetArgs(gdm.DaemonSet, *gdm.NodeGroup.Config)
+	err = rteupdate.DaemonSetArgs(gdm.DaemonSet, *gdm.NodeGroup.Config)
+	if err != nil {
+		klog.V(5).InfoS("DaemonSet update: cannot update arguments", "mcp", mcpName, "daemonset", gdm.DaemonSet.Name, "error", err)
+		return err
+	}
+
+	rteupdate.DaemonSetTolerations(gdm.DaemonSet, gdm.NodeGroup.Config.Tolerations)
+	return nil
 }
 
 func isDaemonSetReady(ds *appsv1.DaemonSet) bool {

--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -182,6 +182,14 @@ func DaemonSetArgs(ds *appsv1.DaemonSet, conf nropv1.NodeGroupConfig) error {
 	return nil
 }
 
+func DaemonSetTolerations(ds *appsv1.DaemonSet, userTolerations []corev1.Toleration) {
+	if len(userTolerations) == 0 {
+		return
+	}
+	podSpec := &ds.Spec.Template.Spec // shortcut
+	podSpec.Tolerations = nropv1.CloneTolerations(userTolerations)
+}
+
 func ContainerConfig(ds *appsv1.DaemonSet, name string) error {
 	cnt := k8swgobjupdate.FindContainerByName(ds.Spec.Template.Spec.Containers, MainContainerName)
 	if cnt == nil {

--- a/pkg/objectupdate/rte/rte_test.go
+++ b/pkg/objectupdate/rte/rte_test.go
@@ -169,6 +169,117 @@ func TestUpdateDaemonSetArgs(t *testing.T) {
 	}
 }
 
+func TestUpdateDaemonSetTolerations(t *testing.T) {
+	type testCase struct {
+		name         string
+		conf         nropv1.NodeGroupConfig
+		existingTols []corev1.Toleration
+		expectedTols []corev1.Toleration
+	}
+
+	testCases := []testCase{
+		{
+			name:         "defaults",
+			conf:         nropv1.NodeGroupConfig{},
+			expectedTols: []corev1.Toleration{},
+		},
+		{
+			name: "add tolerations",
+			conf: nropv1.NodeGroupConfig{
+				Tolerations: []corev1.Toleration{
+					{
+						Key:    "foo",
+						Value:  "1",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+					{
+						Key:    "bar",
+						Value:  "A",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+				},
+			},
+			expectedTols: []corev1.Toleration{
+				{
+					Key:    "foo",
+					Value:  "1",
+					Effect: corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "bar",
+					Value:  "A",
+					Effect: corev1.TaintEffectNoSchedule,
+				},
+			},
+		},
+		{
+			name: "overrides existing tolerations",
+			conf: nropv1.NodeGroupConfig{
+				Tolerations: []corev1.Toleration{
+					{
+						Key:    "bar",
+						Value:  "A",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+				},
+			},
+			existingTols: []corev1.Toleration{
+				{
+					Key:    "foo",
+					Value:  "1",
+					Effect: corev1.TaintEffectNoSchedule,
+				},
+			},
+			expectedTols: []corev1.Toleration{
+				{
+					Key:    "bar",
+					Value:  "A",
+					Effect: corev1.TaintEffectNoSchedule,
+				},
+			},
+		},
+		{
+			name: "conflicting with existing tolerations",
+			conf: nropv1.NodeGroupConfig{
+				Tolerations: []corev1.Toleration{
+					{
+						Key:    "foo",
+						Value:  "42",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+				},
+			},
+			existingTols: []corev1.Toleration{
+				{
+					Key:    "foo",
+					Value:  "1",
+					Effect: corev1.TaintEffectNoSchedule,
+				},
+			},
+			expectedTols: []corev1.Toleration{
+				{
+					Key:    "foo",
+					Value:  "42",
+					Effect: corev1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			origDs := testDs.DeepCopy()
+			origDs.Spec.Template.Spec.Tolerations = nropv1.CloneTolerations(tc.existingTols)
+			ds := origDs.DeepCopy()
+
+			DaemonSetTolerations(ds, tc.conf.Tolerations)
+			if !reflect.DeepEqual(ds.Spec.Template.Spec.Tolerations, tc.expectedTols) {
+				t.Fatalf("update failed: expected=%v got=%v", tc.expectedTols, ds.Spec.Template.Spec.Tolerations)
+			}
+		})
+	}
+}
+
 func expectCommandLine(t *testing.T, ds, origDs *appsv1.DaemonSet, testName string, expectedArgs []string) {
 	expectedArgs = append(expectedArgs, commonArgs...)
 	actualArgsSet := getSetFromStringList(ds.Spec.Template.Spec.Containers[0].Args)

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -49,6 +49,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
+	rtemanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte"
 	nropmcp "github.com/openshift-kni/numaresources-operator/internal/machineconfigpools"
 	"github.com/openshift-kni/numaresources-operator/internal/relatedobjects"
 	"github.com/openshift-kni/numaresources-operator/pkg/kubeletconfig"
@@ -775,8 +776,102 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 				return kcCmNamesCur
 			}).WithContext(ctx).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Equal(kcCmNamesPre))
 		})
+
+		It("should enable to change tolerations in the RTE daemonsets", func(ctx context.Context) {
+			By("getting RTE manifests object")
+			// TODO: this is similar but not quite what the main operator does
+			rteManifests, err := rtemanifests.GetManifests(configuration.Plat, configuration.PlatVersion, "", true)
+			Expect(err).ToNot(HaveOccurred(), "cannot get the RTE manifests")
+
+			By("getting NROP object")
+			nroKey := objects.NROObjectKey()
+			nroOperObj := nropv1.NUMAResourcesOperator{}
+
+			err = fxt.Client.Get(context.TODO(), nroKey, &nroOperObj)
+			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", nroKey.String())
+
+			if len(nroOperObj.Spec.NodeGroups) != 1 {
+				// TODO: this is the simplest case, there is no hard requirement really
+				// but we took the simplest option atm
+				e2efixture.Skipf(fxt, "more than one NodeGroup not yet supported, found %d", len(nroOperObj.Spec.NodeGroups))
+			}
+
+			By("checking the DSs owned by NROP")
+			dsObj := appsv1.DaemonSet{}
+			dsKey := wait.ObjectKey{
+				Namespace: nroOperObj.Status.DaemonSets[0].Namespace,
+				Name:      nroOperObj.Status.DaemonSets[0].Name,
+			}
+
+			err = fxt.Client.Get(context.TODO(), client.ObjectKey{Namespace: dsKey.Namespace, Name: dsKey.Name}, &dsObj)
+			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", dsKey.String())
+			expectedTolerations := rteManifests.DaemonSet.Spec.Template.Spec.Tolerations // shortcut
+			gotTolerations := dsObj.Spec.Template.Spec.Tolerations                       // shortcut
+			expectEqualTolerations(gotTolerations, expectedTolerations)
+
+			By("adding extra tolerations")
+			updatedNropObj := setRTETolerations(context.TODO(), fxt.Client, nroKey, []corev1.Toleration{sriovToleration()})
+			By("waiting for DaemonSet to be ready")
+			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(1*time.Minute).ForDaemonSetUpdateByKey(context.TODO(), dsKey)
+			Expect(err).ToNot(HaveOccurred(), "daemonset %s did not start updated: %v", dsKey.String(), err)
+			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(context.TODO(), dsKey)
+			Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
+
+			defer func(ctx context.Context) {
+				By("removing extra tolerations")
+				_ = setRTETolerations(ctx, fxt.Client, nroKey, []corev1.Toleration{})
+				By("waiting for DaemonSet to be ready")
+				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(1*time.Minute).ForDaemonSetUpdateByKey(ctx, dsKey)
+				Expect(err).ToNot(HaveOccurred(), "daemonset %s did not start updated: %v", dsKey.String(), err)
+				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
+				Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
+			}(context.TODO())
+
+			By("checking the tolerations in the owned DaemonSet")
+			err = fxt.Client.Get(context.TODO(), client.ObjectKey{Namespace: dsKey.Namespace, Name: dsKey.Name}, &dsObj)
+			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", dsKey.String())
+
+			expectedTolerations = updatedNropObj.Spec.NodeGroups[0].Config.Tolerations // shortcut
+			gotTolerations = dsObj.Spec.Template.Spec.Tolerations                      // shortcut
+			expectEqualTolerations(gotTolerations, expectedTolerations)
+		})
 	})
 })
+
+func expectEqualTolerations(tolsA, tolsB []corev1.Toleration) {
+	GinkgoHelper()
+
+	// TODO: sort, then check
+	Expect(tolsA).To(Equal(tolsB), "mismatched tolerations")
+}
+
+func setRTETolerations(ctx context.Context, cli client.Client, nroKey client.ObjectKey, tols []corev1.Toleration) *nropv1.NUMAResourcesOperator {
+	GinkgoHelper()
+
+	nropOperObj := nropv1.NUMAResourcesOperator{}
+	Eventually(func(g Gomega) {
+		err := cli.Get(ctx, nroKey, &nropOperObj)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		if nropOperObj.Spec.NodeGroups[0].Config == nil {
+			nropOperObj.Spec.NodeGroups[0].Config = &nropv1.NodeGroupConfig{}
+		}
+		nropOperObj.Spec.NodeGroups[0].Config.Tolerations = tols
+		err = cli.Update(ctx, &nropOperObj)
+		g.Expect(err).ToNot(HaveOccurred())
+	}).WithTimeout(5 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
+
+	return &nropOperObj
+}
+
+func sriovToleration() corev1.Toleration {
+	return corev1.Toleration{
+		Key:      "sriov",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "true",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+}
 
 func daemonSetListToNamespacedNameList(dss []*appsv1.DaemonSet) []nropv1.NamespacedName {
 	ret := make([]nropv1.NamespacedName, 0, len(dss))


### PR DESCRIPTION
add support to inject (and override) the RTE tolerations.
The user-provided tolerations will completely override the manifests tolerations.
If the user removes the tolerations, then the operator will enforce again the manifest ones (possibly, no tolerations).

The recommended flow to add/change the default tolerations (if any) is to
1. find the owned daemonsets: nrop.Status.DaemonSets
2. lookup the owned daemonsets using the namespace/name pair found in
   the previous step
3. inspect the DS manifests to learn about the current tolerations
4. set new tolerations in nrop.Spec.NodeGroup[*].Config.Tolerations
   taking into account the existing ones