### PR TITLE
runner: enable custom execution of test suites

### DIFF
--- a/Dockerfile.openshift.tests
+++ b/Dockerfile.openshift.tests
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 COPY e2e-nrop-*.test /usr/local/bin/
-COPY run-e2e-nrop-serial.sh /usr/local/bin
+COPY run-e2e-nrop-*.sh /usr/local/bin
 COPY numacell /bin
 COPY pause /
-ENTRYPOINT ["/usr/local/bin/run-e2e-nrop-serial.sh"]
+CMD ["/usr/local/bin/run-e2e-nrop-serial.sh"]


### PR DESCRIPTION
Initially, the numaresources-operator-tests image was configured exclusively for executing the serial test suite, which posed a challenge in achieving our goal of enabling it to run both serial and must-gather test suites. The modification of this image is driven by our intent to broaden its usage within our testing-related CI process. We aim to encompass as many test suites as possible under our CI pipeline.

To support our goal, we have introduced a must-gather runner script derived from the 'hack/run-test-must-gather-e2e.sh.' Note that we deliberately avoided bootstrapping the must-gather script to adhere to 'test-e2e-runner.sh,' as our objective is to provide flexibility beyond the constraints defined by ginkgo flags.

Signed-off-by: Sargun Narula <snarula@redhat.com>