### PR TITLE
pkg: k8sclient: deprecate package

### DIFF
--- a/pkg/k8sclientset/doc.go
+++ b/pkg/k8sclientset/doc.go
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * WARNING: this package is DEPRECATED and will be removed in a future version.
+ * Users are advised to use the generic client from the controller-runtime
+ * package (see: https://github.com/kubernetes-sigs/controller-runtime/tree/main/pkg/client)
+ * or any other similar replacement.
+ * Because of the deprecation, this package could be up to date with the API changes.
+ */
+package k8sclientset


### PR DESCRIPTION
deprecate the autogenerated k8sclientset package;
use controller-runtime generic client instead.