### PR TITLE
deps: deployer: consume ocp415 selinux fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-logr/logr v1.2.4
 	github.com/google/go-cmp v0.5.9
 	github.com/jaypipes/ghw v0.9.0
-	github.com/k8stopologyawareschedwg/deployer v0.18.2
+	github.com/k8stopologyawareschedwg/deployer v0.18.3
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.1
 	github.com/k8stopologyawareschedwg/podfingerprint v0.2.2
 	github.com/k8stopologyawareschedwg/resource-topology-exporter v0.16.1-0.20231211140359-6dba655b8b2a

--- a/go.sum
+++ b/go.sum
@@ -1091,8 +1091,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/k8stopologyawareschedwg/deployer v0.18.2 h1:W9MwJqoAmvyD18SGzcY2UEC72t0DYAUwmlhsOyyMdOA=
-github.com/k8stopologyawareschedwg/deployer v0.18.2/go.mod h1:IMlcFrSMaZFgskzbWg0lskT9zZ3YagTU7DbM9nTWw5k=
+github.com/k8stopologyawareschedwg/deployer v0.18.3 h1:6N676KGOVm4LGrBn6OsGo/4n+Q74+nLcYmxtp6cGQss=
+github.com/k8stopologyawareschedwg/deployer v0.18.3/go.mod h1:IMlcFrSMaZFgskzbWg0lskT9zZ3YagTU7DbM9nTWw5k=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.1 h1:BI3L7hNqRvXtB42FO4NI/0ZjDDVRPOMBDFLShhFtf28=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.1/go.mod h1:AkACMQGiTgCt0lQw3m7TTU8PLH9lYKNK5e9DqFf5VuM=
 github.com/k8stopologyawareschedwg/podfingerprint v0.2.2 h1:iFHPfZInM9pz2neye5RdmORMp1hPmte1EGJYpOOzZVg=

--- a/vendor/github.com/k8stopologyawareschedwg/deployer/pkg/assets/selinux/assets.go
+++ b/vendor/github.com/k8stopologyawareschedwg/deployer/pkg/assets/selinux/assets.go
@@ -19,6 +19,8 @@ const (
 	// TODO: demote public constant here once we can remove from the public API
 	ocpVersion412 = "v4.12"
 	ocpVersion413 = "v4.13"
+	ocpVersion414 = "v4.14"
+	ocpVersion415 = "v4.15"
 )
 
 //go:embed selinuxinstall.service.template
@@ -29,7 +31,8 @@ var policy embed.FS
 
 func GetPolicy(ver platform.Version) ([]byte, error) {
 	// keep it ordered from most recent supported to the oldest supported
-	for _, cand := range []string{ocpVersion413, ocpVersion412, OCPVersion411, ocpVersion410} {
+	allVersions := knownVersions()
+	for _, cand := range allVersions {
 		// error should never happen: we control the input here
 		ok, err := ver.AtLeastString(cand)
 		if err != nil {
@@ -41,6 +44,17 @@ func GetPolicy(ver platform.Version) ([]byte, error) {
 	}
 	// just in case we end up here first supported version is 4.10, hence this is a safe fallback
 	return policy.ReadFile(policyPathFromVer(ocpVersion410))
+}
+
+func knownVersions() []string {
+	return []string{
+		ocpVersion415,
+		ocpVersion414,
+		ocpVersion413,
+		ocpVersion412,
+		OCPVersion411,
+		ocpVersion410,
+	}
 }
 
 func policyPathFromVer(ver string) string {

--- a/vendor/github.com/k8stopologyawareschedwg/deployer/pkg/assets/selinux/policy/ocp_v4.14.cil
+++ b/vendor/github.com/k8stopologyawareschedwg/deployer/pkg/assets/selinux/policy/ocp_v4.14.cil
@@ -1,0 +1,25 @@
+(block rte
+	(type process)
+	(roletype system_r process)
+	(typeattributeset domain (process))
+	;
+	; Giving rte.process the same attributes as container_t
+	(typeattributeset container_domain (process))
+	(typeattributeset container_net_domain (process))
+	(typeattributeset svirt_sandbox_domain (process))
+	(typeattributeset sandbox_net_domain (process))
+	; MCS is leveraged by container_t and others, like us, to prevent cross-pod communication.
+	(typeattributeset mcs_constrained_type (process))
+	;
+	; Allow access to procfs (also needed by libraries)
+	(allow process proc_type (file (open read)))
+	;
+	; Allow to RTE pod access to /run/rte directory
+	(allow process container_var_run_t (dir (add_name write)))
+	(allow process container_var_run_t (file (create read write open)))
+	;
+	; Allow to RTE pod connect, read and write permissions to /var/lib/kubelet/pod-resource/kubelet.sock
+	(allow process container_var_lib_t (sock_file (open getattr read write ioctl lock append)))
+	(allow process container_var_lib_t (unix_stream_socket (connectto)))
+	(allow process unconfined_service_t (unix_stream_socket (connectto)))
+)

--- a/vendor/github.com/k8stopologyawareschedwg/deployer/pkg/assets/selinux/policy/ocp_v4.15.cil
+++ b/vendor/github.com/k8stopologyawareschedwg/deployer/pkg/assets/selinux/policy/ocp_v4.15.cil
@@ -1,0 +1,25 @@
+(block rte
+	(type process)
+	(roletype system_r process)
+	(typeattributeset domain (process))
+	;
+	; Giving rte.process the same attributes as container_t
+	(typeattributeset container_domain (process))
+	(typeattributeset container_net_domain (process))
+	(typeattributeset svirt_sandbox_domain (process))
+	(typeattributeset sandbox_net_domain (process))
+	; MCS is leveraged by container_t and others, like us, to prevent cross-pod communication.
+	(typeattributeset mcs_constrained_type (process))
+	;
+	; Allow access to procfs (also needed by libraries)
+	(allow process proc_type (file (open read)))
+	;
+	; Allow to RTE pod access to /run/rte directory
+	(allow process container_var_run_t (dir (add_name write)))
+	(allow process container_var_run_t (file (create read write open)))
+	;
+	; Allow to RTE pod connect, read and write permissions to /var/lib/kubelet/pod-resource/kubelet.sock
+	(allow process container_var_lib_t (sock_file (open getattr read write ioctl lock append)))
+	(allow process container_var_lib_t (unix_stream_socket (connectto)))
+	(allow process kubelet_t (unix_stream_socket (connectto)))
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -172,7 +172,7 @@ github.com/josharian/intern
 # github.com/json-iterator/go v1.1.12
 ## explicit; go 1.12
 github.com/json-iterator/go
-# github.com/k8stopologyawareschedwg/deployer v0.18.2
+# github.com/k8stopologyawareschedwg/deployer v0.18.3
 ## explicit; go 1.19
 github.com/k8stopologyawareschedwg/deployer/pkg/assets/rte
 github.com/k8stopologyawareschedwg/deployer/pkg/assets/selinux


### PR DESCRIPTION
bump deployer dep to consume selinux fixes for OCP >= 4.15