### PR TITLE
runner: replaced CMD

### DIFF
--- a/Dockerfile.openshift.tests
+++ b/Dockerfile.openshift.tests
@@ -3,4 +3,4 @@ COPY e2e-nrop-*.test /usr/local/bin/
 COPY run-e2e-nrop-*.sh /usr/local/bin
 COPY numacell /bin
 COPY pause /
-CMD ["/usr/local/bin/run-e2e-nrop-serial.sh"]
+ENTRYPOINT ["/usr/local/bin/run-e2e-nrop-serial.sh"]


### PR DESCRIPTION
The CMD command has been replaced with the ENTRYPOINT, the motive behind this is change was to consider the serial test runner as default.

Signed-off-by: Sargun Narula [snarula@redhat.com](mailto:snarula@redhat.com)