### PR TITLE
serial: tests: introduce tier 0

### DIFF
--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -63,7 +63,7 @@ var _ = Describe("[Install] continuousIntegration", func() {
 	})
 
 	Context("with a running cluster with all the components", func() {
-		It("[test_id:47574][tier1] should perform overall deployment and verify the condition is reported as available", func() {
+		It("[test_id:47574][tier0] should perform overall deployment and verify the condition is reported as available", func() {
 			deployedObj := deploy.OverallDeployment()
 			nname := client.ObjectKeyFromObject(deployedObj.NroObj)
 			Expect(nname.Name).ToNot(BeEmpty())

--- a/test/e2e/serial/tests/non_regression_fundamentals.go
+++ b/test/e2e/serial/tests/non_regression_fundamentals.go
@@ -127,7 +127,7 @@ var _ = Describe("[serial][fundamentals][scheduler][nonreg] numaresources fundam
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 		})
 
-		It("[tier1][test_id:47611] should run a guaranteed pod", func() {
+		It("[tier0][test_id:47611] should run a guaranteed pod", func() {
 			testPod = objects.NewTestPodPause(fxt.Namespace.Name, "testpod")
 			testPod.Spec.SchedulerName = serialconfig.Config.SchedulerName
 			testPod.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
@@ -235,20 +235,20 @@ var _ = Describe("[serial][fundamentals][scheduler][nonreg] numaresources fundam
 					Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 				}
 			},
-			Entry("should handle a burst of qos=guaranteed pods [tier1]", func(pod *corev1.Pod) {
+			Entry("should handle a burst of qos=guaranteed pods [tier0]", func(pod *corev1.Pod) {
 				pod.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
 					corev1.ResourceCPU:    *resource.NewQuantity(cpusPerPod, resource.DecimalSI),
 					corev1.ResourceMemory: resource.MustParse("64Mi"),
 				}
 			}),
-			Entry("should handle a burst of qos=burstable pods [tier2]", func(pod *corev1.Pod) {
+			Entry("should handle a burst of qos=burstable pods [tier1]", func(pod *corev1.Pod) {
 				pod.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
 					corev1.ResourceCPU:    *resource.NewQuantity(cpusPerPod, resource.DecimalSI),
 					corev1.ResourceMemory: resource.MustParse("64Mi"),
 				}
 			}),
 			// this is REALLY REALLY to prevent the most catastrophic regressions
-			Entry("should handle a burst of qos=best-effort pods [tier3]", func(pod *corev1.Pod) {}),
+			Entry("should handle a burst of qos=best-effort pods [tier2]", func(pod *corev1.Pod) {}),
 		)
 
 		DescribeTable("[nodeAll] against all the available worker nodes",
@@ -331,20 +331,20 @@ var _ = Describe("[serial][fundamentals][scheduler][nonreg] numaresources fundam
 					Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 				}
 			},
-			Entry("should handle a burst of qos=guaranteed pods [tier1]", func(pod *corev1.Pod) {
+			Entry("should handle a burst of qos=guaranteed pods [tier0]", func(pod *corev1.Pod) {
 				pod.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
 					corev1.ResourceCPU:    *resource.NewQuantity(cpusPerPod, resource.DecimalSI),
 					corev1.ResourceMemory: resource.MustParse("64Mi"),
 				}
 			}),
-			Entry("should handle a burst of qos=burstable pods [tier2]", func(pod *corev1.Pod) {
+			Entry("should handle a burst of qos=burstable pods [tier1]", func(pod *corev1.Pod) {
 				pod.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
 					corev1.ResourceCPU:    *resource.NewQuantity(cpusPerPod, resource.DecimalSI),
 					corev1.ResourceMemory: resource.MustParse("64Mi"),
 				}
 			}),
 			// this is REALLY REALLY to prevent the most catastrophic regressions
-			Entry("should handle a burst of qos=best-effort pods [tier3]", func(pod *corev1.Pod) {}),
+			Entry("should handle a burst of qos=best-effort pods [tier2]", func(pod *corev1.Pod) {}),
 		)
 
 		// TODO: mixed

--- a/test/e2e/serial/tests/scheduler_cache.go
+++ b/test/e2e/serial/tests/scheduler_cache.go
@@ -64,7 +64,7 @@ type interferenceDesc struct {
 	ratio int
 }
 
-var _ = Describe("[serial][scheduler][cache][tier1] scheduler cache", Label("scheduler", "cache", "tier1"), func() {
+var _ = Describe("[serial][scheduler][cache][tier0] scheduler cache", Label("scheduler", "cache", "tier0"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 

--- a/test/e2e/serial/tests/scheduler_cache_stall.go
+++ b/test/e2e/serial/tests/scheduler_cache_stall.go
@@ -45,7 +45,7 @@ import (
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 )
 
-var _ = Describe("[serial][scheduler][cache][tier1] scheduler cache stall", Label("scheduler", "cache", "stall", "tier1"), func() {
+var _ = Describe("[serial][scheduler][cache] scheduler cache stall", Label("scheduler", "cache", "stall"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 
@@ -109,7 +109,7 @@ var _ = Describe("[serial][scheduler][cache][tier1] scheduler cache stall", Labe
 			klog.Infof("using MCP %q - refresh period %v", mcpName, refreshPeriod)
 		})
 
-		When("there are jobs in the cluster", Label("job", "generic"), func() {
+		When("there are jobs in the cluster [tier0]", Label("job", "generic", "tier0"), func() {
 			var idleJob *batchv1.Job
 			var hostsRequired int
 			var NUMAZonesRequired int
@@ -302,13 +302,13 @@ var _ = Describe("[serial][scheduler][cache][tier1] scheduler cache stall", Labe
 						Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 					}
 				},
-				Entry("should handle a burst of qos=guaranteed pods [tier1]", func(pod *corev1.Pod) {
+				Entry("should handle a burst of qos=guaranteed pods [tier0]", func(pod *corev1.Pod) {
 					pod.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
 						corev1.ResourceCPU:    *resource.NewQuantity(cpusPerPod, resource.DecimalSI),
 						corev1.ResourceMemory: resource.MustParse("64Mi"),
 					}
 				}),
-				Entry("should handle a burst of qos=burstable pods [tier2]", func(pod *corev1.Pod) {
+				Entry("should handle a burst of qos=burstable pods [tier0]", func(pod *corev1.Pod) {
 					pod.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
 						corev1.ResourceCPU:    *resource.NewQuantity(cpusPerPod, resource.DecimalSI),
 						corev1.ResourceMemory: resource.MustParse("64Mi"),

--- a/test/e2e/serial/tests/workload_placement_resources.go
+++ b/test/e2e/serial/tests/workload_placement_resources.go
@@ -84,7 +84,7 @@ var _ = Describe("[serial][disruptive][scheduler][byres] numaresources workload 
 	Context("with at least two nodes suitable", func() {
 		// FIXME: this is a slight abuse of DescribeTable, but we need to run
 		// the same code with a different test_id per tmscope
-		DescribeTable("[tier1][ressched] a guaranteed pod with one container should be placed and aligned on the node",
+		DescribeTable("[tier0][ressched] a guaranteed pod with one container should be placed and aligned on the node",
 			func(tmPolicy, tmScope string, requiredRes, expectedFreeRes corev1.ResourceList) {
 				nrtCandidates, targetNodeName := setupNodes(fxt, desiredNodesState{
 					NRTList:           nrtList,

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -264,7 +264,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 		// FIXME: this is a slight abuse of DescribeTable, but we need to run
 		// the same code which a different test_id per tmscope
-		DescribeTable("[tier1] a deployment with a guaranteed pod with one container should be scheduled into one NUMA zone",
+		DescribeTable("[tier0] a deployment with a guaranteed pod with one container should be scheduled into one NUMA zone",
 			func(tmPolicy, tmScope string, requiredRes, paddingRes corev1.ResourceList) {
 				setupCluster(requiredRes, paddingRes, tmPolicy, tmScope)
 
@@ -508,7 +508,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}).WithTimeout(time.Minute).WithPolling(time.Second*5).Should(BeTrue(), "resources not restored on %q", updatedPod.Spec.NodeName)
 		},
 
-		Entry("[test_id:47575][tmscope:cnt][tier1] should make a pod with two gu cnt land on a node with enough resources on a specific NUMA zone, each cnt on a different zone",
+		Entry("[test_id:47575][tmscope:cnt][tier0] should make a pod with two gu cnt land on a node with enough resources on a specific NUMA zone, each cnt on a different zone",
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -537,7 +537,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 			[]corev1.ResourceList{},
 		),
-		Entry("[test_id:47577][tmscope:pod][tier1] should make a pod with two gu cnt land on a node with enough resources on a specific NUMA zone, all cnt on the same zone",
+		Entry("[test_id:47577][tmscope:pod][tier0] should make a pod with two gu cnt land on a node with enough resources on a specific NUMA zone, all cnt on the same zone",
 			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -1089,7 +1089,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				},
 			},
 		),
-		Entry("[test_id:54016][tmscope:pod][tier1][devices] should make a pod with one gu cnt requesting devices land on a node with enough resources on a specific NUMA zone",
+		Entry("[test_id:54016][tmscope:pod][tier0][devices] should make a pod with one gu cnt requesting devices land on a node with enough resources on a specific NUMA zone",
 			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -1161,7 +1161,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				},
 			},
 		),
-		Entry("[test_id:55431][tmscope:pod][tier1][devices] should make a besteffort pod requesting devices land on a node with enough resources on a specific NUMA zone",
+		Entry("[test_id:55431][tmscope:pod][tier0][devices] should make a besteffort pod requesting devices land on a node with enough resources on a specific NUMA zone",
 			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -1409,7 +1409,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		// but only one container can be aligned to a single numa node while the second container cannot. Because of that, the pod should keep on pending and we expect
 		// to see the reason for not scheduling the pod on that target node as "cannot align container: testcnt-1", because the other worker nodes have insufficient
 		// free resources to accommodate the pod thus they will be rejected as candidates at earlier stage
-		Entry("[tier1][unsched][tmscope:container][cpu] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
+		Entry("[tier0][unsched][tmscope:container][cpu] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			nrosched.ErrorCannotAlignContainer,
 			podResourcesRequest{
@@ -1469,7 +1469,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				},
 			},
 		),
-		Entry("[tier1][unsched][tmscope:container][memory] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
+		Entry("[tier0][unsched][tmscope:container][memory] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			nrosched.ErrorCannotAlignContainer,
 			podResourcesRequest{
@@ -1527,7 +1527,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				},
 			},
 		),
-		Entry("[tier1][unsched][tmscope:container][hugepages2Mi] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
+		Entry("[tier0][unsched][tmscope:container][hugepages2Mi] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			nrosched.ErrorCannotAlignContainer,
 			podResourcesRequest{
@@ -1584,7 +1584,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				},
 			},
 		),
-		Entry("[tier1][unsched][tmscope:container][hugepages1Gi] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
+		Entry("[tier0][unsched][tmscope:container][hugepages1Gi] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			nrosched.ErrorCannotAlignContainer,
 			podResourcesRequest{


### PR DESCRIPTION
Now that we have a simple way to run all tests up to a given tier, included (see: f69ac68a6375fec6ec355c44bd1c6d02a36a7593) we can review our tiers.

The ter1 tests had 47 tests, roughly, which is great on a hand but bad on the other hand, because the very purpose of tiering was to have a strict and well delimited set of tests.

We promote the most critical tier1 tests to tier0 tests. Tiering is not set in stone - tests will be moved among tiers.

But tier size should always kept at bay in the coming changes. As rule of thumb, no tier should contain more than 20-25% of total tests; and this is especially true for high (tier0/tier1) tests.

Fixes: #814 