### PR TITLE
WIP: api: numaresourcesopereator: MCP status reflection is optional

### DIFF
--- a/api/numaresourcesoperator/v1/numaresourcesoperator_types.go
+++ b/api/numaresourcesoperator/v1/numaresourcesoperator_types.go
@@ -105,6 +105,7 @@ type NUMAResourcesOperatorStatus struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=status,displayName="RTE DaemonSets"
 	DaemonSets []NamespacedName `json:"daemonsets,omitempty"`
 	// MachineConfigPools resolved from configured node groups
+	// +optional
 	//+operator-sdk:csv:customresourcedefinitions:type=status,displayName="RTE MCPs from node groups"
 	MachineConfigPools []MachineConfigPool `json:"machineconfigpools,omitempty"`
 	// Conditions show the current state of the NUMAResourcesOperator Operator


### PR DESCRIPTION
The NUMAResourcesOperator object initially reflected the status of the selected MCP in its own status. This helped the initial (very initial, bootstrapping) stage, but quickly becomes large and it is essentially unnecessaty and wasteful.

We start declaring the values optional.
Future changes, backward compatibility allowing, will stop reflecting the status to save bandwidth, and unblock future compatibility.