### PR TITLE
[release-4.14][manual] consume support for scheduler plugin informerMode from upstream

### DIFF
--- a/controllers/numaresourcesscheduler_controller.go
+++ b/controllers/numaresourcesscheduler_controller.go
@@ -176,16 +176,9 @@ func (r *NUMAResourcesSchedulerReconciler) syncNUMASchedulerResources(ctx contex
 	defer klog.V(4).Info("SchedulerSync stop")
 
 	schedSpec := instance.Spec.Normalize()
-
 	cacheResyncPeriod := unpackAPIResyncPeriod(schedSpec.CacheResyncPeriod)
 
-	resyncPeriod := int64(cacheResyncPeriod.Seconds())
-	params := k8swgmanifests.ConfigParams{
-		ProfileName: schedSpec.SchedulerName,
-		Cache: &k8swgmanifests.ConfigCacheParams{
-			ResyncPeriodSeconds: &resyncPeriod,
-		},
-	}
+	params := configParamsFromSchedSpec(schedSpec, cacheResyncPeriod)
 
 	schedName, ok := schedstate.SchedulerNameFromObject(r.SchedulerManifests.ConfigMap)
 	if !ok {
@@ -247,4 +240,15 @@ func unpackAPIResyncPeriod(reconcilePeriod *metav1.Duration) time.Duration {
 	period := reconcilePeriod.Round(time.Second)
 	klog.InfoS("setting reconcile period", "computed", period, "supplied", reconcilePeriod)
 	return period
+}
+
+func configParamsFromSchedSpec(schedSpec nropv1.NUMAResourcesSchedulerSpec, cacheResyncPeriod time.Duration) k8swgmanifests.ConfigParams {
+	resyncPeriod := int64(cacheResyncPeriod.Seconds())
+	params := k8swgmanifests.ConfigParams{
+		ProfileName: schedSpec.SchedulerName,
+		Cache: &k8swgmanifests.ConfigCacheParams{
+			ResyncPeriodSeconds: &resyncPeriod,
+		},
+	}
+	return params
 }

--- a/controllers/numaresourcesscheduler_controller.go
+++ b/controllers/numaresourcesscheduler_controller.go
@@ -250,5 +250,36 @@ func configParamsFromSchedSpec(schedSpec nropv1.NUMAResourcesSchedulerSpec, cach
 			ResyncPeriodSeconds: &resyncPeriod,
 		},
 	}
+
+	var informerMode string
+	if *schedSpec.SchedulerInformer == k8swgmanifests.CacheInformerDedicated {
+		informerMode = k8swgmanifests.CacheInformerDedicated
+	} else {
+		informerMode = k8swgmanifests.CacheInformerShared
+	}
+	params.Cache.InformerMode = &informerMode
+	klog.InfoS("setting cache parameters", dumpConfigCacheParams(params.Cache)...)
+
 	return params
+}
+
+func dumpConfigCacheParams(ccp *k8swgmanifests.ConfigCacheParams) []interface{} {
+	return []interface{}{
+		"resyncPeriod", strInt64Ptr(ccp.ResyncPeriodSeconds),
+		"informerMode", strStringPtr(ccp.InformerMode),
+	}
+}
+
+func strInt64Ptr(ip *int64) string {
+	if ip == nil {
+		return "N/A"
+	}
+	return fmt.Sprintf("%d", *ip)
+}
+
+func strStringPtr(sp *string) string {
+	if sp == nil {
+		return "N/A"
+	}
+	return *sp
 }

--- a/pkg/objectupdate/sched/sched.go
+++ b/pkg/objectupdate/sched/sched.go
@@ -40,10 +40,8 @@ const (
 
 const (
 	PFPStatusDumpEnvVar = "PFP_STATUS_DUMP"
-	NRTInformerEnvVar   = "NRT_ENABLE_INFORMER"
 
-	PFPStatusDir   = "/run/pfpstatus"
-	NRTInformerVal = "true"
+	PFPStatusDir = "/run/pfpstatus"
 )
 
 // TODO: we should inject also the mount point. As it is now, the information is split between the manifest
@@ -71,13 +69,6 @@ func DeploymentEnvVarSettings(dp *appsv1.Deployment, spec nropv1.NUMAResourcesSc
 		setContainerEnvVar(cnt, PFPStatusDumpEnvVar, PFPStatusDir)
 	} else {
 		deleteContainerEnvVar(cnt, PFPStatusDumpEnvVar)
-	}
-
-	informerMode := *spec.SchedulerInformer
-	if informerMode == nropv1.SchedulerInformerDedicated {
-		setContainerEnvVar(cnt, NRTInformerEnvVar, NRTInformerVal)
-	} else {
-		deleteContainerEnvVar(cnt, NRTInformerEnvVar)
 	}
 }
 


### PR DESCRIPTION
Previously, the NUMA-aware scheduler plugin had d/s-specific code to enable the separate informer, which was in turn needed to get the full pod list vs the filtered pod list the scheduler framework provides. Thus, we had d/s specific enablement in the operator. Since commit https://github.com/kubernetes-sigs/scheduler-plugins/pull/599 the upstream added support for the separate informer, consumed by the KNI scheduler since commit https://github.com/openshift-kni/scheduler-plugins/pull/161. Remove the d/s specific enablement and set the proper configuration value.

We expect no changes from UX perspective. This is an internal change only.

backport notice: add targeted fixes to make this PR independent from (the backport of) #801 
backport notice: manual backport of #845 