### PR TITLE
flags: identify -v with single hyphen

### DIFF
--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -511,7 +511,7 @@ spec:
                         operator: Exists
               containers:
               - args:
-                - --v=4
+                - -v=4
                 - --leader-elect
                 - --enable-scheduler
                 command:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
-        - "--v=10"
+        - "-v=10"
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,7 +44,7 @@ spec:
       - command:
         - /bin/numaresources-operator
         args:
-        - --v=4
+        - -v=4
         - --leader-elect
         - --enable-scheduler
         image: controller:latest

--- a/pkg/loglevel/loglevel.go
+++ b/pkg/loglevel/loglevel.go
@@ -60,7 +60,7 @@ func UpdatePodSpec(podSpec *corev1.PodSpec, cntName string, level operatorv1.Log
 	if flags == nil {
 		return fmt.Errorf("cannot modify the arguments for container %s", cnt.Name)
 	}
-	flags.SetOption("--v", kLog.String())
+	flags.SetOption("-v", kLog.String())
 	klog.InfoS("container klog level", "container", cnt.Name, "-v", kLog.String())
 	cnt.Args = flags.Argv()
 	return nil

--- a/test/e2e/rte/rte_test.go
+++ b/test/e2e/rte/rte_test.go
@@ -82,11 +82,11 @@ var _ = ginkgo.Describe("with a running cluster with all the components", func()
 
 					found, match := matchLogLevelToKlog(rteCnt, nropObj.Spec.LogLevel)
 					if !found {
-						klog.Warningf("--v flag doesn't exist in container %q args managed by DaemonSet: %q", rteCnt.Name, ds.Name)
+						klog.Warningf("-v flag doesn't exist in container %q args managed by DaemonSet: %q", rteCnt.Name, ds.Name)
 						return false
 					}
 					if !match {
-						klog.Warningf("LogLevel %s doesn't match the existing --v flag in container: %q under DaemonSet: %q", nropObj.Spec.LogLevel, rteCnt.Name, ds.Name)
+						klog.Warningf("LogLevel %s doesn't match the existing -v flag in container: %q under DaemonSet: %q", nropObj.Spec.LogLevel, rteCnt.Name, ds.Name)
 						return false
 					}
 				}
@@ -121,12 +121,12 @@ var _ = ginkgo.Describe("with a running cluster with all the components", func()
 
 					found, match := matchLogLevelToKlog(rteCnt, nropObj.Spec.LogLevel)
 					if !found {
-						klog.Warningf("--v flag doesn't exist in container %q args under DaemonSet: %q", rteCnt.Name, ds.Name)
+						klog.Warningf("-v flag doesn't exist in container %q args under DaemonSet: %q", rteCnt.Name, ds.Name)
 						return false
 					}
 
 					if !match {
-						klog.Warningf("LogLevel %s doesn't match the existing --v flag in container: %q managed by DaemonSet: %q", nropObj.Spec.LogLevel, rteCnt.Name, ds.Name)
+						klog.Warningf("LogLevel %s doesn't match the existing -v flag in container: %q managed by DaemonSet: %q", nropObj.Spec.LogLevel, rteCnt.Name, ds.Name)
 						return false
 					}
 				}

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -366,12 +366,12 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 					cnt := &ds.Spec.Template.Spec.Containers[0]
 					found, match := matchLogLevelToKlog(cnt, nroOperObj.Spec.LogLevel)
 					if !found {
-						klog.Warningf("--v flag doesn't exist in container %q args under DaemonSet: %q", cnt.Name, ds.Name)
+						klog.Warningf("-v  flag doesn't exist in container %q args under DaemonSet: %q", cnt.Name, ds.Name)
 						return false, nil
 					}
 
 					if !match {
-						klog.Warningf("LogLevel %s doesn't match the existing --v flag in container: %q managed by DaemonSet: %q", nroOperObj.Spec.LogLevel, cnt.Name, ds.Name)
+						klog.Warningf("LogLevel %s doesn't match the existing -v  flag in container: %q managed by DaemonSet: %q", nroOperObj.Spec.LogLevel, cnt.Name, ds.Name)
 						return false, nil
 					}
 				}


### PR DESCRIPTION
Follow the convention by referring to single-letter identifier, -v here, with single hyphen.

A scheduler and deployer with similar PR will follow as well as bumping the versions.