### PR TITLE
version: generalize discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,9 @@ binary-e2e-sched:
 	go test -c -v -o bin/e2e-nrop-sched.test ./test/e2e/sched
 
 binary-e2e-serial:
-	CGO_ENABLED=0 go test -c -v -o bin/e2e-nrop-serial.test ./test/e2e/serial
+	LDFLAGS+="-X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/buildhelper version) "; \
+	LDFLAGS+="-X github.com/openshift-kni/numaresources-operator/pkg/version.gitcommit=$(shell bin/buildhelper commit)"; \
+	CGO_ENABLED=0 go test -c -v -o bin/e2e-nrop-serial.test -ldflags "$$LDFLAGS" ./test/e2e/serial
 
 binary-e2e-tools:
 	go test -c -v -o bin/e2e-nrop-tools.test ./test/e2e/tools

--- a/pkg/version/discover.go
+++ b/pkg/version/discover.go
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ */
+
+package version
+
+import (
+	"context"
+	"runtime"
+
+	"k8s.io/klog/v2"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform/detect"
+)
+
+func DiscoverCluster(ctx context.Context, programName, platformName, platformVersion string) (platform.Platform, platform.Version, error) {
+	klog.InfoS("starting", "program", programName, "version", Get(), "gitcommit", GetGitCommit(), "golang", runtime.Version())
+
+	// if it is unknown, it's fine
+	userPlatform, _ := platform.ParsePlatform(platformName)
+	userPlatformVersion, _ := platform.ParseVersion(platformVersion)
+
+	plat, reason, err := detect.FindPlatform(ctx, userPlatform)
+	klog.InfoS("platform detection", "kind", plat.Discovered, "reason", reason)
+	clusterPlatform := plat.Discovered
+	if clusterPlatform == platform.Unknown {
+		klog.ErrorS(err, "cannot autodetect the platform, and no platform given")
+		return clusterPlatform, "", err
+	}
+
+	platVersion, source, err := detect.FindVersion(ctx, clusterPlatform, userPlatformVersion)
+	klog.InfoS("platform detection", "version", platVersion.Discovered, "reason", source)
+	clusterPlatformVersion := Minimize(platVersion.Discovered)
+	if clusterPlatformVersion == platform.MissingVersion {
+		klog.ErrorS(err, "cannot autodetect the platform version, and no platform given")
+		return clusterPlatform, clusterPlatformVersion, err
+	}
+
+	klog.InfoS("detected cluster", "platform", clusterPlatform, "version", clusterPlatformVersion)
+
+	return clusterPlatform, clusterPlatformVersion, nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,18 +1,18 @@
 /*
-Copyright 2021.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ */
 
 package version
 

--- a/test/e2e/serial/README.md
+++ b/test/e2e/serial/README.md
@@ -29,7 +29,9 @@ they found it before they run.
 - `E2E_NROP_MCP_UPDATE_INTERVAL` (accepts a duration, e.g. `10s`) instructs the suite about how much it should
   wait between checks for MCP updates.
 - `E2E_NROP_PLATFORM` (accepts a string, e.g. `Kubernetes`, `OpenShift`) instructs the suite to *disable* the
-  autodetection of the platform and force it to the provided value.
+  autodetection of the platform name and force it to the provided value.
+- `E2E_NROP_PLATFORM_VERSION` (accepts a string, e.g. `1.30`, `4.16`) instructs the suite to *disable* the
+  autodetection of the platform version and force it to the provided value.
 - `E2E_NROP_DUMP_EVENTS` (accepts boolean, e.g. `true`) requests the suite to dump events pertaining to pods
   failed unexpectedly on standard output, alongside (not replacing) the logging of the said events.
 - `E2E_NROP_TARGET_NODE` (accepts string, e.g. `node-0.my-cluster.io`) instructs the suite to always pick the

--- a/test/e2e/serial/e2e_serial_test.go
+++ b/test/e2e/serial/e2e_serial_test.go
@@ -23,6 +23,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	_ "github.com/openshift-kni/numaresources-operator/test/utils/configuration"
+
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 	_ "github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests"
 )
@@ -35,14 +37,15 @@ func TestSerial(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	Expect(serialconfig.CheckNodesTopology(context.TODO())).Should(Succeed())
+	ctx := context.Background()
+	Expect(serialconfig.CheckNodesTopology(ctx)).Should(Succeed())
 	serialconfig.Setup()
 	setupExecuted = true
 })
 
 var _ = AfterSuite(func() {
-	if setupExecuted {
-		serialconfig.Teardown()
+	if !setupExecuted {
+		return
 	}
-
+	serialconfig.Teardown()
 })


### PR DESCRIPTION
Generalize the platform and version discovery and
move it into a function; the gaol is to have common code to discover **and log** and use it both in the operator and in the serial suite entry point, so in the latter we have clear logs.