### PR TITLE
OCPBUGS-30236: controller: kubelet: skip config with empty payload

### DIFF
--- a/controllers/kubeletconfig_controller_test.go
+++ b/controllers/kubeletconfig_controller_test.go
@@ -129,6 +129,22 @@ var _ = Describe("Test KubeletConfig Reconcile", func() {
 				event := <-fakeRecorder.Events
 				Expect(event).To(ContainSubstring("ProcessFailed"))
 			})
+
+			It("should skip invalid kubeletconfig", func() {
+				invalidMcoKc := testobjs.NewKubeletConfigWithoutData("test1", label1, mcp1.Spec.MachineConfigSelector)
+				reconciler, err := NewFakeKubeletConfigReconciler(nro, mcp1, invalidMcoKc)
+				Expect(err).ToNot(HaveOccurred())
+
+				key := client.ObjectKeyFromObject(mcoKc1)
+				_, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
+				Expect(err).ToNot(HaveOccurred())
+
+				// verify creation event
+				fakeRecorder, ok := reconciler.Recorder.(*record.FakeRecorder)
+				Expect(ok).To(BeTrue())
+				event := <-fakeRecorder.Events
+				Expect(event).To(ContainSubstring("ProcessSkip"))
+			})
 		})
 	})
 })

--- a/internal/objects/objects.go
+++ b/internal/objects/objects.go
@@ -113,6 +113,14 @@ func NewKubeletConfig(name string, labels map[string]string, machineConfigSelect
 }
 
 func NewKubeletConfigWithData(name string, labels map[string]string, machineConfigSelector *metav1.LabelSelector, data []byte) *machineconfigv1.KubeletConfig {
+	kc := NewKubeletConfigWithoutData(name, labels, machineConfigSelector)
+	kc.Spec.KubeletConfig = &runtime.RawExtension{
+		Raw: data,
+	}
+	return kc
+}
+
+func NewKubeletConfigWithoutData(name string, labels map[string]string, machineConfigSelector *metav1.LabelSelector) *machineconfigv1.KubeletConfig {
 	return &machineconfigv1.KubeletConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "KubeletConfig",
@@ -124,9 +132,6 @@ func NewKubeletConfigWithData(name string, labels map[string]string, machineConf
 		},
 		Spec: machineconfigv1.KubeletConfigSpec{
 			MachineConfigPoolSelector: machineConfigSelector,
-			KubeletConfig: &runtime.RawExtension{
-				Raw: data,
-			},
 		},
 	}
 }

--- a/pkg/kubeletconfig/kubeletconfig.go
+++ b/pkg/kubeletconfig/kubeletconfig.go
@@ -18,19 +18,30 @@ package kubeletconfig
 
 import (
 	"encoding/json"
+	"errors"
 
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 
 	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
 
+var (
+	MissingPayloadError = errors.New("missing kubeletconfig payload")
+)
+
 func MCOKubeletConfToKubeletConf(mcoKc *mcov1.KubeletConfig) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
+	if mcoKc.Spec.KubeletConfig == nil {
+		return nil, MissingPayloadError
+	}
 	kc := &kubeletconfigv1beta1.KubeletConfiguration{}
 	err := json.Unmarshal(mcoKc.Spec.KubeletConfig.Raw, kc)
 	return kc, err
 }
 
 func KubeletConfToMCKubeletConf(kcObj *kubeletconfigv1beta1.KubeletConfiguration, kcAsMc *mcov1.KubeletConfig) error {
+	if kcAsMc.Spec.KubeletConfig == nil {
+		return MissingPayloadError
+	}
 	rawKc, err := json.Marshal(kcObj)
 	kcAsMc.Spec.KubeletConfig.Raw = rawKc
 	return err

--- a/pkg/kubeletconfig/kubeletconfig_test.go
+++ b/pkg/kubeletconfig/kubeletconfig_test.go
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ */
+
+package kubeletconfig
+
+import (
+	"errors"
+	"testing"
+
+	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+)
+
+func TestMissingPayloadMCOKubeletConfToKubeletConf(t *testing.T) {
+	kc, err := MCOKubeletConfToKubeletConf(&mcov1.KubeletConfig{})
+	if kc != nil {
+		t.Errorf("non-nil kubeletconfig from nil payload")
+	}
+	if !errors.Is(err, MissingPayloadError) {
+		t.Errorf("unexpected error from nil payload; %v", err)
+	}
+}
+
+func TestMissingPayloadKubeletConfToMCKubeletConf(t *testing.T) {
+	k8sKc := kubeletconfigv1beta1.KubeletConfiguration{}
+	mcoKc := mcov1.KubeletConfig{}
+	err := KubeletConfToMCKubeletConf(&k8sKc, &mcoKc)
+	if !errors.Is(err, MissingPayloadError) {
+		t.Errorf("unexpected error from nil payload; %v", err)
+	}
+}


### PR DESCRIPTION
MCO's KubeletConfig can be sent with empty payload, for example when configuring autosizing:

```
apiVersion: machineconfiguration.openshift.io/v1
kind: KubeletConfig
metadata:
  name: autosizing-master
spec:
  autoSizingReserved: true
  machineConfigPoolSelector:
    matchLabels:
      pools.operator.machineconfiguration.openshift.io/master: ""
```

In general there's not much we can do when obeserving these kubeletconfig objects anyway, so we skip them.

Please note: the control loop still depends on the fact there
1. is just one kubeletconfig object *with payload*
2. there's no merge logic

as it stands today both still should be core assumptions regarding how MCO works.