### PR TITLE
docs: add architecture and roadmap

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,52 @@
+# NUMA Resources Operator architecture
+
+## concepts
+
+The NUMA Resources Operator is a pilot operator to deploy all the components needed for the out-of-tree NUMA aware scheduler:
+1. NodeResourceTopology API (out-of-tree CRD-based API)
+2. ResourceTopologyExporter (RTE) as topology info provider
+3. The out-of-tree secondary scheduler with the NodeResourceTopologyMatch plugins enabled
+
+In addition, the operator repo includes a extensive e2e test suite (so-called "serial suite")
+
+## building blocks
+
+The operator is built on top of two main community-based projects: [the deployer toolkit](https://github.com/k8stopologyawareschedwg/deployer)
+and [the resource topology exporter](https://github.com/k8stopologyawareschedwg/resource-topology-exporter).
+
+The deployer toolkit provides functionalities to process the YAML manifests (or their golang object representation) to install all the components
+in the NUMA-aware stack. It's the core on which the operator builds on, adding operator-specific customizations.
+
+The resource-topology-exporter is vendored to enable the "bundled operand" pattern (see below). The operand reuses most of the RTE code, just
+replacing the main entry point.
+
+Logically, the operator manages three operands (API, RTE, scheduler) but it depends on just a single artifact for the operand (the scheduler),
+while the other two operands (API, RTE) are bundled in the same operator image.
+
+## bundled operand
+
+Instead of consuming a separate image like we do for the secondary scheduler, we bundle the RTE operand adding the binary in the operator image,
+which has multiple entry points.
+
+This decision was taken in order to minimize the number of artifacts and narrow down as much as possible the dependency chain.
+
+We foresee RTE as the first operand to be replaced, and in general is the easiest to replace. `nfd-topology-updater` is already part of NFD
+and a supported component. On the other hand, the secondary scheduler is likely to stick around for a while more - and that's also easier to
+support because secondary schedulers are not uncommon in the kubernetes ecosystem.
+
+## controllers
+
+The operator has three controllers and three control loop. Likewise well-formed controllers, they are independent from each other and will
+reconcile the cluster state towards a functional NUMA-aware scheduler installation.
+
+1. the numaresourcesoperator controller manages the NRT API and the RTE daemonsets. There's no obvious place to manage the NRT API, so we
+   decide to bundle in the same controller which manages RTE, because the RTE is the component which suffers (slightly) more the lack of
+   the API, so it makes sense to ensure its presence.
+2. the numaresourcesscheduler controller manages the secondary scheduler. It's a minimal replacement for the secondary-scheduler-operator
+   with some custom additions specific to the NUMA-aware scheduler. It's relatively isolated in the codebase because it was the last
+   addition which was performed when key gaps where identified in the secondary-scheduler-controller for the NUMA-aware usecase.
+3. the kubeletconfig controller distills the topology manager configuration from the Machine Config Operator  and makes it available
+   to the RTEs to properly propagate the information. RTEs can fetch the same information in many ways (e.g. reading the host's kubelet
+   configuration). This approach was taken because it is a good compromise between security, practicality, maintainability, but being
+   the least critical controller this can perhaps replaced in the future. This functionality should be subsumed by the operator
+   managing the RTE replacement.

--- a/README.md
+++ b/README.md
@@ -16,11 +16,24 @@ Assuming you can push container images to a container registry and you are in th
 
 For further details, please refer to the [operator-sdk documentation](https://sdk.operatorframework.io/docs/olm-integration/tutorial-bundle/)
 
+## roadmap
+
+The NUMA Resources operator is meant to have a limited lifetime, because all the operands it manages have a path towards
+integration in core k8s or towards replacement with other established components:
+1. The NodResourceTopology API is meant to be proposed to be accepted among the k8s APIs
+2. The ResourceTopologyExporter is meant to be replaced by nfd-topology-updater, part of the Node Feature Discovery project,
+   and managed by the nfd-operator
+3. The out-of-tree scheduler plugin is meant to be proposed to be accepted in the k8s core repo; for the mid-term,
+   it should be managed by the secondary-scheduler-operator.
+
+Once all the components are merged or replaced, we plan to extract the testsuite, and then to deprecate and dissolve
+the NUMA Resources Operator.
+
 ## current limitations
 
 Please check the [issues section](https://github.com/openshift-kni/numaresources-operator/issues) for the known issues and limitations of the NUMA resources operator.
 
-## Additional noteworthy information
+## additional noteworthy information
 
 NRT objects only take into consideration exclusively allocated CPUs while accounting. In order for a pod to be allocated exclusive CPUs, it HAS to belong to Guaranteed QoS class (request=limit) and request has to be integral. Therefore, CPUs in the shared pool because of pods belonging to best effort/burstable QoS or guaranteed pod with non-integral CPU request would not be accounted for in the NRT objects. Please refer to CPU Manager docs [here](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy) for more detail on this.
 
@@ -34,3 +47,13 @@ There is **no support** for these e2e tests images, and they are recommended to 
 
 See `README.tests.md` for detailed instructions about how to run the suite.
 See `tests/e2e/serial/README.md` for fine details about the suite and developer instructions.
+
+## linking bugs and issues to PRs
+
+PRs fixing issues may link either
+1. [the project issues](https://github.com/openshift-kni/numaresources-operator/issues) per standard github flow (preferred)
+   Please link the PR using `Fixes: #12345` in the PR description and/or link using the github UI
+2. [the OCPBUGS jira board](https://issues.redhat.com/projects/OCPBUGS/issues).
+   Please link the PR using the `OCPBUGS-12345: ` prefix in the PR description.
+
+we currently don't support other issue trackers.


### PR DESCRIPTION
add a section in the README to sketch the future plans, and start an ARCHITECTURE document to describe in
broad strokes how the operator is designed.