### PR TITLE
e2e: api: add and use support to sort tolerations

### DIFF
--- a/api/numaresourcesoperator/v1/numaresourcesoperator_normalize.go
+++ b/api/numaresourcesoperator/v1/numaresourcesoperator_normalize.go
@@ -16,7 +16,11 @@
 
 package v1
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+)
 
 func (nodeGroup NodeGroup) NormalizeConfig() NodeGroupConfig {
 	conf := DefaultNodeGroupConfig()
@@ -53,5 +57,23 @@ func CloneTolerations(tols []corev1.Toleration) []corev1.Toleration {
 	for _, tol := range tols {
 		ret = append(ret, *tol.DeepCopy())
 	}
+	return ret
+}
+
+// SortedTolerations return a sorted clone of the provided toleration slice
+func SortedTolerations(tols []corev1.Toleration) []corev1.Toleration {
+	ret := CloneTolerations(tols)
+	sort.SliceStable(ret, func(i, j int) bool {
+		if ret[i].Key != ret[j].Key {
+			return ret[i].Key < ret[j].Key
+		}
+		if ret[i].Operator != ret[j].Operator {
+			return ret[i].Operator < ret[j].Operator
+		}
+		if ret[i].Value != ret[j].Value {
+			return ret[i].Value < ret[j].Value
+		}
+		return ret[i].Effect < ret[j].Effect
+	})
 	return ret
 }

--- a/api/numaresourcesoperator/v1/numaresourcesoperator_normalize_test.go
+++ b/api/numaresourcesoperator/v1/numaresourcesoperator_normalize_test.go
@@ -108,3 +108,180 @@ func TestNodeGroupConfigMerge(t *testing.T) {
 		})
 	}
 }
+
+func TestSortedTolerations(t *testing.T) {
+	type testCase struct {
+		name     string
+		tols     []corev1.Toleration
+		expected []corev1.Toleration
+	}
+
+	testCases := []testCase{
+		{
+			name:     "nil",
+			expected: []corev1.Toleration{},
+		},
+		{
+			name:     "empty",
+			tols:     []corev1.Toleration{},
+			expected: []corev1.Toleration{},
+		},
+		{
+			name: "1 element",
+			tols: []corev1.Toleration{
+				{
+					Key:      "sriov",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "true",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			expected: []corev1.Toleration{
+				{
+					Key:      "sriov",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "true",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+		},
+		{
+			name: "shortlist",
+			tols: []corev1.Toleration{
+				{
+					Key:      "foo",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "1",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "abc",
+					Operator: corev1.TolerationOpExists,
+					Value:    "def",
+					Effect:   corev1.TaintEffectNoExecute,
+				},
+				{
+					Key:      "bar",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "bar",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			expected: []corev1.Toleration{
+				{
+					Key:      "abc",
+					Operator: corev1.TolerationOpExists,
+					Value:    "def",
+					Effect:   corev1.TaintEffectNoExecute,
+				},
+				{
+					Key:      "bar",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "bar",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "foo",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "1",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+		},
+		{
+			name: "presorted",
+			tols: []corev1.Toleration{
+				{
+					Key:      "abc",
+					Operator: corev1.TolerationOpExists,
+					Value:    "def",
+					Effect:   corev1.TaintEffectNoExecute,
+				},
+				{
+					Key:      "bar",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "bar",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "foo",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "1",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			expected: []corev1.Toleration{
+				{
+					Key:      "abc",
+					Operator: corev1.TolerationOpExists,
+					Value:    "def",
+					Effect:   corev1.TaintEffectNoExecute,
+				},
+				{
+					Key:      "bar",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "bar",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "foo",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "1",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+		},
+		{
+			name: "inverted",
+			tols: []corev1.Toleration{
+				{
+					Key:      "foo",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "1",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "bar",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "bar",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "abc",
+					Operator: corev1.TolerationOpExists,
+					Value:    "def",
+					Effect:   corev1.TaintEffectNoExecute,
+				},
+			},
+			expected: []corev1.Toleration{
+				{
+					Key:      "abc",
+					Operator: corev1.TolerationOpExists,
+					Value:    "def",
+					Effect:   corev1.TaintEffectNoExecute,
+				},
+				{
+					Key:      "bar",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "bar",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "foo",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "1",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SortedTolerations(tc.tols)
+			if !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("mismatched tolerations:\ngot=%+v\nexpected=%+v", got, tc.expected)
+			}
+		})
+	}
+}

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -840,9 +840,9 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 
 func expectEqualTolerations(tolsA, tolsB []corev1.Toleration) {
 	GinkgoHelper()
-
-	// TODO: sort, then check
-	Expect(tolsA).To(Equal(tolsB), "mismatched tolerations")
+	tA := nropv1.SortedTolerations(tolsA)
+	tB := nropv1.SortedTolerations(tolsB)
+	Expect(tA).To(Equal(tB), "mismatched tolerations")
 }
 
 func setRTETolerations(ctx context.Context, cli client.Client, nroKey client.ObjectKey, tols []corev1.Toleration) *nropv1.NUMAResourcesOperator {

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -49,7 +49,6 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
-	rtemanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte"
 	nropmcp "github.com/openshift-kni/numaresources-operator/internal/machineconfigpools"
 	"github.com/openshift-kni/numaresources-operator/internal/relatedobjects"
 	"github.com/openshift-kni/numaresources-operator/pkg/kubeletconfig"
@@ -776,102 +775,8 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 				return kcCmNamesCur
 			}).WithContext(ctx).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Equal(kcCmNamesPre))
 		})
-
-		It("should enable to change tolerations in the RTE daemonsets", func(ctx context.Context) {
-			By("getting RTE manifests object")
-			// TODO: this is similar but not quite what the main operator does
-			rteManifests, err := rtemanifests.GetManifests(configuration.Plat, configuration.PlatVersion, "", true)
-			Expect(err).ToNot(HaveOccurred(), "cannot get the RTE manifests")
-
-			By("getting NROP object")
-			nroKey := objects.NROObjectKey()
-			nroOperObj := nropv1.NUMAResourcesOperator{}
-
-			err = fxt.Client.Get(context.TODO(), nroKey, &nroOperObj)
-			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", nroKey.String())
-
-			if len(nroOperObj.Spec.NodeGroups) != 1 {
-				// TODO: this is the simplest case, there is no hard requirement really
-				// but we took the simplest option atm
-				e2efixture.Skipf(fxt, "more than one NodeGroup not yet supported, found %d", len(nroOperObj.Spec.NodeGroups))
-			}
-
-			By("checking the DSs owned by NROP")
-			dsObj := appsv1.DaemonSet{}
-			dsKey := wait.ObjectKey{
-				Namespace: nroOperObj.Status.DaemonSets[0].Namespace,
-				Name:      nroOperObj.Status.DaemonSets[0].Name,
-			}
-
-			err = fxt.Client.Get(context.TODO(), client.ObjectKey{Namespace: dsKey.Namespace, Name: dsKey.Name}, &dsObj)
-			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", dsKey.String())
-			expectedTolerations := rteManifests.DaemonSet.Spec.Template.Spec.Tolerations // shortcut
-			gotTolerations := dsObj.Spec.Template.Spec.Tolerations                       // shortcut
-			expectEqualTolerations(gotTolerations, expectedTolerations)
-
-			By("adding extra tolerations")
-			updatedNropObj := setRTETolerations(context.TODO(), fxt.Client, nroKey, []corev1.Toleration{sriovToleration()})
-			By("waiting for DaemonSet to be ready")
-			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(1*time.Minute).ForDaemonSetUpdateByKey(context.TODO(), dsKey)
-			Expect(err).ToNot(HaveOccurred(), "daemonset %s did not start updated: %v", dsKey.String(), err)
-			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(context.TODO(), dsKey)
-			Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
-
-			defer func(ctx context.Context) {
-				By("removing extra tolerations")
-				_ = setRTETolerations(ctx, fxt.Client, nroKey, []corev1.Toleration{})
-				By("waiting for DaemonSet to be ready")
-				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(1*time.Minute).ForDaemonSetUpdateByKey(ctx, dsKey)
-				Expect(err).ToNot(HaveOccurred(), "daemonset %s did not start updated: %v", dsKey.String(), err)
-				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
-				Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
-			}(context.TODO())
-
-			By("checking the tolerations in the owned DaemonSet")
-			err = fxt.Client.Get(context.TODO(), client.ObjectKey{Namespace: dsKey.Namespace, Name: dsKey.Name}, &dsObj)
-			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", dsKey.String())
-
-			expectedTolerations = updatedNropObj.Spec.NodeGroups[0].Config.Tolerations // shortcut
-			gotTolerations = dsObj.Spec.Template.Spec.Tolerations                      // shortcut
-			expectEqualTolerations(gotTolerations, expectedTolerations)
-		})
 	})
 })
-
-func expectEqualTolerations(tolsA, tolsB []corev1.Toleration) {
-	GinkgoHelper()
-	tA := nropv1.SortedTolerations(tolsA)
-	tB := nropv1.SortedTolerations(tolsB)
-	Expect(tA).To(Equal(tB), "mismatched tolerations")
-}
-
-func setRTETolerations(ctx context.Context, cli client.Client, nroKey client.ObjectKey, tols []corev1.Toleration) *nropv1.NUMAResourcesOperator {
-	GinkgoHelper()
-
-	nropOperObj := nropv1.NUMAResourcesOperator{}
-	Eventually(func(g Gomega) {
-		err := cli.Get(ctx, nroKey, &nropOperObj)
-		g.Expect(err).ToNot(HaveOccurred())
-
-		if nropOperObj.Spec.NodeGroups[0].Config == nil {
-			nropOperObj.Spec.NodeGroups[0].Config = &nropv1.NodeGroupConfig{}
-		}
-		nropOperObj.Spec.NodeGroups[0].Config.Tolerations = tols
-		err = cli.Update(ctx, &nropOperObj)
-		g.Expect(err).ToNot(HaveOccurred())
-	}).WithTimeout(5 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
-
-	return &nropOperObj
-}
-
-func sriovToleration() corev1.Toleration {
-	return corev1.Toleration{
-		Key:      "sriov",
-		Operator: corev1.TolerationOpEqual,
-		Value:    "true",
-		Effect:   corev1.TaintEffectNoSchedule,
-	}
-}
 
 func daemonSetListToNamespacedNameList(dss []*appsv1.DaemonSet) []nropv1.NamespacedName {
 	ret := make([]nropv1.NamespacedName, 0, len(dss))

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+
+	rtemanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte"
+	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
+	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
+	"github.com/openshift-kni/numaresources-operator/internal/wait"
+	"github.com/openshift-kni/numaresources-operator/test/utils/configuration"
+	e2efixture "github.com/openshift-kni/numaresources-operator/test/utils/fixture"
+	e2enrt "github.com/openshift-kni/numaresources-operator/test/utils/noderesourcetopologies"
+	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
+
+	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
+)
+
+var _ = Describe("[serial][disruptive][slow] numaresources configuration management", Serial, func() {
+	var fxt *e2efixture.Fixture
+	var nrtList nrtv1alpha2.NodeResourceTopologyList
+	var nrts []nrtv1alpha2.NodeResourceTopology
+
+	BeforeEach(func(ctx context.Context) {
+		Expect(serialconfig.Config).ToNot(BeNil())
+		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
+
+		var err error
+		fxt, err = e2efixture.Setup("e2e-test-configuration", serialconfig.Config.NRTList)
+		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
+
+		err = fxt.Client.List(ctx, &nrtList)
+		Expect(err).ToNot(HaveOccurred())
+
+		// we're ok with any TM policy as long as the updater can handle it,
+		// we use this as proxy for "there is valid NRT data for at least X nodes
+		nrts = e2enrt.FilterByTopologyManagerPolicy(nrtList.Items, intnrt.SingleNUMANode)
+		if len(nrts) < 2 {
+			Skip(fmt.Sprintf("not enough nodes with valid policy - found %d", len(nrts)))
+		}
+
+		// Note that this test, being part of "serial", expects NO OTHER POD being scheduled
+		// in between, so we consider this information current and valid when the It()s run.
+	})
+
+	AfterEach(func(_ context.Context) {
+		err := e2efixture.Teardown(fxt)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("cluster has at least one suitable node", func() {
+		It("should enable to change tolerations in the RTE daemonsets", func(ctx context.Context) {
+			By("getting RTE manifests object")
+			// TODO: this is similar but not quite what the main operator does
+			rteManifests, err := rtemanifests.GetManifests(configuration.Plat, configuration.PlatVersion, "", true)
+			Expect(err).ToNot(HaveOccurred(), "cannot get the RTE manifests")
+
+			By("getting NROP object")
+			nroKey := objects.NROObjectKey()
+			nroOperObj := nropv1.NUMAResourcesOperator{}
+
+			err = fxt.Client.Get(ctx, nroKey, &nroOperObj)
+			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", nroKey.String())
+
+			if len(nroOperObj.Spec.NodeGroups) != 1 {
+				// TODO: this is the simplest case, there is no hard requirement really
+				// but we took the simplest option atm
+				e2efixture.Skipf(fxt, "more than one NodeGroup not yet supported, found %d", len(nroOperObj.Spec.NodeGroups))
+			}
+
+			By("checking the DSs owned by NROP")
+			dsObj := appsv1.DaemonSet{}
+			dsKey := wait.ObjectKey{
+				Namespace: nroOperObj.Status.DaemonSets[0].Namespace,
+				Name:      nroOperObj.Status.DaemonSets[0].Name,
+			}
+
+			err = fxt.Client.Get(ctx, client.ObjectKey{Namespace: dsKey.Namespace, Name: dsKey.Name}, &dsObj)
+			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", dsKey.String())
+			expectedTolerations := rteManifests.DaemonSet.Spec.Template.Spec.Tolerations // shortcut
+			gotTolerations := dsObj.Spec.Template.Spec.Tolerations                       // shortcut
+			expectEqualTolerations(gotTolerations, expectedTolerations)
+
+			By("adding extra tolerations")
+			updatedNropObj := setRTETolerations(ctx, fxt.Client, nroKey, []corev1.Toleration{sriovToleration()})
+			By("waiting for DaemonSet to be ready")
+			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(1*time.Minute).ForDaemonSetUpdateByKey(ctx, dsKey)
+			Expect(err).ToNot(HaveOccurred(), "daemonset %s did not start updated: %v", dsKey.String(), err)
+			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
+			Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
+
+			defer func(ctx context.Context) {
+				By("removing extra tolerations")
+				_ = setRTETolerations(ctx, fxt.Client, nroKey, []corev1.Toleration{})
+				By("waiting for DaemonSet to be ready")
+				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(1*time.Minute).ForDaemonSetUpdateByKey(ctx, dsKey)
+				Expect(err).ToNot(HaveOccurred(), "daemonset %s did not start updated: %v", dsKey.String(), err)
+				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
+				Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
+			}(ctx)
+
+			By("checking the tolerations in the owned DaemonSet")
+			err = fxt.Client.Get(ctx, client.ObjectKey{Namespace: dsKey.Namespace, Name: dsKey.Name}, &dsObj)
+			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", dsKey.String())
+
+			expectedTolerations = updatedNropObj.Spec.NodeGroups[0].Config.Tolerations // shortcut
+			gotTolerations = dsObj.Spec.Template.Spec.Tolerations                      // shortcut
+			expectEqualTolerations(gotTolerations, expectedTolerations)
+		})
+	})
+})
+
+func expectEqualTolerations(tolsA, tolsB []corev1.Toleration) {
+	GinkgoHelper()
+	tA := nropv1.SortedTolerations(tolsA)
+	tB := nropv1.SortedTolerations(tolsB)
+	Expect(tA).To(Equal(tB), "mismatched tolerations")
+}
+
+func setRTETolerations(ctx context.Context, cli client.Client, nroKey client.ObjectKey, tols []corev1.Toleration) *nropv1.NUMAResourcesOperator {
+	GinkgoHelper()
+
+	nropOperObj := nropv1.NUMAResourcesOperator{}
+	Eventually(func(g Gomega) {
+		err := cli.Get(ctx, nroKey, &nropOperObj)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		if nropOperObj.Spec.NodeGroups[0].Config == nil {
+			nropOperObj.Spec.NodeGroups[0].Config = &nropv1.NodeGroupConfig{}
+		}
+		nropOperObj.Spec.NodeGroups[0].Config.Tolerations = tols
+		err = cli.Update(ctx, &nropOperObj)
+		g.Expect(err).ToNot(HaveOccurred())
+	}).WithTimeout(5 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
+
+	return &nropOperObj
+}
+
+func sriovToleration() corev1.Toleration {
+	return corev1.Toleration{
+		Key:      "sriov",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "true",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+}


### PR DESCRIPTION
Make sure we compare sorted tolerations in the e2e tests, so we minimize flakes.
No intended changes in behavior.