### PR TITLE
build: golang: remove 'latest' floating tag refs

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -25,8 +25,8 @@ RUN mkdir -p $HOME && \
     tar -C /usr/local -xzf go.tar.gz && \
     rm go.tar.gz && \
     # get required golang tools and OC client
-    go install golang.org/x/lint/golint@latest && \
-    go install github.com/mattn/goveralls@latest && \
+    go install golang.org/x/lint/golint@v0.0.0-20210508222113-6edffad5e616 && \
+    go install github.com/mattn/goveralls@v0.0.12 && \
     go clean -cache -modcache && \
     rm -rf ${GOPATH}/src/* && \
     rm -rf ${GOPATH}/pkg/* && \

--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,8 @@ kustomize: ## Download kustomize locally if necessary.
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
-	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+	# this is the last version before the bump golang 1.20 -> 1.22. We want to avoid the go.mod version format changes - for now.
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20230927023946-553bd00cfec5)
 
 # go-install-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))


### PR DESCRIPTION
never use floating tags in the build system, not
even for CI tests. Always pin explicit versions.