### PR TITLE
RFE-5013: RTE: more e2e tests

### DIFF
--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -48,7 +48,7 @@ import (
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 )
 
-var _ = Describe("[serial][disruptive][slow] numaresources RTE tolerations support", Serial, func() {
+var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerations support", Serial, func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 	var nrts []nrtv1alpha2.NodeResourceTopology

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -109,12 +109,6 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 
 			By("adding extra tolerations")
 			updatedNropObj := setRTETolerations(ctx, fxt.Client, nroKey, []corev1.Toleration{sriovToleration()})
-			By("waiting for DaemonSet to be ready")
-			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(1*time.Minute).ForDaemonSetUpdateByKey(ctx, dsKey)
-			Expect(err).ToNot(HaveOccurred(), "daemonset %s did not start updated: %v", dsKey.String(), err)
-			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
-			Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
-
 			defer func(ctx context.Context) {
 				By("removing extra tolerations")
 				_ = setRTETolerations(ctx, fxt.Client, nroKey, []corev1.Toleration{})
@@ -124,6 +118,12 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
 				Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
 			}(ctx)
+
+			By("waiting for DaemonSet to be ready")
+			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(1*time.Minute).ForDaemonSetUpdateByKey(ctx, dsKey)
+			Expect(err).ToNot(HaveOccurred(), "daemonset %s did not start updated: %v", dsKey.String(), err)
+			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
+			Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
 
 			By("checking the tolerations in the owned DaemonSet")
 			err = fxt.Client.Get(ctx, client.ObjectKey{Namespace: dsKey.Namespace, Name: dsKey.Name}, &dsObj)

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -139,7 +139,7 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 				}).WithTimeout(5 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
 			})
 
-			It("should handle invalid field: effect [test_id:OCP-72862]", func(ctx context.Context) {
+			It("[test_id:72862] should handle invalid field: effect", func(ctx context.Context) {
 				By("adding extra invalid tolerations with wrong effect field")
 				_ = setRTETolerations(ctx, fxt.Client, nroKey, []corev1.Toleration{
 					{
@@ -169,7 +169,7 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 			})
 		})
 
-		It("should enable to change tolerations in the RTE daemonsets [tier3]", func(ctx context.Context) {
+		It("[tier3] should enable to change tolerations in the RTE daemonsets", func(ctx context.Context) {
 			By("getting RTE manifests object")
 			// TODO: this is similar but not quite what the main operator does
 			rteManifests, err := rtemanifests.GetManifests(configuration.Plat, configuration.PlatVersion, "", true)
@@ -236,7 +236,7 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 				Expect(int(updatedDs.Status.NumberReady)).To(Equal(len(workers)), "RTE DS ready=%v original worker nodes=%d", updatedDs.Status.NumberReady, len(workers))
 			})
 
-			It("should handle untolerations of tainted nodes while RTEs are running [tier2][test_id:OCP-72857]", func(ctx context.Context) {
+			It("[tier2][test_id:72857] should handle untolerations of tainted nodes while RTEs are running", func(ctx context.Context) {
 				var err error
 				By("adding extra tolerations")
 				_ = setRTETolerations(ctx, fxt.Client, nroKey, testToleration())
@@ -312,7 +312,7 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 				Expect(int(updatedDs.Status.NumberReady)).To(Equal(len(workers)), "RTE DS ready=%v original worker nodes=%d", updatedDs.Status.NumberReady, len(workers))
 			})
 
-			It("should tolerate partial taints and not schedule or evict the pod on the tainted node [tier2][test_id:OCP-72861]", func(ctx context.Context) {
+			It("[tier2][test_id:72861] should tolerate partial taints and not schedule or evict the pod on the tainted node", func(ctx context.Context) {
 				var err error
 				By("getting the worker nodes")
 				workers, err = nodes.GetWorkerNodes(fxt.Client, context.TODO())


### PR DESCRIPTION
add e2e test to cover invalid tolerations in the spec - NROP will act as passthrough here, by design
add e2e test to cover un-toleration while RTE is running, let's ensure the expected behavior