### PR TITLE
CNF-11848: [release-4.15][manual] RTE: add support to add extra tolerations

### DIFF
--- a/api/numaresourcesoperator/v1/numaresourcesoperator_normalize.go
+++ b/api/numaresourcesoperator/v1/numaresourcesoperator_normalize.go
@@ -16,7 +16,11 @@
 
 package v1
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+)
 
 func (nodeGroup NodeGroup) NormalizeConfig() NodeGroupConfig {
 	conf := DefaultNodeGroupConfig()
@@ -50,5 +54,23 @@ func CloneTolerations(tols []corev1.Toleration) []corev1.Toleration {
 	for _, tol := range tols {
 		ret = append(ret, *tol.DeepCopy())
 	}
+	return ret
+}
+
+// SortedTolerations return a sorted clone of the provided toleration slice
+func SortedTolerations(tols []corev1.Toleration) []corev1.Toleration {
+	ret := CloneTolerations(tols)
+	sort.SliceStable(ret, func(i, j int) bool {
+		if ret[i].Key != ret[j].Key {
+			return ret[i].Key < ret[j].Key
+		}
+		if ret[i].Operator != ret[j].Operator {
+			return ret[i].Operator < ret[j].Operator
+		}
+		if ret[i].Value != ret[j].Value {
+			return ret[i].Value < ret[j].Value
+		}
+		return ret[i].Effect < ret[j].Effect
+	})
 	return ret
 }

--- a/api/numaresourcesoperator/v1/numaresourcesoperator_normalize_test.go
+++ b/api/numaresourcesoperator/v1/numaresourcesoperator_normalize_test.go
@@ -21,8 +21,30 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestNodeGroupNormalizeConfigKeepsTolerations(t *testing.T) {
+	expectedTols := []corev1.Toleration{
+		{
+			Key:    "foo",
+			Value:  "1",
+			Effect: corev1.TaintEffectNoSchedule,
+		},
+	}
+
+	ng := NodeGroup{
+		Config: &NodeGroupConfig{
+			Tolerations: CloneTolerations(expectedTols),
+		},
+	}
+
+	ngConf := ng.NormalizeConfig()
+	if !reflect.DeepEqual(expectedTols, ngConf.Tolerations) {
+		t.Fatalf("tolerations lost: from=%+v to=%+v", expectedTols, ngConf.Tolerations)
+	}
+}
 
 func TestNodeGroupConfigMerge(t *testing.T) {
 	podsFp := PodsFingerprintingEnabled

--- a/api/numaresourcesoperator/v1/numaresourcesoperator_types.go
+++ b/api/numaresourcesoperator/v1/numaresourcesoperator_types.go
@@ -17,6 +17,7 @@
 package v1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -86,6 +87,11 @@ type NodeGroupConfig struct {
 	// +optional
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Topology info refresh period setting",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	InfoRefreshPeriod *metav1.Duration `json:"infoRefreshPeriod,omitempty"`
+	// Tolerations overrides tolerations to be set into RTE daemonsets for this NodeGroup. If not empty, the tolerations will be the one set here.
+	// Leave empty to make the system use the default tolerations.
+	// +optional
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Extra tolerations for the topology updater daemonset",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 
 // NodeGroup defines group of nodes that will run resource topology exporter daemon set

--- a/api/numaresourcesoperator/v1/zz_generated.deepcopy.go
+++ b/api/numaresourcesoperator/v1/zz_generated.deepcopy.go
@@ -24,6 +24,7 @@ package v1
 import (
 	configv1 "github.com/openshift/api/config/v1"
 	machineconfiguration_openshift_iov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -359,6 +360,13 @@ func (in *NodeGroupConfig) DeepCopyInto(out *NodeGroupConfig) {
 		in, out := &in.InfoRefreshPeriod, &out.InfoRefreshPeriod
 		*out = new(metav1.Duration)
 		**out = **in
+	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]corev1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 

--- a/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_conversion.go
+++ b/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_conversion.go
@@ -192,6 +192,7 @@ func convertNodeGroupConfigV1Alpha1ToV1(src NodeGroupConfig) *nropv1.NodeGroupCo
 	if src.InfoRefreshPeriod != nil {
 		dst.InfoRefreshPeriod = src.InfoRefreshPeriod.DeepCopy()
 	}
+	// v1alpha1 does not have tolerations, so nothing to do
 	return &dst
 }
 
@@ -220,6 +221,7 @@ func convertNodeGroupConfigV1ToV1Alpha1(src nropv1.NodeGroupConfig) *NodeGroupCo
 	if src.InfoRefreshPeriod != nil {
 		dst.InfoRefreshPeriod = src.InfoRefreshPeriod.DeepCopy()
 	}
+	// v1alpha1 does not have tolerations, so nothing to do
 	return &dst
 }
 

--- a/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -82,6 +82,52 @@ spec:
                           - Enabled
                           - EnabledExclusiveResources
                           type: string
+                        tolerations:
+                          description: Tolerations overrides tolerations to be set
+                            into RTE daemonsets for this NodeGroup. If not empty,
+                            the tolerations will be the one set here. Leave empty
+                            to make the system use the default tolerations.
+                          items:
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect>
+                              using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to
+                                  match. Empty means match all taint effects. When
+                                  specified, allowed values are NoSchedule, PreferNoSchedule
+                                  and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If
+                                  the key is empty, operator must be Exists; this
+                                  combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints
+                                  of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect
+                                  NoExecute, otherwise this field is ignored) tolerates
+                                  the taint. By default, it is not set, which means
+                                  tolerate the taint forever (do not evict). Zero
+                                  and negative values will be treated as 0 (evict
+                                  immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value
+                                  should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
                       type: object
                     machineConfigPoolSelector:
                       description: MachineConfigPoolSelector defines label selector
@@ -299,6 +345,52 @@ spec:
                           - Enabled
                           - EnabledExclusiveResources
                           type: string
+                        tolerations:
+                          description: Tolerations overrides tolerations to be set
+                            into RTE daemonsets for this NodeGroup. If not empty,
+                            the tolerations will be the one set here. Leave empty
+                            to make the system use the default tolerations.
+                          items:
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect>
+                              using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to
+                                  match. Empty means match all taint effects. When
+                                  specified, allowed values are NoSchedule, PreferNoSchedule
+                                  and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If
+                                  the key is empty, operator must be Exists; this
+                                  combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints
+                                  of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect
+                                  NoExecute, otherwise this field is ignored) tolerates
+                                  the taint. By default, it is not set, which means
+                                  tolerate the taint forever (do not evict). Zero
+                                  and negative values will be treated as 0 (evict
+                                  immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value
+                                  should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
                       type: object
                     name:
                       description: Name the name of the machine config pool

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -111,6 +111,13 @@ spec:
         path: nodeGroups[0].config.podsFingerprinting
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tolerations overrides tolerations to be set into RTE daemonsets
+          for this NodeGroup. If not empty, the tolerations will be the one set here.
+          Leave empty to make the system use the default tolerations.
+        displayName: Extra tolerations for the topology updater daemonset
+        path: nodeGroups[0].config.tolerations
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Optional Namespace/Name glob patterns of pod to ignore at node
           level
         displayName: Optional ignore pod namespace/name glob patterns

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -83,6 +83,52 @@ spec:
                           - Enabled
                           - EnabledExclusiveResources
                           type: string
+                        tolerations:
+                          description: Tolerations overrides tolerations to be set
+                            into RTE daemonsets for this NodeGroup. If not empty,
+                            the tolerations will be the one set here. Leave empty
+                            to make the system use the default tolerations.
+                          items:
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect>
+                              using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to
+                                  match. Empty means match all taint effects. When
+                                  specified, allowed values are NoSchedule, PreferNoSchedule
+                                  and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If
+                                  the key is empty, operator must be Exists; this
+                                  combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints
+                                  of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect
+                                  NoExecute, otherwise this field is ignored) tolerates
+                                  the taint. By default, it is not set, which means
+                                  tolerate the taint forever (do not evict). Zero
+                                  and negative values will be treated as 0 (evict
+                                  immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value
+                                  should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
                       type: object
                     machineConfigPoolSelector:
                       description: MachineConfigPoolSelector defines label selector
@@ -300,6 +346,52 @@ spec:
                           - Enabled
                           - EnabledExclusiveResources
                           type: string
+                        tolerations:
+                          description: Tolerations overrides tolerations to be set
+                            into RTE daemonsets for this NodeGroup. If not empty,
+                            the tolerations will be the one set here. Leave empty
+                            to make the system use the default tolerations.
+                          items:
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect>
+                              using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to
+                                  match. Empty means match all taint effects. When
+                                  specified, allowed values are NoSchedule, PreferNoSchedule
+                                  and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If
+                                  the key is empty, operator must be Exists; this
+                                  combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints
+                                  of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect
+                                  NoExecute, otherwise this field is ignored) tolerates
+                                  the taint. By default, it is not set, which means
+                                  tolerate the taint forever (do not evict). Zero
+                                  and negative values will be treated as 0 (evict
+                                  immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value
+                                  should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
                       type: object
                     name:
                       description: Name the name of the machine config pool

--- a/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
@@ -51,6 +51,13 @@ spec:
         path: nodeGroups[0].config.podsFingerprinting
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tolerations overrides tolerations to be set into RTE daemonsets
+          for this NodeGroup. If not empty, the tolerations will be the one set here.
+          Leave empty to make the system use the default tolerations.
+        displayName: Extra tolerations for the topology updater daemonset
+        path: nodeGroups[0].config.tolerations
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Optional Namespace/Name glob patterns of pod to ignore at node
           level
         displayName: Optional ignore pod namespace/name glob patterns

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -690,7 +690,14 @@ func daemonsetUpdater(mcpName string, gdm *rtestate.GeneratedDesiredManifest) er
 		return err
 	}
 
-	return rteupdate.DaemonSetArgs(gdm.DaemonSet, *gdm.NodeGroup.Config)
+	err = rteupdate.DaemonSetArgs(gdm.DaemonSet, *gdm.NodeGroup.Config)
+	if err != nil {
+		klog.V(5).InfoS("DaemonSet update: cannot update arguments", "mcp", mcpName, "daemonset", gdm.DaemonSet.Name, "error", err)
+		return err
+	}
+
+	rteupdate.DaemonSetTolerations(gdm.DaemonSet, gdm.NodeGroup.Config.Tolerations)
+	return nil
 }
 
 func isDaemonSetReady(ds *appsv1.DaemonSet) bool {

--- a/controllers/numaresourcesoperator_controller_test.go
+++ b/controllers/numaresourcesoperator_controller_test.go
@@ -643,6 +643,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 			mcp = testobjs.NewMachineConfigPool("test", labels, &metav1.LabelSelector{MatchLabels: labels}, &metav1.LabelSelector{MatchLabels: labels})
 		})
+
 		It("should set defaults in the DS objects", func() {
 			nro := testobjs.NewNUMAResourcesOperatorWithNodeGroupConfig(objectnames.DefaultNUMAResourcesOperatorCrName, &labSel, nil)
 
@@ -868,12 +869,139 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 			// we need to do the first iteration here because the DS object is created in the second
 			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
-			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(reconciler.Client.Get(context.TODO(), mcpDSKey, ds)).ToNot(HaveOccurred())
 
 			args = ds.Spec.Template.Spec.Containers[0].Args
 			Expect(args).To(ContainElement("--pods-fingerprint-method=all"), "malformed args: %v", args)
+		})
+
+		It("should keep the manifest tolerations if not set", func() {
+			conf := nropv1.DefaultNodeGroupConfig()
+			Expect(conf.Tolerations).To(BeEmpty())
+			nro := testobjs.NewNUMAResourcesOperatorWithNodeGroupConfig(objectnames.DefaultNUMAResourcesOperatorCrName, &labSel, &conf)
+
+			reconciler := reconcileObjects(nro, mcp)
+
+			mcpDSKey := client.ObjectKey{
+				Name:      objectnames.GetComponentName(nro.Name, mcp.Name),
+				Namespace: testNamespace,
+			}
+			ds := &appsv1.DaemonSet{}
+			Expect(reconciler.Client.Get(context.TODO(), mcpDSKey, ds)).To(Succeed())
+
+			Expect(ds.Spec.Template.Spec.Tolerations).To(Equal(reconciler.RTEManifests.DaemonSet.Spec.Template.Spec.Tolerations), "mismatched DS default tolerations")
+		})
+
+		It("should add the extra tolerations in the DS objects", func() {
+			conf := nropv1.DefaultNodeGroupConfig()
+			conf.Tolerations = []corev1.Toleration{
+				{
+					Key:    "foo",
+					Value:  "1",
+					Effect: corev1.TaintEffectNoSchedule,
+				},
+			}
+			nro := testobjs.NewNUMAResourcesOperatorWithNodeGroupConfig(objectnames.DefaultNUMAResourcesOperatorCrName, &labSel, &conf)
+
+			reconciler := reconcileObjects(nro, mcp)
+
+			mcpDSKey := client.ObjectKey{
+				Name:      objectnames.GetComponentName(nro.Name, mcp.Name),
+				Namespace: testNamespace,
+			}
+			ds := &appsv1.DaemonSet{}
+			Expect(reconciler.Client.Get(context.TODO(), mcpDSKey, ds)).To(Succeed())
+
+			Expect(ds.Spec.Template.Spec.Tolerations).To(Equal(conf.Tolerations), "mismatched DS tolerations")
+		})
+
+		It("should replace the extra tolerations in the DS objects", func() {
+			conf := nropv1.DefaultNodeGroupConfig()
+			conf.Tolerations = []corev1.Toleration{
+				{
+					Key:    "foo",
+					Value:  "1",
+					Effect: corev1.TaintEffectNoSchedule,
+				},
+			}
+			nro := testobjs.NewNUMAResourcesOperatorWithNodeGroupConfig(objectnames.DefaultNUMAResourcesOperatorCrName, &labSel, &conf)
+
+			reconciler := reconcileObjects(nro, mcp)
+
+			mcpDSKey := client.ObjectKey{
+				Name:      objectnames.GetComponentName(nro.Name, mcp.Name),
+				Namespace: testNamespace,
+			}
+			ds := &appsv1.DaemonSet{}
+			Expect(reconciler.Client.Get(context.TODO(), mcpDSKey, ds)).To(Succeed())
+
+			Expect(ds.Spec.Template.Spec.Tolerations).To(Equal(conf.Tolerations), "mismatched DS tolerations (round 1)")
+
+			key := client.ObjectKeyFromObject(nro)
+
+			nroUpdated := &nropv1.NUMAResourcesOperator{}
+			Eventually(func() error {
+				Expect(reconciler.Client.Get(context.TODO(), key, nroUpdated)).To(Succeed())
+				nroUpdated.Spec.NodeGroups[0].Config.Tolerations = []corev1.Toleration{
+					{
+						Key:    "bar",
+						Value:  "2",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+					{
+						Key:    "baz",
+						Value:  "3",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+				}
+				return reconciler.Client.Update(context.TODO(), nroUpdated)
+			}).WithPolling(1 * time.Second).WithTimeout(30 * time.Second).Should(Succeed())
+
+			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(reconciler.Client.Get(context.TODO(), mcpDSKey, ds)).To(Succeed())
+			Expect(ds.Spec.Template.Spec.Tolerations).To(Equal(nroUpdated.Spec.NodeGroups[0].Config.Tolerations), "mismatched DS tolerations (round 2)")
+		})
+
+		It("should remove the extra tolerations in the DS objects", func() {
+			conf := nropv1.DefaultNodeGroupConfig()
+			conf.Tolerations = []corev1.Toleration{
+				{
+					Key:    "foo",
+					Value:  "1",
+					Effect: corev1.TaintEffectNoSchedule,
+				},
+			}
+			nro := testobjs.NewNUMAResourcesOperatorWithNodeGroupConfig(objectnames.DefaultNUMAResourcesOperatorCrName, &labSel, &conf)
+
+			reconciler := reconcileObjects(nro, mcp)
+
+			mcpDSKey := client.ObjectKey{
+				Name:      objectnames.GetComponentName(nro.Name, mcp.Name),
+				Namespace: testNamespace,
+			}
+			ds := &appsv1.DaemonSet{}
+			Expect(reconciler.Client.Get(context.TODO(), mcpDSKey, ds)).To(Succeed())
+
+			Expect(ds.Spec.Template.Spec.Tolerations).To(Equal(conf.Tolerations), "mismatched DS tolerations")
+
+			key := client.ObjectKeyFromObject(nro)
+
+			Eventually(func() error {
+				nroUpdated := &nropv1.NUMAResourcesOperator{}
+				Expect(reconciler.Client.Get(context.TODO(), key, nroUpdated)).To(Succeed())
+				nroUpdated.Spec.NodeGroups[0].Config.Tolerations = nil
+				return reconciler.Client.Update(context.TODO(), nroUpdated)
+			}).WithPolling(1 * time.Second).WithTimeout(30 * time.Second).Should(Succeed())
+
+			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(reconciler.Client.Get(context.TODO(), mcpDSKey, ds)).To(Succeed())
+			Expect(ds.Spec.Template.Spec.Tolerations).To(Equal(reconciler.RTEManifests.DaemonSet.Spec.Template.Spec.Tolerations), "DS tolerations not restored to defaults")
 		})
 	})
 })

--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -174,6 +174,14 @@ func DaemonSetArgs(ds *appsv1.DaemonSet, conf nropv1.NodeGroupConfig) error {
 	return nil
 }
 
+func DaemonSetTolerations(ds *appsv1.DaemonSet, userTolerations []corev1.Toleration) {
+	if len(userTolerations) == 0 {
+		return
+	}
+	podSpec := &ds.Spec.Template.Spec // shortcut
+	podSpec.Tolerations = nropv1.CloneTolerations(userTolerations)
+}
+
 func ContainerConfig(ds *appsv1.DaemonSet, name string) error {
 	cnt := k8swgobjupdate.FindContainerByName(ds.Spec.Template.Spec.Containers, MainContainerName)
 	if cnt == nil {

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -48,7 +48,6 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
-	rtemanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte"
 	nropmcp "github.com/openshift-kni/numaresources-operator/internal/machineconfigpools"
 	"github.com/openshift-kni/numaresources-operator/internal/relatedobjects"
 	"github.com/openshift-kni/numaresources-operator/pkg/kubeletconfig"
@@ -775,102 +774,8 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 				return kcCmNamesCur
 			}).WithContext(ctx).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Equal(kcCmNamesPre))
 		})
-
-		It("should enable to change tolerations in the RTE daemonsets", func(ctx context.Context) {
-			By("getting RTE manifests object")
-			// TODO: this is similar but not quite what the main operator does
-			rteManifests, err := rtemanifests.GetManifests(configuration.Plat, configuration.PlatVersion, "", true)
-			Expect(err).ToNot(HaveOccurred(), "cannot get the RTE manifests")
-
-			By("getting NROP object")
-			nroKey := objects.NROObjectKey()
-			nroOperObj := nropv1.NUMAResourcesOperator{}
-
-			err = fxt.Client.Get(context.TODO(), nroKey, &nroOperObj)
-			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", nroKey.String())
-
-			if len(nroOperObj.Spec.NodeGroups) != 1 {
-				// TODO: this is the simplest case, there is no hard requirement really
-				// but we took the simplest option atm
-				e2efixture.Skipf(fxt, "more than one NodeGroup not yet supported, found %d", len(nroOperObj.Spec.NodeGroups))
-			}
-
-			By("checking the DSs owned by NROP")
-			dsObj := appsv1.DaemonSet{}
-			dsKey := wait.ObjectKey{
-				Namespace: nroOperObj.Status.DaemonSets[0].Namespace,
-				Name:      nroOperObj.Status.DaemonSets[0].Name,
-			}
-
-			err = fxt.Client.Get(context.TODO(), client.ObjectKey{Namespace: dsKey.Namespace, Name: dsKey.Name}, &dsObj)
-			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", dsKey.String())
-			expectedTolerations := rteManifests.DaemonSet.Spec.Template.Spec.Tolerations // shortcut
-			gotTolerations := dsObj.Spec.Template.Spec.Tolerations                       // shortcut
-			expectEqualTolerations(gotTolerations, expectedTolerations)
-
-			By("adding extra tolerations")
-			updatedNropObj := setRTETolerations(context.TODO(), fxt.Client, nroKey, []corev1.Toleration{sriovToleration()})
-			By("waiting for DaemonSet to be ready")
-			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(1*time.Minute).ForDaemonSetUpdateByKey(context.TODO(), dsKey)
-			Expect(err).ToNot(HaveOccurred(), "daemonset %s did not start updated: %v", dsKey.String(), err)
-			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(context.TODO(), dsKey)
-			Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
-
-			defer func(ctx context.Context) {
-				By("removing extra tolerations")
-				_ = setRTETolerations(ctx, fxt.Client, nroKey, []corev1.Toleration{})
-				By("waiting for DaemonSet to be ready")
-				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(1*time.Minute).ForDaemonSetUpdateByKey(ctx, dsKey)
-				Expect(err).ToNot(HaveOccurred(), "daemonset %s did not start updated: %v", dsKey.String(), err)
-				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
-				Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
-			}(context.TODO())
-
-			By("checking the tolerations in the owned DaemonSet")
-			err = fxt.Client.Get(context.TODO(), client.ObjectKey{Namespace: dsKey.Namespace, Name: dsKey.Name}, &dsObj)
-			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", dsKey.String())
-
-			expectedTolerations = updatedNropObj.Spec.NodeGroups[0].Config.Tolerations // shortcut
-			gotTolerations = dsObj.Spec.Template.Spec.Tolerations                      // shortcut
-			expectEqualTolerations(gotTolerations, expectedTolerations)
-		})
 	})
 })
-
-func expectEqualTolerations(tolsA, tolsB []corev1.Toleration) {
-	GinkgoHelper()
-	tA := nropv1.SortedTolerations(tolsA)
-	tB := nropv1.SortedTolerations(tolsB)
-	Expect(tA).To(Equal(tB), "mismatched tolerations")
-}
-
-func setRTETolerations(ctx context.Context, cli client.Client, nroKey client.ObjectKey, tols []corev1.Toleration) *nropv1.NUMAResourcesOperator {
-	GinkgoHelper()
-
-	nropOperObj := nropv1.NUMAResourcesOperator{}
-	Eventually(func(g Gomega) {
-		err := cli.Get(ctx, nroKey, &nropOperObj)
-		g.Expect(err).ToNot(HaveOccurred())
-
-		if nropOperObj.Spec.NodeGroups[0].Config == nil {
-			nropOperObj.Spec.NodeGroups[0].Config = &nropv1.NodeGroupConfig{}
-		}
-		nropOperObj.Spec.NodeGroups[0].Config.Tolerations = tols
-		err = cli.Update(ctx, &nropOperObj)
-		g.Expect(err).ToNot(HaveOccurred())
-	}).WithTimeout(5 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
-
-	return &nropOperObj
-}
-
-func sriovToleration() corev1.Toleration {
-	return corev1.Toleration{
-		Key:      "sriov",
-		Operator: corev1.TolerationOpEqual,
-		Value:    "true",
-		Effect:   corev1.TaintEffectNoSchedule,
-	}
-}
 
 func daemonSetListToNamespacedNameList(dss []*appsv1.DaemonSet) []nropv1.NamespacedName {
 	ret := make([]nropv1.NamespacedName, 0, len(dss))

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -48,6 +48,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
+	rtemanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte"
 	nropmcp "github.com/openshift-kni/numaresources-operator/internal/machineconfigpools"
 	"github.com/openshift-kni/numaresources-operator/internal/relatedobjects"
 	"github.com/openshift-kni/numaresources-operator/pkg/kubeletconfig"
@@ -774,8 +775,102 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 				return kcCmNamesCur
 			}).WithContext(ctx).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Equal(kcCmNamesPre))
 		})
+
+		It("should enable to change tolerations in the RTE daemonsets", func(ctx context.Context) {
+			By("getting RTE manifests object")
+			// TODO: this is similar but not quite what the main operator does
+			rteManifests, err := rtemanifests.GetManifests(configuration.Plat, configuration.PlatVersion, "", true)
+			Expect(err).ToNot(HaveOccurred(), "cannot get the RTE manifests")
+
+			By("getting NROP object")
+			nroKey := objects.NROObjectKey()
+			nroOperObj := nropv1.NUMAResourcesOperator{}
+
+			err = fxt.Client.Get(context.TODO(), nroKey, &nroOperObj)
+			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", nroKey.String())
+
+			if len(nroOperObj.Spec.NodeGroups) != 1 {
+				// TODO: this is the simplest case, there is no hard requirement really
+				// but we took the simplest option atm
+				e2efixture.Skipf(fxt, "more than one NodeGroup not yet supported, found %d", len(nroOperObj.Spec.NodeGroups))
+			}
+
+			By("checking the DSs owned by NROP")
+			dsObj := appsv1.DaemonSet{}
+			dsKey := wait.ObjectKey{
+				Namespace: nroOperObj.Status.DaemonSets[0].Namespace,
+				Name:      nroOperObj.Status.DaemonSets[0].Name,
+			}
+
+			err = fxt.Client.Get(context.TODO(), client.ObjectKey{Namespace: dsKey.Namespace, Name: dsKey.Name}, &dsObj)
+			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", dsKey.String())
+			expectedTolerations := rteManifests.DaemonSet.Spec.Template.Spec.Tolerations // shortcut
+			gotTolerations := dsObj.Spec.Template.Spec.Tolerations                       // shortcut
+			expectEqualTolerations(gotTolerations, expectedTolerations)
+
+			By("adding extra tolerations")
+			updatedNropObj := setRTETolerations(context.TODO(), fxt.Client, nroKey, []corev1.Toleration{sriovToleration()})
+			By("waiting for DaemonSet to be ready")
+			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(1*time.Minute).ForDaemonSetUpdateByKey(context.TODO(), dsKey)
+			Expect(err).ToNot(HaveOccurred(), "daemonset %s did not start updated: %v", dsKey.String(), err)
+			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(context.TODO(), dsKey)
+			Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
+
+			defer func(ctx context.Context) {
+				By("removing extra tolerations")
+				_ = setRTETolerations(ctx, fxt.Client, nroKey, []corev1.Toleration{})
+				By("waiting for DaemonSet to be ready")
+				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(1*time.Minute).ForDaemonSetUpdateByKey(ctx, dsKey)
+				Expect(err).ToNot(HaveOccurred(), "daemonset %s did not start updated: %v", dsKey.String(), err)
+				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
+				Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
+			}(context.TODO())
+
+			By("checking the tolerations in the owned DaemonSet")
+			err = fxt.Client.Get(context.TODO(), client.ObjectKey{Namespace: dsKey.Namespace, Name: dsKey.Name}, &dsObj)
+			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", dsKey.String())
+
+			expectedTolerations = updatedNropObj.Spec.NodeGroups[0].Config.Tolerations // shortcut
+			gotTolerations = dsObj.Spec.Template.Spec.Tolerations                      // shortcut
+			expectEqualTolerations(gotTolerations, expectedTolerations)
+		})
 	})
 })
+
+func expectEqualTolerations(tolsA, tolsB []corev1.Toleration) {
+	GinkgoHelper()
+
+	// TODO: sort, then check
+	Expect(tolsA).To(Equal(tolsB), "mismatched tolerations")
+}
+
+func setRTETolerations(ctx context.Context, cli client.Client, nroKey client.ObjectKey, tols []corev1.Toleration) *nropv1.NUMAResourcesOperator {
+	GinkgoHelper()
+
+	nropOperObj := nropv1.NUMAResourcesOperator{}
+	Eventually(func(g Gomega) {
+		err := cli.Get(ctx, nroKey, &nropOperObj)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		if nropOperObj.Spec.NodeGroups[0].Config == nil {
+			nropOperObj.Spec.NodeGroups[0].Config = &nropv1.NodeGroupConfig{}
+		}
+		nropOperObj.Spec.NodeGroups[0].Config.Tolerations = tols
+		err = cli.Update(ctx, &nropOperObj)
+		g.Expect(err).ToNot(HaveOccurred())
+	}).WithTimeout(5 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
+
+	return &nropOperObj
+}
+
+func sriovToleration() corev1.Toleration {
+	return corev1.Toleration{
+		Key:      "sriov",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "true",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+}
 
 func daemonSetListToNamespacedNameList(dss []*appsv1.DaemonSet) []nropv1.NamespacedName {
 	ret := make([]nropv1.NamespacedName, 0, len(dss))

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -839,9 +839,9 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 
 func expectEqualTolerations(tolsA, tolsB []corev1.Toleration) {
 	GinkgoHelper()
-
-	// TODO: sort, then check
-	Expect(tolsA).To(Equal(tolsB), "mismatched tolerations")
+	tA := nropv1.SortedTolerations(tolsA)
+	tB := nropv1.SortedTolerations(tolsB)
+	Expect(tA).To(Equal(tB), "mismatched tolerations")
 }
 
 func setRTETolerations(ctx context.Context, cli client.Client, nroKey client.ObjectKey, tols []corev1.Toleration) *nropv1.NUMAResourcesOperator {

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+
+	rtemanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte"
+	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
+	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
+	"github.com/openshift-kni/numaresources-operator/internal/wait"
+	"github.com/openshift-kni/numaresources-operator/test/utils/configuration"
+	e2efixture "github.com/openshift-kni/numaresources-operator/test/utils/fixture"
+	e2enrt "github.com/openshift-kni/numaresources-operator/test/utils/noderesourcetopologies"
+	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
+
+	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
+)
+
+var _ = Describe("[serial][disruptive][slow] numaresources configuration management", Serial, func() {
+	var fxt *e2efixture.Fixture
+	var nrtList nrtv1alpha2.NodeResourceTopologyList
+	var nrts []nrtv1alpha2.NodeResourceTopology
+
+	BeforeEach(func(ctx context.Context) {
+		Expect(serialconfig.Config).ToNot(BeNil())
+		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
+
+		var err error
+		fxt, err = e2efixture.Setup("e2e-test-configuration", serialconfig.Config.NRTList)
+		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
+
+		err = fxt.Client.List(ctx, &nrtList)
+		Expect(err).ToNot(HaveOccurred())
+
+		// we're ok with any TM policy as long as the updater can handle it,
+		// we use this as proxy for "there is valid NRT data for at least X nodes
+		nrts = e2enrt.FilterByTopologyManagerPolicy(nrtList.Items, intnrt.SingleNUMANode)
+		if len(nrts) < 2 {
+			Skip(fmt.Sprintf("not enough nodes with valid policy - found %d", len(nrts)))
+		}
+
+		// Note that this test, being part of "serial", expects NO OTHER POD being scheduled
+		// in between, so we consider this information current and valid when the It()s run.
+	})
+
+	AfterEach(func(_ context.Context) {
+		err := e2efixture.Teardown(fxt)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("cluster has at least one suitable node", func() {
+		It("should enable to change tolerations in the RTE daemonsets", func(ctx context.Context) {
+			By("getting RTE manifests object")
+			// TODO: this is similar but not quite what the main operator does
+			rteManifests, err := rtemanifests.GetManifests(configuration.Plat, configuration.PlatVersion, "", true)
+			Expect(err).ToNot(HaveOccurred(), "cannot get the RTE manifests")
+
+			By("getting NROP object")
+			nroKey := objects.NROObjectKey()
+			nroOperObj := nropv1.NUMAResourcesOperator{}
+
+			err = fxt.Client.Get(ctx, nroKey, &nroOperObj)
+			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", nroKey.String())
+
+			if len(nroOperObj.Spec.NodeGroups) != 1 {
+				// TODO: this is the simplest case, there is no hard requirement really
+				// but we took the simplest option atm
+				e2efixture.Skipf(fxt, "more than one NodeGroup not yet supported, found %d", len(nroOperObj.Spec.NodeGroups))
+			}
+
+			By("checking the DSs owned by NROP")
+			dsObj := appsv1.DaemonSet{}
+			dsKey := wait.ObjectKey{
+				Namespace: nroOperObj.Status.DaemonSets[0].Namespace,
+				Name:      nroOperObj.Status.DaemonSets[0].Name,
+			}
+
+			err = fxt.Client.Get(ctx, client.ObjectKey{Namespace: dsKey.Namespace, Name: dsKey.Name}, &dsObj)
+			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", dsKey.String())
+			expectedTolerations := rteManifests.DaemonSet.Spec.Template.Spec.Tolerations // shortcut
+			gotTolerations := dsObj.Spec.Template.Spec.Tolerations                       // shortcut
+			expectEqualTolerations(gotTolerations, expectedTolerations)
+
+			By("adding extra tolerations")
+			updatedNropObj := setRTETolerations(ctx, fxt.Client, nroKey, []corev1.Toleration{sriovToleration()})
+			By("waiting for DaemonSet to be ready")
+			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(1*time.Minute).ForDaemonSetUpdateByKey(ctx, dsKey)
+			Expect(err).ToNot(HaveOccurred(), "daemonset %s did not start updated: %v", dsKey.String(), err)
+			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
+			Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
+
+			defer func(ctx context.Context) {
+				By("removing extra tolerations")
+				_ = setRTETolerations(ctx, fxt.Client, nroKey, []corev1.Toleration{})
+				By("waiting for DaemonSet to be ready")
+				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(1*time.Minute).ForDaemonSetUpdateByKey(ctx, dsKey)
+				Expect(err).ToNot(HaveOccurred(), "daemonset %s did not start updated: %v", dsKey.String(), err)
+				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
+				Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
+			}(ctx)
+
+			By("checking the tolerations in the owned DaemonSet")
+			err = fxt.Client.Get(ctx, client.ObjectKey{Namespace: dsKey.Namespace, Name: dsKey.Name}, &dsObj)
+			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", dsKey.String())
+
+			expectedTolerations = updatedNropObj.Spec.NodeGroups[0].Config.Tolerations // shortcut
+			gotTolerations = dsObj.Spec.Template.Spec.Tolerations                      // shortcut
+			expectEqualTolerations(gotTolerations, expectedTolerations)
+		})
+	})
+})
+
+func expectEqualTolerations(tolsA, tolsB []corev1.Toleration) {
+	GinkgoHelper()
+	tA := nropv1.SortedTolerations(tolsA)
+	tB := nropv1.SortedTolerations(tolsB)
+	Expect(tA).To(Equal(tB), "mismatched tolerations")
+}
+
+func setRTETolerations(ctx context.Context, cli client.Client, nroKey client.ObjectKey, tols []corev1.Toleration) *nropv1.NUMAResourcesOperator {
+	GinkgoHelper()
+
+	nropOperObj := nropv1.NUMAResourcesOperator{}
+	Eventually(func(g Gomega) {
+		err := cli.Get(ctx, nroKey, &nropOperObj)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		if nropOperObj.Spec.NodeGroups[0].Config == nil {
+			nropOperObj.Spec.NodeGroups[0].Config = &nropv1.NodeGroupConfig{}
+		}
+		nropOperObj.Spec.NodeGroups[0].Config.Tolerations = tols
+		err = cli.Update(ctx, &nropOperObj)
+		g.Expect(err).ToNot(HaveOccurred())
+	}).WithTimeout(5 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
+
+	return &nropOperObj
+}
+
+func sriovToleration() corev1.Toleration {
+	return corev1.Toleration{
+		Key:      "sriov",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "true",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+}

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -48,7 +48,7 @@ import (
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 )
 
-var _ = Describe("[serial][disruptive][slow] numaresources RTE tolerations support", Serial, func() {
+var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerations support", Serial, func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 	var nrts []nrtv1alpha2.NodeResourceTopology

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -109,12 +109,6 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 
 			By("adding extra tolerations")
 			updatedNropObj := setRTETolerations(ctx, fxt.Client, nroKey, []corev1.Toleration{sriovToleration()})
-			By("waiting for DaemonSet to be ready")
-			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(1*time.Minute).ForDaemonSetUpdateByKey(ctx, dsKey)
-			Expect(err).ToNot(HaveOccurred(), "daemonset %s did not start updated: %v", dsKey.String(), err)
-			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
-			Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
-
 			defer func(ctx context.Context) {
 				By("removing extra tolerations")
 				_ = setRTETolerations(ctx, fxt.Client, nroKey, []corev1.Toleration{})
@@ -124,6 +118,12 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
 				Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
 			}(ctx)
+
+			By("waiting for DaemonSet to be ready")
+			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(1*time.Minute).ForDaemonSetUpdateByKey(ctx, dsKey)
+			Expect(err).ToNot(HaveOccurred(), "daemonset %s did not start updated: %v", dsKey.String(), err)
+			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
+			Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
 
 			By("checking the tolerations in the owned DaemonSet")
 			err = fxt.Client.Get(ctx, client.ObjectKey{Namespace: dsKey.Namespace, Name: dsKey.Name}, &dsObj)

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -139,7 +139,7 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 				}).WithTimeout(5 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
 			})
 
-			It("should handle invalid field: effect [test_id:OCP-72862]", func(ctx context.Context) {
+			It("[test_id:72862] should handle invalid field: effect", func(ctx context.Context) {
 				By("adding extra invalid tolerations with wrong effect field")
 				_ = setRTETolerations(ctx, fxt.Client, nroKey, []corev1.Toleration{
 					{
@@ -169,7 +169,7 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 			})
 		})
 
-		It("should enable to change tolerations in the RTE daemonsets [tier3]", func(ctx context.Context) {
+		It("[tier3] should enable to change tolerations in the RTE daemonsets", func(ctx context.Context) {
 			By("getting RTE manifests object")
 			// TODO: this is similar but not quite what the main operator does
 			rteManifests, err := rtemanifests.GetManifests(configuration.Plat, configuration.PlatVersion, "", true)
@@ -236,7 +236,7 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 				Expect(int(updatedDs.Status.NumberReady)).To(Equal(len(workers)), "RTE DS ready=%v original worker nodes=%d", updatedDs.Status.NumberReady, len(workers))
 			})
 
-			It("should handle untolerations of tainted nodes while RTEs are running [tier2][test_id:OCP-72857]", func(ctx context.Context) {
+			It("[tier2][test_id:72857] should handle untolerations of tainted nodes while RTEs are running", func(ctx context.Context) {
 				var err error
 				By("adding extra tolerations")
 				_ = setRTETolerations(ctx, fxt.Client, nroKey, testToleration())
@@ -312,7 +312,7 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 				Expect(int(updatedDs.Status.NumberReady)).To(Equal(len(workers)), "RTE DS ready=%v original worker nodes=%d", updatedDs.Status.NumberReady, len(workers))
 			})
 
-			It("should tolerate partial taints and not schedule or evict the pod on the tainted node [tier2][test_id:OCP-72861]", func(ctx context.Context) {
+			It("[tier2][test_id:72861] should tolerate partial taints and not schedule or evict the pod on the tainted node", func(ctx context.Context) {
 				var err error
 				By("getting the worker nodes")
 				workers, err = nodes.GetWorkerNodes(fxt.Client, context.TODO())


### PR DESCRIPTION
add support to inject (and override) the RTE tolerations.
The user-provided tolerations will completely override the manifests tolerations.
If the user removes the tolerations, then the operator will enforce again the manifest ones (possibly, no tolerations).

The recommended flow to add/change the default tolerations (if any) is to
1. find the owned daemonsets: nrop.Status.DaemonSets
2. lookup the owned daemonsets using the namespace/name pair found in
   the previous step
3. inspect the DS manifests to learn about the current tolerations
4. set new tolerations in nrop.Spec.NodeGroup[*].Config.Tolerations
   taking into account the existing ones

cumulative backport of #808 #887 #894 #901 