### PR TITLE
toolchain: ghactions: bump toolchain to 1.21.z

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.6
+        go-version: 1.21.8
 
     - name: Verify modules
       run: go mod verify

--- a/.github/workflows/ciformat.yml
+++ b/.github/workflows/ciformat.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.6
+        go-version: 1.21.8
 
     - name: format
       run: ./hack/check-format.sh

--- a/.github/workflows/cilint-custom.yml
+++ b/.github/workflows/cilint-custom.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.6
+        go-version: 1.21.8
 
     - name: Fetch golangci-lint
       run: |

--- a/.github/workflows/cilint.yml
+++ b/.github/workflows/cilint.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.6
+        go-version: 1.21.8
 
     - name: Verify
       uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/e2e-local.yaml
+++ b/.github/workflows/e2e-local.yaml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.6
+        go-version: 1.21.8
 
     - name: Verify modules
       run: go mod verify

--- a/.github/workflows/e2e-tools.yml
+++ b/.github/workflows/e2e-tools.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.6
+        go-version: 1.21.8
 
     - name: Verify modules
       run: go mod verify

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.6
+        go-version: 1.21.8
 
     - name: Verify modules
       run: go mod verify

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.6
+        go-version: 1.21.8
 
     - name: Run Linter
       run: make golangci-lint

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-go@v3
         id: go
         with:
-          go-version: 1.20.6
+          go-version: 1.21.8
 
       - name: Set release version env var
         run: |


### PR DESCRIPTION
no reason to be stuck on golang 1.20.z, not even on CI