### PR TITLE
Ensure that NROP metrics are served securely

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -14,15 +14,55 @@ spec:
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
+        - "--config-file=/etc/kube-rbac-proxy/config.yaml"
+        - "--tls-cert-file=/etc/tls/private/tls.crt"
+        - "--tls-private-key-file=/etc/tls/private/tls.key"
+        - "--client-ca-file=/etc/tls/client/client-ca-file"
+        - "--allow-paths=/metrics"
         - "--logtostderr=true"
         - "-v=10"
         ports:
         - containerPort: 8443
           protocol: TCP
           name: https
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/kube-rbac-proxy
+          name: secret-kube-rbac-proxy-metric
+          readOnly: true
+        - mountPath: /etc/tls/private
+          name: secret-kube-rbac-proxy-tls
+          readOnly: true
+        - mountPath: /etc/tls/client
+          name: metrics-client-ca
+          readOnly: true
+      - volumes:
+        # Secret created by the service CA operator.
+        # We assume that the Kubernetes service exposing the application's pods has the
+        # "service.beta.openshift.io/serving-cert-secret-name: kube-rbac-proxy-tls"
+        # annotation.
+        - name: secret-kube-rbac-proxy-tls
+          secret:
+            secretName: kube-rbac-proxy-tls
+        # Secret containing the kube-rbac-proxy configuration (see below).
+        - name: secret-kube-rbac-proxy-metric
+          secret:
+            secretName: secret-kube-rbac-proxy-metric
+        # ConfigMap containing the CA used to verify the client certificate.
+        - name: metrics-client-ca
+          configMap:
+            name: metrics-client-ca
       - name: manager
         args:
         - "--platform=kubernetes"
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
+        - "--metrics-cacert-file=/etc/tls/client/client-ca-file"
+        - "--metrics-cert-file=/etc/tls/private/tls.crt"
+        - "--metrics-key-file=/etc/tls/private/tls.key"
         - "--leader-elect"

--- a/config/default/secret-kube-rbac-proxy.yaml
+++ b/config/default/secret-kube-rbac-proxy.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-kube-rbac-proxy-metric
+  namespace: system
+stringData:
+  config.yaml: |-
+    "authorization":
+      "static":
+      - "path": "/metrics"
+        "resourceRequest": false
+        "user":
+          "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
+        "verb": "get"    
+type: Opaque

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -12,9 +12,12 @@ spec:
     - path: /metrics
       port: https
       scheme: https
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      bearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tlsConfig:
-        insecureSkipVerify: true
+        caFile: /etc/tls/client/client-ca-file
+        certFile: /etc/tls/private/tls.crt
+        insecureSkipVerify: false
+        keyFile: /etc/tls/private/tls.key
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/main.go
+++ b/main.go
@@ -69,15 +69,16 @@ const (
 )
 
 const (
-	defaultWebhookPort = 9443
-	defaultMetricsAddr = ":8080"
-	defaultProbeAddr   = ":8081"
-	defaultImage       = ""
-	defaultNamespace   = "numaresources-operator"
-	defaultCertsDir    = "/etc/secrets/nrop"
-	defaultTLSCert     = defaultCertsDir + "tls.crt"
-	defaultTLSKey      = defaultCertsDir + "tls.key"
-	caCert             = defaultCertsDir + "/ca.crt"
+	defaultWebhookPort    = 9443
+	defaultMetricsAddr    = ":8080"
+	defaultMetricsEnabled = true
+	defaultProbeAddr      = ":8081"
+	defaultImage          = ""
+	defaultNamespace      = "numaresources-operator"
+	defaultCertsDir       = "/etc/secrets/nrop"
+	defaultTLSCert        = defaultCertsDir + "tls.crt"
+	defaultTLSKey         = defaultCertsDir + "tls.key"
+	caCert                = defaultCertsDir + "/ca.crt"
 )
 
 var (
@@ -128,6 +129,8 @@ func (pa *Params) SetDefaults() {
 	pa.probeAddr = defaultProbeAddr
 	pa.render.Namespace = defaultNamespace
 	pa.render.Image = defaultImage
+	pa.enableMetrics = defaultMetricsEnabled
+
 }
 
 func (pa *Params) FromFlags() {


### PR DESCRIPTION
Add Kube-rbac-proxy side car container to NROP deployment to ensure that NROP metrics are served securely.

Reference doc: https://rhobs-handbook.netlify.app/products/openshiftmonitoring/collecting_metrics.md/