### PR TITLE
internal: expose function to list all pods on a node

### DIFF
--- a/internal/podlist/node.go
+++ b/internal/podlist/node.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package podlist
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (fnd Finder) OnNode(ctx context.Context, nodeName string) ([]corev1.Pod, error) {
+	sel, err := fields.ParseSelector("spec.nodeName=" + nodeName)
+	if err != nil {
+		return nil, err
+	}
+
+	podList := &corev1.PodList{}
+	err = fnd.List(ctx, podList, &client.ListOptions{FieldSelector: sel})
+	return podList.Items, err
+}

--- a/test/e2e/rte/rte_test.go
+++ b/test/e2e/rte/rte_test.go
@@ -46,6 +46,7 @@ import (
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
 	nodegroupv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1/helper/nodegroup"
 	"github.com/openshift-kni/numaresources-operator/internal/machineconfigpools"
+	"github.com/openshift-kni/numaresources-operator/internal/podlist"
 	"github.com/openshift-kni/numaresources-operator/internal/remoteexec"
 	"github.com/openshift-kni/numaresources-operator/pkg/loglevel"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
@@ -270,7 +271,7 @@ var _ = ginkgo.Describe("with a running cluster with all the components", func()
 		for _, rteDs := range rteDss {
 			ginkgo.By(fmt.Sprintf("checking DS: %s/%s status=[%v]", rteDs.Namespace, rteDs.Name, toJSON(rteDs.Status)))
 
-			rtePods, err := podlistByDaemonset(clients.K8sClient, rteDs)
+			rtePods, err := podlist.With(clients.Client).ByDaemonset(context.TODO(), rteDs)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(rtePods).ToNot(gomega.BeEmpty(), "no RTE pods found for %s/%s", rteDs.Namespace, rteDs.Name)
 
@@ -336,20 +337,6 @@ func rteConfigMapToRTEConfig(cm *corev1.ConfigMap) (*rteconfig.Config, error) {
 	// TODO constant
 	err := yaml.Unmarshal([]byte(cm.Data["config.yaml"]), rc)
 	return rc, err
-}
-
-func podlistByDaemonset(cs kubernetes.Interface, ds appsv1.DaemonSet) ([]corev1.Pod, error) {
-	sel, err := metav1.LabelSelectorAsSelector(ds.Spec.Selector)
-	if err != nil {
-		return nil, err
-	}
-
-	podList, err := cs.CoreV1().Pods(ds.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: sel.String()})
-	if err != nil {
-		return nil, err
-	}
-
-	return podList.Items, nil
 }
 
 func toJSON(obj interface{}) string {

--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -337,7 +337,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			for _, nodeName := range e2efixture.ListNodeNames(nrtNames) {
 
 				//calculate base load on the node
-				baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), nodeName)
+				baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), nodeName)
 				Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", nodeName)
 				klog.Infof(fmt.Sprintf("computed base load: %s", baseload))
 

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -342,7 +342,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			klog.Infof("initial NRT target: %s", intnrt.ToString(*targetNrtInitial))
 
 			//calculate base load on the target node
-			baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), targetNodeName)
+			baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), targetNodeName)
 			Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", targetNodeName)
 			By(fmt.Sprintf("considering the computed base load: %s", baseload))
 
@@ -366,7 +366,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 				Expect(err).NotTo(HaveOccurred())
 
 				//calculate base load on the node
-				baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), nodeName)
+				baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), nodeName)
 				Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", nodeName)
 				klog.Infof(fmt.Sprintf("computed base load: %s", baseload))
 
@@ -518,7 +518,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			}
 
 			//calculate base load on the target node
-			baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), targetNodeName)
+			baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), targetNodeName)
 			Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", targetNodeName)
 			klog.Infof(fmt.Sprintf("computed base load: %s", baseload))
 

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -187,7 +187,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 					nrtInfo, err := e2enrt.FindFromList(nrtCandidates, nodeName)
 					Expect(err).NotTo(HaveOccurred(), "missing NRT Info for node %q", nodeName)
 
-					baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), nodeName)
+					baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), nodeName)
 					Expect(err).NotTo(HaveOccurred(), "cannot get the base load for %q", nodeName)
 
 					for zIdx, zone := range nrtInfo.Zones {
@@ -341,7 +341,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 					nrtInfo, err := e2enrt.FindFromList(nrtTwoZoneCandidates, nodeName)
 					Expect(err).NotTo(HaveOccurred(), "missing NRT Info for node %q", nodeName)
 
-					baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), nodeName)
+					baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), nodeName)
 					Expect(err).NotTo(HaveOccurred(), "cannot get the base load for %q", nodeName)
 
 					for zIdx, zone := range nrtInfo.Zones {
@@ -371,7 +371,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				By("padding a NUMA node on the target node")
 				var paddingPodsTargetNode []*corev1.Pod
 
-				baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), targetNodeName)
+				baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), targetNodeName)
 				Expect(err).NotTo(HaveOccurred(), "cannot get the base load for %q", targetNodeName)
 
 				for zIdx, zone := range targetNrtInitial.Zones {

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -568,7 +568,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}
 
 			// calculate base load on the target node
-			baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), targetNodeName)
+			baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), targetNodeName)
 			Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", targetNodeName)
 			klog.Infof(fmt.Sprintf("computed base load: %s", baseload))
 

--- a/test/e2e/serial/tests/workload_placement_nodelabel.go
+++ b/test/e2e/serial/tests/workload_placement_nodelabel.go
@@ -149,7 +149,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				nrtInfo, err := e2enrt.FindFromList(nrtCandidates, nodeName)
 				Expect(err).NotTo(HaveOccurred(), "missing NRT info for %q", nodeName)
 
-				baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), nodeName)
+				baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), nodeName)
 				Expect(err).NotTo(HaveOccurred(), "cannot get the base load for %q", nodeName)
 
 				for zIdx, zone := range nrtInfo.Zones {

--- a/test/e2e/serial/tests/workload_placement_resources.go
+++ b/test/e2e/serial/tests/workload_placement_resources.go
@@ -203,7 +203,7 @@ func setupNodes(fxt *e2efixture.Fixture, nodesState desiredNodesState) ([]nrtv1a
 		nrtInfo, err := e2enrt.FindFromList(nrtCandidates, nodeName)
 		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "missing NRT info for %q", nodeName)
 
-		baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), nodeName)
+		baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), nodeName)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred(), "missing node load info for %q", nodeName)
 		By(fmt.Sprintf("computed base load: %s", baseload))
 
@@ -220,7 +220,7 @@ func setupNodes(fxt *e2efixture.Fixture, nodesState desiredNodesState) ([]nrtv1a
 
 	By("Padding the target node")
 
-	baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), targetNodeName)
+	baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), targetNodeName)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "missing node load info for %q", targetNodeName)
 	By(fmt.Sprintf("computed base load: %s", baseload))
 

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -1970,7 +1970,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 })
 
 func setupPadding(fxt *e2efixture.Fixture, nrtList nrtv1alpha2.NodeResourceTopologyList, padInfo paddingInfo) []*corev1.Pod {
-	baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), padInfo.targetNodeName)
+	baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), padInfo.targetNodeName)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "missing node load info for %q", padInfo.targetNodeName)
 	By(fmt.Sprintf("computed base load: %s", baseload))
 
@@ -2016,7 +2016,7 @@ func setupPaddingForUnsuitableNodes(offset int, fxt *e2efixture.Fixture, nrtList
 		nrtInfo, err := e2enrt.FindFromList(nrtList.Items, unsuitableNodeName)
 		ExpectWithOffset(offset, err).ToNot(HaveOccurred(), "missing NRT info for %q", unsuitableNodeName)
 
-		baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), unsuitableNodeName)
+		baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), unsuitableNodeName)
 		ExpectWithOffset(offset, err).ToNot(HaveOccurred(), "missing node load info for %q", unsuitableNodeName)
 		By(fmt.Sprintf("computed base load: %s", baseload))
 

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -139,7 +139,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 				nrtInfo, err := e2enrt.FindFromList(nrtCandidates, nodeName)
 				Expect(err).NotTo(HaveOccurred(), "missing NRT info for %q", nodeName)
 
-				baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), nodeName)
+				baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), nodeName)
 				Expect(err).NotTo(HaveOccurred(), "cannot get base load for %q", nodeName)
 
 				for idx, zone := range nrtInfo.Zones {
@@ -351,7 +351,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 				nrtInfo, err := e2enrt.FindFromList(nrtCandidates, nodeName)
 				Expect(err).NotTo(HaveOccurred(), "missing NRT info for %q", nodeName)
 
-				baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), nodeName)
+				baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), nodeName)
 				Expect(err).NotTo(HaveOccurred(), "cannot get base load for %q", nodeName)
 
 				for zoneIdx, zone := range nrtInfo.Zones {
@@ -499,7 +499,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 				nrtInfo, err := e2enrt.FindFromList(nrtCandidates, nodeName)
 				Expect(err).NotTo(HaveOccurred(), "missing NRT info for %q", nodeName)
 
-				baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), nodeName)
+				baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), nodeName)
 				Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", nodeName)
 
 				paddingResources, err := e2enrt.SaturateNodeUntilLeft(*nrtInfo, baseload.Resources)
@@ -521,7 +521,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 
 			By("Padding target node")
 			//calculate base load on the target node
-			targetNodeBaseLoad, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), targetNodeName)
+			targetNodeBaseLoad, err := nodes.GetLoad(fxt.Client, context.TODO(), targetNodeName)
 			Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", targetNodeName)
 
 			// Pad the zones so no one could handle both containers
@@ -811,7 +811,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			for _, nodeName := range e2efixture.ListNodeNames(nrtCandidateNames) {
 
 				//calculate base load on the node
-				baseload, err := nodes.GetLoad(fxt.K8sClient, context.TODO(), nodeName)
+				baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), nodeName)
 				Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", nodeName)
 				klog.Infof(fmt.Sprintf("computed base load: %s", baseload))
 


### PR DESCRIPTION
This functionality was already used scattered across the codebase, let's consolidate in a single function.