### PR TITLE
[release-4.13][manual] kubeletconfig: ignore nonmatching kubeletconfig objects

### DIFF
--- a/controllers/kubeletconfig_controller.go
+++ b/controllers/kubeletconfig_controller.go
@@ -172,26 +172,26 @@ func (r *KubeletConfigReconciler) reconcileConfigMap(ctx context.Context, instan
 		return nil, err
 	}
 
-	generatedName := objectnames.GetComponentName(instance.Name, mcp.Name)
+	return r.syncConfigMap(ctx, mcoKc, kubeletConfig, instance, mcp.Name)
+}
+
+func (r *KubeletConfigReconciler) syncConfigMap(ctx context.Context, mcoKc *mcov1.KubeletConfig, kubeletConfig *kubeletconfigv1beta1.KubeletConfiguration, instance *nropv1.NUMAResourcesOperator, mcpName string) (*corev1.ConfigMap, error) {
+	generatedName := objectnames.GetComponentName(instance.Name, mcpName)
 	klog.V(3).InfoS("generated configMap name", "generatedName", generatedName)
 
 	podExcludes := podExcludesListToMap(instance.Spec.PodExcludes)
-
 	klog.V(5).InfoS("using podExcludes", "podExcludes", podExcludes)
-	return r.syncConfigMap(ctx, mcoKc, kubeletConfig, generatedName, podExcludes)
-}
 
-func (r *KubeletConfigReconciler) syncConfigMap(ctx context.Context, mcoKc *mcov1.KubeletConfig, kubeletConfig *kubeletconfigv1beta1.KubeletConfiguration, name string, podExcludes map[string]string) (*corev1.ConfigMap, error) {
 	data, err := rteconfig.Render(kubeletConfig, podExcludes)
 	if err != nil {
-		klog.ErrorS(err, "rendering config", "namespace", r.Namespace, "name", name)
+		klog.ErrorS(err, "rendering config", "namespace", r.Namespace, "name", generatedName)
 		return nil, err
 	}
-	rendered := rteconfig.CreateConfigMap(r.Namespace, name, string(data))
+	rendered := rteconfig.CreateConfigMap(r.Namespace, generatedName, data)
 	cfgManifests := cfgstate.Manifests{
-		Config: rendered,
+		Config: rteconfig.AddSoftRefLabels(rendered, instance.Name, mcpName),
 	}
-	existing := cfgstate.FromClient(ctx, r.Client, r.Namespace, name)
+	existing := cfgstate.FromClient(ctx, r.Client, r.Namespace, generatedName)
 	for _, objState := range existing.State(cfgManifests) {
 		// the owner should be the KubeletConfig object and not the NUMAResourcesOperator CR
 		// this means that when KubeletConfig will get deleted, the ConfigMap gets deleted as well

--- a/controllers/kubeletconfig_controller.go
+++ b/controllers/kubeletconfig_controller.go
@@ -123,10 +123,15 @@ func (r *KubeletConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 type InvalidKubeletConfig struct {
 	ObjectName string
+	Err        error
 }
 
 func (e *InvalidKubeletConfig) Error() string {
 	return "invalid KubeletConfig object: " + e.ObjectName
+}
+
+func (e *InvalidKubeletConfig) Unwrap() error {
+	return e.Err
 }
 
 func (r *KubeletConfigReconciler) reconcileConfigMap(ctx context.Context, instance *nropv1.NUMAResourcesOperator, kcKey client.ObjectKey) (*corev1.ConfigMap, error) {
@@ -134,6 +139,26 @@ func (r *KubeletConfigReconciler) reconcileConfigMap(ctx context.Context, instan
 	if err := r.Client.Get(ctx, kcKey, mcoKc); err != nil {
 		return nil, err
 	}
+
+	mcps, err := machineconfigpools.GetListByNodeGroupsV1(ctx, r.Client, instance.Spec.NodeGroups)
+	if err != nil {
+		return nil, err
+	}
+
+	mcp, err := machineconfigpools.FindBySelector(mcps, mcoKc.Spec.MachineConfigPoolSelector)
+	if err != nil {
+		klog.ErrorS(err, "cannot find a matching mcp for MCO KubeletConfig", "name", kcKey.Name)
+		var notFound *machineconfigpools.NotFound
+		if errors.As(err, &notFound) {
+			return nil, &InvalidKubeletConfig{
+				ObjectName: kcKey.Name,
+				Err:        notFound,
+			}
+		}
+		return nil, err
+	}
+
+	klog.V(3).InfoS("matched MCP to MCO KubeletConfig", "kubeletconfig name", kcKey.Name, "MCP name", mcp.Name)
 
 	// nothing we care about, and we can't do much anyway
 	if mcoKc.Spec.KubeletConfig == nil {
@@ -146,18 +171,6 @@ func (r *KubeletConfigReconciler) reconcileConfigMap(ctx context.Context, instan
 		klog.ErrorS(err, "cannot extract KubeletConfiguration from MCO KubeletConfig", "name", kcKey.Name)
 		return nil, err
 	}
-
-	mcps, err := machineconfigpools.GetListByNodeGroupsV1(ctx, r.Client, instance.Spec.NodeGroups)
-	if err != nil {
-		return nil, err
-	}
-
-	mcp, err := machineconfigpools.FindBySelector(mcps, mcoKc.Spec.MachineConfigPoolSelector)
-	if err != nil {
-		klog.ErrorS(err, "cannot find a matching mcp for MCO KubeletConfig", "name", kcKey.Name)
-		return nil, err
-	}
-	klog.InfoS("matched MCP to MCO KubeletConfig", "kubeletconfig name", kcKey.Name, "MCP name", mcp.Name)
 
 	generatedName := objectnames.GetComponentName(instance.Name, mcp.Name)
 	klog.V(3).InfoS("generated configMap name", "generatedName", generatedName)

--- a/controllers/kubeletconfig_controller_test.go
+++ b/controllers/kubeletconfig_controller_test.go
@@ -115,11 +115,11 @@ var _ = Describe("Test KubeletConfig Reconcile", func() {
 			})
 
 			It("should send events when NRO present and operation failure", func() {
-				brokenMcoKc := testobjs.NewKubeletConfigWithData("test1", label1, mcp1.Spec.MachineConfigSelector, []byte(""))
+				brokenMcoKc := testobjs.NewKubeletConfigWithData("broken", label1, mcp1.Spec.MachineConfigSelector, []byte(""))
 				reconciler, err := NewFakeKubeletConfigReconciler(nro, mcp1, brokenMcoKc)
 				Expect(err).ToNot(HaveOccurred())
 
-				key := client.ObjectKeyFromObject(mcoKc1)
+				key := client.ObjectKeyFromObject(brokenMcoKc)
 				_, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 				Expect(err).To(HaveOccurred())
 

--- a/controllers/kubeletconfig_controller_test.go
+++ b/controllers/kubeletconfig_controller_test.go
@@ -166,14 +166,7 @@ var _ = Describe("Test KubeletConfig Reconcile", func() {
 			})
 
 			It("should ignore non-matching kubeketconfigs", func() {
-				ctrlPlaneLabSel := &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"pools.operator.machineconfiguration.openshift.io/ctrlplane": "",
-					},
-				}
-				var true_ bool = true
-				ctrlPlaneKc := testobjs.NewKubeletConfigWithoutData("autoresize-ctrlplane", nil, ctrlPlaneLabSel)
-				ctrlPlaneKc.Spec.AutoSizingReserved = &true_
+				ctrlPlaneKc := testobjs.NewKubeletConfigAutoresizeControlPlane()
 
 				reconciler, err := NewFakeKubeletConfigReconciler(nro, mcp1, mcoKc1, ctrlPlaneKc)
 				Expect(err).ToNot(HaveOccurred())

--- a/internal/machineconfigpools/machineconfigpools_test.go
+++ b/internal/machineconfigpools/machineconfigpools_test.go
@@ -1,0 +1,197 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ */
+
+package machineconfigpools
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFindBySelector(t *testing.T) {
+	type testCase struct {
+		name          string
+		mcps          []*mcov1.MachineConfigPool
+		labelSelector *metav1.LabelSelector
+		expectedMCP   *mcov1.MachineConfigPool
+		expectedErr   error
+	}
+
+	testCases := []testCase{
+		{
+			name:        "all empty",
+			expectedErr: &NotFound{},
+		},
+		{
+			name: "mcps but missing labelSelectorector",
+			mcps: []*mcov1.MachineConfigPool{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mcp1",
+						Labels: map[string]string{
+							"foo1": "bar1",
+						},
+					},
+					Spec: mcov1.MachineConfigPoolSpec{
+						MachineConfigSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"foo1": "bar1",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mcp2",
+						Labels: map[string]string{
+							"foo2a": "bar2a",
+							"foo2b": "bar2b",
+						},
+					},
+					Spec: mcov1.MachineConfigPoolSpec{
+						MachineConfigSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"foo2a": "bar2a",
+								"foo2b": "bar2b",
+							},
+						},
+					},
+				},
+			},
+			expectedErr: &NotFound{},
+		},
+		{
+			name: "mcps but mismatching labelSelectorector",
+			mcps: []*mcov1.MachineConfigPool{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mcp1",
+					},
+					Spec: mcov1.MachineConfigPoolSpec{
+						MachineConfigSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"foo1": "bar1",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mcp2",
+					},
+					Spec: mcov1.MachineConfigPoolSpec{
+						MachineConfigSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"foo2a": "bar2a",
+								"foo2b": "bar2b",
+							},
+						},
+					},
+				},
+			},
+			labelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"foo3": "bar3",
+				},
+			},
+			expectedErr: &NotFound{
+				Selector: "&LabelSelector{MatchLabels:map[string]string{foo3: bar3,},MatchExpressions:[]LabelSelectorRequirement{},}",
+			},
+		},
+		{
+			name: "mcps and matching labelSelectorector",
+			mcps: []*mcov1.MachineConfigPool{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mcp1",
+						Labels: map[string]string{
+							"foo1": "bar1",
+						},
+					},
+					Spec: mcov1.MachineConfigPoolSpec{
+						MachineConfigSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"foo1": "bar1",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mcp2",
+						Labels: map[string]string{
+							"foo2a": "bar2a",
+							"foo2b": "bar2b",
+						},
+					},
+					Spec: mcov1.MachineConfigPoolSpec{
+						MachineConfigSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"foo2a": "bar2a",
+								"foo2b": "bar2b",
+							},
+						},
+					},
+				},
+			},
+			labelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"foo2a": "bar2a",
+					"foo2b": "bar2b",
+				},
+			},
+			expectedMCP: &mcov1.MachineConfigPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mcp2",
+					Labels: map[string]string{
+						"foo2a": "bar2a",
+						"foo2b": "bar2b",
+					},
+				},
+				Spec: mcov1.MachineConfigPoolSpec{
+					MachineConfigSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"foo2a": "bar2a",
+							"foo2b": "bar2b",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := FindBySelector(tc.mcps, tc.labelSelector)
+			if err == nil && tc.expectedErr != nil {
+				t.Errorf("got no error but expected %v", tc.expectedErr)
+			} else if err != nil && tc.expectedErr == nil {
+				t.Errorf("got error %v but expected none", err)
+			} else if err != nil && tc.expectedErr != nil {
+				if !errors.Is(err, tc.expectedErr) {
+					t.Errorf("got error %v but expected %v", err, tc.expectedErr)
+				}
+			}
+			if !reflect.DeepEqual(tc.expectedMCP, got) {
+				t.Errorf("expected MCP %v got %v", tc.expectedMCP, got)
+			}
+		})
+	}
+}

--- a/internal/objects/objects.go
+++ b/internal/objects/objects.go
@@ -136,6 +136,19 @@ func NewKubeletConfigWithoutData(name string, labels map[string]string, machineC
 	}
 }
 
+func NewKubeletConfigAutoresizeControlPlane() *machineconfigv1.KubeletConfig {
+	ctrlPlaneLabSel := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			// must NOT be picked up by MCP controller so the cluster state is not actually altered
+			"pools.operator.machineconfiguration.openshift.io/ctrplane-invalid-test": "",
+		},
+	}
+	var true_ bool = true
+	ctrlPlaneKc := NewKubeletConfigWithoutData("autoresize-ctrlplane", nil, ctrlPlaneLabSel)
+	ctrlPlaneKc.Spec.AutoSizingReserved = &true_
+	return ctrlPlaneKc
+}
+
 func NewNamespace(name string) *corev1.Namespace {
 	return &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{

--- a/internal/wait/kubeletconfig.go
+++ b/internal/wait/kubeletconfig.go
@@ -24,8 +24,7 @@ import (
 )
 
 func (wt Waiter) ForMCOKubeletConfigDeleted(ctx context.Context, kcName string) error {
-	immediate := true
-	return k8swait.PollUntilContextTimeout(ctx, wt.PollInterval, wt.PollTimeout, immediate, func(ctx2 context.Context) (bool, error) {
+	return k8swait.PollImmediateWithContext(ctx, wt.PollInterval, wt.PollTimeout, func(ctx2 context.Context) (bool, error) {
 		kc := &machineconfigv1.KubeletConfig{}
 		key := ObjectKey{Name: kcName}
 		err := wt.Cli.Get(ctx2, key.AsKey(), kc)

--- a/internal/wait/kubeletconfig.go
+++ b/internal/wait/kubeletconfig.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wait
+
+import (
+	"context"
+
+	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	k8swait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+func (wt Waiter) ForMCOKubeletConfigDeleted(ctx context.Context, kcName string) error {
+	immediate := true
+	return k8swait.PollUntilContextTimeout(ctx, wt.PollInterval, wt.PollTimeout, immediate, func(ctx2 context.Context) (bool, error) {
+		kc := &machineconfigv1.KubeletConfig{}
+		key := ObjectKey{Name: kcName}
+		err := wt.Cli.Get(ctx2, key.AsKey(), kc)
+		return deletionStatusFromError("MCOKubeletConfig", key, err)
+	})
+}

--- a/rte/pkg/config/config.go
+++ b/rte/pkg/config/config.go
@@ -32,6 +32,11 @@ import (
 
 const (
 	Key string = "config.yaml"
+
+	LabelOperatorName  string = "numaresourcesoperator.nodetopology.openshift.io/name"
+	LabelNodeGroupName string = "nodegroup.nodetopology.openshift.io"
+
+	LabelNodeGroupKindMachineConfigPool string = "machineconfigpool"
 )
 
 type Config struct {
@@ -90,6 +95,15 @@ func CreateConfigMap(namespace, name, configData string) *corev1.ConfigMap {
 			Key: configData,
 		},
 	}
+	return cm
+}
+
+func AddSoftRefLabels(cm *corev1.ConfigMap, instanceName, mcpName string) *corev1.ConfigMap {
+	if cm.Labels == nil {
+		cm.Labels = make(map[string]string)
+	}
+	cm.Labels[LabelOperatorName] = instanceName
+	cm.Labels[LabelNodeGroupName+"/"+LabelNodeGroupKindMachineConfigPool] = mcpName
 	return cm
 }
 


### PR DESCRIPTION
This is a manual cherry-pick of #903 