### PR TITLE
e2e: wait for ds creation before checking it is ready

### DIFF
--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -266,7 +266,9 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 				By("deleting the DS to force the system recreate the pod")
 				// hack! remove the DS object to make the operator recreate the DS and thus restart all the pods
 				Expect(fxt.Client.Delete(ctx, updatedDs)).Should(Succeed())
-				By(fmt.Sprintf("checking that the DaemonSet is still ready - should match worker nodes count %d", len(workers)))
+				By(fmt.Sprintf("checking that the DaemonSet is recreated with matching worker nodes count %d", len(workers)))
+				ds, err := wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDaemonsetPodsCreation(ctx, dsKey, len(workers))
+				Expect(err).NotTo(HaveOccurred(), "pods number is not as expected for daemonset: expected %d found %d", len(workers), ds.Status.CurrentNumberScheduled)
 				// the key will remain the same, the DS namespaced name is predictable and fixed
 				updatedDs, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
 				Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)


### PR DESCRIPTION
The test deletes ds and immediately checks for it to be ready using its object key. When there is no ds yet the test would fail because the object it is trying to search is not found on the cluster.

To prevent this from happening, add wait after the ds is deleted to make sure it is recreated with the expected pod count (not ready yet though).

This was also driving another failure in the next test (72861) where when it checks the number of pods owned by ds it retrieves a double count because of the terminating pods that still exist on the cluster:

```
shajmakh@shajmakh-thinkpadt590 ~ $ oc get ds,pod
NAME                                          DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                     AGE
daemonset.apps/numaresourcesoperator-worker   2         2         2       2            2           node-role.kubernetes.io/worker=   26s

NAME                                                    READY   STATUS        RESTARTS   AGE
pod/numaresources-controller-manager-65b9bf8d6f-f5bx6   1/1     Running       0          29h
pod/numaresourcesoperator-worker-2fv87                  2/2     Terminating   0          33s
pod/numaresourcesoperator-worker-2xc2q                  2/2     Terminating   0          66s
pod/numaresourcesoperator-worker-ppdm5                  2/2     Running       0          24s
pod/numaresourcesoperator-worker-psx85                  2/2     Running       0          24s
pod/secondary-scheduler-75777d89cc-vqgcf                1/1     Running       0          22h
shajmakh@shajmakh-thinkpadt590 ~ $
```