### PR TITLE
images: streamline overhaul the image management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,29 +138,31 @@ test-must-gather-e2e: build-must-gather-e2e
 ##@ Build
 
 binary: build-tools
-	LDFLAGS="-s -w "; \
-	LDFLAGS+="-X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/buildhelper version) "; \
-	LDFLAGS+="-X github.com/openshift-kni/numaresources-operator/pkg/version.gitcommit=$(shell bin/buildhelper commit)"; \
+	LDFLAGS="-s -w"; \
+	LDFLAGS+=" -X github.com/openshift-kni/numaresources-operator/pkg/version.gitcommit=$(shell bin/buildhelper commit)"; \
+	LDFLAGS+=" -X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/buildhelper version)"; \
+	LDFLAGS+=" -X github.com/openshift-kni/numaresources-operator/pkg/images.tag=$(VERSION)"; \
 	go build -mod=vendor -o bin/manager -ldflags "$$LDFLAGS" main.go
 
 binary-rte: build-tools
-	LDFLAGS="-s -w "; \
-	LDFLAGS+="-X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/buildhelper version) "; \
-	LDFLAGS+="-X github.com/openshift-kni/numaresources-operator/pkg/version.gitcommit=$(shell bin/buildhelper commit)"; \
+	LDFLAGS="-s -w"; \
+	LDFLAGS+=" -X github.com/openshift-kni/numaresources-operator/pkg/version.gitcommit=$(shell bin/buildhelper commit)"; \
+	LDFLAGS+=" -X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/buildhelper version)"; \
+	LDFLAGS+=" -X github.com/openshift-kni/numaresources-operator/pkg/images.tag=$(VERSION)"; \
 	go build -mod=vendor -o bin/exporter -ldflags "$$LDFLAGS" rte/main.go
 
 binary-nrovalidate: build-tools
-	LDFLAGS="-s -w "; \
-	LDFLAGS+="-X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/buildhelper version) "; \
+	LDFLAGS="-s -w"; \
+	LDFLAGS+=" -X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/buildhelper version)"; \
 	go build -mod=vendor -o bin/nrovalidate -ldflags "$$LDFLAGS" cmd/nrovalidate/main.go
 
 binary-nrtcacheck: build-tools
-	LDFLAGS="-s -w "; \
-	LDFLAGS+="-X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/buildhelper version) "; \
+	LDFLAGS="-s -w" \
+	LDFLAGS+=" -X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/buildhelper version)"; \
 	go build -mod=vendor -o bin/nrtcacheck -ldflags "$$LDFLAGS" cmd/nrtcacheck/main.go
 
 binary-numacell: build-tools
-	LDFLAGS="-s -w "; \
+	LDFLAGS="-s -w" \
 	CGO_ENABLED=0 go build -mod=vendor -o bin/numacell -ldflags "$$LDFLAGS" test/deviceplugin/cmd/numacell/main.go
 
 binary-all: binary binary-rte binary-nrovalidate binary-nrtcacheck

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -55,6 +55,7 @@ import (
 	"github.com/openshift-kni/numaresources-operator/internal/relatedobjects"
 	"github.com/openshift-kni/numaresources-operator/pkg/apply"
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
+	"github.com/openshift-kni/numaresources-operator/pkg/images"
 	"github.com/openshift-kni/numaresources-operator/pkg/loglevel"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
 	apistate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/api"
@@ -74,7 +75,7 @@ type NUMAResourcesOperatorReconciler struct {
 	APIManifests    apimanifests.Manifests
 	RTEManifests    rtemanifests.Manifests
 	Namespace       string
-	ImageSpec       string
+	Images          images.Data
 	ImagePullPolicy corev1.PullPolicy
 	Recorder        record.EventRecorder
 	ForwardMCPConds bool
@@ -390,7 +391,7 @@ func (r *NUMAResourcesOperatorReconciler) syncNUMAResourcesOperatorResources(ctx
 	var err error
 	var daemonSetsNName []nropv1.NamespacedName
 
-	err = rteupdate.DaemonSetUserImageSettings(r.RTEManifests.DaemonSet, instance.Spec.ExporterImage, r.ImageSpec, r.ImagePullPolicy)
+	err = rteupdate.DaemonSetUserImageSettings(r.RTEManifests.DaemonSet, instance.Spec.ExporterImage, r.Images.Preferred(), r.ImagePullPolicy)
 	if err != nil {
 		return daemonSetsNName, err
 	}

--- a/controllers/numaresourcesoperator_controller_test.go
+++ b/controllers/numaresourcesoperator_controller_test.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
+	"github.com/openshift-kni/numaresources-operator/pkg/images"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectstate/rte"
 	"github.com/openshift-kni/numaresources-operator/pkg/status"
@@ -80,8 +81,10 @@ func NewFakeNUMAResourcesOperatorReconciler(plat platform.Platform, platVersion 
 		APIManifests: apiManifests,
 		RTEManifests: rteManifests,
 		Namespace:    testNamespace,
-		ImageSpec:    testImageSpec,
-		Recorder:     recorder,
+		Images: images.Data{
+			Builtin: testImageSpec,
+		},
+		Recorder: recorder,
 	}, nil
 }
 

--- a/pkg/images/discover.go
+++ b/pkg/images/discover.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package images
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+type Data struct {
+	User    string // dynamic, learned from the user
+	Self    string // dynamic, learned from the cluster
+	Builtin string // static, determined at built time
+}
+
+// Discovered returns the image Spec learned from the environment (dynamic)
+func (da Data) Discovered() string {
+	if da.User != "" {
+		return da.User
+	}
+	return da.Self
+}
+
+// Preferred returns the image spec to use, preferring the dynamic
+func (da Data) Preferred() string {
+	if dyn := da.Discovered(); dyn != "" {
+		return dyn
+	}
+	return da.Builtin
+}
+
+func Discover(ctx context.Context, userImageSpec string) (Data, corev1.PullPolicy) {
+	imageSpec, pullPolicy, err := GetCurrentImage(ctx)
+	if err != nil {
+		// intentionally continue
+		klog.InfoS("unable to find current image, using hardcoded", "error", err)
+	}
+	data := Data{
+		User:    userImageSpec,
+		Self:    imageSpec,
+		Builtin: SpecPath(),
+	}
+	klog.InfoS("discovered RTE image", "user", data.User, "self", data.Self, "builtin", data.Builtin, "preferred", data.Preferred())
+	return data, pullPolicy
+}

--- a/pkg/images/discover_test.go
+++ b/pkg/images/discover_test.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package images
+
+import "testing"
+
+func TestDataPreferred(t *testing.T) {
+	testCases := []struct {
+		name     string
+		imgs     Data
+		expected string
+	}{
+		{
+			name:     "empty",
+			imgs:     Data{},
+			expected: "",
+		},
+		{
+			name: "user-only",
+			imgs: Data{
+				User: "user-image",
+			},
+			expected: "user-image",
+		},
+		{
+			name: "self-only",
+			imgs: Data{
+				Self: "self-image",
+			},
+			expected: "self-image",
+		},
+		{
+			name: "builtin-only",
+			imgs: Data{
+				Builtin: "builtin-image",
+			},
+			expected: "builtin-image",
+		},
+		{
+			name: "user overrides self",
+			imgs: Data{
+				User: "user-image",
+				Self: "self-image",
+			},
+			expected: "user-image",
+		},
+		{
+			name: "user overrides builtin",
+			imgs: Data{
+				User:    "user-image",
+				Builtin: "builtin-image",
+			},
+			expected: "user-image",
+		},
+		{
+			name: "self overrides builtin",
+			imgs: Data{
+				Self:    "self-image",
+				Builtin: "builtin-image",
+			},
+			expected: "self-image",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.imgs.Preferred()
+			if got != tc.expected {
+				t.Errorf("data %v expected %q got %q", tc.imgs, tc.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/images/fetch.go
+++ b/pkg/images/fetch.go
@@ -1,4 +1,6 @@
 /*
+ * Copyright 2021 Red Hat, Inc.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -10,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Copyright 2021 Red Hat, Inc.
  */
 
 package images

--- a/pkg/images/version.go
+++ b/pkg/images/version.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package images
+
+const (
+	defaultRepo string = "quay.io/openshift-kni"
+	defaultName string = "numaresources-operator"
+	defaultTag  string = "devel"
+)
+
+// tag Must not be const, supposed to be set using ldflags at build time
+var tag = defaultTag
+
+// Tag returns the image tag as a string
+func Tag() string {
+	return tag
+}
+
+// Name returns the image name as a string
+func Name() string {
+	return defaultName
+}
+
+// Repo returns the image repo as a string
+func Repo() string {
+	return defaultRepo
+}
+
+// SpecPath() returns the image full image spec path as a string
+func SpecPath() string {
+	return Repo() + "/" + Name() + ":" + Tag()
+}

--- a/pkg/images/version_test.go
+++ b/pkg/images/version_test.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package images
+
+import "testing"
+
+func TestTag(t *testing.T) {
+	if Tag() == "" {
+		t.Errorf("empty tag")
+	}
+}
+
+func TestName(t *testing.T) {
+	if Name() == "" {
+		t.Errorf("empty name")
+	}
+}
+
+func TestRepo(t *testing.T) {
+	if Repo() == "" {
+		t.Errorf("empty repo")
+	}
+}
+
+func TestSpecPath(t *testing.T) {
+	if SpecPath() == "" {
+		t.Errorf("empty spec path")
+	}
+}


### PR DESCRIPTION
We bundle operator and operand (RTE) in the same image. The operator learn which is its own image by inspecting its own pod, and the user can override the value setting the corresponding field in the NodeConfig struct.

Since the beginning we wanted also to make the images configurable for development purposes. This feature never materialized.

In addition, the detection and image replacement code got messier over time, with no real cleanup.

To address both these needs, overhaul and simplify the image management. All changes are expected to
be transparent for regular users, outside development environments.