### PR TITLE
sched: api: generate config v1

### DIFF
--- a/pkg/numaresourcesscheduler/manifests/yaml/configmap.nrt.yaml
+++ b/pkg/numaresourcesscheduler/manifests/yaml/configmap.nrt.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: placeholder
 data:
   "config.yaml": |
-    apiVersion: kubescheduler.config.k8s.io/v1beta3
+    apiVersion: kubescheduler.config.k8s.io/v1
     kind: KubeSchedulerConfiguration
     leaderElection:
       leaderElect: false
@@ -43,7 +43,7 @@ data:
         pluginConfig:
         - name: NodeResourceTopologyMatch
           args:
-            apiVersion: kubescheduler.config.k8s.io/v1beta3
+            apiVersion: kubescheduler.config.k8s.io/v1
             kind: NodeResourceTopologyMatchArgs
             scoringStrategy:
               type: LeastAllocated

--- a/pkg/numaresourcesscheduler/objectstate/sched/sched_test.go
+++ b/pkg/numaresourcesscheduler/objectstate/sched/sched_test.go
@@ -61,13 +61,13 @@ func TestDeploymentNamespacedNameFromObject(t *testing.T) {
 }
 
 const (
-	schedConfigNoProfiles = `apiVersion: kubescheduler.config.k8s.io/v1beta3
+	schedConfigNoProfiles = `apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
 profiles: []`
 
-	schedConfigOK = `apiVersion: kubescheduler.config.k8s.io/v1beta3
+	schedConfigOK = `apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false

--- a/pkg/objectupdate/sched/fakeconfs.go
+++ b/pkg/objectupdate/sched/fakeconfs.go
@@ -24,14 +24,14 @@ import (
 )
 
 const (
-	schedConfig = `apiVersion: kubescheduler.config.k8s.io/v1beta3
+	schedConfig = `apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
 profiles:
 - pluginConfig:
   - args:
-      apiVersion: kubescheduler.config.k8s.io/v1beta3
+      apiVersion: kubescheduler.config.k8s.io/v1
       cacheResyncPeriodSeconds: 3
       kind: NodeResourceTopologyMatchArgs
       scoringStrategy:
@@ -54,14 +54,14 @@ profiles:
       - name: NodeResourceTopologyMatch
   schedulerName: test-topo-aware-sched`
 
-	schedConfigWithPeriod = `apiVersion: kubescheduler.config.k8s.io/v1beta3
+	schedConfigWithPeriod = `apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
 profiles:
   - pluginConfig:
     - args:
-        apiVersion: kubescheduler.config.k8s.io/v1beta3
+        apiVersion: kubescheduler.config.k8s.io/v1
         cacheResyncPeriodSeconds: 3
         kind: NodeResourceTopologyMatchArgs
         scoringStrategy:
@@ -86,14 +86,14 @@ profiles:
 )
 
 const (
-	expectedYAMLWithReconcilePeriod = `apiVersion: kubescheduler.config.k8s.io/v1beta3
+	expectedYAMLWithReconcilePeriod = `apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
 profiles:
 - pluginConfig:
   - args:
-      apiVersion: kubescheduler.config.k8s.io/v1beta3
+      apiVersion: kubescheduler.config.k8s.io/v1
       cacheResyncPeriodSeconds: 3
       kind: NodeResourceTopologyMatchArgs
       scoringStrategy:
@@ -117,14 +117,14 @@ profiles:
   schedulerName: test-topo-aware-sched
 `
 
-	expectedYAMLWithoutReconcile = `apiVersion: kubescheduler.config.k8s.io/v1beta3
+	expectedYAMLWithoutReconcile = `apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
 profiles:
 - pluginConfig:
   - args:
-      apiVersion: kubescheduler.config.k8s.io/v1beta3
+      apiVersion: kubescheduler.config.k8s.io/v1
       kind: NodeResourceTopologyMatchArgs
       scoringStrategy:
         resources:


### PR DESCRIPTION
The v1beta3 scheduler configuration is being phased out from the scheduler plugin repo (at least), so let's jump to v1. There are non functional changes anyway.