### PR TITLE
e2e serial: initiate NRT list in each test independently

### DIFF
--- a/test/e2e/serial/config/fixture.go
+++ b/test/e2e/serial/config/fixture.go
@@ -66,7 +66,7 @@ var Config *E2EConfig
 
 func SetupFixture() error {
 	var err error
-	Config, err = NewFixtureWithOptions("e2e-test-infra", e2efixture.OptionRandomizeName|e2efixture.OptionAvoidCooldown)
+	Config, err = NewFixtureWithOptions("e2e-test-infra", e2efixture.OptionRandomizeName|e2efixture.OptionAvoidCooldown|e2efixture.OptionStaticClusterData)
 	return err
 }
 

--- a/test/e2e/serial/tests/resource_hostlevel.go
+++ b/test/e2e/serial/tests/resource_hostlevel.go
@@ -56,8 +56,6 @@ var _ = Describe("[serial] numaresources host-level resources", Serial, func() {
 
 	AfterEach(func() {
 		Expect(e2efixture.Teardown(fxt)).To(Succeed())
-		By("waiting for the NRT data to settle")
-		e2efixture.MustSettleNRT(fxt)
 	})
 
 	Context("with at least two nodes suitable", func() {

--- a/test/utils/noderesourcetopologies/noderesourcetopologies.go
+++ b/test/utils/noderesourcetopologies/noderesourcetopologies.go
@@ -561,3 +561,22 @@ func ResourceInfoProvidingAtMost(resources []nrtv1alpha2.ResourceInfo, resName s
 	}
 	return true
 }
+
+func EqualNRTListsItems(nrtListA, nrtListB nrtv1alpha2.NodeResourceTopologyList) (bool, error) {
+	for _, nrtA := range nrtListA.Items {
+		nrtB, err := FindFromList(nrtListB.Items, nrtA.Name)
+		if err != nil {
+			return false, fmt.Errorf("failed to find NRT data for node %q in both lists: %v", nrtA.Name, err)
+		}
+		rebootTest := false
+		ok, err := e2enrt.EqualZones(nrtB.Zones, nrtA.Zones, rebootTest)
+		if err != nil {
+			return false, fmt.Errorf("failed while comparing %q NRT zones: %v", nrtA.Name, err)
+		}
+		if !ok {
+			klog.Infof("NRT mismatch for node %q", nrtA.Name)
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/test/utils/noderesourcetopologies/noderesourcetopologies_test.go
+++ b/test/utils/noderesourcetopologies/noderesourcetopologies_test.go
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package noderesourcetopologies
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+)
+
+func TestEqualNRTListsItems(t *testing.T) {
+	testCases := []struct {
+		description string
+		data1       nrtv1alpha2.NodeResourceTopologyList
+		data2       nrtv1alpha2.NodeResourceTopologyList
+		expected    bool
+	}{
+		{
+			description: "equal",
+			data1: nrtv1alpha2.NodeResourceTopologyList{
+				Items: []nrtv1alpha2.NodeResourceTopology{
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-0"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-000",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:        "foo",
+										Capacity:    resource.MustParse("1"),
+										Allocatable: resource.MustParse("1"),
+										Available:   resource.MustParse("1"),
+									},
+								},
+							},
+							{
+								Name: "Zone-001",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:        "bar",
+										Capacity:    resource.MustParse("4"),
+										Allocatable: resource.MustParse("4"),
+										Available:   resource.MustParse("4"),
+									},
+									{
+										Name:        "foo",
+										Capacity:    resource.MustParse("2"),
+										Allocatable: resource.MustParse("2"),
+										Available:   resource.MustParse("2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			data2: nrtv1alpha2.NodeResourceTopologyList{
+				Items: []nrtv1alpha2.NodeResourceTopology{
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-0"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-001",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:        "bar",
+										Capacity:    resource.MustParse("4"),
+										Allocatable: resource.MustParse("4"),
+										Available:   resource.MustParse("4"),
+									},
+									{
+										Name:        "foo",
+										Capacity:    resource.MustParse("2"),
+										Allocatable: resource.MustParse("2"),
+										Available:   resource.MustParse("2"),
+									},
+								},
+							},
+							{
+								Name: "Zone-000",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:        "foo",
+										Capacity:    resource.MustParse("1"),
+										Allocatable: resource.MustParse("1"),
+										Available:   resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			description: "different values - not equal",
+			data1: nrtv1alpha2.NodeResourceTopologyList{
+				Items: []nrtv1alpha2.NodeResourceTopology{
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-0"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-000",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:        "foo",
+										Capacity:    resource.MustParse("1"),
+										Allocatable: resource.MustParse("1"),
+										Available:   resource.MustParse("1"),
+									},
+								},
+							},
+							{
+								Name: "Zone-001",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:        "bar",
+										Capacity:    resource.MustParse("4"),
+										Allocatable: resource.MustParse("4"),
+										Available:   resource.MustParse("4"),
+									},
+									{
+										Name:        "foo",
+										Capacity:    resource.MustParse("2"),
+										Allocatable: resource.MustParse("2"),
+										Available:   resource.MustParse("2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			data2: nrtv1alpha2.NodeResourceTopologyList{
+				Items: []nrtv1alpha2.NodeResourceTopology{
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-0"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-001",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:        "bar",
+										Capacity:    resource.MustParse("4"),
+										Allocatable: resource.MustParse("4"),
+										Available:   resource.MustParse("4"),
+									},
+									{
+										Name:        "foo",
+										Capacity:    resource.MustParse("2"),
+										Allocatable: resource.MustParse("2"),
+										Available:   resource.MustParse("1"), // diff is here
+									},
+								},
+							},
+							{
+								Name: "Zone-000",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:        "foo",
+										Capacity:    resource.MustParse("1"),
+										Allocatable: resource.MustParse("1"),
+										Available:   resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			description: "empty data - equal",
+			data1: nrtv1alpha2.NodeResourceTopologyList{
+				Items: []nrtv1alpha2.NodeResourceTopology{
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-0"},
+						Zones:      nrtv1alpha2.ZoneList{},
+					},
+				},
+			},
+			data2: nrtv1alpha2.NodeResourceTopologyList{
+				Items: []nrtv1alpha2.NodeResourceTopology{
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-0"},
+						Zones:      nrtv1alpha2.ZoneList{},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			description: "missing zone - not equal",
+			data1: nrtv1alpha2.NodeResourceTopologyList{
+				Items: []nrtv1alpha2.NodeResourceTopology{
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-0"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-000",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:        "foo",
+										Capacity:    resource.MustParse("1"),
+										Allocatable: resource.MustParse("1"),
+										Available:   resource.MustParse("1"),
+									},
+								},
+							},
+							{
+								Name: "Zone-001",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:        "bar",
+										Capacity:    resource.MustParse("4"),
+										Allocatable: resource.MustParse("4"),
+										Available:   resource.MustParse("4"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			data2: nrtv1alpha2.NodeResourceTopologyList{
+				Items: []nrtv1alpha2.NodeResourceTopology{
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-0"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-000",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:        "foo",
+										Capacity:    resource.MustParse("1"),
+										Allocatable: resource.MustParse("1"),
+										Available:   resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			got, _ := EqualNRTListsItems(tc.data1, tc.data2)
+			if got != tc.expected {
+				t.Errorf("test: %s; \n   got=%v expected=%v\n", tc.description, got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Before this change, each test used the data of NRT list that was
gathered at the beginning of the suite and compared it with the NRT data gathered after each test to ensure the NRTs are settled. This is fine as long as the resources topology is guaranteed not to be updated in a way that messes up the teardown comparison.

Since we cannot specify the tools used to set up the resources in the
testing environment, hence no guarantee the topology would stay the same from the beginning of the suite till the end; we record the NRT data on each test fetching it directly from the cluster, independent from the data gathered at the start of the suite.