### PR TITLE
e2e: drop host-level resources when padding numa cells

### DIFF
--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -1003,7 +1003,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 func makePaddingPod(namespace, nodeName string, zone nrtv1alpha2.Zone, podReqs corev1.ResourceList) (*corev1.Pod, error) {
 	klog.Infof("want to have zone %q with allocatable: %s", zone.Name, e2ereslist.ToString(podReqs))
 
-	paddingReqs, err := e2enrt.SaturateZoneUntilLeft(zone, podReqs)
+	paddingReqs, err := e2enrt.SaturateZoneUntilLeft(zone, podReqs, e2enrt.DropHostLevelRes)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -542,7 +542,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 					targetNodeBaseLoad.Apply(zoneRes)
 				}
 
-				paddingRes, err := e2enrt.SaturateZoneUntilLeft(zone, zoneRes)
+				paddingRes, err := e2enrt.SaturateZoneUntilLeft(zone, zoneRes, e2enrt.DropHostLevelRes)
 				Expect(err).NotTo(HaveOccurred(), "could not get padding resources for node %q", targetNrt.Name)
 
 				podName := fmt.Sprintf("padding-tgt-%d", zoneIdx)


### PR DESCRIPTION
A problem was caught during workload placement tests requiring pre-padding numa zones as test setup. The problem was that the cluster had leftover workloads that consumed host-level resources and that was counted in the base load of the node. Later on, the test expected to pad Numa zones consider host-level resources to be part of the padder resources. The setup failed because host-level resources are not numa scoped.

Adjust the relevant methods that pad numa zones to filter specified resources such as ephemeral storage.