### PR TITLE
e2e: label tests for non supporting versions

### DIFF
--- a/hack/run-test-serial-e2e.sh
+++ b/hack/run-test-serial-e2e.sh
@@ -88,6 +88,11 @@ while [[ $# -gt 0 ]]; do
 			shift
 			shift
 			;;
+		--label-filter)
+			LABEL_FILTER="-ginkgo.label-filter='$2'"
+			shift
+			shift
+			;;
 		--report-file)
 			REPORT_FILE="$2"
 			shift
@@ -97,16 +102,17 @@ while [[ $# -gt 0 ]]; do
 			echo "usage: $0 [options]"
 			echo "[options] are always '--opt val' and never '--opt=val'"
 			echo "available options:"
-			echo "--setup               perform cluster setup before to run the tests (if enabled, see --no-run-tests)"
-			echo "--teardown            perform cluster teardown after having run the tests (if enabled, see --no-run-tests)"
-			echo "--no-run-tests        don't run the tests (see --setup and --teardown)"
-			echo "--no-color            force colored output to off"
-			echo "--dry-run             logs what about to do, but don't actually do it"
-			echo "--focus <regex>       only run cases matching <regex> (passed to -ginkgo.focus)"
-			echo "--tier-up-to <N>      run cases belonging to all tiers up to <N> (passed to -ginkgo.focus)"
-			echo "--skip <regex>        skip cases matching <regex> (passed to -ginkgo.skip)"
-			echo "--report-file <file>  write report file for this suite on <file>"
-			echo "--help                shows this message and helps correctly"
+			echo "--setup                 perform cluster setup before to run the tests (if enabled, see --no-run-tests)"
+			echo "--teardown              perform cluster teardown after having run the tests (if enabled, see --no-run-tests)"
+			echo "--no-run-tests          don't run the tests (see --setup and --teardown)"
+			echo "--no-color              force colored output to off"
+			echo "--dry-run               logs what about to do, but don't actually do it"
+			echo "--focus <regex>         only run cases matching <regex> (passed to -ginkgo.focus)"
+			echo "--tier-up-to <N>        run cases belonging to all tiers up to <N> (passed to -ginkgo.focus)"
+			echo "--skip <regex>          skip cases matching <regex> (passed to -ginkgo.skip)"
+			echo "--label-filter <query>  filter cases based on the matching <query> (passed to -ginkgo.label-filter)"
+			echo "--report-file <file>    write report file for this suite on <file>"
+			echo "--help                  shows this message and helps correctly"
 			exit 0
 			;;
 		*)
@@ -186,6 +192,7 @@ function runtests() {
 		--ginkgo.junit-report=${REPORT_FILE} \
 		${NO_COLOR} \
 		${SKIP} \
+		${LABEL_FILTER} \
 		${FOCUS}
 }
 

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -51,7 +51,7 @@ import (
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 )
 
-var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerations support", Serial, func() {
+var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerations support", Serial, Label("no-4.13"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 

--- a/test/e2e/serial/tests/workload_placement_no_nrt.go
+++ b/test/e2e/serial/tests/workload_placement_no_nrt.go
@@ -39,7 +39,7 @@ import (
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 )
 
-var _ = Describe("[serial] numaresources profile update", Serial, func() {
+var _ = Describe("[serial] numaresources profile update", Serial, Label("no-4.13", "no-4.14", "no-4.15"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 


### PR DESCRIPTION
For running the regressions we use the latest tests image (from master), with no filters on the tests so all tests executed on all versions.

The problem is that some tests are relevant only for specific releases and executing them on non-supporting versions results in greater execution time and noisy failures.

Considering so far that there are no major changes in the operator functionality between the different supported releases, the proposed update is to label specs that aren't relevant to run on specific ystream, and in the d/s CI (as serial doesn't run u/s) we use --ginkgo.label-filter=QUERY to filter out these tests.