### PR TITLE
e2e: align tags and labels

### DIFF
--- a/hack/run-test-serial-e2e.sh
+++ b/hack/run-test-serial-e2e.sh
@@ -88,6 +88,11 @@ while [[ $# -gt 0 ]]; do
 			shift
 			shift
 			;;
+		--label-filter)
+			LABEL_FILTER="-ginkgo.label-filter='$2'"
+			shift
+			shift
+			;;
 		--report-file)
 			REPORT_FILE="$2"
 			shift
@@ -97,16 +102,17 @@ while [[ $# -gt 0 ]]; do
 			echo "usage: $0 [options]"
 			echo "[options] are always '--opt val' and never '--opt=val'"
 			echo "available options:"
-			echo "--setup               perform cluster setup before to run the tests (if enabled, see --no-run-tests)"
-			echo "--teardown            perform cluster teardown after having run the tests (if enabled, see --no-run-tests)"
-			echo "--no-run-tests        don't run the tests (see --setup and --teardown)"
-			echo "--no-color            force colored output to off"
-			echo "--dry-run             logs what about to do, but don't actually do it"
-			echo "--focus <regex>       only run cases matching <regex> (passed to -ginkgo.focus)"
-			echo "--tier-up-to <N>      run cases belonging to all tiers up to <N> (passed to -ginkgo.focus)"
-			echo "--skip <regex>        skip cases matching <regex> (passed to -ginkgo.skip)"
-			echo "--report-file <file>  write report file for this suite on <file>"
-			echo "--help                shows this message and helps correctly"
+			echo "--setup                 perform cluster setup before to run the tests (if enabled, see --no-run-tests)"
+			echo "--teardown              perform cluster teardown after having run the tests (if enabled, see --no-run-tests)"
+			echo "--no-run-tests          don't run the tests (see --setup and --teardown)"
+			echo "--no-color              force colored output to off"
+			echo "--dry-run               logs what about to do, but don't actually do it"
+			echo "--focus <regex>         only run cases matching <regex> (passed to -ginkgo.focus)"
+			echo "--tier-up-to <N>        run cases belonging to all tiers up to <N> (passed to -ginkgo.focus)"
+			echo "--skip <regex>          skip cases matching <regex> (passed to -ginkgo.skip)"
+			echo "--label-filter <query>  filter cases based on the matching <query> (passed to -ginkgo.label-filter)"
+			echo "--report-file <file>    write report file for this suite on <file>"
+			echo "--help                  shows this message and helps correctly"
 			exit 0
 			;;
 		*)
@@ -186,6 +192,7 @@ function runtests() {
 		--ginkgo.junit-report=${REPORT_FILE} \
 		${NO_COLOR} \
 		${SKIP} \
+		${LABEL_FILTER} \
 		${FOCUS}
 }
 

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -70,7 +70,7 @@ import (
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 )
 
-var _ = Describe("[serial][disruptive][slow] numaresources configuration management", Serial, Label("disruptive", "slow"), func() {
+var _ = Describe("[serial][disruptive] numaresources configuration management", Serial, Label("disruptive"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 	var nrts []nrtv1alpha2.NodeResourceTopology

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -70,7 +70,7 @@ import (
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 )
 
-var _ = Describe("[serial][disruptive][slow] numaresources configuration management", Serial, func() {
+var _ = Describe("[serial][disruptive][slow] numaresources configuration management", Serial, Label("disruptive", "slow"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 	var nrts []nrtv1alpha2.NodeResourceTopology
@@ -105,7 +105,7 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 	Context("cluster has at least one suitable node", func() {
 		timeout := 5 * time.Minute
 
-		It("[test_id:47674][reboot_required][slow][images][tier2] should be able to modify the configurable values under the NUMAResourcesOperator CR", func() {
+		It("[test_id:47674][reboot_required][slow][images][tier2] should be able to modify the configurable values under the NUMAResourcesOperator CR", Label("reboot_required", "slow", "images", "tier2"), func() {
 			fxt.IsRebootTest = true
 			nroOperObj := &nropv1.NUMAResourcesOperator{}
 			nroKey := objects.NROObjectKey()
@@ -321,7 +321,7 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 
 		})
 
-		It("[test_id:54916][tier2] should be able to modify the configurable values under the NUMAResourcesScheduler CR", func() {
+		It("[test_id:54916][tier2] should be able to modify the configurable values under the NUMAResourcesScheduler CR", Label("tier2"), func() {
 			initialNroSchedObj := &nropv1.NUMAResourcesScheduler{}
 			nroSchedKey := objects.NROSchedObjectKey()
 			err := fxt.Client.Get(context.TODO(), nroSchedKey, initialNroSchedObj)
@@ -387,7 +387,7 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.SchedulerTestName)
 		})
 
-		It("[test_id:47585][reboot_required][slow] can change kubeletconfig and controller should adapt", func() {
+		It("[test_id:47585][reboot_required][slow] can change kubeletconfig and controller should adapt", Label("reboot_required", "slow"), func() {
 			fxt.IsRebootTest = true
 			nroOperObj := &nropv1.NUMAResourcesOperator{}
 			nroKey := objects.NROObjectKey()
@@ -659,7 +659,7 @@ var _ = Describe("[serial][disruptive][slow] numaresources configuration managem
 			Expect(nrsGot).To(Equal(nrsExpected), "mismatching related objects for NUMAResourcesScheduler")
 		})
 
-		It("[slow][tier1] ignores non-matching kubeletconfigs", func(ctx context.Context) {
+		It("[slow][tier1] ignores non-matching kubeletconfigs", Label("slow", "tier1"), func(ctx context.Context) {
 			By("getting the NROP object")
 			nroOperObj := &nropv1.NUMAResourcesOperator{}
 			nroKey := objects.NROObjectKey()

--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -50,7 +50,7 @@ import (
 	e2epadder "github.com/openshift-kni/numaresources-operator/test/utils/padder"
 )
 
-var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement", Serial, func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement", Serial, Label("disruptive", "scheduler"), func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
@@ -138,7 +138,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}
 		})
 
-		It("[test_id:47584][tier2][nonreg] should be able to schedule guaranteed pod in selective way", func() {
+		It("[test_id:47584][tier2][nonreg] should be able to schedule guaranteed pod in selective way", Label("tier2", "nonreg"), func() {
 			nodesNameSet := e2enrt.AccumulateNames(nrts)
 			targetNodeName, ok := e2efixture.PopNodeName(nodesNameSet)
 			Expect(ok).To(BeTrue())
@@ -200,7 +200,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(ok).To(BeTrue(), "NRT resources not restored correctly on %q", targetNodeName)
 		})
 
-		It("[test_id:48964][tier3][nonreg] should be able to schedule a guaranteed deployment pod to a specific node", func() {
+		It("[test_id:48964][tier3][nonreg] should be able to schedule a guaranteed deployment pod to a specific node", Label("tier3", "nonreg"), func() {
 			nrtInitialList := nrtv1alpha2.NodeResourceTopologyList{}
 
 			err := fxt.Client.List(context.TODO(), &nrtInitialList)
@@ -322,7 +322,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 	})
 
 	Context("Requesting resources that are greater than allocatable at numa level", func() {
-		It("[test_id:47613][tier3][nonreg][unsched] should not schedule a pod requesting resources that are not allocatable at numa level", func() {
+		It("[test_id:47613][tier3][nonreg][unsched] should not schedule a pod requesting resources that are not allocatable at numa level", Label("tier3", "nonreg", "unsched"), func() {
 			//the test can run on node with any numa number, so no need to filter the nrts
 			nrtNames := e2enrt.AccumulateNames(nrts)
 

--- a/test/e2e/serial/tests/non_regression_fundamentals.go
+++ b/test/e2e/serial/tests/non_regression_fundamentals.go
@@ -66,7 +66,7 @@ var _ = Describe("[serial][fundamentals][scheduler][nonreg] numaresources fundam
 	Context("using the NUMA-aware scheduler with NRT data", func() {
 		var cpusPerPod int64 = 2 // must be even. Must be >= 2
 
-		DescribeTable("[node1] against a single node",
+		DescribeTable("[node1] against a single node", Label("node1"),
 			// the ourpose of this test is to send a burst of pods towards a node. Each pod must require resources in such a way
 			// that overreservation will allow only a chunk of pod to go running, while the other will be kept pending.
 			// when scheduler cache resync happens, the scheduler will send the remaining pods, and all of them must eventually
@@ -147,23 +147,23 @@ var _ = Describe("[serial][fundamentals][scheduler][nonreg] numaresources fundam
 					Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 				}
 			},
-			Entry("should handle a burst of qos=guaranteed pods [tier0]", func(pod *corev1.Pod) {
+			Entry("should handle a burst of qos=guaranteed pods [tier0]", Label("tier0"), func(pod *corev1.Pod) {
 				pod.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
 					corev1.ResourceCPU:    *resource.NewQuantity(cpusPerPod, resource.DecimalSI),
 					corev1.ResourceMemory: resource.MustParse("64Mi"),
 				}
 			}),
-			Entry("should handle a burst of qos=burstable pods [tier1]", func(pod *corev1.Pod) {
+			Entry("should handle a burst of qos=burstable pods [tier1]", Label("tier1"), func(pod *corev1.Pod) {
 				pod.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
 					corev1.ResourceCPU:    *resource.NewQuantity(cpusPerPod, resource.DecimalSI),
 					corev1.ResourceMemory: resource.MustParse("64Mi"),
 				}
 			}),
 			// this is REALLY REALLY to prevent the most catastrophic regressions
-			Entry("should handle a burst of qos=best-effort pods [tier2]", func(pod *corev1.Pod) {}),
+			Entry("should handle a burst of qos=best-effort pods [tier2]", Label("tier2"), func(pod *corev1.Pod) {}),
 		)
 
-		DescribeTable("[nodeAll] against all the available worker nodes",
+		DescribeTable("[nodeAll] against all the available worker nodes", Label("nodeAll"),
 			// like [node1] tests, but flooding all the available worker nodes - not just one.
 			// note this require different constants for calibration. Again values determined by trial and error,
 			// no hard rules yet.
@@ -243,20 +243,20 @@ var _ = Describe("[serial][fundamentals][scheduler][nonreg] numaresources fundam
 					Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 				}
 			},
-			Entry("should handle a burst of qos=guaranteed pods [tier0]", func(pod *corev1.Pod) {
+			Entry("should handle a burst of qos=guaranteed pods [tier0]", Label("tier0"), func(pod *corev1.Pod) {
 				pod.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
 					corev1.ResourceCPU:    *resource.NewQuantity(cpusPerPod, resource.DecimalSI),
 					corev1.ResourceMemory: resource.MustParse("64Mi"),
 				}
 			}),
-			Entry("should handle a burst of qos=burstable pods [tier1]", func(pod *corev1.Pod) {
+			Entry("should handle a burst of qos=burstable pods [tier1]", Label("tier1"), func(pod *corev1.Pod) {
 				pod.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
 					corev1.ResourceCPU:    *resource.NewQuantity(cpusPerPod, resource.DecimalSI),
 					corev1.ResourceMemory: resource.MustParse("64Mi"),
 				}
 			}),
 			// this is REALLY REALLY to prevent the most catastrophic regressions
-			Entry("should handle a burst of qos=best-effort pods [tier2]", func(pod *corev1.Pod) {}),
+			Entry("should handle a burst of qos=best-effort pods [tier2]", Label("tier2"), func(pod *corev1.Pod) {}),
 		)
 
 		// TODO: mixed

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -52,7 +52,7 @@ import (
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 )
 
-var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workload resource accounting", Serial, func() {
+var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workload resource accounting", Serial, Label("disruptive", "scheduler", "resacct"), func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
@@ -112,7 +112,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			}
 		})
 
-		It("[placement][test_id:49068][tier2] should keep the pod pending if not enough resources available, then schedule when resources are freed", func() {
+		It("[placement][test_id:49068][tier2] should keep the pod pending if not enough resources available, then schedule when resources are freed", Label("placement", "tier2"), func() {
 			// make sure this is > 1 and LESS than required Res!
 			unsuitableFreeRes := corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("2"),
@@ -408,7 +408,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			klog.Infof("reference NRT target: %s", intnrt.ToString(*targetNrtReference))
 		})
 
-		It("[test_id:48685][tier1] should properly schedule a best-effort pod with no changes in NRTs", func() {
+		It("[test_id:48685][tier1] should properly schedule a best-effort pod with no changes in NRTs", Label("tier1"), func() {
 			By("create a best-effort pod")
 
 			pod := objects.NewTestPodPause(fxt.Namespace.Name, "testpod-be")
@@ -437,7 +437,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:48686][tier1] should properly schedule a burstable pod with no changes in NRTs", func() {
+		It("[test_id:48686][tier1] should properly schedule a burstable pod with no changes in NRTs", Label("tier1"), func() {
 			By("create a burstable pod")
 
 			pod := objects.NewTestPodPause(fxt.Namespace.Name, "testpod-bu")
@@ -468,7 +468,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:47618][tier2] should properly schedule deployment with burstable pod with no changes in NRTs", func() {
+		It("[test_id:47618][tier2] should properly schedule deployment with burstable pod with no changes in NRTs", Label("tier2"), func() {
 			By("create a deployment with one burstable pod")
 			deploymentName := "test-dp"
 			var replicas int32 = 1
@@ -509,7 +509,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(e2enrt.CheckEqualAvailableResources(*targetNrtReference, *targetNrtCurrent)).To(BeTrue(), "new resources are accounted in NRT although scheduling burstable pod")
 		})
 
-		It("[tier2] should properly schedule a burstable pod when one of the containers is asking for requests=limits, with no changes in NRTs", func() {
+		It("[tier2] should properly schedule a burstable pod when one of the containers is asking for requests=limits, with no changes in NRTs", Label("tier2"), func() {
 			By("create a burstable pod")
 			pod := objects.NewTestPodPause(fxt.Namespace.Name, "testpod-bu")
 			pod.Spec.SchedulerName = serialconfig.Config.SchedulerName
@@ -579,7 +579,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:47620][tier2] should properly schedule a burstable pod with no changes in NRTs followed by a guaranteed pod that stays pending till burstable pod is deleted", func() {
+		It("[test_id:47620][tier2] should properly schedule a burstable pod with no changes in NRTs followed by a guaranteed pod that stays pending till burstable pod is deleted", Label("tier2"), func() {
 			By("create a burstable pod")
 
 			podBurstable := objects.NewTestPodPause(fxt.Namespace.Name, "testpod-first-bu")
@@ -718,7 +718,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 
 		})
 
-		It("[test_id:49071][tier2] should properly schedule daemonset with burstable pod with no changes in NRTs", func() {
+		It("[test_id:49071][tier2] should properly schedule daemonset with burstable pod with no changes in NRTs", Label("tier2"), func() {
 			By("create a daemonset with one burstable pod")
 			dsName := "test-ds"
 

--- a/test/e2e/serial/tests/resource_hostlevel.go
+++ b/test/e2e/serial/tests/resource_hostlevel.go
@@ -40,7 +40,7 @@ import (
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 )
 
-var _ = Describe("[serial][hostlevel] numaresources host-level resources", Serial, func() {
+var _ = Describe("[serial][hostlevel] numaresources host-level resources", Serial, Label("hostlevel"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 
@@ -65,7 +65,7 @@ var _ = Describe("[serial][hostlevel] numaresources host-level resources", Seria
 		// It should behave exactly like scope=pod. But we keep these tests as non-regression
 		// to have a signal the system is behaving as expected.
 		// This is the reason we don't filter for scope, but only by policy.
-		DescribeTable("[tier0][hostlevel] a pod should be placed and aligned on the node",
+		DescribeTable("[tier0][hostlevel] a pod should be placed and aligned on the node", Label("tier0", "hostlevel"),
 			func(tmPolicy string, requiredRes []corev1.ResourceList, expectedQOS corev1.PodQOSClass) {
 				ctx := context.TODO()
 				nrtCandidates := filterNodes(fxt, desiredNodesState{
@@ -123,6 +123,7 @@ var _ = Describe("[serial][hostlevel] numaresources host-level resources", Seria
 				expectNRTConsumedResources(fxt, *targetNrtInitial, accumulatedRes, updatedPod)
 			},
 			Entry("[qos:gu] with ephemeral storage, single-container",
+				Label("qos:gu"),
 				intnrt.SingleNUMANode,
 				// required resources for the test pod
 				[]corev1.ResourceList{
@@ -135,6 +136,7 @@ var _ = Describe("[serial][hostlevel] numaresources host-level resources", Seria
 				corev1.PodQOSGuaranteed,
 			),
 			Entry("[qos:bu] with ephemeral storage, single-container",
+				Label("qos:bu"),
 				intnrt.SingleNUMANode,
 				// required resources for the test pod
 				[]corev1.ResourceList{
@@ -147,6 +149,7 @@ var _ = Describe("[serial][hostlevel] numaresources host-level resources", Seria
 				corev1.PodQOSBurstable,
 			),
 			Entry("[qos:be] with ephemeral storage, single-container",
+				Label("qos:be"),
 				intnrt.SingleNUMANode,
 				// required resources for the test pod
 				[]corev1.ResourceList{
@@ -157,6 +160,7 @@ var _ = Describe("[serial][hostlevel] numaresources host-level resources", Seria
 				corev1.PodQOSBestEffort,
 			),
 			Entry("[test_id:74249][qos:gu] with ephemeral storage, multi-container",
+				Label("qos:gu"),
 				intnrt.SingleNUMANode,
 				// required resources for the test pod
 				[]corev1.ResourceList{
@@ -184,6 +188,7 @@ var _ = Describe("[serial][hostlevel] numaresources host-level resources", Seria
 				corev1.PodQOSGuaranteed,
 			),
 			Entry("[test_id:74250][qos:gu] with ephemeral storage, multi-container, fractional",
+				Label("qos:gu"),
 				intnrt.SingleNUMANode,
 				// required resources for the test pod
 				[]corev1.ResourceList{
@@ -212,6 +217,7 @@ var _ = Describe("[serial][hostlevel] numaresources host-level resources", Seria
 			),
 
 			Entry("[test_id:74251][qos:bu] with ephemeral storage, multi-container, fractional",
+				Label("qos:bu"),
 				intnrt.SingleNUMANode,
 				// required resources for the test pod
 				[]corev1.ResourceList{
@@ -239,6 +245,7 @@ var _ = Describe("[serial][hostlevel] numaresources host-level resources", Seria
 				corev1.PodQOSBurstable,
 			),
 			Entry("[test_id:74252][qos:be] with ephemeral storage, multi-container", //TODO test with devices and hugepages requests and fix automation
+				Label("qos:be"),
 				intnrt.SingleNUMANode,
 				// required resources for the test pod
 				[]corev1.ResourceList{
@@ -255,7 +262,7 @@ var _ = Describe("[serial][hostlevel] numaresources host-level resources", Seria
 	})
 
 	Context("[unsched] without suitable nodes with enough host level resources", func() {
-		DescribeTable("[hostlevel][failalign] a pod with multi containers should be pending due to unavailable host-level resources",
+		DescribeTable("[hostlevel][failalign] a pod with multi containers should be pending due to unavailable host-level resources", Label("hostlevel", "failalign"),
 			func(tmPolicy string, requiredRes []corev1.ResourceList, expectedQOS corev1.PodQOSClass) {
 				ctx := context.TODO()
 				nrtCandidates := filterNodes(fxt, desiredNodesState{
@@ -338,6 +345,7 @@ var _ = Describe("[serial][hostlevel] numaresources host-level resources", Seria
 				Expect(isFailed).To(BeTrue(), "pod %s/%s with scheduler %s did NOT fail", updatedPod.Namespace, updatedPod.Name, updatedPod.Spec.SchedulerName)
 			},
 			Entry("[test_id:74253][tier2][qos:gu][unsched] with ephemeral storage, multi-container",
+				Label("tier2", "qos:gu", "unsched"),
 				intnrt.SingleNUMANode,
 				// required resources for the test pod
 				[]corev1.ResourceList{
@@ -355,6 +363,7 @@ var _ = Describe("[serial][hostlevel] numaresources host-level resources", Seria
 				corev1.PodQOSGuaranteed,
 			),
 			Entry("[test_id:74254][tier2][qos:bu][unsched] with ephemeral storage, multi-container",
+				Label("tier2", "qos:bu", "unsched"),
 				intnrt.SingleNUMANode,
 				// required resources for the test pod
 				[]corev1.ResourceList{
@@ -371,6 +380,7 @@ var _ = Describe("[serial][hostlevel] numaresources host-level resources", Seria
 				corev1.PodQOSBurstable,
 			),
 			Entry("[test_id:74255][tier3][qos:be][unsched] with ephemeral storage, multi-container",
+				Label("tier3", "qos:be", "unsched"),
 				intnrt.SingleNUMANode,
 				// required resources for the test pod
 				[]corev1.ResourceList{

--- a/test/e2e/serial/tests/scheduler_cache.go
+++ b/test/e2e/serial/tests/scheduler_cache.go
@@ -64,7 +64,7 @@ type interferenceDesc struct {
 	ratio int
 }
 
-var _ = Describe("[serial][scheduler][cache][tier0] scheduler cache", Label("scheduler", "cache", "tier0"), func() {
+var _ = Describe("[serial][scheduler][cache][tier0] scheduler cache", Serial, Label("scheduler", "cache", "tier0"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 
@@ -311,6 +311,7 @@ var _ = Describe("[serial][scheduler][cache][tier0] scheduler cache", Label("sch
 					}
 				},
 				Entry("from GU pods, low",
+					Label("qos:gu"),
 					machineDesc{
 						coresPerCPU:            2,
 						desiredPodsPerNUMAZone: 2,
@@ -321,6 +322,7 @@ var _ = Describe("[serial][scheduler][cache][tier0] scheduler cache", Label("sch
 						qos:   corev1.PodQOSGuaranteed,
 					}),
 				Entry("from BU pods, moderate",
+					Label("qos:bu"),
 					machineDesc{
 						coresPerCPU:            2,
 						desiredPodsPerNUMAZone: 4,

--- a/test/e2e/serial/tests/scheduler_cache_stall.go
+++ b/test/e2e/serial/tests/scheduler_cache_stall.go
@@ -229,7 +229,7 @@ var _ = Describe("[serial][scheduler][cache] scheduler cache stall", Label("sche
 				}
 			})
 
-			DescribeTable("[nodeAll] against all the available worker nodes",
+			DescribeTable("[nodeAll] against all the available worker nodes", Label("nodeAll"),
 				// like non-regression tests, but with jobs present
 
 				func(setupPod setupPodFunc) {
@@ -302,13 +302,13 @@ var _ = Describe("[serial][scheduler][cache] scheduler cache stall", Label("sche
 						Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 					}
 				},
-				Entry("should handle a burst of qos=guaranteed pods [tier0]", func(pod *corev1.Pod) {
+				Entry("should handle a burst of qos=guaranteed pods [tier0]", Label("tier0"), func(pod *corev1.Pod) {
 					pod.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
 						corev1.ResourceCPU:    *resource.NewQuantity(cpusPerPod, resource.DecimalSI),
 						corev1.ResourceMemory: resource.MustParse("64Mi"),
 					}
 				}),
-				Entry("should handle a burst of qos=burstable pods [tier0]", func(pod *corev1.Pod) {
+				Entry("should handle a burst of qos=burstable pods [tier0]", Label("tier0"), func(pod *corev1.Pod) {
 					pod.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
 						corev1.ResourceCPU:    *resource.NewQuantity(cpusPerPod, resource.DecimalSI),
 						corev1.ResourceMemory: resource.MustParse("64Mi"),

--- a/test/e2e/serial/tests/scheduler_removal.go
+++ b/test/e2e/serial/tests/scheduler_removal.go
@@ -42,7 +42,7 @@ import (
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 )
 
-var _ = Describe("[serial][disruptive][scheduler][rmsched] numaresources scheduler removal on a live cluster", Serial, func() {
+var _ = Describe("[serial][disruptive][scheduler][rmsched] numaresources scheduler removal on a live cluster", Serial, Label("disruptive", "scheduler", "rmsched"), func() {
 	var fxt *e2efixture.Fixture
 
 	BeforeEach(func() {
@@ -65,7 +65,7 @@ var _ = Describe("[serial][disruptive][scheduler][rmsched] numaresources schedul
 	})
 
 	When("removing the topology aware scheduler from a live cluster", func() {
-		It("[case:1][test_id:47593][tier1] should keep existing workloads running", func() {
+		It("[case:1][test_id:47593][tier1] should keep existing workloads running", Label("tier1"), func() {
 			var err error
 
 			dp := createDeploymentSync(fxt, "testdp", serialconfig.Config.SchedulerName)
@@ -88,7 +88,7 @@ var _ = Describe("[serial][disruptive][scheduler][rmsched] numaresources schedul
 			}
 		})
 
-		It("[case:2][test_id:49093][tier1][unsched] should keep new scheduled workloads pending", func() {
+		It("[case:2][test_id:49093][tier1][unsched] should keep new scheduled workloads pending", Label("tier1", "unsched"), func() {
 			var err error
 
 			By(fmt.Sprintf("deleting the NRO Scheduler object: %s", serialconfig.Config.NROSchedObj.Name))
@@ -113,7 +113,7 @@ var _ = Describe("[serial][disruptive][scheduler][rmsched] numaresources schedul
 	})
 })
 
-var _ = Describe("[serial][disruptive][scheduler] numaresources scheduler restart on a live cluster", Serial, func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources scheduler restart on a live cluster", Serial, Label("disruptive", "scheduler"), func() {
 	var fxt *e2efixture.Fixture
 	var nroSchedObj *nropv1.NUMAResourcesScheduler
 	var schedulerName string
@@ -140,7 +140,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources scheduler restar
 	})
 
 	When("restarting the topology aware scheduler in a live cluster", func() {
-		It("[case:1][test_id:48069][tier2] should schedule any pending workloads submitted while the scheduler was unavailable", func() {
+		It("[case:1][test_id:48069][tier2] should schedule any pending workloads submitted while the scheduler was unavailable", Label("tier2"), func() {
 			var err error
 
 			dpNName := nroSchedObj.Status.Deployment // shortcut

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -51,7 +51,7 @@ import (
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 )
 
-var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerations support", Serial, func() {
+var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerations support", Serial, Label("disruptive", "slow", "rtetols"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 
@@ -104,7 +104,7 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", dsKey.String())
 		})
 
-		When("[tier2] invalid tolerations are submitted ", func() {
+		When("[tier2] invalid tolerations are submitted ", Label("tier2"), func() {
 			It("should handle invalid field: operator", func(ctx context.Context) {
 				By("adding extra invalid tolerations with wrong operator field")
 				_ = setRTETolerations(ctx, fxt.Client, nroKey, []corev1.Toleration{
@@ -164,7 +164,7 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 			})
 		})
 
-		It("[tier3] should enable to change tolerations in the RTE daemonsets", func(ctx context.Context) {
+		It("[tier3] should enable to change tolerations in the RTE daemonsets", Label("tier3"), func(ctx context.Context) {
 			By("getting RTE manifests object")
 			// TODO: this is similar but not quite what the main operator does
 			rteManifests, err := rtemanifests.GetManifests(configuration.Plat, configuration.PlatVersion, "", true)
@@ -226,7 +226,7 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 				Expect(int(updatedDs.Status.NumberReady)).To(Equal(len(workers)), "RTE DS ready=%v original worker nodes=%d", updatedDs.Status.NumberReady, len(workers))
 			})
 
-			It("[tier2][test_id:72857] should handle untolerations of tainted nodes while RTEs are running", func(ctx context.Context) {
+			It("[tier2][test_id:72857] should handle untolerations of tainted nodes while RTEs are running", Label("tier2"), func(ctx context.Context) {
 				var err error
 				By("adding extra tolerations")
 				_ = setRTETolerations(ctx, fxt.Client, nroKey, testToleration())
@@ -282,7 +282,7 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 				Expect(int(updatedDs.Status.NumberReady)).To(Equal(len(workers)-1), "updated DS ready=%v original worker nodes=%d", updatedDs.Status.NumberReady, len(workers)-1)
 			})
 
-			It("[tier3] should evict running RTE pod if taint-tolartion matching criteria is shaken - NROP CR toleration update", func(ctx context.Context) {
+			It("[tier3] should evict running RTE pod if taint-tolartion matching criteria is shaken - NROP CR toleration update", Label("tier3"), func(ctx context.Context) {
 				By("add toleration with value to the NROP CR")
 				tolerateVal := corev1.Toleration{
 					Key:      testKey,
@@ -337,7 +337,7 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 				Expect(err).ToNot(HaveOccurred(), "pod %s/%s still exists", podOnNode.Namespace, podOnNode.Name)
 			})
 
-			It("[tier3] should evict running RTE pod if taint-tolartion matching criteria is shaken - node taints update", func(ctx context.Context) {
+			It("[tier3] should evict running RTE pod if taint-tolartion matching criteria is shaken - node taints update", Label("tier3"), func(ctx context.Context) {
 				By("taint one node with taint value and NoExecute effect")
 				var err error
 				workers, err = nodes.GetWorkerNodes(fxt.Client, ctx)
@@ -421,7 +421,7 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 				Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
 			})
 
-			It("[tier2][test_id:72861] should tolerate partial taints and not schedule or evict the pod on the tainted node", func(ctx context.Context) {
+			It("[tier2][test_id:72861] should tolerate partial taints and not schedule or evict the pod on the tainted node", Label("tier2"), func(ctx context.Context) {
 				var err error
 				By("getting the worker nodes")
 				workers, err = nodes.GetWorkerNodes(fxt.Client, context.TODO())
@@ -470,7 +470,7 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 				}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 			})
 
-			It("[tier3][test_id:72859] should not restart a running RTE pod on tainted node with NoSchedule effect", func(ctx context.Context) {
+			It("[tier3][test_id:72859] should not restart a running RTE pod on tainted node with NoSchedule effect", Label("tier3"), func(ctx context.Context) {
 				By("taint one worker node")
 				var err error
 				workers, err = nodes.GetWorkerNodes(fxt.Client, ctx)
@@ -590,7 +590,7 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 					}
 				})
 
-				It("[test_id:72854][reboot_required][slow][tier2] should add tolerations in-place while RTEs are running", func(ctx context.Context) {
+				It("[test_id:72854][reboot_required][slow][tier2] should add tolerations in-place while RTEs are running", Label("reboot_required", "slow", "tier2"), func(ctx context.Context) {
 					fxt.IsRebootTest = true
 					By("create NROP CR with no tolerations to the tainted node")
 					nropNewObj := nroOperObj.DeepCopy()
@@ -627,7 +627,7 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 					Expect(found).To(BeTrue(), "no RTE pod was found on node %q", taintedNode.Name)
 				})
 
-				It("[test_id:72855][reboot_required][slow][tier2] should tolerate node taint on NROP CR creation", func(ctx context.Context) {
+				It("[test_id:72855][reboot_required][slow][tier2] should tolerate node taint on NROP CR creation", Label("reboot_required", "slow", "tier2"), func(ctx context.Context) {
 					fxt.IsRebootTest = true
 					By("add tolerations to NROP CR to tolerate the taint - no RTE running yet on any node")
 					nropNewObj := nroOperObj.DeepCopy()
@@ -658,7 +658,7 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 				})
 			})
 
-			It("[tier3] should evict RTE pod on tainted node with NoExecute effect and restore it when taint is removed", func(ctx context.Context) {
+			It("[tier3] should evict RTE pod on tainted node with NoExecute effect and restore it when taint is removed", Label("tier3"), func(ctx context.Context) {
 				By("taint one worker node with NoExecute effect")
 				var err error
 				workers, err = nodes.GetWorkerNodes(fxt.Client, ctx)

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -51,7 +51,7 @@ import (
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 )
 
-var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerations support", Serial, Label("disruptive", "slow", "rtetols"), func() {
+var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations support", Serial, Label("disruptive", "rtetols"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 
@@ -226,7 +226,7 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 				Expect(int(updatedDs.Status.NumberReady)).To(Equal(len(workers)), "RTE DS ready=%v original worker nodes=%d", updatedDs.Status.NumberReady, len(workers))
 			})
 
-			It("[tier2][test_id:72857] should handle untolerations of tainted nodes while RTEs are running", Label("tier2"), func(ctx context.Context) {
+			It("[tier2][slow][test_id:72857] should handle untolerations of tainted nodes while RTEs are running", Label("slow", "tier2"), func(ctx context.Context) {
 				var err error
 				By("adding extra tolerations")
 				_ = setRTETolerations(ctx, fxt.Client, nroKey, testToleration())
@@ -282,7 +282,7 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 				Expect(int(updatedDs.Status.NumberReady)).To(Equal(len(workers)-1), "updated DS ready=%v original worker nodes=%d", updatedDs.Status.NumberReady, len(workers)-1)
 			})
 
-			It("[tier3] should evict running RTE pod if taint-tolartion matching criteria is shaken - NROP CR toleration update", Label("tier3"), func(ctx context.Context) {
+			It("[tier3][slow] should evict running RTE pod if taint-toleration matching criteria is shaken - NROP CR toleration update", Label("tier3", "slow"), func(ctx context.Context) {
 				By("add toleration with value to the NROP CR")
 				tolerateVal := corev1.Toleration{
 					Key:      testKey,
@@ -337,7 +337,7 @@ var _ = Describe("[serial][disruptive][slow][rtetols] numaresources RTE tolerati
 				Expect(err).ToNot(HaveOccurred(), "pod %s/%s still exists", podOnNode.Namespace, podOnNode.Name)
 			})
 
-			It("[tier3] should evict running RTE pod if taint-tolartion matching criteria is shaken - node taints update", Label("tier3"), func(ctx context.Context) {
+			It("[tier3][slow] should evict running RTE pod if taint-tolartion matching criteria is shaken - node taints update", Label("tier3", "slow"), func(ctx context.Context) {
 				By("taint one node with taint value and NoExecute effect")
 				var err error
 				workers, err = nodes.GetWorkerNodes(fxt.Client, ctx)

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -51,7 +51,7 @@ import (
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 )
 
-var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhead", Serial, func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhead", Serial, Label("disruptive", "scheduler"), func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
@@ -138,7 +138,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 					}
 				}
 			})
-			It("[test_id:47582][tier2] schedule a guaranteed Pod in a single NUMA zone and check overhead is not accounted in NRT", func() {
+			It("[test_id:47582][tier2] schedule a guaranteed Pod in a single NUMA zone and check overhead is not accounted in NRT", Label("tier2"), func() {
 
 				// even if it is not a hard rule, and even if there are a LOT of edge cases, a good starting point is usually
 				// in the ballpark of 5x the base load. We start like this
@@ -273,7 +273,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				}
 			})
 
-			It("[test_id:53819][tier2][unsched] Pod pending when resources requested + pod overhead don't fit on the target node; NRT objects are not updated", func() {
+			It("[test_id:53819][tier2][unsched] Pod pending when resources requested + pod overhead don't fit on the target node; NRT objects are not updated", Label("tier2", "unsched"), func() {
 				var targetNodeName string
 				var targetNrtInitial *nrtv1alpha2.NodeResourceTopology
 				var targetNrtListInitial nrtv1alpha2.NodeResourceTopologyList

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -66,7 +66,7 @@ import (
 	e2epadder "github.com/openshift-kni/numaresources-operator/test/utils/padder"
 )
 
-var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement", Serial, func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement", Serial, Label("disruptive", "scheduler"), func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
@@ -153,7 +153,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}
 		})
 
-		It("[test_id:47591][tier1] should modify workload post scheduling while keeping the resource requests available", func() {
+		It("[test_id:47591][tier1] should modify workload post scheduling while keeping the resource requests available", Label("tier1"), func() {
 			paddedNodeNames := sets.New[string](padder.GetPaddedNodes()...)
 			nodesNameSet := e2enrt.AccumulateNames(nrts)
 			// the only node which was not padded is the targetedNode
@@ -543,7 +543,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}
 		})
 
-		It("[test_id:48746][tier2] should modify workload post scheduling while keeping the resource requests available across all NUMA node", func() {
+		It("[test_id:48746][tier2] should modify workload post scheduling while keeping the resource requests available across all NUMA node", Label("tier2"), func() {
 			paddedNodeNames := sets.New[string](padder.GetPaddedNodes()...)
 			nodesNameSet := e2enrt.AccumulateNames(nrts)
 			// the only node which was not padded is the targetedNode

--- a/test/e2e/serial/tests/workload_placement_no_nrt.go
+++ b/test/e2e/serial/tests/workload_placement_no_nrt.go
@@ -60,7 +60,7 @@ var _ = Describe("[serial] numaresources profile update", Serial, func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	Context("[no_nrt] using the NUMA-aware scheduler without updated NRT data", func() {
+	Context("[no_nrt] using the NUMA-aware scheduler without updated NRT data", Label("no_nrt"), func() {
 		var testPod *corev1.Pod
 		nropObjInitial := &nropv1.NUMAResourcesOperator{}
 		initialInfoRefreshPause := *nropv1.DefaultNodeGroupConfig().InfoRefreshPause
@@ -88,7 +88,7 @@ var _ = Describe("[serial] numaresources profile update", Serial, func() {
 			updateInfoRefreshPause(fxt, initialInfoRefreshPause, nropObjInitial)
 		})
 
-		It("[tier1] should make a best-effort pod running", func() {
+		It("[tier1] should make a best-effort pod running", Label("tier1"), func() {
 			By("create best-effort pod expect it to start running")
 			testPod := objects.NewTestPodPause(fxt.Namespace.Name, "testpod")
 			testPod.Spec.SchedulerName = serialconfig.Config.SchedulerName
@@ -102,7 +102,7 @@ var _ = Describe("[serial] numaresources profile update", Serial, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[tier1] should make a burstable pod running", func() {
+		It("[tier1] should make a burstable pod running", Label("tier1"), func() {
 			By("create burstable pod and expect it to run")
 			testPod = objects.NewTestPodPause(fxt.Namespace.Name, "testpod")
 			testPod.Spec.SchedulerName = serialconfig.Config.SchedulerName
@@ -119,7 +119,7 @@ var _ = Describe("[serial] numaresources profile update", Serial, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[tier1][test_id:47611] should make a guaranteed pod running", func() {
+		It("[tier1][test_id:47611] should make a guaranteed pod running", Label("tier1"), func() {
 			By("create guaranteed pod and expect it to run")
 			testPod = objects.NewTestPodPause(fxt.Namespace.Name, "testpod")
 			testPod.Spec.SchedulerName = serialconfig.Config.SchedulerName

--- a/test/e2e/serial/tests/workload_placement_nodelabel.go
+++ b/test/e2e/serial/tests/workload_placement_nodelabel.go
@@ -52,7 +52,7 @@ import (
 
 type getNodeAffinityFunc func(labelName string, labelValue []string, selectOperator corev1.NodeSelectorOperator) *corev1.Affinity
 
-var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement considering node selector", Serial, func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement considering node selector", Serial, Label("disruptive", "scheduler"), func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
@@ -182,7 +182,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("[test_id:47598][tier2] should place the pod in the node with available resources in one NUMA zone and fulfilling node selector", func() {
+		It("[test_id:47598][tier2] should place the pod in the node with available resources in one NUMA zone and fulfilling node selector", Label("tier2"), func() {
 			By(fmt.Sprintf("Labeling nodes %q and %q with label %q:%q", targetNodeName, alternativeNodeName, labelName, labelValueMedium))
 
 			unlabelTarget, err := labelNodeWithValue(fxt.Client, labelName, labelValueMedium, targetNodeName)
@@ -278,7 +278,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				}
 			})
 
-			DescribeTable("[tier2] a guaranteed deployment pod with nodeAffinity should be scheduled on one NUMA zone on a matching labeled node with enough resources", Serial,
+			DescribeTable("[tier2] a guaranteed deployment pod with nodeAffinity should be scheduled on one NUMA zone on a matching labeled node with enough resources", Serial, Label("tier2"),
 				func(getNodeAffFunc getNodeAffinityFunc) {
 					affinity := getNodeAffFunc(labelName, []string{labelValueLarge, labelValueMedium}, corev1.NodeSelectorOpIn)
 					By(fmt.Sprintf("create a deployment with one guaranteed pod with node affinity property: %+v ", affinity.NodeAffinity))

--- a/test/e2e/serial/tests/workload_placement_resources.go
+++ b/test/e2e/serial/tests/workload_placement_resources.go
@@ -53,7 +53,7 @@ import (
  * rinse and repeat for CPUs, devices, hugepages...
  */
 
-var _ = Describe("[serial][disruptive][scheduler][byres] numaresources workload placement considering specific resources requests", Serial, func() {
+var _ = Describe("[serial][disruptive][scheduler][byres] numaresources workload placement considering specific resources requests", Serial, Label("disruptive", "scheduler", "byres"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 
@@ -85,6 +85,7 @@ var _ = Describe("[serial][disruptive][scheduler][byres] numaresources workload 
 		// FIXME: this is a slight abuse of DescribeTable, but we need to run
 		// the same code with a different test_id per tmscope
 		DescribeTable("[tier0][ressched] a guaranteed pod with one container should be placed and aligned on the node",
+			Label("tier0", "ressched"),
 			func(tmPolicy, tmScope string, requiredRes, expectedFreeRes corev1.ResourceList) {
 				ctx := context.TODO()
 
@@ -125,6 +126,7 @@ var _ = Describe("[serial][disruptive][scheduler][byres] numaresources workload 
 				Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 			},
 			Entry("[tmscope:pod] with topology-manager-scope: pod, using memory as deciding factor",
+				Label("tmscope:pod"),
 				intnrt.SingleNUMANode,
 				intnrt.Pod,
 				// required resources for the test pod
@@ -147,6 +149,7 @@ var _ = Describe("[serial][disruptive][scheduler][byres] numaresources workload 
 				},
 			),
 			Entry("[tmscope:pod] with topology-manager-scope: pod, using CPU as the deciding factor",
+				Label("tmscope:pod"),
 				intnrt.SingleNUMANode,
 				intnrt.Pod,
 				// required resources for the test pod

--- a/test/e2e/serial/tests/workload_placement_taint.go
+++ b/test/e2e/serial/tests/workload_placement_taint.go
@@ -49,7 +49,7 @@ import (
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 )
 
-var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement considering taints", Serial, func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement considering taints", Serial, Label("disruptive", "scheduler"), func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
@@ -163,7 +163,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			checkNodesUntainted(fxt.Client, nodeNames)
 		})
 
-		It("[test_id:47594][tier1] should make a pod with a toleration land on a node with enough resources on a specific NUMA zone", func() {
+		It("[test_id:47594][tier1] should make a pod with a toleration land on a node with enough resources on a specific NUMA zone", Label("tier1"), func() {
 			paddedNodeNames := sets.New[string](padder.GetPaddedNodes()...)
 			nodesNameSet := e2enrt.AccumulateNames(nrts)
 			// the only node which was not padded is the targetedNode

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -74,7 +74,7 @@ type tmScopeFuncs struct {
 
 type tmScopeFuncsHandler map[string]tmScopeFuncs
 
-var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement considering TM policy", Serial, func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement considering TM policy", Serial, Label("disruptive", "scheduler"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 	tmSingleNUMANodeFuncsHandler := tmScopeFuncsHandler{
@@ -173,6 +173,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		// FIXME: this is a slight abuse of DescribeTable, but we need to run
 		// the same code which a different test_id per tmscope
 		DescribeTable("[tier1] a guaranteed pod with one container should be scheduled into one NUMA zone",
+			Label("tier1"),
 			func(tmPolicy, tmScope string, requiredRes, paddingRes corev1.ResourceList) {
 				setupCluster(requiredRes, paddingRes, tmPolicy, tmScope)
 
@@ -210,6 +211,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				expectNRTConsumedResources(fxt, targetNrtInitial, requiredRes, updatedPod)
 			},
 			Entry("[test_id:48713][tmscope:cnt] with topology-manager-scope: container",
+				Label("tmscope:cnt"),
 				intnrt.SingleNUMANode,
 				intnrt.Container,
 				corev1.ResourceList{
@@ -222,6 +224,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				},
 			),
 			Entry("[test_id:50156][tmscope:pod] with topology-manager-scope: pod",
+				Label("tmscope:pod"),
 				intnrt.SingleNUMANode,
 				intnrt.Pod,
 				corev1.ResourceList{
@@ -234,6 +237,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				},
 			),
 			Entry("[test_id:50158][tmscope:cnt][hugepages] with topology-manager-scope: container with hugepages",
+				Label("tmscope:cnt", "hugepages"),
 				intnrt.SingleNUMANode,
 				intnrt.Container,
 				corev1.ResourceList{
@@ -248,6 +252,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				},
 			),
 			Entry("[test_id:50157][tmscope:pod][hugepages] with topology-manager-scope: pod with hugepages",
+				Label("tmscope:pod", "hugepages"),
 				intnrt.SingleNUMANode,
 				intnrt.Pod,
 				corev1.ResourceList{
@@ -266,6 +271,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		// FIXME: this is a slight abuse of DescribeTable, but we need to run
 		// the same code which a different test_id per tmscope
 		DescribeTable("[tier0] a deployment with a guaranteed pod with one container should be scheduled into one NUMA zone",
+			Label("tier0"),
 			func(tmPolicy, tmScope string, requiredRes, paddingRes corev1.ResourceList) {
 				setupCluster(requiredRes, paddingRes, tmPolicy, tmScope)
 
@@ -311,6 +317,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				expectNRTConsumedResources(fxt, targetNrtInitial, requiredRes, &pods[0])
 			},
 			Entry("[test_id:47583][tmscope:cnt] with topology-manager-scope: container",
+				Label("tmscope:cnt"),
 				intnrt.SingleNUMANode,
 				intnrt.Container,
 				corev1.ResourceList{
@@ -323,6 +330,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				},
 			),
 			Entry("[test_id:50159][tmscope:pod] with topology-manager-scope: pod",
+				Label("tmscope:pod"),
 				intnrt.SingleNUMANode,
 				intnrt.Pod,
 				corev1.ResourceList{
@@ -335,6 +343,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				},
 			),
 			Entry("[test_id:50165][tmscope:cnt][hugepages] with topology-manager-scope: container and with hugepages",
+				Label("tmscope:cnt", "hugepages"),
 				intnrt.SingleNUMANode,
 				intnrt.Container,
 				corev1.ResourceList{
@@ -349,6 +358,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				},
 			),
 			Entry("[test_id:50182][tmscope:pod][hugepages] with topology-manager-scope: pod and with hugepages",
+				Label("tmscope:pod", "hugepages"),
 				intnrt.SingleNUMANode,
 				intnrt.Pod,
 				corev1.ResourceList{
@@ -365,7 +375,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		)
 	})
 
-	DescribeTable("[placement] cluster with multiple worker nodes suitable",
+	DescribeTable("[placement] cluster with multiple worker nodes suitable", Label("placement"),
 		func(policyFuncs tmScopeFuncs, podRes podResourcesRequest, unsuitableFreeRes, targetFreeResPerNUMA []corev1.ResourceList) {
 
 			hostsRequired := 2
@@ -510,6 +520,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		},
 
 		Entry("[test_id:47575][tmscope:cnt][tier0] should make a pod with two gu cnt land on a node with enough resources on a specific NUMA zone, each cnt on a different zone",
+			Label("tmscope:cnt", "tier0"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -539,6 +550,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			[]corev1.ResourceList{},
 		),
 		Entry("[test_id:47577][tmscope:pod][tier0] should make a pod with two gu cnt land on a node with enough resources on a specific NUMA zone, all cnt on the same zone",
+			Label("tmscope:pod", "tier0"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -574,6 +586,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:50183][tmscope:cnt][hugepages] should make a pod with two gu cnt land on a node with enough resources with hugepages on a specific NUMA zone, each cnt on a different zone",
+			Label("tmscope:cnt", "hugepages"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -606,6 +619,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			[]corev1.ResourceList{},
 		),
 		Entry("[test_id:50184][tmscope:pod][hugepages] should make a pod with two gu cnt land on a node with enough resources with hugepages on a specific NUMA zone, all cnt on the same zone",
+			Label("tmscope:pod", "hugepages"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -646,6 +660,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[tier1][testtype4][tmscope:container] should make a pod with three gu cnt land on a node with enough resources, containers should be spread on a different zone",
+			Label("tier1", "tmscope:cnt"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -689,6 +704,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[tier1][testtype4][tmscope:container][cpu] pod with two gu cnt land on a node with enough resources, containers should be spread on a different zone",
+			Label("tier1", "tmscope:cnt", "cpu"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -740,6 +756,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[tier1][testtype4][tmscope:container][memory] pod with two gu cnt land on a node with enough resources, containers should be spread on a different zone",
+			Label("tier1", "tmscope:cnt", "memory"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -791,6 +808,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[tier1][testtype4][tmscope:container][hugepages2Mi] pod with two gu cnt land on a node with enough resources, containers should be spread on a different zone",
+			Label("tier1", "tmscope:cnt", "hugepages2Mi"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -842,6 +860,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[tier1][testtype4][tmscope:container][hugepages1Gi] pod with two gu cnt land on a node with enough resources, containers should be spread on a different zone",
+			Label("tier1", "tmscope:cnt", "hugepages1Gi"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -892,6 +911,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:54021][tier1][testtype4][tmscope:container][devices] pod with two gu cnt land on a node with enough resources, containers should be spread on a different zone",
+			Label("tier1", "tmscope:cnt", "devices"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -941,6 +961,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[tier1][testtype11][tmscope:container] should make a pod with one init cnt and three gu cnt land on a node with enough resources, containers should be spread on a different zone",
+			Label("tier1", "tmscope:cnt"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				initCnt: []corev1.ResourceList{
@@ -990,6 +1011,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[tier1][testtype29][tmscope:container] should make a pod with 3 gu cnt and 3 init cnt land on a node with enough resources, when sum of init and app cnt resources are more than node resources",
+			Label("tier1", "tmscope:cnt"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				initCnt: []corev1.ResourceList{
@@ -1047,6 +1069,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:54018][tmscope:cnt][devices] should make a pod with two gu cnt land on a node with enough resources with devices on a specific NUMA zone,  containers should be spread on a different zone",
+			Label("tmscope:cnt", "devices"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -1091,6 +1114,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:54016][tmscope:pod][tier0][devices] should make a pod with one gu cnt requesting devices land on a node with enough resources on a specific NUMA zone",
+			Label("tier0", "tmscope:pod", "devices"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -1126,6 +1150,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:54025][tmscope:cnt][tier2][devices] should make a besteffort pod requesting devices land on a node with enough resources on a specific NUMA zone, containers should be spread on a different zone",
+			Label("tier2", "tmscope:cnt", "devices"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -1163,6 +1188,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:55431][tmscope:pod][tier0][devices] should make a besteffort pod requesting devices land on a node with enough resources on a specific NUMA zone",
+			Label("tier0", "tmscope:pod", "devices"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -1195,6 +1221,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:55450][tmscope:pod][tier2][devices][hostlevel] should make a burstable pod requesting devices land on a node with enough resources on a specific NUMA zone",
+			Label("tier2", "tmscope:pod", "devices", "hostlevel"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -1232,6 +1259,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:54024][tmscope:cnt][tier2][devices][hostlevel] should make a burstable pod requesting devices land on a node with enough resources on a specific NUMA zone, containers should be spread on a different zone",
+			Label("tier2", "tmscope:cnt", "devices", "hostlevel"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{
@@ -1273,7 +1301,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		),
 	)
 
-	DescribeTable("[placement][unsched] cluster with one worker nodes suitable",
+	DescribeTable("[placement][unsched] cluster with one worker nodes suitable", Label("placement", "unsched"),
 		func(policyFuncs tmScopeFuncs, errMsg string, podRes podResourcesRequest, unsuitableFreeRes, targetFreeResPerNUMA []corev1.ResourceList) {
 
 			hostsRequired := 2
@@ -1416,6 +1444,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		// to see the reason for not scheduling the pod on that target node as "cannot align container: testcnt-1", because the other worker nodes have insufficient
 		// free resources to accommodate the pod thus they will be rejected as candidates at earlier stage
 		Entry("[tier0][unsched][tmscope:container][cpu] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
+			Label("tier0", "unsched", "tmscope:cnt", "cpu"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			nrosched.ErrorCannotAlignContainer,
 			podResourcesRequest{
@@ -1476,6 +1505,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:74256][tier3][unsched][tmscope:pod][cpu] guaranteed pod with multi cnt with fractional cpus keep on pending because cannot align the second container to a single numa node",
+			Label("tier3", "unsched", "tmscope:pod", "cpu"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			nrosched.ErrorCannotAlignPod,
 			podResourcesRequest{
@@ -1520,6 +1550,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:74257][tier3][unsched][tmscope:pod][cpu][nonreg] burstable pod with multi cnt with fractional cpus keep on pending because of not enough free cpus",
+			Label("tier3", "unsched", "tmscope:pod", "cpu", "nonreg"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			"0.* nodes are available: [0-9]* Insufficient cpu",
 			podResourcesRequest{
@@ -1561,6 +1592,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[tier0][unsched][tmscope:container][memory] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
+			Label("tier0", "unsched", "tmscope:cnt", "memory"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			nrosched.ErrorCannotAlignContainer,
 			podResourcesRequest{
@@ -1619,6 +1651,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[tier0][unsched][tmscope:container][hugepages2Mi] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
+			Label("tier0", "unsched", "tmscope:cnt", "hugepages2Mi"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			nrosched.ErrorCannotAlignContainer,
 			podResourcesRequest{
@@ -1676,6 +1709,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[tier0][unsched][tmscope:container][hugepages1Gi] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
+			Label("tier0", "unsched", "tmscope:cnt", "hugepages1Gi"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			nrosched.ErrorCannotAlignContainer,
 			podResourcesRequest{
@@ -1732,6 +1766,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:54020][tier2][unsched][tmscope:container][devices] pod with two gu cnt requesting multiple device types keep on pending because cannot align the second container to a single numa node",
+			Label("tier2", "unsched", "tmscope:cnt", "devices"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			nrosched.ErrorCannotAlignContainer,
 			podResourcesRequest{
@@ -1784,6 +1819,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:54019][tier1][unsched][tmscope:container][devices] pod with two gu cnt keep on pending because cannot align the second container to a single numa node",
+			Label("tier1", "unsched", "tmscope:cnt", "devices"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			nrosched.ErrorCannotAlignContainer,
 			podResourcesRequest{
@@ -1828,6 +1864,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:54017][tier1][unsched][tmscope:pod][devices] pod with two gu cnt keep on pending because cannot align the both containers on single numa",
+			Label("tier1", "unsched", "tmscope:pod", "devices"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			nrosched.ErrorCannotAlignPod,
 			podResourcesRequest{
@@ -1872,6 +1909,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:55430][tier2][unsched][tmscope:pod][devices] besteffort pod requesting multiple device types keep on pending because cannot align the container to a single numa node",
+			Label("tier2", "unsched", "tmscope:pod", "devices"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			nrosched.ErrorCannotAlignPod,
 			podResourcesRequest{
@@ -1917,6 +1955,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:55429][tier2][unsched][tmscope:pod][devices] burstable pod requesting multiple device types keep on pending because cannot align the container to a single numa node",
+			Label("tier2", "unsched", "tmscope:pod", "devices"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			nrosched.ErrorCannotAlignPod,
 			podResourcesRequest{
@@ -1967,6 +2006,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:54023][tier2][unsched][tmscope:container][devices] besteffort pod requesting multiple device types keep on pending because cannot align the container to a single numa node",
+			Label("tier2", "unsched", "tmscope:cnt", "devices"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			nrosched.ErrorCannotAlignContainer,
 			podResourcesRequest{
@@ -2013,6 +2053,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("[test_id:54022][tier2][unsched][tmscope:container][devices] burstable pod requesting multiple device types keep on pending because cannot align the container to a single numa node",
+			Label("tier2", "unsched", "tmscope:cnt", "devices"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			nrosched.ErrorCannotAlignContainer,
 			podResourcesRequest{

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -52,7 +52,7 @@ import (
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 )
 
-var _ = Describe("[serial][disruptive][scheduler] numaresources workload unschedulable", Serial, func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload unschedulable", Serial, Label("disruptive", "scheduler"), func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
@@ -277,7 +277,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			}
 		})
 
-		It("[test_id:47619][tier3][unsched][default-scheduler] a deployment with a guaranteed pod resources available on one node but not on a single numa; scheduled by default scheduler", func() {
+		It("[test_id:47619][tier3][unsched][default-scheduler] a deployment with a guaranteed pod resources available on one node but not on a single numa; scheduled by default scheduler", Label("tier2", "unsched", "default-scheduler"), func() {
 			By("Scheduling the testing deployment")
 			deploymentName := "test-dp-with-default-sched"
 			var replicas int32 = 1
@@ -317,7 +317,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 	})
 
 	Context("with at least two nodes with two numa zones and enough resources in one numa zone", func() {
-		It("[test_id:47592][tier2][unsched][failalign] a daemonset with a guaranteed pod resources available on one node/one single numa zone but not in any other node", Label("unsched", "failalign"), func() {
+		It("[test_id:47592][tier2][unsched][failalign] a daemonset with a guaranteed pod resources available on one node/one single numa zone but not in any other node", Label("tier2", "unsched", "failalign"), func() {
 			requiredNUMAZones := 2
 			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", requiredNUMAZones))
 			nrtCandidates := e2enrt.FilterZoneCountEqual(nrts, requiredNUMAZones)
@@ -446,7 +446,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 	})
 
 	Context("with at least one node", func() {
-		It("[test_id:47616][tier2][tmscope:pod][failalign] pod with two containers each on one numa zone can NOT be scheduled", Label("failalign"), func() {
+		It("[test_id:47616][tier2][tmscope:pod][failalign] pod with two containers each on one numa zone can NOT be scheduled", Label("tier2", "tmscope:pod", "failalign"), func() {
 			// Requirements:
 			// Need at least this nodes
 			neededNodes := 1
@@ -619,7 +619,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 
 	// other than the other tests, here we expect all the worker nodes (including none-bm hosts) to be padded
 	Context("with zero suitable nodes", func() {
-		It("[test_id:47615][tier2][unsched] a deployment with multiple guaranteed pods resources that doesn't fit at the NUMA level", func() {
+		It("[test_id:47615][tier2][unsched] a deployment with multiple guaranteed pods resources that doesn't fit at the NUMA level", Label("tier2", "unsched"), func() {
 			neededNodes := 1
 			numOfnrtCandidates := len(nrts)
 			if numOfnrtCandidates < neededNodes {
@@ -843,7 +843,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			e2efixture.MustSettleNRT(fxt)
 		})
 
-		It("[test_id:47614][tier3][unsched][pod] workload requests guaranteed pod resources available on one node but not on a single numa", func() {
+		It("[test_id:47614][tier3][unsched][pod] workload requests guaranteed pod resources available on one node but not on a single numa", Label("tier3", "unsched", "pod"), func() {
 
 			By("Scheduling the testing pod")
 			pod := objects.NewTestPodPause(fxt.Namespace.Name, "testpod")
@@ -861,7 +861,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:47614][tier3][unsched][deployment] a deployment with a guaranteed pod resources available on one node but not on a single numa", func() {
+		It("[test_id:47614][tier3][unsched][deployment] a deployment with a guaranteed pod resources available on one node but not on a single numa", Label("tier3", "unsched", "deployment"), func() {
 
 			By("Scheduling the testing deployment")
 			deploymentName := "test-dp"
@@ -896,7 +896,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			}
 		})
 
-		It("[test_id:47614][tier3][unsched][daemonset] a daemonset with a guaranteed pod resources available on one node but not on a single numa", func() {
+		It("[test_id:47614][tier3][unsched][daemonset] a daemonset with a guaranteed pod resources available on one node but not on a single numa", Label("tier3", "unsched", "daemonset"), func() {
 
 			By("Scheduling the testing daemonset")
 			dsName := "test-ds"


### PR DESCRIPTION
reflect all tags but `testtype` and `test_id` into labels. From now on we should always add together labels and tags, if we add tags. Label is now the preferred way, but tags aren't forbidden yet, just deprecated.