### PR TITLE
e2e: get NRT list after it settles

### DIFF
--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -606,9 +606,6 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			updatedDp, err := wait.With(fxt.Client).Interval(10*time.Second).Timeout(2*time.Minute).ForDeploymentComplete(context.TODO(), dp)
 			Expect(err).ToNot(HaveOccurred())
 
-			nrtPostCreateDeploymentList, err := e2enrt.GetUpdated(fxt.Client, nrtList, time.Minute)
-			Expect(err).ToNot(HaveOccurred())
-
 			pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *updatedDp)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(pods)).To(Equal(2))
@@ -626,6 +623,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			By("wait for NRT data to settle")
 			e2efixture.MustSettleNRT(fxt)
+
+			nrtPostCreateDeploymentList, err := e2enrt.GetUpdated(fxt.Client, nrtList, time.Minute)
+			Expect(err).ToNot(HaveOccurred())
 
 			nrtPostCreate, err := e2enrt.FindFromList(nrtPostCreateDeploymentList.Items, targetNodeName)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
The test sometimes fails on inconsistent resources because the check is looking on an outdated NRT list which was fetched before NRT settles.

Relocate listing the NRTs to after they settle.