### PR TITLE
e2e: manager: add features introspection

### DIFF
--- a/.github/workflows/e2e-tools.yml
+++ b/.github/workflows/e2e-tools.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Build tools
       run: |
-        make build-tools binary-nrovalidate
+        make build-tools binary-nrovalidate bin/mkginkgolabelfilter binary
 
     - name: Create K8s Kind Cluster
       run: |

--- a/.github/workflows/support-tools.yml
+++ b/.github/workflows/support-tools.yml
@@ -1,0 +1,43 @@
+name: Build support tools binaries
+
+on:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: setup golang
+        uses: actions/setup-go@v2
+        id: go
+        with:
+          go-version: 1.22.4
+
+  build:
+    needs: [setup]
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: build tools' binaries
+        run: |
+          make bin/mkginkgolabelfilter
+          make bin/catkubeletconfmap
+
+      - name: release the binaries
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: bin/*
+          tag: support-tools

--- a/Makefile
+++ b/Makefile
@@ -386,7 +386,7 @@ goversion:
 build-tools: goversion bin/buildhelper bin/envsubst bin/lsplatform
 
 .PHONY: build-tools-all
-build-tools-all: goversion bin/buildhelper bin/envsubst bin/lsplatform bin/catkubeletconfmap bin/watchnrtattr
+build-tools-all: goversion bin/buildhelper bin/envsubst bin/lsplatform bin/catkubeletconfmap bin/watchnrtattr bin/mkginkgolabelfilter
 
 bin/buildhelper:
 	@go build -o bin/buildhelper tools/buildhelper/buildhelper.go
@@ -398,10 +398,15 @@ bin/lsplatform:
 	@go build -o bin/lsplatform tools/lsplatform/lsplatform.go
 
 bin/catkubeletconfmap:
-	@go build -o bin/catkubeletconfmap tools/catkubeletconfmap/catkubeletconfmap.go
+	LDFLAGS="-static"
+	CGO_ENABLED=0 go build -o bin/catkubeletconfmap -ldflags "$$LDFLAGS" tools/catkubeletconfmap/catkubeletconfmap.go
 
 bin/watchnrtattr:
 	@go build -o bin/watchnrtattr tools/watchnrtattr/watchnrtattr.go
+
+bin/mkginkgolabelfilter:
+	LDFLAGS="-static"
+	@go build -o bin/mkginkgolabelfilter -ldflags "$$LDFLAGS" tools/mkginkgolabelfilter/mkginkgolabelfilter.go
 
 verify-generated: bundle generate
 	@echo "Verifying that all code is committed after updating deps and formatting and generating code"

--- a/doc/features/README.md
+++ b/doc/features/README.md
@@ -1,0 +1,52 @@
+Features introspection in e2e tests
+======================================
+
+**Goal**
+
+Provide a way to identify the active features for every supported operator version.
+
+**Design**
+
+- Provide the possibility to group a set of tests that verify a common feature using ginkgo Label("feature:<topic>").
+  A Topic should describe the main feature being tested or the unique effect of the test on the cluster. For instance:
+  `feature:schedrst`: indicates that the test is expected to restart the schedular, be it a pod restart or a complete removal of the scheduler and recreation.
+  `feature:rtetols`: indicates that the test is testing the new feature RTE tolerations, which involves specific non-default configuration on the operator CRs hence functional effects.
+  `feature:unsched`: indicates that the test workload is anticipated to be un-schedulable for any reason for example: insufficient resources (pod is pending), TAE (failed)..
+  `feature:wlplacement`: indicates that the test challenges the scheduler to place a workload on a node. This is a common label for most of the functional tests.
+    - Rules for creating a new topic
+        - A topic should point out briefly the new feature being tested or the unique effect of the test on the cluster
+        - The topic should be lowercase
+        - For composite topics use `_` between the words, e.g no_nrt
+        - Should not consist of any of `&|!,()/`
+- Define the list of supported features for each version.
+- Allow the user to list the supported features by adding new flag, `-inspect-features` which if passed the numaresources-operator binary on the controller pod will list the active features for the deployed version of the operator.
+- For automated bugs' scenarios that their fix is not back-ported to all versions use keywords tags that briefly describes the bug's main check.
+
+**List active features**
+
+Once the operator is installed, perform the following on the controller manager pod:
+
+```azure
+oc exec -it numaresources-controller-manager-95dd55c6-k6428 -n openshift-numaresources -- /bin/numaresources-operator --inspect-features
+ ```
+
+Example output:
+```
+{"active":["config","nonreg","hostlevel","resacct","cache","stall","rmsched","rtetols","overhead","wlplacement","unsched","nonrt","taint","nodelabel","byres","tmpol"]}
+```
+
+**Use case example: run tests for supported features only**
+
+To build the filter label query of the supported features on a specific version, a binary called `mkginkgolabelfilter` exists in `releases/support-tools` which expects a JSON input showing the supported features from the operator controller pod as follows:
+
+To use the helper tool perform the following:
+
+```
+# curl -L -o mkginkgolabelfilter https://github.com/openshift-kni/numaresources-operator/releases/download/support-tools/mkginkgolabelfilter
+# chmod 755 mkginkgolabelfilter
+# ./mkginkgolabelfilter # This will wait to read the input which should be the output of the --inspect-features above
+{"active":["config","nonreg","hostlevel","resacct","cache","stall","rmsched","rtetols","overhead","wlplacement","unsched","nonrt","taint","nodelabel","byres","tmpol"]}
+feature: consistAny {config,nonreg,hostlevel,resacct,cache,stall,rmsched,rtetols,overhead,wlplacement,unsched,nonrt,taint,nodelabel,byres,tmpol}
+```
+
+Then later in the podman command of running the tests use `--filter-label` with the output of the tool to run tests of supported features only.  

--- a/internal/api/features/_topics.json
+++ b/internal/api/features/_topics.json
@@ -1,0 +1,20 @@
+{
+  "active": [
+    "config",
+    "nonreg",
+    "hostlevel",
+    "resacct",
+    "cache",
+    "stall",
+    "schedrst",
+    "rtetols",
+    "overhead",
+    "wlplacement",
+    "unsched",
+    "nonrt",
+    "taint",
+    "nodelabel",
+    "byres",
+    "tmpol"
+  ]
+}

--- a/internal/api/features/topics.go
+++ b/internal/api/features/topics.go
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ */
+
+package features
+
+import (
+	_ "embed"
+	"encoding/json"
+)
+
+//go:embed _topics.json
+var topicsData string
+
+func GetTopics() TopicInfo {
+	var tp TopicInfo
+	_ = json.Unmarshal([]byte(topicsData), &tp)
+	return tp
+}

--- a/internal/api/features/topics_test.go
+++ b/internal/api/features/topics_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/utils/strings/slices"
+)
+
+func TestGetTopics(t *testing.T) {
+	type testcase struct {
+		name       string
+		topicsList string
+		isPositive bool
+	}
+	testcases := []testcase{
+		{
+			name:       "with list of well known topics that every release operator must support",
+			topicsList: "config,nonreg,hostlevel,resacct,cache,stall,schedrst,overhead,wlplacement,unsched,taint,nodelabel,byres,tmpol",
+			isPositive: true,
+		},
+		{
+			name:       "with inactive topics included",
+			topicsList: "config,nonreg,hostlevel,notfound,cache",
+			isPositive: false,
+		},
+	}
+
+	actual := GetTopics()
+	for _, tc := range testcases {
+		topicsStr := strings.TrimSpace(tc.topicsList)
+		topics := strings.Split(topicsStr, ",")
+		tp := findMissingTopics(actual.Active, topics)
+
+		if len(tp) > 0 && tc.isPositive {
+			t.Errorf("expected to include topic(s) %v but it didn't, list found: %v", tp, actual.Active)
+		}
+
+		if len(tp) == 0 && !tc.isPositive {
+			t.Errorf("active topics included unsupported topic(s) %v, list found: %v", tp, actual.Active)
+		}
+	}
+}
+
+func findMissingTopics(agianstList, sublist []string) []string {
+	missing := []string{}
+	for _, el := range sublist {
+		if !slices.Contains(agianstList, el) {
+			missing = append(missing, el)
+		}
+	}
+	return missing
+}

--- a/internal/api/features/types.go
+++ b/internal/api/features/types.go
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ */
+
+package features
+
+import (
+	"fmt"
+
+	goversion "github.com/aquasecurity/go-version/pkg/version"
+)
+
+const (
+	Version = "v4.17.0"
+)
+
+type Metadata struct {
+	// semantic versioning vX.Y.Z, e.g. v1.0.0
+	Version string `json:"version"`
+}
+
+type TopicInfo struct {
+	Metadata Metadata `json:"metadata"`
+	// unsorted list of topics active (supported)
+	Active []string `json:"active"`
+}
+
+func NewTopicInfo() TopicInfo {
+	return TopicInfo{
+		Metadata: Metadata{
+			Version: Version,
+		},
+	}
+}
+
+func (tp TopicInfo) Validate() error {
+	if tp.Metadata.Version == "" {
+		return fmt.Errorf("metadata: missing version")
+	}
+	if _, err := goversion.Parse(tp.Metadata.Version); err != nil {
+		return fmt.Errorf("metadata: malformed version: %w", err)
+	}
+	if len(tp.Active) == 0 {
+		return fmt.Errorf("missing active topics")
+	}
+	return nil
+}

--- a/internal/api/features/types_test.go
+++ b/internal/api/features/types_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewTopicInfo(t *testing.T) {
+	actual := NewTopicInfo()
+	expected := TopicInfo{
+		Metadata: Metadata{
+			Version: Version,
+		},
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("got different new TopicInfo than expected: expected:\n%+v\ngot:\n%+v\n", expected, actual)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	nonEmpty := []string{"foo", "bar"}
+	posTests := []TopicInfo{
+		{
+			Metadata: Metadata{
+				Version: Version,
+			},
+			Active: GetTopics().Active,
+		},
+		{
+			Metadata: Metadata{
+				Version: "2.0-4",
+			},
+			Active: nonEmpty,
+		},
+		{
+			Metadata: Metadata{
+				Version: "v4.10.0-202312160824.p0.g89f320d.assembly.stream",
+			},
+			Active: nonEmpty,
+		},
+		{
+			Metadata: Metadata{
+				Version: "v1.11.16-rc.1",
+			},
+			Active: nonEmpty,
+		},
+		{
+			Metadata: Metadata{
+				Version: "4.17",
+			},
+			Active: nonEmpty,
+		},
+	}
+
+	for _, tc := range posTests {
+		if err := tc.Validate(); err != nil {
+			t.Errorf("valid topics %+v failed validation:%v\n", tc, err)
+		}
+	}
+
+	negTests := []TopicInfo{
+		NewTopicInfo(),
+		{
+			Metadata: Metadata{
+				Version: "v4.v10.v0-2023121608y.stream",
+			},
+			Active: nonEmpty,
+		},
+		{
+			Metadata: Metadata{
+				Version: "4-v1. 6",
+			},
+			Active: nonEmpty,
+		},
+	}
+
+	for _, tc := range negTests {
+		if err := tc.Validate(); err == nil {
+			t.Errorf("invalid topics %+v passed validation\n", tc)
+		}
+	}
+}

--- a/test/e2e/serial/README.md
+++ b/test/e2e/serial/README.md
@@ -55,3 +55,9 @@ they found it before they run.
 - `E2E_RTE_CI_IMAGE` (accepts string, e.g `quay.io/openshift-kni/resource-topology-exporter:test-ci`) sets the 
   RTE image to be used for testing purposes particularly for modifying the operator object.
   
+### Tests tagging 
+
+- Tagging tests to a specific feature functionality were done by adding tags in the spec description like `It("[rtetols][distruptive]...")`.
+Starting Jul 2024, while the master branch is pointing to 4.17, the new preferred way to tag tests is using ginkgo `Label("")` such as `Context("should run pods requesting host-level resources", Label("hostlevel","distruptive"), func(){..})`. Tags aren't forbidden yet; they are just deprecated, so whenever a tag is added, a label is also required.
+- Each test should have the importance tag which is one of the below:
+`tier0` means critical; `tier1` means important; `tier2` means medium priority; `tier3` means low priority test.

--- a/test/e2e/serial/e2e_serial_test.go
+++ b/test/e2e/serial/e2e_serial_test.go
@@ -33,7 +33,7 @@ var setupExecuted = false
 
 func TestSerial(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "NUMAResources serial e2e tests")
+	RunSpecs(t, "NUMAResources serial e2e tests", Label("e2e:serial"))
 }
 
 var _ = BeforeSuite(func() {

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -74,7 +74,7 @@ import (
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 )
 
-var _ = Describe("[serial][disruptive] numaresources configuration management", Serial, Label("disruptive"), func() {
+var _ = Describe("[serial][disruptive] numaresources configuration management", Serial, Label("disruptive"), Label("feature:config"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 	var nrts []nrtv1alpha2.NodeResourceTopology
@@ -617,7 +617,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			Expect(err).ToNot(HaveOccurred(), "failed to check the NodeGroupConfig status for %q", nroKey.String())
 		})
 
-		It("should report relatedObjects in the status", func(ctx context.Context) {
+		It("should report relatedObjects in the status", Label("related_objects"), func(ctx context.Context) {
 			By("getting NROP object")
 			nroKey := objects.NROObjectKey()
 			nroOperObj := nropv1.NUMAResourcesOperator{}

--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -50,7 +50,7 @@ import (
 	e2epadder "github.com/openshift-kni/numaresources-operator/test/utils/padder"
 )
 
-var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement", Serial, Label("disruptive", "scheduler"), func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement", Serial, Label("disruptive", "scheduler"), Label("feature:nonreg"), func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
@@ -322,7 +322,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 	})
 
 	Context("Requesting resources that are greater than allocatable at numa level", func() {
-		It("[test_id:47613][tier3][nonreg][unsched] should not schedule a pod requesting resources that are not allocatable at numa level", Label("tier3", "nonreg", "unsched"), func() {
+		It("[test_id:47613][tier3][nonreg][unsched] should not schedule a pod requesting resources that are not allocatable at numa level", Label("tier3", "nonreg", "unsched"), Label("feature:unsched"), func() {
 			//the test can run on node with any numa number, so no need to filter the nrts
 			nrtNames := e2enrt.AccumulateNames(nrts)
 

--- a/test/e2e/serial/tests/non_regression_fundamentals.go
+++ b/test/e2e/serial/tests/non_regression_fundamentals.go
@@ -42,7 +42,7 @@ import (
 
 type setupPodFunc func(pod *corev1.Pod)
 
-var _ = Describe("[serial][fundamentals][scheduler][nonreg] numaresources fundamentals non-regression", Serial, func() {
+var _ = Describe("[serial][fundamentals][scheduler][nonreg] numaresources fundamentals non-regression", Serial, Label("fundamentals", "scheduler", "nonreg"), Label("feature:nonreg"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -52,7 +52,7 @@ import (
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 )
 
-var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workload resource accounting", Serial, Label("disruptive", "scheduler", "resacct"), func() {
+var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workload resource accounting", Serial, Label("disruptive", "scheduler", "resacct"), Label("feature:resacct"), func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha2.NodeResourceTopologyList

--- a/test/e2e/serial/tests/resource_hostlevel.go
+++ b/test/e2e/serial/tests/resource_hostlevel.go
@@ -40,7 +40,7 @@ import (
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 )
 
-var _ = Describe("[serial][hostlevel] numaresources host-level resources", Serial, Label("hostlevel"), func() {
+var _ = Describe("[serial][hostlevel] numaresources host-level resources", Serial, Label("hostlevel"), Label("feature:hostlevel"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 
@@ -60,7 +60,7 @@ var _ = Describe("[serial][hostlevel] numaresources host-level resources", Seria
 		Expect(e2efixture.Teardown(fxt)).To(Succeed())
 	})
 
-	Context("with at least two nodes suitable", func() {
+	Context("with at least two nodes suitable", Label("tier0"), func() {
 		// testing scope=container is pointless in this case: 1 pod with 1 container.
 		// It should behave exactly like scope=pod. But we keep these tests as non-regression
 		// to have a signal the system is behaving as expected.
@@ -262,7 +262,7 @@ var _ = Describe("[serial][hostlevel] numaresources host-level resources", Seria
 	})
 
 	Context("[unsched] without suitable nodes with enough host level resources", func() {
-		DescribeTable("[hostlevel][failalign] a pod with multi containers should be pending due to unavailable host-level resources", Label("hostlevel", "failalign"),
+		DescribeTable("[hostlevel][failalign] a pod with multi containers should be pending due to unavailable host-level resources", Label("hostlevel", "failalign"), Label("feature:unsched"),
 			func(tmPolicy string, requiredRes []corev1.ResourceList, expectedQOS corev1.PodQOSClass) {
 				ctx := context.TODO()
 				nrtCandidates := filterNodes(fxt, desiredNodesState{

--- a/test/e2e/serial/tests/scheduler_cache.go
+++ b/test/e2e/serial/tests/scheduler_cache.go
@@ -64,7 +64,7 @@ type interferenceDesc struct {
 	ratio int
 }
 
-var _ = Describe("[serial][scheduler][cache][tier0] scheduler cache", Serial, Label("scheduler", "cache", "tier0"), func() {
+var _ = Describe("[serial][scheduler][cache][tier0] scheduler cache", Serial, Label("scheduler", "cache", "tier0"), Label("feature:cache"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 

--- a/test/e2e/serial/tests/scheduler_cache_stall.go
+++ b/test/e2e/serial/tests/scheduler_cache_stall.go
@@ -45,7 +45,7 @@ import (
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 )
 
-var _ = Describe("[serial][scheduler][cache] scheduler cache stall", Label("scheduler", "cache", "stall"), func() {
+var _ = Describe("[serial][scheduler][cache] scheduler cache stall", Label("scheduler", "cache", "stall"), Label("feature:cache", "feature:stall"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 

--- a/test/e2e/serial/tests/scheduler_removal.go
+++ b/test/e2e/serial/tests/scheduler_removal.go
@@ -42,7 +42,7 @@ import (
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 )
 
-var _ = Describe("[serial][disruptive][scheduler][schedrst] numaresources scheduler removal on a live cluster", Serial, Label("disruptive", "scheduler", "schedrst"), func() {
+var _ = Describe("[serial][disruptive][scheduler][schedrst] numaresources scheduler removal on a live cluster", Serial, Label("disruptive", "scheduler", "schedrst"), Label("feature:schedrst"), func() {
 	var fxt *e2efixture.Fixture
 
 	BeforeEach(func() {
@@ -88,7 +88,7 @@ var _ = Describe("[serial][disruptive][scheduler][schedrst] numaresources schedu
 			}
 		})
 
-		It("[case:2][test_id:49093][tier1][unsched] should keep new scheduled workloads pending", Label("tier1", "unsched"), func() {
+		It("[case:2][test_id:49093][tier1][unsched] should keep new scheduled workloads pending", Label("tier1", "unsched"), Label("feature:unsched"), func() {
 			var err error
 
 			By(fmt.Sprintf("deleting the NRO Scheduler object: %s", serialconfig.Config.NROSchedObj.Name))

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -51,7 +51,7 @@ import (
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 )
 
-var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations support", Serial, Label("disruptive", "rtetols"), func() {
+var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations support", Serial, Label("disruptive", "rtetols"), Label("feature:rtetols"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -51,7 +51,7 @@ import (
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 )
 
-var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhead", Serial, Label("disruptive", "scheduler"), func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhead", Serial, Label("disruptive", "scheduler"), Label("feature:overhead"), func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
@@ -273,7 +273,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				}
 			})
 
-			It("[test_id:53819][tier2][unsched] Pod pending when resources requested + pod overhead don't fit on the target node; NRT objects are not updated", Label("tier2", "unsched"), func() {
+			It("[test_id:53819][tier2][unsched] Pod pending when resources requested + pod overhead don't fit on the target node; NRT objects are not updated", Label("tier2", "unsched"), Label("feature:unsched"), func() {
 				var targetNodeName string
 				var targetNrtInitial *nrtv1alpha2.NodeResourceTopology
 				var targetNrtListInitial nrtv1alpha2.NodeResourceTopologyList

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -66,7 +66,7 @@ import (
 	e2epadder "github.com/openshift-kni/numaresources-operator/test/utils/padder"
 )
 
-var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement", Serial, Label("disruptive", "scheduler"), func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement", Serial, Label("disruptive", "scheduler"), Label("feature:wlplacement"), func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha2.NodeResourceTopologyList

--- a/test/e2e/serial/tests/workload_placement_no_nrt.go
+++ b/test/e2e/serial/tests/workload_placement_no_nrt.go
@@ -39,7 +39,7 @@ import (
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 )
 
-var _ = Describe("[serial] numaresources profile update", Serial, func() {
+var _ = Describe("[serial] numaresources profile update", Serial, Label("feature:wlplacement", "feature:nonrt"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 

--- a/test/e2e/serial/tests/workload_placement_nodelabel.go
+++ b/test/e2e/serial/tests/workload_placement_nodelabel.go
@@ -52,7 +52,7 @@ import (
 
 type getNodeAffinityFunc func(labelName string, labelValue []string, selectOperator corev1.NodeSelectorOperator) *corev1.Affinity
 
-var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement considering node selector", Serial, Label("disruptive", "scheduler"), func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement considering node selector", Serial, Label("disruptive", "scheduler"), Label("feature:wlplacement", "feature:nodelabel"), func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha2.NodeResourceTopologyList

--- a/test/e2e/serial/tests/workload_placement_resources.go
+++ b/test/e2e/serial/tests/workload_placement_resources.go
@@ -53,7 +53,7 @@ import (
  * rinse and repeat for CPUs, devices, hugepages...
  */
 
-var _ = Describe("[serial][disruptive][scheduler][byres] numaresources workload placement considering specific resources requests", Serial, Label("disruptive", "scheduler", "byres"), func() {
+var _ = Describe("[serial][disruptive][scheduler][byres] numaresources workload placement considering specific resources requests", Serial, Label("disruptive", "scheduler", "byres"), Label("feature:wlplacement", "feature:byres"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 

--- a/test/e2e/serial/tests/workload_placement_taint.go
+++ b/test/e2e/serial/tests/workload_placement_taint.go
@@ -49,7 +49,7 @@ import (
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 )
 
-var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement considering taints", Serial, Label("disruptive", "scheduler"), func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement considering taints", Serial, Label("disruptive", "scheduler"), Label("feature:wlplacement", "feature:taint"), func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha2.NodeResourceTopologyList

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -74,7 +74,7 @@ type tmScopeFuncs struct {
 
 type tmScopeFuncsHandler map[string]tmScopeFuncs
 
-var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement considering TM policy", Serial, Label("disruptive", "scheduler"), func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement considering TM policy", Serial, Label("disruptive", "scheduler"), Label("feature:wlplacement", "feature:tmpol"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
 	tmSingleNUMANodeFuncsHandler := tmScopeFuncsHandler{
@@ -1301,7 +1301,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		),
 	)
 
-	DescribeTable("[placement][unsched] cluster with one worker nodes suitable", Label("placement", "unsched"),
+	DescribeTable("[placement][unsched] cluster with one worker nodes suitable", Label("placement", "unsched"), Label("feature:unsched"),
 		func(policyFuncs tmScopeFuncs, errMsg string, podRes podResourcesRequest, unsuitableFreeRes, targetFreeResPerNUMA []corev1.ResourceList) {
 
 			hostsRequired := 2
@@ -1551,6 +1551,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		),
 		Entry("[test_id:74257][tier3][unsched][tmscope:pod][cpu][nonreg] burstable pod with multi cnt with fractional cpus keep on pending because of not enough free cpus",
 			Label("tier3", "unsched", "tmscope:pod", "cpu", "nonreg"),
+			Label("feature:nonreg"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Pod],
 			"0.* nodes are available: [0-9]* Insufficient cpu",
 			podResourcesRequest{

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -52,7 +52,7 @@ import (
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 )
 
-var _ = Describe("[serial][disruptive][scheduler] numaresources workload unschedulable", Serial, Label("disruptive", "scheduler"), func() {
+var _ = Describe("[serial][disruptive][scheduler] numaresources workload unschedulable", Serial, Label("disruptive", "scheduler"), Label("feature:unsched"), func() {
 	var fxt *e2efixture.Fixture
 	var padder *e2epadder.Padder
 	var nrtList nrtv1alpha2.NodeResourceTopologyList

--- a/test/e2e/tools/mkginkgolabelfilter_test.go
+++ b/test/e2e/tools/mkginkgolabelfilter_test.go
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tools
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/klog/v2"
+)
+
+var _ = Describe("[tools][mkginkgolabelfilter] Auxiliary tools", Label("tools", "mkginkgolabelfilter"), func() {
+	Context("with the binary available", func() {
+		It("should run tool with different inputs", func(ctx context.Context) {
+			type testcase struct {
+				name        string
+				input       string
+				expectedOut string
+			}
+			testcases := []testcase{
+				{
+					name:        "should create a filter that matches the a valid input",
+					input:       `{"active":["foo","bar","foobar"]}`,
+					expectedOut: "feature: consistAny {foo,bar,foobar}\n",
+				},
+				{
+					name:        "should fail on an invalid json format",
+					input:       `("active"=["foo","bar"])`,
+					expectedOut: "",
+				},
+				{
+					name:        "should return empty features on a valid json format and non-matching topic info - no active",
+					input:       `{"supported":["foo","bar","foobar"]}`,
+					expectedOut: "feature: consistAny {}\n",
+				},
+				{
+					name:        "should fail on a valid json format and partially matching topic info",
+					input:       `{"supported":["foo","bar"],"active":["foobar"]}`,
+					expectedOut: "feature: consistAny {foobar}\n",
+				},
+			}
+
+			cmdline := []string{
+				filepath.Join(BinariesPath, "mkginkgolabelfilter"),
+			}
+			expectExecutableExists(cmdline[0])
+			for _, tc := range testcases {
+				klog.Infof("running %q\n", tc.name)
+				buffer := bytes.Buffer{}
+				toolCmd := exec.Command(cmdline[0])
+				_, err := buffer.Write(append([]byte(tc.input), "\n"...))
+				Expect(err).ToNot(HaveOccurred())
+				toolCmd.Stdin = &buffer
+
+				out, err := toolCmd.Output()
+
+				Expect(string(out)).To(Equal(tc.expectedOut), "different output found:\n%v\nexpected:\n%v", string(out), tc.expectedOut)
+				if tc.expectedOut == "" {
+					Expect(err).To(HaveOccurred())
+				}
+			}
+		})
+	})
+})

--- a/tools/mkginkgolabelfilter/mkginkgolabelfilter.go
+++ b/tools/mkginkgolabelfilter/mkginkgolabelfilter.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/openshift-kni/numaresources-operator/internal/api/features"
+)
+
+func main() {
+	var help bool
+	flag.BoolVar(&help, "h", help, "outputs tool description")
+	flag.Parse()
+
+	if help {
+		e := features.NewTopicInfo()
+		e.Active = []string{"feature_1", "feature_2"}
+		filter := fmt.Sprintf("feature: consistAny {%s}\n", strings.Join(e.Active, ","))
+		fmt.Printf("The tool expects a json format text and parses it into TopicInfo struct, then prints out a ginkgo label filter for the active features.\nExample: for input\n%+v\nthe tool will print\n%s\n", e, filter)
+		os.Exit(0)
+	}
+
+	var topics features.TopicInfo
+	err := json.NewDecoder(os.Stdin).Decode(&topics)
+	if err != nil {
+		log.Fatalf("error decoding topics data: %v", err)
+	}
+	fmt.Printf("feature: consistAny {%s}\n", strings.Join(topics.Active, ","))
+}


### PR DESCRIPTION
As we proceed to maintain one tests image exported from the main branch,
some tests verify specific features that are active on
specific releases only.

Classify the tests of serial suite by features using ginkgo Labels on
specs so that later one can filter tests based on these features to run
only the active features per release.

