### PR TITLE
makefile: build serial bin with race detector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ binary-e2e-sched:
 binary-e2e-serial:
 	LDFLAGS+="-X github.com/openshift-kni/numaresources-operator/pkg/version.version=$(shell bin/buildhelper version) "; \
 	LDFLAGS+="-X github.com/openshift-kni/numaresources-operator/pkg/version.gitcommit=$(shell bin/buildhelper commit)"; \
-	CGO_ENABLED=0 go test -c -v -o bin/e2e-nrop-serial.test -ldflags "$$LDFLAGS" ./test/e2e/serial
+	CGO_ENABLED=0 go test -race -c -v -o bin/e2e-nrop-serial.test -ldflags "$$LDFLAGS" ./test/e2e/serial
 
 binary-e2e-tools:
 	go test -c -v -o bin/e2e-nrop-tools.test ./test/e2e/tools

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 test-unit: test-unit-pkgs test-controllers
 
 test-unit-pkgs:
-	go test ./api/... ./pkg/... ./rte/pkg/... ./internal/...
+	go test -race ./api/... ./pkg/... ./rte/pkg/... ./internal/...
 
 test-controllers: envtest
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./controllers/...
@@ -171,13 +171,13 @@ binary-e2e-rte-local:
 	go test -c -v -o bin/e2e-nrop-rte-local.test ./test/e2e/rte/local
 
 binary-e2e-rte: binary-e2e-rte-local
-	go test -c -v -o bin/e2e-nrop-rte.test ./test/e2e/rte
+	go test -race -c -v -o bin/e2e-nrop-rte.test ./test/e2e/rte
 
 binary-e2e-install:
-	go test -v -c -o bin/e2e-nrop-install.test ./test/e2e/install && go test -v -c -o bin/e2e-nrop-sched-install.test ./test/e2e/sched/install
+	go test -race -v -c -o bin/e2e-nrop-install.test ./test/e2e/install && go test -v -c -o bin/e2e-nrop-sched-install.test ./test/e2e/sched/install
 
 binary-e2e-uninstall:
-	go test -v -c -o bin/e2e-nrop-uninstall.test ./test/e2e/uninstall && go test -v -c -o bin/e2e-nrop-sched-uninstall.test ./test/e2e/sched/uninstall
+	go test -race -v -c -o bin/e2e-nrop-uninstall.test ./test/e2e/uninstall && go test -v -c -o bin/e2e-nrop-sched-uninstall.test ./test/e2e/sched/uninstall
 
 binary-e2e-sched:
 	go test -c -v -o bin/e2e-nrop-sched.test ./test/e2e/sched


### PR DESCRIPTION
Tests in serial often fails and there is no clear reason from the logs, although elaborated, on why the failure happened.

Build the serial suite binary with race detector so that when tests run a warning is shown pointing to occured race.

This is meant to help debug the failing tests but not actually fixing them or preventing race conditions.

xref: https://go.dev/doc/articles/race_detector