### PR TITLE
manifests: label: add `app` label

### DIFF
--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -500,12 +500,14 @@ spec:
         serviceAccountName: numaresources-controller-manager
       deployments:
       - label:
+          app: numaresources-operator
           control-plane: controller-manager
         name: numaresources-controller-manager
         spec:
           replicas: 1
           selector:
             matchLabels:
+              app: numaresources-operator
               control-plane: controller-manager
           strategy: {}
           template:
@@ -513,6 +515,7 @@ spec:
               annotations:
                 target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
+                app: numaresources-operator
                 control-plane: controller-manager
             spec:
               affinity:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -13,10 +13,12 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
+    app: numaresources-operator
     control-plane: controller-manager
 spec:
   selector:
     matchLabels:
+      app: numaresources-operator
       control-plane: controller-manager
   replicas: 1
   template:
@@ -24,6 +26,7 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
+        app: numaresources-operator
         control-plane: controller-manager
     spec:
       securityContext:


### PR DESCRIPTION
In order to discover the deployment and/or the operator pod, filtering by `app` label is the recommended way.
We add the label to enable so.