### PR TITLE
e2e: simplify reboot test 47674 and minor fix

### DIFF
--- a/internal/wait/machineconfig.go
+++ b/internal/wait/machineconfig.go
@@ -27,6 +27,11 @@ import (
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
 
+const (
+	CurrentConfigNodeAnnotation = "machineconfiguration.openshift.io/currentConfig"
+	DesiredConfigNodeAnnotation = "machineconfiguration.openshift.io/desiredConfig"
+)
+
 func (wt Waiter) ForMachineConfigPoolDeleted(ctx context.Context, mcp *machineconfigv1.MachineConfigPool) error {
 	immediate := false
 	err := k8swait.PollUntilContextTimeout(ctx, wt.PollInterval, wt.PollTimeout, immediate, func(aContext context.Context) (bool, error) {

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -208,11 +208,12 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 				Expect(err).ToNot(HaveOccurred())
 
 				By("waiting for mcp to start updating")
-				waitForMcpsCondition(fxt.Client, context.TODO(), mcps, machineconfigv1.MachineConfigPoolUpdating)
+				err = waitForMcpsCondition(fxt.Client, context.TODO(), mcps, machineconfigv1.MachineConfigPoolUpdating)
+				Expect(err).ToNot(HaveOccurred())
 
 				By("wait for mcp to get updated")
-				waitForMcpsCondition(fxt.Client, context.TODO(), mcps, machineconfigv1.MachineConfigPoolUpdated)
-
+				err = waitForMcpsCondition(fxt.Client, context.TODO(), mcps, machineconfigv1.MachineConfigPoolUpdated)
+				Expect(err).ToNot(HaveOccurred())
 			}() //end of defer
 
 			// here we expect mcp-test and worker mcps to get updated.
@@ -229,13 +230,16 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("waiting for the new mcps to get updated")
-			waitForMcpsCondition(fxt.Client, context.TODO(), newMcps, machineconfigv1.MachineConfigPoolUpdated)
+			err = waitForMcpsCondition(fxt.Client, context.TODO(), newMcps, machineconfigv1.MachineConfigPoolUpdated)
+			Expect(err).ToNot(HaveOccurred())
 
 			By("waiting for the old mcps to start updating")
-			waitForMcpsCondition(fxt.Client, context.TODO(), initialMcps, machineconfigv1.MachineConfigPoolUpdating)
+			err = waitForMcpsCondition(fxt.Client, context.TODO(), initialMcps, machineconfigv1.MachineConfigPoolUpdating)
+			Expect(err).ToNot(HaveOccurred())
 
 			By("waiting for the old mcps to get updated")
-			waitForMcpsCondition(fxt.Client, context.TODO(), initialMcps, machineconfigv1.MachineConfigPoolUpdated)
+			err = waitForMcpsCondition(fxt.Client, context.TODO(), initialMcps, machineconfigv1.MachineConfigPoolUpdated)
+			Expect(err).ToNot(HaveOccurred())
 
 			By(fmt.Sprintf("Verify RTE daemonsets have the updated node selector matching to the new mcp %q", mcp.Name))
 			Eventually(func() (bool, error) {
@@ -447,10 +451,12 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			}).WithTimeout(10 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
 
 			By("waiting for mcp to start updating")
-			waitForMcpsCondition(fxt.Client, context.TODO(), mcps, machineconfigv1.MachineConfigPoolUpdating)
+			err = waitForMcpsCondition(fxt.Client, context.TODO(), mcps, machineconfigv1.MachineConfigPoolUpdating)
+			Expect(err).ToNot(HaveOccurred())
 
 			By("wait for mcp to get updated")
-			waitForMcpsCondition(fxt.Client, context.TODO(), mcps, machineconfigv1.MachineConfigPoolUpdated)
+			err = waitForMcpsCondition(fxt.Client, context.TODO(), mcps, machineconfigv1.MachineConfigPoolUpdated)
+			Expect(err).ToNot(HaveOccurred())
 
 			defer func() {
 				By("reverting kubeletconfig changes")
@@ -470,10 +476,12 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 				}).WithTimeout(10 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
 
 				By("waiting for mcp to start updating")
-				waitForMcpsCondition(fxt.Client, context.TODO(), mcps, machineconfigv1.MachineConfigPoolUpdating)
+				err = waitForMcpsCondition(fxt.Client, context.TODO(), mcps, machineconfigv1.MachineConfigPoolUpdating)
+				Expect(err).ToNot(HaveOccurred())
 
 				By("wait for mcp to get updated")
-				waitForMcpsCondition(fxt.Client, context.TODO(), mcps, machineconfigv1.MachineConfigPoolUpdated)
+				err = waitForMcpsCondition(fxt.Client, context.TODO(), mcps, machineconfigv1.MachineConfigPoolUpdated)
+				Expect(err).ToNot(HaveOccurred())
 			}()
 
 			By("checking that NUMAResourcesOperator's ConfigMap has changed")
@@ -1005,7 +1013,7 @@ func accumulateKubeletConfigNames(cms []corev1.ConfigMap) sets.Set[string] {
 	return cmNames
 }
 
-func waitForMcpsCondition(cli client.Client, ctx context.Context, mcps []*machineconfigv1.MachineConfigPool, condition machineconfigv1.MachineConfigPoolConditionType) {
+func waitForMcpsCondition(cli client.Client, ctx context.Context, mcps []*machineconfigv1.MachineConfigPool, condition machineconfigv1.MachineConfigPoolConditionType) error {
 	var eg errgroup.Group
 	for _, mcp := range mcps {
 		klog.Infof("wait for mcp %q to meet condition %q", mcp.Name, condition)
@@ -1019,9 +1027,7 @@ func waitForMcpsCondition(cli client.Client, ctx context.Context, mcps []*machin
 			return err
 		})
 	}
-	if err := eg.Wait(); err != nil {
-		fmt.Printf("An error occurred: %v\n", err)
-	}
+	return eg.Wait()
 }
 
 const (

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -427,13 +427,8 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 				g.Expect(err).ToNot(HaveOccurred())
 			}).WithTimeout(10 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
 
-			By("waiting for mcp to start updating")
-			err = waitForMcpsCondition(fxt.Client, context.TODO(), mcps, machineconfigv1.MachineConfigPoolUpdating)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("wait for mcp to get updated")
-			err = waitForMcpsCondition(fxt.Client, context.TODO(), mcps, machineconfigv1.MachineConfigPoolUpdated)
-			Expect(err).ToNot(HaveOccurred())
+			By("waiting for mcp to update")
+			waitForMcpUpdate(fxt.Client, context.TODO(), mcps)
 
 			defer func() {
 				By("reverting kubeletconfig changes")
@@ -452,13 +447,8 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 					g.Expect(err).ToNot(HaveOccurred())
 				}).WithTimeout(10 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
 
-				By("waiting for mcp to start updating")
-				err = waitForMcpsCondition(fxt.Client, context.TODO(), mcps, machineconfigv1.MachineConfigPoolUpdating)
-				Expect(err).ToNot(HaveOccurred())
-
-				By("wait for mcp to get updated")
-				err = waitForMcpsCondition(fxt.Client, context.TODO(), mcps, machineconfigv1.MachineConfigPoolUpdated)
-				Expect(err).ToNot(HaveOccurred())
+				By("waiting for mcp to update")
+				waitForMcpUpdate(fxt.Client, context.TODO(), mcps)
 			}()
 
 			By("checking that NUMAResourcesOperator's ConfigMap has changed")

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -786,10 +786,8 @@ func sriovToleration() corev1.Toleration {
 
 func waitForMcpUpdate(cli client.Client, ctx context.Context, mcps []*machineconfigv1.MachineConfigPool) {
 	By("waiting for mcp to start updating")
-	err := waitForMcpsCondition(cli, ctx, mcps, machineconfigv1.MachineConfigPoolUpdating)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(waitForMcpsCondition(cli, ctx, mcps, machineconfigv1.MachineConfigPoolUpdating)).To(Succeed())
 
 	By("wait for mcp to get updated")
-	err = waitForMcpsCondition(cli, ctx, mcps, machineconfigv1.MachineConfigPoolUpdated)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(waitForMcpsCondition(cli, ctx, mcps, machineconfigv1.MachineConfigPoolUpdated)).To(Succeed())
 }

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -531,14 +532,15 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 				var taintedNode *corev1.Node
 
 				BeforeEach(func(ctx context.Context) {
-
 					By("delete current NROP CR from the cluster")
-					err := fxt.Client.Delete(ctx, &nroOperObj)
+					mcpsInfo, err := buildMCPsInfo(fxt.Client, ctx, nroOperObj)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(len(mcpsInfo)).To(BeNumerically(">", 0))
+
+					err = fxt.Client.Delete(ctx, &nroOperObj)
 					Expect(err).ToNot(HaveOccurred())
 
-					mcps, err := nropmcp.GetListByNodeGroupsV1(ctx, e2eclient.Client, nroOperObj.Spec.NodeGroups)
-					Expect(err).ToNot(HaveOccurred())
-					waitForMcpUpdate(fxt.Client, ctx, mcps)
+					waitForMcpUpdate(fxt.Client, ctx, mcpsInfo, MachineConfig)
 
 					By("taint one worker node")
 					workers, err = nodes.GetWorkers(fxt.DEnv())
@@ -569,12 +571,15 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 						nropNewObj.ObjectMeta = metav1.ObjectMeta{
 							Name: nroOperObj.Name,
 						}
+
 						err = fxt.Client.Create(ctx, nropNewObj)
 						Expect(err).ToNot(HaveOccurred())
 
-						mcps, err := nropmcp.GetListByNodeGroupsV1(ctx, e2eclient.Client, nropNewObj.Spec.NodeGroups)
+						mcpsInfo, err := buildMCPsInfo(fxt.Client, ctx, *nropNewObj)
 						Expect(err).ToNot(HaveOccurred())
-						waitForMcpUpdate(fxt.Client, ctx, mcps)
+						Expect(len(mcpsInfo)).To(BeNumerically(">", 0))
+
+						waitForMcpUpdate(fxt.Client, ctx, mcpsInfo, MachineCount)
 					} else {
 						Eventually(func(g Gomega) {
 							err := fxt.Client.Get(ctx, nroKey, nropNewObj)
@@ -598,12 +603,15 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 					nropNewObj.ObjectMeta = metav1.ObjectMeta{
 						Name: nroOperObj.Name,
 					}
+
 					err := fxt.Client.Create(ctx, nropNewObj)
 					Expect(err).ToNot(HaveOccurred())
 
-					mcps, err := nropmcp.GetListByNodeGroupsV1(ctx, e2eclient.Client, nropNewObj.Spec.NodeGroups)
+					mcpsInfo, err := buildMCPsInfo(fxt.Client, ctx, *nropNewObj)
 					Expect(err).ToNot(HaveOccurred())
-					waitForMcpUpdate(fxt.Client, ctx, mcps)
+					Expect(len(mcpsInfo)).To(BeNumerically(">", 0))
+
+					waitForMcpUpdate(fxt.Client, ctx, mcpsInfo, MachineCount)
 
 					klog.Info("waiting for DaemonSet to be ready")
 					ds, err := wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDaemonsetPodsCreation(ctx, dsKey, len(workers)-1)
@@ -643,9 +651,11 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 					err := fxt.Client.Create(ctx, nropNewObj)
 					Expect(err).ToNot(HaveOccurred())
 
-					mcps, err := nropmcp.GetListByNodeGroupsV1(ctx, e2eclient.Client, nropNewObj.Spec.NodeGroups)
+					mcpsInfo, err := buildMCPsInfo(fxt.Client, ctx, *nropNewObj)
 					Expect(err).ToNot(HaveOccurred())
-					waitForMcpUpdate(fxt.Client, ctx, mcps)
+					Expect(len(mcpsInfo)).To(BeNumerically(">", 0))
+
+					waitForMcpUpdate(fxt.Client, ctx, mcpsInfo, MachineCount)
 
 					klog.Info("waiting for DaemonSet to be ready")
 					ds, err := wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDaemonsetPodsCreation(ctx, dsKey, len(workers))
@@ -717,6 +727,42 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 	})
 })
 
+func buildMCPsInfo(cli client.Client, ctx context.Context, nroObj nropv1.NUMAResourcesOperator) ([]mcpInfo, error) {
+	mcpsInfo := []mcpInfo{}
+	var updatedNroObj nropv1.NUMAResourcesOperator
+
+	err := cli.Get(ctx, client.ObjectKeyFromObject(&nroObj), &updatedNroObj)
+	if err != nil {
+		return mcpsInfo, err
+	}
+	mcps, err := nropmcp.GetListByNodeGroupsV1(ctx, cli, updatedNroObj.Spec.NodeGroups)
+	if err != nil {
+		return mcpsInfo, err
+	}
+
+	for _, mcp := range mcps {
+		klog.InfoS("construct mcp info", "mcp name", mcp.Name)
+		nodeLabels := mcp.Spec.NodeSelector.MatchLabels
+		nodes := &corev1.NodeList{}
+		err := cli.List(ctx, nodes, &client.ListOptions{LabelSelector: labels.SelectorFromSet(nodeLabels)})
+		if err != nil {
+			return mcpsInfo, err
+		}
+		if len(nodes.Items) == 0 {
+			return mcpsInfo, fmt.Errorf("empty node list for mcp %s", mcp.Name)
+		}
+		// TODO: support correlated labels on nodes for different MCPs
+
+		mcpInfo := mcpInfo{
+			obj:           mcp,
+			initialConfig: mcp.Status.Configuration.Name,
+			sampleNode:    nodes.Items[0],
+		}
+		mcpsInfo = append(mcpsInfo, mcpInfo)
+	}
+	return mcpsInfo, nil
+}
+
 func isRTEPodFoundOnNode(cli client.Client, ctx context.Context, nodeName string) (corev1.Pod, bool) {
 	pods, err := podlist.With(cli).OnNode(ctx, nodeName)
 	Expect(err).NotTo(HaveOccurred(), "Unable to get pods from node %q: %v", nodeName, err)
@@ -784,10 +830,63 @@ func sriovToleration() corev1.Toleration {
 	}
 }
 
-func waitForMcpUpdate(cli client.Client, ctx context.Context, mcps []*machineconfigv1.MachineConfigPool) {
-	By("waiting for mcp to start updating")
-	Expect(waitForMcpsCondition(cli, ctx, mcps, machineconfigv1.MachineConfigPoolUpdating)).To(Succeed())
+func waitForMcpUpdate(cli client.Client, ctx context.Context, mcpsInfo []mcpInfo, updateType MCPUpdateType) {
+	for _, info := range mcpsInfo {
+		/*
+				For every mcp check the following:
+				1. soft requirement: loop over until condition Updating==true
+			    2. loop over until condition Updated==true, is a must
+				3. check the sample node is updated with new config in its annotations, both for desired and current, is a must
+		*/
 
-	By("wait for mcp to get updated")
-	Expect(waitForMcpsCondition(cli, ctx, mcps, machineconfigv1.MachineConfigPoolUpdated)).To(Succeed())
+		By(fmt.Sprintf("verify updates for mcp %q", info.obj.Name))
+		klog.Info("waiting for mcp to start updating")
+		err := waitForMcpsCondition(cli, ctx, []*machineconfigv1.MachineConfigPool{info.obj}, machineconfigv1.MachineConfigPoolUpdating)
+		if err != nil {
+			// just warn here because the switch between the mcp conditions: updated->updating->updated can be faster
+			// and may be missed while the condition was actually met at some point
+			klog.Warningf("failed to find mcps while in updating status")
+		}
+
+		klog.Info("wait for mcp to get updated")
+		//here we must fail on errors
+		Expect(waitForMcpsCondition(cli, ctx, []*machineconfigv1.MachineConfigPool{info.obj}, machineconfigv1.MachineConfigPoolUpdated)).To(Succeed())
+
+		var updatedMcp machineconfigv1.MachineConfigPool
+		Expect(cli.Get(ctx, client.ObjectKeyFromObject(info.obj), &updatedMcp)).To(Succeed())
+		// Note: when update type is MachineCount, don't check for difference between initial config and current config
+		// on the updated mcp because mcp going into an update doesn't always it goes into a configuration update and
+		// thus associated to different MC, it could be because new nodes are joining the pool so the MC update is
+		// happening on those nodes
+		updatedConfig := updatedMcp.Status.Configuration.Name
+		if updateType == MachineConfig {
+			Expect(updatedConfig).ToNot(Equal(info.initialConfig))
+		}
+
+		// MachineConfig update type will also update the node currentConfig so check that anyway
+		klog.Info("verify mcp config is updated by ensuring the sample node has updated MC")
+		ok, err := verifyUpdatedMCOnNodes(cli, ctx, info.sampleNode, updatedConfig)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeTrue())
+	}
+}
+
+func verifyUpdatedMCOnNodes(cli client.Client, ctx context.Context, node corev1.Node, desired string) (bool, error) {
+	var updatedNode corev1.Node
+	err := cli.Get(ctx, client.ObjectKeyFromObject(&node), &updatedNode)
+	if err != nil {
+		return false, err
+	}
+
+	nodeDesired := updatedNode.Annotations[wait.DesiredConfigNodeAnnotation]
+	if nodeDesired != desired {
+		return false, fmt.Errorf("desired mc mismatch for node %q", node.Name)
+	}
+	nodeCurrent := updatedNode.Annotations[wait.CurrentConfigNodeAnnotation]
+	if nodeCurrent != desired {
+		return false, fmt.Errorf("current mc mismatch for node %q", node.Name)
+	}
+
+	klog.Infof("node %q is updated with mc %q", node.Name, desired)
+	return true, nil
 }

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -786,8 +786,10 @@ func sriovToleration() corev1.Toleration {
 
 func waitForMcpUpdate(cli client.Client, ctx context.Context, mcps []*machineconfigv1.MachineConfigPool) {
 	By("waiting for mcp to start updating")
-	waitForMcpsCondition(cli, ctx, mcps, machineconfigv1.MachineConfigPoolUpdating)
+	err := waitForMcpsCondition(cli, ctx, mcps, machineconfigv1.MachineConfigPoolUpdating)
+	Expect(err).ToNot(HaveOccurred())
 
 	By("wait for mcp to get updated")
-	waitForMcpsCondition(cli, ctx, mcps, machineconfigv1.MachineConfigPoolUpdated)
+	err = waitForMcpsCondition(cli, ctx, mcps, machineconfigv1.MachineConfigPoolUpdated)
+	Expect(err).ToNot(HaveOccurred())
 }

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -1119,39 +1119,6 @@ func labelNodeWithValue(cli client.Client, key, val, nodeName string) (func() er
 	return unlabelFunc, nil
 }
 
-func unlabelNode(cli client.Client, key, val, nodeName string) (func() error, error) {
-	nodeObj := &corev1.Node{}
-	nodeKey := client.ObjectKey{Name: nodeName}
-	if err := cli.Get(context.TODO(), nodeKey, nodeObj); err != nil {
-		return nil, err
-	}
-	sel, err := labels.Parse(fmt.Sprintf("%s=%s", key, val))
-	if err != nil {
-		return nil, err
-	}
-
-	delete(nodeObj.Labels, key)
-	klog.Infof("remove label %q from node: %q", sel.String(), nodeName)
-	if err := cli.Update(context.TODO(), nodeObj); err != nil {
-		return nil, err
-	}
-
-	labelFunc := func() error {
-		nodeObj := &corev1.Node{}
-		nodeKey := client.ObjectKey{Name: nodeName}
-		if err := cli.Get(context.TODO(), nodeKey, nodeObj); err != nil {
-			return err
-		}
-		nodeObj.Labels[key] = val
-		klog.Infof("add label %q to node: %q", sel.String(), nodeName)
-		if err := cli.Update(context.TODO(), nodeObj); err != nil {
-			return err
-		}
-		return nil
-	}
-	return labelFunc, nil
-}
-
 func availableResourceType(nrtInfo nrtv1alpha2.NodeResourceTopology, resName corev1.ResourceName) resource.Quantity {
 	var res resource.Quantity
 

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -216,9 +216,6 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			updatedDp, err := wait.With(fxt.Client).Interval(10*time.Second).Timeout(time.Minute).ForDeploymentComplete(context.TODO(), dp)
 			Expect(err).ToNot(HaveOccurred())
 
-			nrtPostCreateDeploymentList, err := e2enrt.GetUpdated(fxt.Client, nrtInitialList, time.Minute)
-			Expect(err).ToNot(HaveOccurred())
-
 			pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *updatedDp)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(pods)).To(Equal(1))
@@ -244,6 +241,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			By("wait for NRT data to settle")
 			e2efixture.MustSettleNRT(fxt)
+
+			nrtPostCreateDeploymentList, err := e2enrt.GetUpdated(fxt.Client, nrtInitialList, time.Minute)
+			Expect(err).ToNot(HaveOccurred())
 
 			nrtPostCreate, err := e2enrt.FindFromList(nrtPostCreateDeploymentList.Items, updatedPod.Spec.NodeName)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
The PR is mainly targetting test 47674 stabilization distributed across few commits. so for more details please see each commit. 

The test goal is to check if updating configurable values under the
numaresourcesoperator CR is done successfully with the anticipated
affects.

The test is flaky in the ci because of mainly 2 issues:
1. waiting improperly for the mcp updates (see commit )
2. not handling the mcp errors on time but instead continuing with the
   test steps

In this commit, we reorder the steps and simplify the test while
retaining the goal of it.

The initial scenario was like this:
1. pick target node
        1.1. label it with new role "mcp-test"
        1.2. remove the worker role
2. create new mcp targeting both roles: mcp-test & worker
        2.1. wait on the mcp mcp-test to get updated
        2.2. wait for mcp worker to start updating and finally reach updated
3. update mcp label on the NROP CR to point to mcp-test
        3.1. verify anticipated results of the CR updates
Now the recovery:
4. undo the NROP CR updates
        4.1. wait for worker mcp to start updating and reach updated
5. delete the mcp mcp-test
6. restore the labels on the target node as follows:
        6.1. remove mcp-test label
        6.2. label it back woth worker

In the scenario above, one can see that already the first step is risky
as it is leaving the target node with unknown mapping for mcp because
mcp `mcp-test` is not yet created.
The second inaccurate thing is that mcp `mcp-test` is targetting two roles:
worker & mcp-test while the intention was to have the target node with 1 label and role only. The difference this does is that if an mcp is
targetting 2 roles the RTE pods will be created on all nodes having
one of these roles, so RTE will still be created on the non-target
nodes, which means mcp worker will not be updated because NROP settings
will still target nodes with worker role, hence step 4 will fail.
The failure however will not stop the test from running, thus it will
continue and do the verifications, and the verification will pass because the test waited long enough on step 4 to update the RTEs on the nodes.
When the test recovers, the recovery is also done incorrectly.
Starting the defers in LIFO order, starting from step 5, it deletes mcp
which holds one machine that has only one role, so after deletion that
one machine will be looking for a machine config but it won't find it
because it was deleted. The other wrong step is that again leaving the
node with no labels (unlabel then label) while it should be done (label
then unlabel). This leaves the environment messed up for the next tests
as mcp is stuck updating.

To fix this we simplify the test (wait for less updates) to make it more stable by following the
below steps:
1. create mcp `mcp-test` targetting one role `mcp-test`
2. pick target node and label it with mcp-test role (keep the old roles)
        2.1. this will trigger mcp update on mcp-test, and it will be
very quick so we allow to check the condition every 2 seconds (see
previous commit)
3. update NROP CR to use mcp-test. this will trigger an update on worker
   mcp because NROP settings will be removed from the non-target nodes.
Nodes associated with mcp-test will not observe an update because NROP is
already configured on them and the only anticipated update would be on
the RTE ds -> restarted with new node-selector
        3.1 wait for mcp update on worker mcp
4. verify nrop cr updates results
Recovery:
5. undo NROP updates
        5.1. wait for mcp update on worker mcp only. remember target
node has worker role.
6. remove mcp-test label off the target node
        6.1 wait for mcp update on worker mcp. this should be quick.
7. delete the mcp-test mcp. no waiting is needed for mcp update.