### PR TITLE
tests: add fake entry point

### DIFF
--- a/test/e2e/serial/tests/e2e_serial_test.go
+++ b/test/e2e/serial/tests/e2e_serial_test.go
@@ -1,0 +1,34 @@
+//go:build ginkgo_labels_hack
+// +build ginkgo_labels_hack
+
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tests
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	_ "github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests"
+	_ "github.com/openshift-kni/numaresources-operator/test/utils/configuration"
+)
+
+func TestSerialTests(t *testing.T) {
+	RunSpecs(t, "NUMAResources serial e2e tests", Label("e2e:serial"))
+}


### PR DESCRIPTION
this is ONLY to make
`ginkgo labels -r`
`gingko labels ./test/e2e/serial/tests`
work

the build tak is supposed to prevent the bogus entry to be consumed in the test binaries, so no ill effects or any change in the e2e serial test binary is expected.