### PR TITLE
doc: examples: add ctrreschk examples

### DIFF
--- a/doc/examples/pod.ctrreschk.yaml
+++ b/doc/examples/pod.ctrreschk.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: chk-pod-
+spec:
+  schedulerName: topo-aware-scheduler
+  containers:
+  - name: ctrreschk
+    image: quay.io/fromani/ctrreschk:v0.0.2024080204
+    imagePullPolicy: Always
+    command: ["/usr/local/bin/ctrreschk", "-S", "align"]
+    resources:
+      limits:
+        cpu: 1
+        memory: 256Mi
+      requests:
+        cpu: 1
+        memory: 256Mi

--- a/doc/examples/pod.lshwinfo.yaml
+++ b/doc/examples/pod.lshwinfo.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: lshwinfo-pod-
+spec:
+  schedulerName: topo-aware-scheduler
+  containers:
+  - name: ctrreschk
+    image: quay.io/fromani/ctrreschk:v0.0.2024080204
+    imagePullPolicy: Always
+    command: ["/usr/local/bin/ctrreschk", "-S", "info"]


### PR DESCRIPTION
ctrreschk is the successor of numalign.
Let's start using it, even if it's still in heavy development.