### PR TITLE
topics: add target and machinery to generate offline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,9 @@ runner-e2e-serial: bin/envsubst
 	hack/render-e2e-runner.sh
 	hack/test-e2e-runner.sh
 
+build-topics:
+	mkdir -p bin && go run tools/lstopics/lstopics.go > bin/topics.json
+
 build: generate fmt vet binary
 
 build-rte: fmt vet binary-rte

--- a/tools/lstopics/lstopics.go
+++ b/tools/lstopics/lstopics.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/openshift-kni/numaresources-operator/internal/api/features"
+)
+
+func main() {
+	err := json.NewEncoder(os.Stdout).Encode(features.GetTopics())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
enable offline generation of topics.json, to enable bundle it into the tests image, or anywhere it is useful.