### PR TITLE
cleanup: remove `internal/nodes`

### DIFF
--- a/api/numaresourcesoperator/v1/numaresourcesscheduler_defaults_test.go
+++ b/api/numaresourcesoperator/v1/numaresourcesscheduler_defaults_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 )
@@ -61,7 +62,7 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: newDefaultReplicas(),
+				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -82,7 +83,7 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: newDefaultReplicas(),
+				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -106,7 +107,7 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: newDefaultReplicas(),
+				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -131,7 +132,7 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: newDefaultReplicas(),
+				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -156,7 +157,7 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: newDefaultReplicas(),
+				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -179,7 +180,7 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 				SchedulerInformer:    &schedInformer,
 				CacheResyncDetection: &cacheResyncDetection,
 				ScoringStrategy:      &scoringStrategyCustom,
-				Replicas:             newDefaultReplicas(),
+				Replicas:             ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -191,7 +192,7 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 					Duration: cacheResyncPeriodCustom,
 				},
 				ScoringStrategy: &scoringStrategyCustom,
-				Replicas:        newInt32(1),
+				Replicas:        ptr.To[int32](1),
 			},
 			expected: NUMAResourcesSchedulerSpec{
 				SchedulerImage: "quay.io/openshift-kni/fake-image-for:test",
@@ -203,7 +204,7 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 				SchedulerInformer:    &schedInformer,
 				CacheResyncDetection: &cacheResyncDetection,
 				ScoringStrategy:      &scoringStrategyCustom,
-				Replicas:             newInt32(1),
+				Replicas:             ptr.To[int32](1),
 			},
 		},
 		{
@@ -215,7 +216,7 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 					Duration: cacheResyncPeriodCustom,
 				},
 				ScoringStrategy: &scoringStrategyCustom,
-				Replicas:        newInt32(5),
+				Replicas:        ptr.To[int32](5),
 			},
 			expected: NUMAResourcesSchedulerSpec{
 				SchedulerImage: "quay.io/openshift-kni/fake-image-for:test",
@@ -227,7 +228,7 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 				SchedulerInformer:    &schedInformer,
 				CacheResyncDetection: &cacheResyncDetection,
 				ScoringStrategy:      &scoringStrategyCustom,
-				Replicas:             newInt32(5),
+				Replicas:             ptr.To[int32](5),
 			},
 		},
 		{
@@ -240,7 +241,7 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 				SchedulerInformer:    &schedInformerCustom,
 				CacheResyncDetection: &cacheResyncDetectionCustom,
 				ScoringStrategy:      &scoringStrategyCustom,
-				Replicas:             newInt32(5),
+				Replicas:             ptr.To[int32](5),
 			},
 			expected: NUMAResourcesSchedulerSpec{
 				CacheResyncPeriod: &metav1.Duration{
@@ -250,7 +251,7 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 				SchedulerInformer:    &schedInformerCustom,
 				CacheResyncDetection: &cacheResyncDetectionCustom,
 				ScoringStrategy:      &scoringStrategyCustom,
-				Replicas:             newInt32(5),
+				Replicas:             ptr.To[int32](5),
 			},
 		},
 		{
@@ -273,7 +274,7 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: newDefaultReplicas(),
+				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -289,7 +290,7 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 				SchedulerInformer:    &schedInformerCustom,
 				CacheResyncDetection: &cacheResyncDetectionCustom,
 				ScoringStrategy:      &scoringStrategyCustom,
-				Replicas:             newInt32(5),
+				Replicas:             ptr.To[int32](5),
 			},
 			expected: NUMAResourcesSchedulerSpec{
 				SchedulerImage: "quay.io/openshift-kni/fake-image-for:test",
@@ -302,7 +303,7 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 				SchedulerInformer:    &schedInformerCustom,
 				CacheResyncDetection: &cacheResyncDetectionCustom,
 				ScoringStrategy:      &scoringStrategyCustom,
-				Replicas:             newInt32(5),
+				Replicas:             ptr.To[int32](5),
 			},
 		},
 	}
@@ -316,12 +317,4 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 			}
 		})
 	}
-}
-
-func newInt32(v int32) *int32 {
-	return &v
-}
-
-func newDefaultReplicas() *int32 {
-	return newInt32(defaultReplicas)
 }

--- a/api/numaresourcesoperator/v1/numaresourcesscheduler_normalize_test.go
+++ b/api/numaresourcesoperator/v1/numaresourcesscheduler_normalize_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 )
@@ -61,7 +62,7 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: newDefaultReplicas(),
+				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -82,7 +83,7 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: newDefaultReplicas(),
+				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -106,7 +107,7 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: newDefaultReplicas(),
+				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -131,7 +132,7 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: newDefaultReplicas(),
+				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -156,7 +157,7 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: newDefaultReplicas(),
+				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -179,7 +180,7 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 				SchedulerInformer:    &schedInformer,
 				CacheResyncDetection: &cacheResyncDetection,
 				ScoringStrategy:      &scoringStrategyCustom,
-				Replicas:             newDefaultReplicas(),
+				Replicas:             ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -191,7 +192,7 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 					Duration: cacheResyncPeriodCustom,
 				},
 				ScoringStrategy: &scoringStrategyCustom,
-				Replicas:        newInt32(1),
+				Replicas:        ptr.To[int32](1),
 			},
 			expected: NUMAResourcesSchedulerSpec{
 				SchedulerImage: "quay.io/openshift-kni/fake-image-for:test",
@@ -203,7 +204,7 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 				SchedulerInformer:    &schedInformer,
 				CacheResyncDetection: &cacheResyncDetection,
 				ScoringStrategy:      &scoringStrategyCustom,
-				Replicas:             newInt32(1),
+				Replicas:             ptr.To[int32](1),
 			},
 		},
 		{
@@ -215,7 +216,7 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 					Duration: cacheResyncPeriodCustom,
 				},
 				ScoringStrategy: &scoringStrategyCustom,
-				Replicas:        newInt32(5),
+				Replicas:        ptr.To[int32](5),
 			},
 			expected: NUMAResourcesSchedulerSpec{
 				SchedulerImage: "quay.io/openshift-kni/fake-image-for:test",
@@ -227,7 +228,7 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 				SchedulerInformer:    &schedInformer,
 				CacheResyncDetection: &cacheResyncDetection,
 				ScoringStrategy:      &scoringStrategyCustom,
-				Replicas:             newInt32(5),
+				Replicas:             ptr.To[int32](5),
 			},
 		},
 		{
@@ -240,7 +241,7 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 				SchedulerInformer:    &schedInformerCustom,
 				CacheResyncDetection: &cacheResyncDetectionCustom,
 				ScoringStrategy:      &scoringStrategyCustom,
-				Replicas:             newInt32(5),
+				Replicas:             ptr.To[int32](5),
 			},
 			expected: NUMAResourcesSchedulerSpec{
 				CacheResyncPeriod: &metav1.Duration{
@@ -250,7 +251,7 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 				SchedulerInformer:    &schedInformerCustom,
 				CacheResyncDetection: &cacheResyncDetectionCustom,
 				ScoringStrategy:      &scoringStrategyCustom,
-				Replicas:             newInt32(5),
+				Replicas:             ptr.To[int32](5),
 			},
 		},
 		{
@@ -273,7 +274,7 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: newDefaultReplicas(),
+				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -289,7 +290,7 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 				SchedulerInformer:    &schedInformerCustom,
 				CacheResyncDetection: &cacheResyncDetectionCustom,
 				ScoringStrategy:      &scoringStrategyCustom,
-				Replicas:             newInt32(5),
+				Replicas:             ptr.To[int32](5),
 			},
 			expected: NUMAResourcesSchedulerSpec{
 				SchedulerImage: "quay.io/openshift-kni/fake-image-for:test",
@@ -302,7 +303,7 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 				SchedulerInformer:    &schedInformerCustom,
 				CacheResyncDetection: &cacheResyncDetectionCustom,
 				ScoringStrategy:      &scoringStrategyCustom,
-				Replicas:             newInt32(5),
+				Replicas:             ptr.To[int32](5),
 			},
 		},
 	}

--- a/cmd/nrtcacheck/main.go
+++ b/cmd/nrtcacheck/main.go
@@ -48,7 +48,6 @@ import (
 	rteupdate "github.com/openshift-kni/numaresources-operator/pkg/objectupdate/rte"
 	"github.com/openshift-kni/numaresources-operator/pkg/version"
 
-	intnodes "github.com/openshift-kni/numaresources-operator/internal/nodes"
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
 	"github.com/openshift-kni/numaresources-operator/internal/schedcache"
 )
@@ -127,7 +126,7 @@ func main() {
 			klog.V(1).ErrorS(err, "getting worker nodes")
 			os.Exit(1)
 		}
-		nodeNames = intnodes.GetNames(workers)
+		nodeNames = objectnames.Nodes(workers)
 		klog.V(2).Infof("using autodetected node list with %d items", len(nodeNames))
 	}
 

--- a/cmd/nrtcacheck/main.go
+++ b/cmd/nrtcacheck/main.go
@@ -39,13 +39,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
+	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil/nodes"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
+
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
 
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
 	rteupdate "github.com/openshift-kni/numaresources-operator/pkg/objectupdate/rte"
 	"github.com/openshift-kni/numaresources-operator/pkg/version"
 
-	"github.com/openshift-kni/numaresources-operator/internal/nodes"
+	intnodes "github.com/openshift-kni/numaresources-operator/internal/nodes"
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
 	"github.com/openshift-kni/numaresources-operator/internal/schedcache"
 )
@@ -119,12 +122,12 @@ func main() {
 		nodeNames = sets.List(parsedArgs.NodeNames)
 		klog.V(2).Infof("using provided node list with %d items", len(nodeNames))
 	} else {
-		workers, err := nodes.GetWorkerNodes(cli, ctx)
+		workers, err := nodes.GetWorkers(&deployer.Environment{Cli: cli, Ctx: ctx})
 		if err != nil {
 			klog.V(1).ErrorS(err, "getting worker nodes")
 			os.Exit(1)
 		}
-		nodeNames = nodes.GetNames(workers)
+		nodeNames = intnodes.GetNames(workers)
 		klog.V(2).Infof("using autodetected node list with %d items", len(nodeNames))
 	}
 

--- a/internal/baseload/baseload.go
+++ b/internal/baseload/baseload.go
@@ -17,17 +17,29 @@
 package baseload
 
 import (
+	"context"
 	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"github.com/openshift-kni/numaresources-operator/internal/podlist"
 	"github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 )
 
 type Load struct {
 	Name      string
 	Resources corev1.ResourceList
+}
+
+func ForNode(cli client.Client, ctx context.Context, nodeName string) (Load, error) {
+	pods, err := podlist.With(cli).OnNode(ctx, nodeName)
+	if err != nil {
+		return Load{Name: nodeName}, err
+	}
+	return FromPods(nodeName, pods), nil
 }
 
 func FromPods(nodeName string, pods []corev1.Pod) Load {

--- a/internal/nodes/nodes.go
+++ b/internal/nodes/nodes.go
@@ -25,9 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
-
-	"github.com/openshift-kni/numaresources-operator/internal/baseload"
-	"github.com/openshift-kni/numaresources-operator/internal/podlist"
 )
 
 const (
@@ -80,17 +77,6 @@ func GetControlPlane(cli client.Client, ctx context.Context, plat platform.Platf
 		return nil, err
 	}
 	return nodeList.Items, nil
-}
-
-func GetLoad(cli client.Client, ctx context.Context, nodeName string) (baseload.Load, error) {
-	nl := baseload.Load{
-		Name: nodeName,
-	}
-	pods, err := podlist.With(cli).OnNode(ctx, nodeName)
-	if err != nil {
-		return nl, err
-	}
-	return baseload.FromPods(nodeName, pods), nil
 }
 
 func GetNames(nodes []corev1.Node) []string {

--- a/internal/nodes/nodes.go
+++ b/internal/nodes/nodes.go
@@ -21,7 +21,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
@@ -40,21 +39,6 @@ const (
 	// LabelWorker contains the key for the worker role label
 	LabelWorkerRole = "node-role.kubernetes.io/worker"
 )
-
-func GetWorkerNodes(cli client.Client, ctx context.Context) ([]corev1.Node, error) {
-	nodes := &corev1.NodeList{}
-	selector, err := labels.Parse(LabelWorkerRole + "=")
-	if err != nil {
-		return nil, err
-	}
-
-	err = cli.List(ctx, nodes, &client.ListOptions{LabelSelector: selector})
-	if err != nil {
-		return nil, err
-	}
-
-	return nodes.Items, nil
-}
 
 func GetControlPlane(cli client.Client, ctx context.Context, plat platform.Platform) ([]corev1.Node, error) {
 	nodeList := &corev1.NodeList{}

--- a/internal/nodes/nodes.go
+++ b/internal/nodes/nodes.go
@@ -17,13 +17,7 @@
 package nodes
 
 import (
-	"context"
-
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 )
 
 const (
@@ -39,29 +33,6 @@ const (
 	// LabelWorker contains the key for the worker role label
 	LabelWorkerRole = "node-role.kubernetes.io/worker"
 )
-
-func GetControlPlane(cli client.Client, ctx context.Context, plat platform.Platform) ([]corev1.Node, error) {
-	nodeList := &corev1.NodeList{}
-	labels := metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			LabelControlPlaneRole: "",
-		},
-	}
-	if plat == platform.Kubernetes {
-		labels.MatchLabels[LabelControlPlaneRole] = ""
-	}
-
-	selNodes, err := metav1.LabelSelectorAsSelector(&labels)
-	if err != nil {
-		return nil, err
-	}
-
-	err = cli.List(ctx, nodeList, &client.ListOptions{LabelSelector: selNodes})
-	if err != nil {
-		return nil, err
-	}
-	return nodeList.Items, nil
-}
 
 func GetNames(nodes []corev1.Node) []string {
 	var nodeNames []string

--- a/internal/nodes/nodes.go
+++ b/internal/nodes/nodes.go
@@ -18,7 +18,6 @@ package nodes
 
 import (
 	"context"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -92,14 +91,6 @@ func GetLoad(cli client.Client, ctx context.Context, nodeName string) (baseload.
 		return nl, err
 	}
 	return baseload.FromPods(nodeName, pods), nil
-}
-
-func GetLabelRoleWorker() string {
-	return fmt.Sprintf("%s/%s", LabelRole, RoleWorker)
-}
-
-func GetLabelRoleMCPTest() string {
-	return fmt.Sprintf("%s/%s", LabelRole, RoleMCPTest)
 }
 
 func GetNames(nodes []corev1.Node) []string {

--- a/pkg/objectnames/nodes.go
+++ b/pkg/objectnames/nodes.go
@@ -14,27 +14,13 @@
  * limitations under the License.
  */
 
-package nodes
+package objectnames
 
 import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-const (
-	LabelRole = "node-role.kubernetes.io"
-
-	RoleControlPlane = "control-plane"
-	RoleWorker       = "worker"
-	RoleMCPTest      = "mcp-test"
-
-	// LabelControlPlaneRole contains the key for the control-plane role label
-	LabelControlPlaneRole = "node-role.kubernetes.io/control-plane"
-
-	// LabelWorker contains the key for the worker role label
-	LabelWorkerRole = "node-role.kubernetes.io/worker"
-)
-
-func GetNames(nodes []corev1.Node) []string {
+func Nodes(nodes []corev1.Node) []string {
 	var nodeNames []string
 	for _, node := range nodes {
 		nodeNames = append(nodeNames, node.Name)

--- a/pkg/validator/schedcache.go
+++ b/pkg/validator/schedcache.go
@@ -21,8 +21,10 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil/nodes"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	deployervalidator "github.com/k8stopologyawareschedwg/deployer/pkg/validator"
-	"github.com/openshift-kni/numaresources-operator/internal/nodes"
+	intnodes "github.com/openshift-kni/numaresources-operator/internal/nodes"
 	"github.com/openshift-kni/numaresources-operator/internal/schedcache"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,7 +40,7 @@ func CollectSchedCache(ctx context.Context, cli client.Client, data *ValidatorDa
 		return err
 	}
 
-	workers, err := nodes.GetWorkerNodes(cli, ctx)
+	workers, err := nodes.GetWorkers(&deployer.Environment{Cli: cli, Ctx: ctx})
 	if err != nil {
 		return err
 	}
@@ -50,7 +52,7 @@ func CollectSchedCache(ctx context.Context, cli client.Client, data *ValidatorDa
 		Log:    logr.Discard(),
 	}
 
-	_, unsynced, err := schedcache.HasSynced(&env, nodes.GetNames(workers))
+	_, unsynced, err := schedcache.HasSynced(&env, intnodes.GetNames(workers))
 	if err != nil {
 		return err
 	}

--- a/pkg/validator/schedcache.go
+++ b/pkg/validator/schedcache.go
@@ -24,8 +24,8 @@ import (
 	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil/nodes"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	deployervalidator "github.com/k8stopologyawareschedwg/deployer/pkg/validator"
-	intnodes "github.com/openshift-kni/numaresources-operator/internal/nodes"
 	"github.com/openshift-kni/numaresources-operator/internal/schedcache"
+	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -52,7 +52,7 @@ func CollectSchedCache(ctx context.Context, cli client.Client, data *ValidatorDa
 		Log:    logr.Discard(),
 	}
 
-	_, unsynced, err := schedcache.HasSynced(&env, intnodes.GetNames(workers))
+	_, unsynced, err := schedcache.HasSynced(&env, objectnames.Nodes(workers))
 	if err != nil {
 		return err
 	}

--- a/test/e2e/sched/install/install_test.go
+++ b/test/e2e/sched/install/install_test.go
@@ -33,8 +33,8 @@ import (
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
-	intnodes "github.com/openshift-kni/numaresources-operator/internal/nodes"
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
+	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
 	"github.com/openshift-kni/numaresources-operator/pkg/status"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
 	"github.com/openshift-kni/numaresources-operator/test/utils/crds"
@@ -103,7 +103,7 @@ var _ = Describe("[Scheduler] install", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nodeList).ToNot(BeEmpty())
 
-			nodeNames := intnodes.GetNames(nodeList)
+			nodeNames := objectnames.Nodes(nodeList)
 			for _, pod := range podList {
 				Expect(pod.Spec.NodeName).To(BeElementOf(nodeNames), "pod: %q landed on node: %q, which is not part of the master nodes group: %v", pod.Name, pod.Spec.NodeName, nodeNames)
 			}

--- a/test/e2e/sched/install/install_test.go
+++ b/test/e2e/sched/install/install_test.go
@@ -29,12 +29,14 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil/nodes"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
+
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
-	"github.com/openshift-kni/numaresources-operator/internal/nodes"
+	intnodes "github.com/openshift-kni/numaresources-operator/internal/nodes"
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
 	"github.com/openshift-kni/numaresources-operator/pkg/status"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
-	"github.com/openshift-kni/numaresources-operator/test/utils/configuration"
 	"github.com/openshift-kni/numaresources-operator/test/utils/crds"
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 )
@@ -97,11 +99,11 @@ var _ = Describe("[Scheduler] install", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(podList).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
 
-			nodeList, err := nodes.GetControlPlane(e2eclient.Client, context.TODO(), configuration.Plat)
+			nodeList, err := nodes.GetControlPlane(&deployer.Environment{Cli: e2eclient.Client, Ctx: context.TODO()})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nodeList).ToNot(BeEmpty())
 
-			nodeNames := nodes.GetNames(nodeList)
+			nodeNames := intnodes.GetNames(nodeList)
 			for _, pod := range podList {
 				Expect(pod.Spec.NodeName).To(BeElementOf(nodeNames), "pod: %q landed on node: %q, which is not part of the master nodes group: %v", pod.Name, pod.Spec.NodeName, nodeNames)
 			}

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -59,7 +59,6 @@ import (
 	"github.com/openshift-kni/numaresources-operator/pkg/kubeletconfig"
 	rteconfig "github.com/openshift-kni/numaresources-operator/rte/pkg/config"
 
-	"github.com/openshift-kni/numaresources-operator/internal/nodes"
 	intobjs "github.com/openshift-kni/numaresources-operator/internal/objects"
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
@@ -119,7 +118,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			Expect(err).ToNot(HaveOccurred(), "cannot get %q in the cluster", nroKey.String())
 			initialNroOperObj := nroOperObj.DeepCopy()
 
-			workers, err := nodes.GetWorkerNodes(fxt.Client, context.TODO())
+			workers, err := depnodes.GetWorkers(fxt.DEnv())
 			Expect(err).ToNot(HaveOccurred())
 
 			targetIdx, ok := e2efixture.PickNodeIndex(workers)
@@ -145,13 +144,13 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			mcp := objects.TestMCP()
 			By(fmt.Sprintf("creating new MCP: %q", mcp.Name))
 			// we must have this label in order to match other machine configs that are necessary for proper functionality
-			mcp.Labels = map[string]string{"machineconfiguration.openshift.io/role": nodes.RoleMCPTest}
+			mcp.Labels = map[string]string{"machineconfiguration.openshift.io/role": getLabelRoleMCPTest()}
 			mcp.Spec.MachineConfigSelector = &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{
 						Key:      "machineconfiguration.openshift.io/role",
 						Operator: metav1.LabelSelectorOpIn,
-						Values:   []string{nodes.RoleWorker, nodes.RoleMCPTest},
+						Values:   []string{depnodes.RoleWorker, getLabelRoleMCPTest()},
 					},
 				},
 			}

--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -26,6 +26,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
+	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil/nodes"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
@@ -35,7 +37,6 @@ import (
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper/attribute"
 
-	"github.com/openshift-kni/numaresources-operator/internal/nodes"
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
@@ -207,7 +208,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			err := fxt.Client.List(context.TODO(), &nrtInitialList)
 			Expect(err).ToNot(HaveOccurred())
 
-			workers, err := nodes.GetWorkerNodes(fxt.Client, context.TODO())
+			workers, err := nodes.GetWorkers(fxt.DEnv())
 			Expect(err).ToNot(HaveOccurred())
 
 			targetIdx, ok := e2efixture.PickNodeIndex(workers)

--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -40,6 +40,7 @@ import (
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
 
+	"github.com/openshift-kni/numaresources-operator/internal/baseload"
 	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 	e2efixture "github.com/openshift-kni/numaresources-operator/test/utils/fixture"
@@ -337,7 +338,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			for _, nodeName := range e2efixture.ListNodeNames(nrtNames) {
 
 				//calculate base load on the node
-				baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), nodeName)
+				baseload, err := baseload.ForNode(fxt.Client, context.TODO(), nodeName)
 				Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", nodeName)
 				klog.Infof(fmt.Sprintf("computed base load: %s", baseload))
 

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -36,8 +36,8 @@ import (
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper/attribute"
 
+	intbaseload "github.com/openshift-kni/numaresources-operator/internal/baseload"
 	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
-	"github.com/openshift-kni/numaresources-operator/internal/nodes"
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
@@ -342,7 +342,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			klog.Infof("initial NRT target: %s", intnrt.ToString(*targetNrtInitial))
 
 			//calculate base load on the target node
-			baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), targetNodeName)
+			baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), targetNodeName)
 			Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", targetNodeName)
 			By(fmt.Sprintf("considering the computed base load: %s", baseload))
 
@@ -366,7 +366,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 				Expect(err).NotTo(HaveOccurred())
 
 				//calculate base load on the node
-				baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), nodeName)
+				baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), nodeName)
 				Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", nodeName)
 				klog.Infof(fmt.Sprintf("computed base load: %s", baseload))
 
@@ -518,7 +518,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			}
 
 			//calculate base load on the target node
-			baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), targetNodeName)
+			baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), targetNodeName)
 			Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", targetNodeName)
 			klog.Infof(fmt.Sprintf("computed base load: %s", baseload))
 

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -25,6 +25,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil/nodes"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -38,7 +40,6 @@ import (
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
 	nropmcp "github.com/openshift-kni/numaresources-operator/internal/machineconfigpools"
-	"github.com/openshift-kni/numaresources-operator/internal/nodes"
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
 	"github.com/openshift-kni/numaresources-operator/pkg/status"
@@ -233,7 +234,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 				extraTols = true
 
 				By("getting the worker nodes")
-				workers, err = nodes.GetWorkerNodes(fxt.Client, context.TODO())
+				workers, err = nodes.GetWorkers(fxt.DEnv())
 				Expect(err).ToNot(HaveOccurred())
 
 				By(fmt.Sprintf("randomly picking the target node (among %d)", len(workers)))
@@ -296,7 +297,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 
 				By("taint one node with value and NoExecute effect")
 				var err error
-				workers, err = nodes.GetWorkerNodes(fxt.Client, ctx)
+				workers, err = nodes.GetWorkers(fxt.DEnv())
 				Expect(err).ToNot(HaveOccurred())
 
 				taintVal1 := fmt.Sprintf("%s=val1:%s", testKey, corev1.TaintEffectNoExecute)
@@ -340,7 +341,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 			It("[tier3][slow] should evict running RTE pod if taint-tolartion matching criteria is shaken - node taints update", Label("tier3", "slow"), func(ctx context.Context) {
 				By("taint one node with taint value and NoExecute effect")
 				var err error
-				workers, err = nodes.GetWorkerNodes(fxt.Client, ctx)
+				workers, err = nodes.GetWorkers(fxt.DEnv())
 				Expect(err).ToNot(HaveOccurred())
 
 				taintVal1 := fmt.Sprintf("%s=val1:%s", testKey, corev1.TaintEffectNoExecute)
@@ -424,7 +425,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 			It("[tier2][test_id:72861] should tolerate partial taints and not schedule or evict the pod on the tainted node", Label("tier2"), func(ctx context.Context) {
 				var err error
 				By("getting the worker nodes")
-				workers, err = nodes.GetWorkerNodes(fxt.Client, context.TODO())
+				workers, err = nodes.GetWorkers(fxt.DEnv())
 				Expect(err).ToNot(HaveOccurred())
 
 				By(fmt.Sprintf("randomly picking the target node (among %d)", len(workers)))
@@ -473,7 +474,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 			It("[tier3][test_id:72859] should not restart a running RTE pod on tainted node with NoSchedule effect", Label("tier3"), func(ctx context.Context) {
 				By("taint one worker node")
 				var err error
-				workers, err = nodes.GetWorkerNodes(fxt.Client, ctx)
+				workers, err = nodes.GetWorkers(fxt.DEnv())
 				Expect(err).ToNot(HaveOccurred())
 
 				tnts, _, err = taints.ParseTaints([]string{testTaint()})
@@ -540,7 +541,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 					waitForMcpUpdate(fxt.Client, ctx, mcps)
 
 					By("taint one worker node")
-					workers, err = nodes.GetWorkerNodes(fxt.Client, ctx)
+					workers, err = nodes.GetWorkers(fxt.DEnv())
 					Expect(err).ToNot(HaveOccurred())
 
 					tnts, _, err = taints.ParseTaints([]string{testTaint()})
@@ -661,7 +662,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 			It("[tier3] should evict RTE pod on tainted node with NoExecute effect and restore it when taint is removed", Label("tier3"), func(ctx context.Context) {
 				By("taint one worker node with NoExecute effect")
 				var err error
-				workers, err = nodes.GetWorkerNodes(fxt.Client, ctx)
+				workers, err = nodes.GetWorkers(fxt.DEnv())
 				Expect(err).ToNot(HaveOccurred())
 
 				tnts, _, err = taints.ParseTaints([]string{testTaintNoExecute()})

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -34,8 +34,8 @@ import (
 
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 
+	intbaseload "github.com/openshift-kni/numaresources-operator/internal/baseload"
 	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
-	"github.com/openshift-kni/numaresources-operator/internal/nodes"
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
 	"github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
@@ -187,7 +187,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 					nrtInfo, err := e2enrt.FindFromList(nrtCandidates, nodeName)
 					Expect(err).NotTo(HaveOccurred(), "missing NRT Info for node %q", nodeName)
 
-					baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), nodeName)
+					baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), nodeName)
 					Expect(err).NotTo(HaveOccurred(), "cannot get the base load for %q", nodeName)
 
 					for zIdx, zone := range nrtInfo.Zones {
@@ -341,7 +341,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 					nrtInfo, err := e2enrt.FindFromList(nrtTwoZoneCandidates, nodeName)
 					Expect(err).NotTo(HaveOccurred(), "missing NRT Info for node %q", nodeName)
 
-					baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), nodeName)
+					baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), nodeName)
 					Expect(err).NotTo(HaveOccurred(), "cannot get the base load for %q", nodeName)
 
 					for zIdx, zone := range nrtInfo.Zones {
@@ -371,7 +371,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				By("padding a NUMA node on the target node")
 				var paddingPodsTargetNode []*corev1.Pod
 
-				baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), targetNodeName)
+				baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), targetNodeName)
 				Expect(err).NotTo(HaveOccurred(), "cannot get the base load for %q", targetNodeName)
 
 				for zIdx, zone := range targetNrtInitial.Zones {

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -47,8 +47,7 @@ import (
 
 	"github.com/openshift-kni/numaresources-operator/pkg/loglevel"
 
-	"github.com/openshift-kni/numaresources-operator/internal/baseload"
-	"github.com/openshift-kni/numaresources-operator/internal/nodes"
+	intbaseload "github.com/openshift-kni/numaresources-operator/internal/baseload"
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
@@ -568,7 +567,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}
 
 			// calculate base load on the target node
-			baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), targetNodeName)
+			baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), targetNodeName)
 			Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", targetNodeName)
 			klog.Infof(fmt.Sprintf("computed base load: %s", baseload))
 
@@ -1188,12 +1187,12 @@ func allocatableResourceType(nrtInfo nrtv1alpha2.NodeResourceTopology, resName c
 // deployment where the number of replicas is the same as the number of
 // NUMA nodes so that all the replicas can successfully obtain resources
 // from all the NUMA nodes.
-func leastAvailableResourceQtyInAllZone(nrtInfo nrtv1alpha2.NodeResourceTopology, baseload baseload.Load, resName corev1.ResourceName) resource.Quantity {
+func leastAvailableResourceQtyInAllZone(nrtInfo nrtv1alpha2.NodeResourceTopology, baseload intbaseload.Load, resName corev1.ResourceName) resource.Quantity {
 	maxResAllocatable := e2enrt.GetMaxAllocatableResourceNumaLevel(nrtInfo, resName)
 	return getLeastAvailableResourceQty(maxResAllocatable, nrtInfo.Zones, resName, baseload)
 }
 
-func getLeastAvailableResourceQty(res resource.Quantity, zones nrtv1alpha2.ZoneList, resName corev1.ResourceName, baseload baseload.Load) resource.Quantity {
+func getLeastAvailableResourceQty(res resource.Quantity, zones nrtv1alpha2.ZoneList, resName corev1.ResourceName, baseload intbaseload.Load) resource.Quantity {
 	var zeroVal resource.Quantity
 
 	// We need to take baseload into consideration here. There is no way to

--- a/test/e2e/serial/tests/workload_placement_nodelabel.go
+++ b/test/e2e/serial/tests/workload_placement_nodelabel.go
@@ -34,8 +34,8 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	intbaseload "github.com/openshift-kni/numaresources-operator/internal/baseload"
 	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
-	"github.com/openshift-kni/numaresources-operator/internal/nodes"
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
@@ -149,7 +149,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				nrtInfo, err := e2enrt.FindFromList(nrtCandidates, nodeName)
 				Expect(err).NotTo(HaveOccurred(), "missing NRT info for %q", nodeName)
 
-				baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), nodeName)
+				baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), nodeName)
 				Expect(err).NotTo(HaveOccurred(), "cannot get the base load for %q", nodeName)
 
 				for zIdx, zone := range nrtInfo.Zones {

--- a/test/e2e/serial/tests/workload_placement_resources.go
+++ b/test/e2e/serial/tests/workload_placement_resources.go
@@ -29,11 +29,12 @@ import (
 
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 
-	"github.com/openshift-kni/numaresources-operator/internal/nodes"
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
 
+	intbaseload "github.com/openshift-kni/numaresources-operator/internal/baseload"
 	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
+
 	e2efixture "github.com/openshift-kni/numaresources-operator/test/utils/fixture"
 	e2enrt "github.com/openshift-kni/numaresources-operator/test/utils/noderesourcetopologies"
 	"github.com/openshift-kni/numaresources-operator/test/utils/nrosched"
@@ -188,7 +189,7 @@ func setupNodes(fxt *e2efixture.Fixture, ctx context.Context, nrtCandidates []nr
 		nrtInfo, err := e2enrt.FindFromList(nrtCandidates, nodeName)
 		Expect(err).NotTo(HaveOccurred(), "missing NRT info for %q", nodeName)
 
-		baseload, err := nodes.GetLoad(fxt.Client, ctx, nodeName)
+		baseload, err := intbaseload.ForNode(fxt.Client, ctx, nodeName)
 		Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", nodeName)
 		By(fmt.Sprintf("computed base load: %s", baseload))
 
@@ -205,7 +206,7 @@ func setupNodes(fxt *e2efixture.Fixture, ctx context.Context, nrtCandidates []nr
 
 	By("Padding the target node")
 
-	baseload, err := nodes.GetLoad(fxt.Client, ctx, targetNodeName)
+	baseload, err := intbaseload.ForNode(fxt.Client, ctx, targetNodeName)
 	Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", targetNodeName)
 	By(fmt.Sprintf("computed base load: %s", baseload))
 

--- a/test/e2e/serial/tests/workload_placement_taint.go
+++ b/test/e2e/serial/tests/workload_placement_taint.go
@@ -37,9 +37,9 @@ import (
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 
 	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
-	intnodes "github.com/openshift-kni/numaresources-operator/internal/nodes"
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
+	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
 
 	e2efixture "github.com/openshift-kni/numaresources-operator/test/utils/fixture"
 	"github.com/openshift-kni/numaresources-operator/test/utils/k8simported/taints"
@@ -152,7 +152,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			nodes, err := nodes.GetWorkers(fxt.DEnv())
 			Expect(err).ToNot(HaveOccurred())
 
-			nodeNames := intnodes.GetNames(nodes)
+			nodeNames := objectnames.Nodes(nodes)
 			doubleCheckedNodeNames := untaintNodes(fxt.Client, nodeNames, tnt)
 			By(fmt.Sprintf("cleaned taint %q from the nodes %v", tnt.String(), doubleCheckedNodeNames))
 

--- a/test/e2e/serial/tests/workload_placement_taint.go
+++ b/test/e2e/serial/tests/workload_placement_taint.go
@@ -32,10 +32,12 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil/nodes"
+
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 
 	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
-	"github.com/openshift-kni/numaresources-operator/internal/nodes"
+	intnodes "github.com/openshift-kni/numaresources-operator/internal/nodes"
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
 
@@ -120,7 +122,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			nodes, err := nodes.GetWorkerNodes(fxt.Client, context.TODO())
+			nodes, err := nodes.GetWorkers(fxt.DEnv())
 			Expect(err).ToNot(HaveOccurred())
 
 			tnts, _, err := taints.ParseTaints([]string{testTaint()})
@@ -147,10 +149,10 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			// leaking taints is especially bad AND we had some bugs in the pass, so let's try our very bes
 			// to be really really sure we didn't pollute the cluster.
-			nodes, err := nodes.GetWorkerNodes(fxt.Client, context.TODO())
+			nodes, err := nodes.GetWorkers(fxt.DEnv())
 			Expect(err).ToNot(HaveOccurred())
 
-			nodeNames := accumulateNodeNames(nodes)
+			nodeNames := intnodes.GetNames(nodes)
 			doubleCheckedNodeNames := untaintNodes(fxt.Client, nodeNames, tnt)
 			By(fmt.Sprintf("cleaned taint %q from the nodes %v", tnt.String(), doubleCheckedNodeNames))
 
@@ -319,14 +321,6 @@ func checkNodesUntainted(cli client.Client, nodeNames []string) {
 			return nil
 		}).WithTimeout(3 * time.Minute).WithPolling(10 * time.Second).ShouldNot(HaveOccurred())
 	}
-}
-
-func accumulateNodeNames(nodes []corev1.Node) []string {
-	var names []string
-	for idx := range nodes {
-		names = append(names, nodes[idx].Name)
-	}
-	return names
 }
 
 func applyTaintToNode(ctx context.Context, cli client.Client, targetNode *corev1.Node, tnt *corev1.Taint) *corev1.Node {

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -36,12 +36,13 @@ import (
 
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 
-	"github.com/openshift-kni/numaresources-operator/internal/nodes"
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
 
+	intbaseload "github.com/openshift-kni/numaresources-operator/internal/baseload"
 	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
+
 	e2efixture "github.com/openshift-kni/numaresources-operator/test/utils/fixture"
 	"github.com/openshift-kni/numaresources-operator/test/utils/images"
 	e2enrt "github.com/openshift-kni/numaresources-operator/test/utils/noderesourcetopologies"
@@ -2107,7 +2108,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 func setupPadding(fxt *e2efixture.Fixture, nrtList nrtv1alpha2.NodeResourceTopologyList, padInfo paddingInfo) []*corev1.Pod {
 	GinkgoHelper()
 
-	baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), padInfo.targetNodeName)
+	baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), padInfo.targetNodeName)
 	Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", padInfo.targetNodeName)
 	By(fmt.Sprintf("computed base load: %s", baseload))
 
@@ -2154,7 +2155,7 @@ func setupPaddingForUnsuitableNodes(fxt *e2efixture.Fixture, nrtList nrtv1alpha2
 		nrtInfo, err := e2enrt.FindFromList(nrtList.Items, unsuitableNodeName)
 		Expect(err).ToNot(HaveOccurred(), "missing NRT info for %q", unsuitableNodeName)
 
-		baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), unsuitableNodeName)
+		baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), unsuitableNodeName)
 		Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", unsuitableNodeName)
 		By(fmt.Sprintf("computed base load: %s", baseload))
 

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -35,8 +35,8 @@ import (
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper/attribute"
 
+	intbaseload "github.com/openshift-kni/numaresources-operator/internal/baseload"
 	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
-	"github.com/openshift-kni/numaresources-operator/internal/nodes"
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
 
@@ -139,7 +139,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 				nrtInfo, err := e2enrt.FindFromList(nrtCandidates, nodeName)
 				Expect(err).NotTo(HaveOccurred(), "missing NRT info for %q", nodeName)
 
-				baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), nodeName)
+				baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), nodeName)
 				Expect(err).NotTo(HaveOccurred(), "cannot get base load for %q", nodeName)
 
 				for idx, zone := range nrtInfo.Zones {
@@ -351,7 +351,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 				nrtInfo, err := e2enrt.FindFromList(nrtCandidates, nodeName)
 				Expect(err).NotTo(HaveOccurred(), "missing NRT info for %q", nodeName)
 
-				baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), nodeName)
+				baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), nodeName)
 				Expect(err).NotTo(HaveOccurred(), "cannot get base load for %q", nodeName)
 
 				for zoneIdx, zone := range nrtInfo.Zones {
@@ -499,7 +499,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 				nrtInfo, err := e2enrt.FindFromList(nrtCandidates, nodeName)
 				Expect(err).NotTo(HaveOccurred(), "missing NRT info for %q", nodeName)
 
-				baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), nodeName)
+				baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), nodeName)
 				Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", nodeName)
 
 				paddingResources, err := e2enrt.SaturateNodeUntilLeft(*nrtInfo, baseload.Resources)
@@ -521,7 +521,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 
 			By("Padding target node")
 			//calculate base load on the target node
-			targetNodeBaseLoad, err := nodes.GetLoad(fxt.Client, context.TODO(), targetNodeName)
+			targetNodeBaseLoad, err := intbaseload.ForNode(fxt.Client, context.TODO(), targetNodeName)
 			Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", targetNodeName)
 
 			// Pad the zones so no one could handle both containers
@@ -811,7 +811,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			for _, nodeName := range e2efixture.ListNodeNames(nrtCandidateNames) {
 
 				//calculate base load on the node
-				baseload, err := nodes.GetLoad(fxt.Client, context.TODO(), nodeName)
+				baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), nodeName)
 				Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", nodeName)
 				klog.Infof(fmt.Sprintf("computed base load: %s", baseload))
 

--- a/test/utils/fixture/fixture.go
+++ b/test/utils/fixture/fixture.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
@@ -35,6 +36,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 
 	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
@@ -194,6 +196,18 @@ func Cooldown(ft *Fixture) {
 	}
 	klog.Warningf("cooling down for %v", cooldownTime)
 	time.Sleep(cooldownTime)
+}
+
+func (fxt *Fixture) DEnv() *deployer.Environment {
+	return fxt.DEnvWithContext(context.TODO())
+}
+
+func (fxt *Fixture) DEnvWithContext(ctx context.Context) *deployer.Environment {
+	return &deployer.Environment{
+		Cli: fxt.Client,
+		Ctx: ctx,
+		Log: logr.Discard(),
+	}
 }
 
 func MustSettleNRT(fxt *Fixture) {


### PR DESCRIPTION
`deployer` >= 0.19 provides most of the functionalities in `internal/nodes`. So we dissolve the latter and we move the code to use the former, to reduce the duplication, even if the API of the deployer package can use some refinement.
In addition, we get rid of another internal duplication by moving to `k8s/utils/ptr`

Fixes: #715 (probably)