### PR TITLE
e2e: adapt performance profile existence and stabilize test

### DIFF
--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -1067,6 +1067,15 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			By("checking the deployment pod has failed scheduling and its at the pending status")
 			pods, err := podlist.With(fxt.Client).ByDeployment(ctx, updatedDeployment)
 			Expect(err).ToNot(HaveOccurred())
+			Expect(len(pods)).To(BeNumerically("<", 10), "")
+
+			podsPending := 0
+			for _, pod := range pods {
+				if pod.Status.Phase == corev1.PodPending {
+					podsPending++
+				}
+			}
+			Expect(podsPending).To(Equal(1))
 
 			pod := &pods[0]
 			Expect(pod.Status.Phase).To(Equal(corev1.PodPending))


### PR DESCRIPTION
This PR follows #962 for adding performance profile dependencies and it adds detection for kubeletconfig changes through performance profile. Also this PR adds test id to the test 75354.
This is a reboot test that is changing the kubeletconfig configuration. The changes here are for detecting if a performance profile exists in the first place and changing the configuration through it otherwise the test will fail.
