### PR TITLE
build: build helper tools in the tests image

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -3,6 +3,7 @@ FROM docker.io/golang:1.22 AS builder
 WORKDIR /go/src/github.com/openshift-kni/numaresources-operator
 COPY . .
 
+RUN make build-tools
 RUN make build-topics
 RUN make build-e2e-all
 RUN make build-numacell


### PR DESCRIPTION
Fixes:
```
[1/2] STEP 1/6: FROM docker.io/golang:1.22 AS builder
[1/2] STEP 2/6: WORKDIR /go/src/github.com/openshift-kni/numaresources-operator
--> Using cache 4f2b3c666f19d45eeed07af4e62c7c8beeb21eea27661161549417ee3498a500
--> 4f2b3c666f19
[1/2] STEP 3/6: COPY . .
--> a1295d77765e
[1/2] STEP 4/6: RUN make build-topics
mkdir -p bin && go run tools/lstopics/lstopics.go > bin/topics.json
--> 3fe26ff2ccb9
[1/2] STEP 5/6: RUN make build-e2e-all
go fmt ./...
go vet ./...
go version go1.22.4 linux/amd64
go test -v -c -o bin/e2e-nrop-install.test ./test/e2e/install && go test -v -c -o bin/e2e-nrop-sched-install.test ./test/e2e/sched/install
go test -c -v -o bin/e2e-nrop-rte-local.test ./test/e2e/rte/local
go test -c -v -o bin/e2e-nrop-rte.test ./test/e2e/rte
go test -c -v -o bin/e2e-nrop-sched.test ./test/e2e/sched
go test -v -c -o bin/e2e-nrop-uninstall.test ./test/e2e/uninstall && go test -v -c -o bin/e2e-nrop-sched-uninstall.test ./test/e2e/sched/uninstall
bash: line 1: bin/buildhelper: No such file or directory
bash: line 1: bin/buildhelper: No such file or directory
LDFLAGS+="-X github.com/openshift-kni/numaresources-operator/pkg/version.version= "; \
LDFLAGS+="-X github.com/openshift-kni/numaresources-operator/pkg/version.gitcommit="; \
CGO_ENABLED=0 go test -c -v -o bin/e2e-nrop-serial.test -ldflags "$LDFLAGS" ./test/e2e/serial
go test -c -v -o bin/e2e-nrop-tools.test ./test/e2e/tools
go test -c -v -o bin/e2e-nrop-must-gather.test ./test/e2e/must-gather
hack/render-e2e-runner.sh
hack/test-e2e-runner.sh
basic sanity tests for /go/src/github.com/openshift-kni/numaresources-operator/bin/run-e2e-nrop-serial.sh:
[TEST] runner exists
[PASS] runner script found
[TEST] --dry-run exits cleanly
[PASS] --dry-run returned zero exit code
[TEST] --dry-run produces expected output
Terminal does not seem to support colored output, disabling it
[PASS] --dry-run produced the expected output
install -m 755 hack/pause bin/
--> 4fbb009289da
```