### PR TITLE
Dockerfile: align OCP/non-OCP

### DIFF
--- a/Dockerfile.openshift.tests
+++ b/Dockerfile.openshift.tests
@@ -4,4 +4,5 @@ COPY run-e2e-nrop-*.sh /usr/local/bin
 COPY numacell /bin
 COPY pause /
 COPY topics.json /usr/local/share
-ENTRYPOINT ["/usr/local/bin/run-e2e-nrop-serial.sh"]
+WORKDIR /usr/local/bin
+CMD ["./run-e2e-nrop-serial.sh"]


### PR DESCRIPTION
PR https://github.com/openshift-kni/numaresources-operator/pull/686 updated the non-OCP Dockerfile only. To preserve/increase image compatibility, we do now the same change for OCP Dockerfiles.