### PR TITLE
[4.16] add features introspection for e2e tests

### DIFF
--- a/.github/workflows/e2e-tools.yml
+++ b/.github/workflows/e2e-tools.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Build tools
       run: |
-        make build-tools binary-nrovalidate
+        make build-tools binary-nrovalidate bin/mkginkgolabelfilter binary
 
     - name: Create K8s Kind Cluster
       run: |

--- a/doc/features/README.md
+++ b/doc/features/README.md
@@ -1,0 +1,52 @@
+Features introspection in e2e tests
+======================================
+
+**Goal**
+
+Provide a way to identify the active features for every supported operator version.
+
+**Design**
+
+- Provide the possibility to group a set of tests that verify a common feature using ginkgo Label("feature:<topic>").
+  A Topic should describe the main feature being tested or the unique effect of the test on the cluster. For instance:
+  `feature:schedrst`: indicates that the test is expected to restart the schedular, be it a pod restart or a complete removal of the scheduler and recreation.
+  `feature:rtetols`: indicates that the test is testing the new feature RTE tolerations, which involves specific non-default configuration on the operator CRs hence functional effects.
+  `feature:unsched`: indicates that the test workload is anticipated to be un-schedulable for any reason for example: insufficient resources (pod is pending), TAE (failed)..
+  `feature:wlplacement`: indicates that the test challenges the scheduler to place a workload on a node. This is a common label for most of the functional tests.
+    - Rules for creating a new topic
+        - A topic should point out briefly the new feature being tested or the unique effect of the test on the cluster
+        - The topic should be lowercase
+        - For composite topics use `_` between the words, e.g no_nrt
+        - Should not consist of any of `&|!,()/`
+- Define the list of supported features for each version.
+- Allow the user to list the supported features by adding new flag, `-inspect-features` which if passed the numaresources-operator binary on the controller pod will list the active features for the deployed version of the operator.
+- For automated bugs' scenarios that their fix is not back-ported to all versions use keywords tags that briefly describes the bug's main check.
+
+**List active features**
+
+Once the operator is installed, perform the following on the controller manager pod:
+
+```azure
+oc exec -it numaresources-controller-manager-95dd55c6-k6428 -n openshift-numaresources -- /bin/numaresources-operator --inspect-features
+ ```
+
+Example output:
+```
+{"active":["config","nonreg","hostlevel","resacct","cache","stall","rmsched","rtetols","overhead","wlplacement","unsched","nonrt","taint","nodelabel","byres","tmpol"]}
+```
+
+**Use case example: run tests for supported features only**
+
+To build the filter label query of the supported features on a specific version, a binary called `mkginkgolabelfilter` exists in `releases/support-tools` which expects a JSON input showing the supported features from the operator controller pod as follows:
+
+To use the helper tool perform the following:
+
+```
+# curl -L -o mkginkgolabelfilter https://github.com/openshift-kni/numaresources-operator/releases/download/support-tools/mkginkgolabelfilter
+# chmod 755 mkginkgolabelfilter
+# ./mkginkgolabelfilter # This will wait to read the input which should be the output of the --inspect-features above
+{"active":["config","nonreg","hostlevel","resacct","cache","stall","rmsched","rtetols","overhead","wlplacement","unsched","nonrt","taint","nodelabel","byres","tmpol"]}
+feature: consistAny {config,nonreg,hostlevel,resacct,cache,stall,rmsched,rtetols,overhead,wlplacement,unsched,nonrt,taint,nodelabel,byres,tmpol}
+```
+
+Then later in the podman command of running the tests use `--filter-label` with the output of the tool to run tests of supported features only.  

--- a/doc/features/README.md
+++ b/doc/features/README.md
@@ -46,7 +46,7 @@ To use the helper tool perform the following:
 # chmod 755 mkginkgolabelfilter
 # ./mkginkgolabelfilter # This will wait to read the input which should be the output of the --inspect-features above
 {"active":["config","nonreg","hostlevel","resacct","cache","stall","rmsched","rtetols","overhead","wlplacement","unsched","nonrt","taint","nodelabel","byres","tmpol"]}
-feature: consistAny {config,nonreg,hostlevel,resacct,cache,stall,rmsched,rtetols,overhead,wlplacement,unsched,nonrt,taint,nodelabel,byres,tmpol}
+feature: containsAny {config,nonreg,hostlevel,resacct,cache,stall,rmsched,rtetols,overhead,wlplacement,unsched,nonrt,taint,nodelabel,byres,tmpol}
 ```
 
 Then later in the podman command of running the tests use `--filter-label` with the output of the tool to run tests of supported features only.  

--- a/internal/api/features/_topics.json
+++ b/internal/api/features/_topics.json
@@ -1,0 +1,21 @@
+{
+  "active": [
+    "config",
+    "nonreg",
+    "hostlevel",
+    "resacct",
+    "cache",
+    "stall",
+    "schedrst",
+    "rtetols",
+    "overhead",
+    "wlplacement",
+    "unsched",
+    "nonrt",
+    "taint",
+    "nodelabel",
+    "byres",
+    "tmpol",
+    "schedattrwatch"
+  ]
+}

--- a/internal/api/features/topics.go
+++ b/internal/api/features/topics.go
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ */
+
+package features
+
+import (
+	_ "embed"
+	"encoding/json"
+)
+
+//go:embed _topics.json
+var topicsData string
+
+func GetTopics() TopicInfo {
+	var tp TopicInfo
+	_ = json.Unmarshal([]byte(topicsData), &tp)
+	return tp
+}

--- a/internal/api/features/topics_test.go
+++ b/internal/api/features/topics_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/utils/strings/slices"
+)
+
+func TestGetTopics(t *testing.T) {
+	type testcase struct {
+		name       string
+		topicsList string
+		isPositive bool
+	}
+	testcases := []testcase{
+		{
+			name:       "with list of well known topics that every release operator must support",
+			topicsList: "config,nonreg,hostlevel,resacct,cache,stall,schedrst,overhead,wlplacement,unsched,taint,nodelabel,byres,tmpol",
+			isPositive: true,
+		},
+		{
+			name:       "with inactive topics included",
+			topicsList: "config,nonreg,hostlevel,notfound,cache",
+			isPositive: false,
+		},
+	}
+
+	actual := GetTopics()
+	for _, tc := range testcases {
+		topicsStr := strings.TrimSpace(tc.topicsList)
+		topics := strings.Split(topicsStr, ",")
+		tp := findMissingTopics(actual.Active, topics)
+
+		if len(tp) > 0 && tc.isPositive {
+			t.Errorf("expected to include topic(s) %v but it didn't, list found: %v", tp, actual.Active)
+		}
+
+		if len(tp) == 0 && !tc.isPositive {
+			t.Errorf("active topics included unsupported topic(s) %v, list found: %v", tp, actual.Active)
+		}
+	}
+}
+
+func findMissingTopics(agianstList, sublist []string) []string {
+	missing := []string{}
+	for _, el := range sublist {
+		if !slices.Contains(agianstList, el) {
+			missing = append(missing, el)
+		}
+	}
+	return missing
+}

--- a/internal/api/features/types.go
+++ b/internal/api/features/types.go
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ */
+
+package features
+
+import (
+	"fmt"
+
+	goversion "github.com/aquasecurity/go-version/pkg/version"
+)
+
+const (
+	Version = "v4.17.0"
+)
+
+type Metadata struct {
+	// semantic versioning vX.Y.Z, e.g. v1.0.0
+	Version string `json:"version"`
+}
+
+type TopicInfo struct {
+	Metadata Metadata `json:"metadata"`
+	// unsorted list of topics active (supported)
+	Active []string `json:"active"`
+}
+
+func NewTopicInfo() TopicInfo {
+	return TopicInfo{
+		Metadata: Metadata{
+			Version: Version,
+		},
+	}
+}
+
+func (tp TopicInfo) Validate() error {
+	if tp.Metadata.Version == "" {
+		return fmt.Errorf("metadata: missing version")
+	}
+	if _, err := goversion.Parse(tp.Metadata.Version); err != nil {
+		return fmt.Errorf("metadata: malformed version: %w", err)
+	}
+	if len(tp.Active) == 0 {
+		return fmt.Errorf("missing active topics")
+	}
+	return nil
+}

--- a/internal/api/features/types_test.go
+++ b/internal/api/features/types_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewTopicInfo(t *testing.T) {
+	actual := NewTopicInfo()
+	expected := TopicInfo{
+		Metadata: Metadata{
+			Version: Version,
+		},
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("got different new TopicInfo than expected: expected:\n%+v\ngot:\n%+v\n", expected, actual)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	nonEmpty := []string{"foo", "bar"}
+	posTests := []TopicInfo{
+		{
+			Metadata: Metadata{
+				Version: Version,
+			},
+			Active: GetTopics().Active,
+		},
+		{
+			Metadata: Metadata{
+				Version: "2.0-4",
+			},
+			Active: nonEmpty,
+		},
+		{
+			Metadata: Metadata{
+				Version: "v4.10.0-202312160824.p0.g89f320d.assembly.stream",
+			},
+			Active: nonEmpty,
+		},
+		{
+			Metadata: Metadata{
+				Version: "v1.11.16-rc.1",
+			},
+			Active: nonEmpty,
+		},
+		{
+			Metadata: Metadata{
+				Version: "4.17",
+			},
+			Active: nonEmpty,
+		},
+	}
+
+	for _, tc := range posTests {
+		if err := tc.Validate(); err != nil {
+			t.Errorf("valid topics %+v failed validation:%v\n", tc, err)
+		}
+	}
+
+	negTests := []TopicInfo{
+		NewTopicInfo(),
+		{
+			Metadata: Metadata{
+				Version: "v4.v10.v0-2023121608y.stream",
+			},
+			Active: nonEmpty,
+		},
+		{
+			Metadata: Metadata{
+				Version: "4-v1. 6",
+			},
+			Active: nonEmpty,
+		},
+	}
+
+	for _, tc := range negTests {
+		if err := tc.Validate(); err == nil {
+			t.Errorf("invalid topics %+v passed validation\n", tc)
+		}
+	}
+}

--- a/test/e2e/serial/README.md
+++ b/test/e2e/serial/README.md
@@ -55,3 +55,9 @@ they found it before they run.
 - `E2E_RTE_CI_IMAGE` (accepts string, e.g `quay.io/openshift-kni/resource-topology-exporter:test-ci`) sets the 
   RTE image to be used for testing purposes particularly for modifying the operator object.
   
+### Tests tagging 
+
+- Tagging tests to a specific feature functionality were done by adding tags in the spec description like `It("[rtetols][distruptive]...")`.
+Starting Jul 2024, while the master branch is pointing to 4.17, the new preferred way to tag tests is using ginkgo `Label("")` such as `Context("should run pods requesting host-level resources", Label("hostlevel","distruptive"), func(){..})`. Tags aren't forbidden yet; they are just deprecated, so whenever a tag is added, a label is also required.
+- Each test should have the importance tag which is one of the below:
+`tier0` means critical; `tier1` means important; `tier2` means medium priority; `tier3` means low priority test.

--- a/test/e2e/tools/mkginkgolabelfilter_test.go
+++ b/test/e2e/tools/mkginkgolabelfilter_test.go
@@ -40,7 +40,7 @@ var _ = Describe("[tools][mkginkgolabelfilter] Auxiliary tools", Label("tools", 
 				{
 					name:        "should create a filter that matches the a valid input",
 					input:       `{"active":["foo","bar","foobar"]}`,
-					expectedOut: "feature: consistAny {foo,bar,foobar}\n",
+					expectedOut: "feature: containsAny {foo,bar,foobar}\n",
 				},
 				{
 					name:        "should fail on an invalid json format",
@@ -50,12 +50,12 @@ var _ = Describe("[tools][mkginkgolabelfilter] Auxiliary tools", Label("tools", 
 				{
 					name:        "should return empty features on a valid json format and non-matching topic info - no active",
 					input:       `{"supported":["foo","bar","foobar"]}`,
-					expectedOut: "feature: consistAny {}\n",
+					expectedOut: "feature: containsAny {}\n",
 				},
 				{
 					name:        "should fail on a valid json format and partially matching topic info",
 					input:       `{"supported":["foo","bar"],"active":["foobar"]}`,
-					expectedOut: "feature: consistAny {foobar}\n",
+					expectedOut: "feature: containsAny {foobar}\n",
 				},
 			}
 

--- a/test/e2e/tools/mkginkgolabelfilter_test.go
+++ b/test/e2e/tools/mkginkgolabelfilter_test.go
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tools
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/klog/v2"
+)
+
+var _ = Describe("[tools][mkginkgolabelfilter] Auxiliary tools", Label("tools", "mkginkgolabelfilter"), func() {
+	Context("with the binary available", func() {
+		It("should run tool with different inputs", func(ctx context.Context) {
+			type testcase struct {
+				name        string
+				input       string
+				expectedOut string
+			}
+			testcases := []testcase{
+				{
+					name:        "should create a filter that matches the a valid input",
+					input:       `{"active":["foo","bar","foobar"]}`,
+					expectedOut: "feature: consistAny {foo,bar,foobar}\n",
+				},
+				{
+					name:        "should fail on an invalid json format",
+					input:       `("active"=["foo","bar"])`,
+					expectedOut: "",
+				},
+				{
+					name:        "should return empty features on a valid json format and non-matching topic info - no active",
+					input:       `{"supported":["foo","bar","foobar"]}`,
+					expectedOut: "feature: consistAny {}\n",
+				},
+				{
+					name:        "should fail on a valid json format and partially matching topic info",
+					input:       `{"supported":["foo","bar"],"active":["foobar"]}`,
+					expectedOut: "feature: consistAny {foobar}\n",
+				},
+			}
+
+			cmdline := []string{
+				filepath.Join(BinariesPath, "mkginkgolabelfilter"),
+			}
+			expectExecutableExists(cmdline[0])
+			for _, tc := range testcases {
+				klog.Infof("running %q\n", tc.name)
+				buffer := bytes.Buffer{}
+				toolCmd := exec.Command(cmdline[0])
+				_, err := buffer.Write(append([]byte(tc.input), "\n"...))
+				Expect(err).ToNot(HaveOccurred())
+				toolCmd.Stdin = &buffer
+
+				out, err := toolCmd.Output()
+
+				Expect(string(out)).To(Equal(tc.expectedOut), "different output found:\n%v\nexpected:\n%v", string(out), tc.expectedOut)
+				if tc.expectedOut == "" {
+					Expect(err).To(HaveOccurred())
+				}
+			}
+		})
+	})
+})

--- a/tools/mkginkgolabelfilter/mkginkgolabelfilter.go
+++ b/tools/mkginkgolabelfilter/mkginkgolabelfilter.go
@@ -35,7 +35,7 @@ func main() {
 	if help {
 		e := features.NewTopicInfo()
 		e.Active = []string{"feature_1", "feature_2"}
-		filter := fmt.Sprintf("feature: consistAny {%s}\n", strings.Join(e.Active, ","))
+		filter := fmt.Sprintf("feature: containsAny {%s}\n", strings.Join(e.Active, ","))
 		fmt.Printf("The tool expects a json format text and parses it into TopicInfo struct, then prints out a ginkgo label filter for the active features.\nExample: for input\n%+v\nthe tool will print\n%s\n", e, filter)
 		os.Exit(0)
 	}
@@ -45,5 +45,5 @@ func main() {
 	if err != nil {
 		log.Fatalf("error decoding topics data: %v", err)
 	}
-	fmt.Printf("feature: consistAny {%s}\n", strings.Join(topics.Active, ","))
+	fmt.Printf("feature: containsAny {%s}\n", strings.Join(topics.Active, ","))
 }

--- a/tools/mkginkgolabelfilter/mkginkgolabelfilter.go
+++ b/tools/mkginkgolabelfilter/mkginkgolabelfilter.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/openshift-kni/numaresources-operator/internal/api/features"
+)
+
+func main() {
+	var help bool
+	flag.BoolVar(&help, "h", help, "outputs tool description")
+	flag.Parse()
+
+	if help {
+		e := features.NewTopicInfo()
+		e.Active = []string{"feature_1", "feature_2"}
+		filter := fmt.Sprintf("feature: consistAny {%s}\n", strings.Join(e.Active, ","))
+		fmt.Printf("The tool expects a json format text and parses it into TopicInfo struct, then prints out a ginkgo label filter for the active features.\nExample: for input\n%+v\nthe tool will print\n%s\n", e, filter)
+		os.Exit(0)
+	}
+
+	var topics features.TopicInfo
+	err := json.NewDecoder(os.Stdin).Decode(&topics)
+	if err != nil {
+		log.Fatalf("error decoding topics data: %v", err)
+	}
+	fmt.Printf("feature: consistAny {%s}\n", strings.Join(topics.Active, ","))
+}


### PR DESCRIPTION
manual backport of several commits related to tests features introspection:
https://github.com/openshift-kni/numaresources-operator/pull/958
https://github.com/openshift-kni/numaresources-operator/commit/21b38df54dc28449b2c4b4da2e842008683e35e4