### PR TITLE
e2e: fix reboot test case 75354 flaky issue

### DIFF
--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -1080,23 +1080,24 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 				klog.Warningf("current length of the pods list: %d, is bigger than %d", len(pods), maxPodsWithTAE)
 			}
 
-			podsPending := 0
+			By("checking to see if there is more than one pod that is pending")
+			pendingPod := corev1.Pod{}
+			numPendingPods := 0
+
 			for _, pod := range pods {
 				if pod.Status.Phase == corev1.PodPending {
-					podsPending++
+					pendingPod = pod
+					numPendingPods++
 				}
 			}
-			Expect(podsPending).To(Equal(1))
-
-			pod := &pods[0]
-			Expect(pod.Status.Phase).To(Equal(corev1.PodPending))
+			Expect(numPendingPods).To(Equal(1))
 
 			schedulerName = nroSchedObj.Status.SchedulerName
 			Expect(schedulerName).ToNot(BeEmpty(), "cannot autodetect the TAS scheduler name from the cluster")
 
-			isFailed, err := nrosched.CheckPodSchedulingFailedWithMsg(fxt.K8sClient, pod.Namespace, pod.Name, schedulerName, fmt.Sprintf("cannot align %s", kcObj.TopologyManagerScope))
+			isFailed, err := nrosched.CheckPodSchedulingFailedWithMsg(fxt.K8sClient, pendingPod.Namespace, pendingPod.Name, schedulerName, fmt.Sprintf("cannot align %s", kcObj.TopologyManagerScope))
 			Expect(err).ToNot(HaveOccurred())
-			Expect(isFailed).To(BeTrue(), "pod %s/%s with scheduler %s did NOT fail", pod.Namespace, pod.Name, schedulerName)
+			Expect(isFailed).To(BeTrue(), "pod %s/%s with scheduler %s did NOT fail", pendingPod.Namespace, pendingPod.Name, schedulerName)
 		})
 	})
 })


### PR DESCRIPTION
This PR addresses a flaky issue on this test case where we are creating a deployment right after we have changes in the kubeletconfig and right after that we assert the number of pendingPods and taking the first pod in the list.

The test assumes that there should always be one pod that is pending. And on some of the test cases this fails exactly on that assumption which in some cases the pods list is more than 1. Below is an example of such a test case that was debugged and catched the issue.

```
NAME                       READY STATUS                 RESTARTS AGE
pod/testdp-9c6dc4b7d-4pqwf 0/1   ContainerStatusUnknown 0        31s
pod/testdp-9c6dc4b7d-67zxr 0/1   ContainerStatusUnknown 0        33s
pod/testdp-9c6dc4b7d-6gtxc 0/1   ContainerStatusUnknown 0        28s
pod/testdp-9c6dc4b7d-755p2 0/1   ContainerStatusUnknown 0        33s
pod/testdp-9c6dc4b7d-7s6fn 0/1   Pending                0        26s
pod/testdp-9c6dc4b7d-8c26j 0/1   ContainerStatusUnknown 0        28s
pod/testdp-9c6dc4b7d-chlpj 0/1   ContainerStatusUnknown 0        28s
pod/testdp-9c6dc4b7d-hqjwp 0/1   ContainerStatusUnknown 0        28s
pod/testdp-9c6dc4b7d-k7qs7 0/1   ContainerStatusUnknown 0        28s
pod/testdp-9c6dc4b7d-k95pt 0/1   ContainerStatusUnknown 0        28s
pod/testdp-9c6dc4b7d-kbpng 0/1   ContainerStatusUnknown 0        32s
pod/testdp=9c6dc4b7d-kv4jt 0/1   ContainerStatusUnknown 0        28s
pod/testdp-9c6dc4b7d-nr2mc 0/1   ContainerStatusUnknown 0        28s
pod/testdp-9c6dc4b7d-nr2sf 0/1   ContainerStatusUnknown 0        33s
pod/testdp-9c6dc4b7d-p6981 0/1   ContainerStatusUnknown 0        28s
pod/testdp-9c6dc4b7d-p876c 0/1   ContainerStatusUnknown 0        28s
pod/testdp-9c6dc4b7d-sk5pn 0/1   ContainerStatusUnknown 0        28s
```

It appears that the correct behavior is right for a single pod which is correctly Pending. But other pods are being created with TopologyAffinityError. Sometimes we have a lot of containers like here with 16 Failed containers and 1 single Pending container and sometimes its 2 that fail and 1 that is Pending. In both cases when this situation occurs it makes the test fail, but the correct behavior is actually happening, we have exactly one pod that is correctly pending, This behavior happens because right after we've made changes to the kubeletconfig and the mcp updates we right away create a deployment and the scheduler haven't picked up the changes from the kubeletconfig yet. Hence grabbing the first pod in the list is false because there could be more than 1 and also because the amount of maxPodsWithTAE can be randomly bigger or smaller then the threshold we don't know how many pods can appear.

To fix this we just need to fetch the correct pod that is pending from the list, because all the other pods are irrelevant and do our following assertions using this pod. So as long as there is exactly one pending pod in the list the scheduler did pick up the changes and it is behaving correctly.