### PR TITLE
WIP: e2e: schedcache: improve serial tests

### DIFF
--- a/test/utils/noderesourcetopologies/noderesourcetopologies_test.go
+++ b/test/utils/noderesourcetopologies/noderesourcetopologies_test.go
@@ -19,6 +19,7 @@ package noderesourcetopologies
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -269,6 +270,580 @@ func TestEqualNRTListsItems(t *testing.T) {
 			got, _ := EqualNRTListsItems(tc.data1, tc.data2)
 			if got != tc.expected {
 				t.Errorf("test: %s; \n   got=%v expected=%v\n", tc.description, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestCheckTotalConsumedResources(t *testing.T) {
+	type testcase struct {
+		description    string
+		nrtInitial     nrtv1alpha2.NodeResourceTopologyList
+		nrtUpdated     nrtv1alpha2.NodeResourceTopologyList
+		resources      corev1.ResourceList
+		qos            corev1.PodQOSClass
+		expectedToPass bool
+	}
+
+	testcases := []testcase{
+		{
+			description: "should pass with no resources, no update",
+			nrtInitial: nrtv1alpha2.NodeResourceTopologyList{
+				Items: []nrtv1alpha2.NodeResourceTopology{
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-0"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-001",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:        "bar",
+										Capacity:    resource.MustParse("4"),
+										Allocatable: resource.MustParse("4"),
+										Available:   resource.MustParse("4"),
+									},
+									{
+										Name:        "foo",
+										Capacity:    resource.MustParse("2"),
+										Allocatable: resource.MustParse("2"),
+										Available:   resource.MustParse("2"),
+									},
+								},
+							},
+							{
+								Name: "Zone-000",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:        "foo",
+										Capacity:    resource.MustParse("1"),
+										Allocatable: resource.MustParse("1"),
+										Available:   resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			nrtUpdated: nrtv1alpha2.NodeResourceTopologyList{
+				Items: []nrtv1alpha2.NodeResourceTopology{
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-0"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-001",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:        "bar",
+										Capacity:    resource.MustParse("4"),
+										Allocatable: resource.MustParse("4"),
+										Available:   resource.MustParse("4"),
+									},
+									{
+										Name:        "foo",
+										Capacity:    resource.MustParse("2"),
+										Allocatable: resource.MustParse("2"),
+										Available:   resource.MustParse("2"),
+									},
+								},
+							},
+							{
+								Name: "Zone-000",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:        "foo",
+										Capacity:    resource.MustParse("1"),
+										Allocatable: resource.MustParse("1"),
+										Available:   resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			resources:      corev1.ResourceList{},
+			qos:            corev1.PodQOSGuaranteed, // although not possible but still should work
+			expectedToPass: true,
+		},
+		{
+			description: "should pass with non empty resources and GU pod with correct updates",
+			nrtInitial: nrtv1alpha2.NodeResourceTopologyList{
+				Items: []nrtv1alpha2.NodeResourceTopology{
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-0"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-001",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "bar",
+										Available: resource.MustParse("4"),
+									},
+									{
+										Name:      "foo",
+										Available: resource.MustParse("2"),
+									},
+									{
+										Name:      string(corev1.ResourceCPU),
+										Available: resource.MustParse("5"),
+									},
+								},
+							},
+							{
+								Name: "Zone-000",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "foo",
+										Available: resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-1"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-001",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "bar",
+										Available: resource.MustParse("4"),
+									},
+									{
+										Name:      "foo",
+										Available: resource.MustParse("2"),
+									},
+								},
+							},
+							{
+								Name: "Zone-000",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "foo",
+										Available: resource.MustParse("1"),
+									},
+									{
+										Name:      string(corev1.ResourceCPU),
+										Available: resource.MustParse("5"),
+									},
+									{
+										Name:      string(corev1.ResourceMemory),
+										Available: resource.MustParse("4Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			nrtUpdated: nrtv1alpha2.NodeResourceTopologyList{
+				Items: []nrtv1alpha2.NodeResourceTopology{
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-0"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-001",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "bar",
+										Available: resource.MustParse("2"),
+									},
+									{
+										Name:      "foo",
+										Available: resource.MustParse("2"),
+									},
+									{
+										Name:      string(corev1.ResourceCPU),
+										Available: resource.MustParse("4"),
+									},
+								},
+							},
+							{
+								Name: "Zone-000",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "foo",
+										Available: resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-1"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-001",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "bar",
+										Available: resource.MustParse("3"),
+									},
+									{
+										Name:      "foo",
+										Available: resource.MustParse("2"),
+									},
+								},
+							},
+							{
+								Name: "Zone-000",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "foo",
+										Available: resource.MustParse("0"),
+									},
+									{
+										Name:      string(corev1.ResourceCPU),
+										Available: resource.MustParse("4"),
+									},
+									{
+										Name:      string(corev1.ResourceMemory),
+										Available: resource.MustParse("2Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			resources: corev1.ResourceList{
+				"foo":                 resource.MustParse("1"),
+				"bar":                 resource.MustParse("3"),
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+			qos:            corev1.PodQOSGuaranteed,
+			expectedToPass: true,
+		},
+		{
+			description: "should pass with non empty resources and BU pod with correct updates",
+			nrtInitial: nrtv1alpha2.NodeResourceTopologyList{
+				Items: []nrtv1alpha2.NodeResourceTopology{
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-0"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-001",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "bar",
+										Available: resource.MustParse("4"),
+									},
+									{
+										Name:      "foo",
+										Available: resource.MustParse("2"),
+									},
+								},
+							},
+							{
+								Name: "Zone-000",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "foo",
+										Available: resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-1"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-001",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "bar",
+										Available: resource.MustParse("4"),
+									},
+									{
+										Name:      "foo",
+										Available: resource.MustParse("2"),
+									},
+								},
+							},
+							{
+								Name: "Zone-000",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "foo",
+										Available: resource.MustParse("1"),
+									},
+									{
+										Name:      string(corev1.ResourceCPU),
+										Available: resource.MustParse("5"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			nrtUpdated: nrtv1alpha2.NodeResourceTopologyList{
+				Items: []nrtv1alpha2.NodeResourceTopology{
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-0"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-001",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "bar",
+										Available: resource.MustParse("2"),
+									},
+									{
+										Name:      "foo",
+										Available: resource.MustParse("2"),
+									},
+								},
+							},
+							{
+								Name: "Zone-000",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "foo",
+										Available: resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-1"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-001",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "bar",
+										Available: resource.MustParse("3"),
+									},
+									{
+										Name:      "foo",
+										Available: resource.MustParse("2"),
+									},
+								},
+							},
+							{
+								Name: "Zone-000",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "foo",
+										Available: resource.MustParse("1"),
+									},
+									{
+										Name:      string(corev1.ResourceCPU),
+										Available: resource.MustParse("5"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			resources: corev1.ResourceList{
+				"bar":              resource.MustParse("3"),
+				corev1.ResourceCPU: resource.MustParse("2"),
+			},
+			qos:            corev1.PodQOSBurstable,
+			expectedToPass: true,
+		},
+		{
+			description: "should pass with non empty resources and BE pod with correct updates",
+			nrtInitial: nrtv1alpha2.NodeResourceTopologyList{
+				Items: []nrtv1alpha2.NodeResourceTopology{
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-0"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-001",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "bar",
+										Available: resource.MustParse("4"),
+									},
+									{
+										Name:      "foo",
+										Available: resource.MustParse("2"),
+									},
+								},
+							},
+							{
+								Name: "Zone-000",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "foo",
+										Available: resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-1"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-001",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "bar",
+										Available: resource.MustParse("4"),
+									},
+									{
+										Name:      "foo",
+										Available: resource.MustParse("2"),
+									},
+								},
+							},
+							{
+								Name: "Zone-000",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "foo",
+										Available: resource.MustParse("1"),
+									},
+									{
+										Name:      string(corev1.ResourceCPU),
+										Available: resource.MustParse("5"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			nrtUpdated: nrtv1alpha2.NodeResourceTopologyList{
+				Items: []nrtv1alpha2.NodeResourceTopology{
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-0"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-001",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "bar",
+										Available: resource.MustParse("2"),
+									},
+									{
+										Name:      "foo",
+										Available: resource.MustParse("2"),
+									},
+								},
+							},
+							{
+								Name: "Zone-000",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "foo",
+										Available: resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-1"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-001",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "bar",
+										Available: resource.MustParse("3"),
+									},
+									{
+										Name:      "foo",
+										Available: resource.MustParse("2"),
+									},
+								},
+							},
+							{
+								Name: "Zone-000",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "foo",
+										Available: resource.MustParse("1"),
+									},
+									{
+										Name:      string(corev1.ResourceCPU),
+										Available: resource.MustParse("5"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			resources: corev1.ResourceList{
+				"bar": resource.MustParse("3"),
+			},
+			qos:            corev1.PodQOSBestEffort,
+			expectedToPass: true,
+		},
+		{
+			description: "should fail with non empty resources and BE pod with empty updates",
+			nrtInitial: nrtv1alpha2.NodeResourceTopologyList{
+				Items: []nrtv1alpha2.NodeResourceTopology{
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-0"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-001",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "bar",
+										Available: resource.MustParse("4"),
+									},
+									{
+										Name:      "foo",
+										Available: resource.MustParse("2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			nrtUpdated: nrtv1alpha2.NodeResourceTopologyList{
+				Items: []nrtv1alpha2.NodeResourceTopology{
+					{
+						ObjectMeta: v1.ObjectMeta{Name: "Node-0"},
+						Zones: nrtv1alpha2.ZoneList{
+							{
+								Name: "Zone-001",
+								Resources: nrtv1alpha2.ResourceInfoList{
+									{
+										Name:      "bar",
+										Available: resource.MustParse("4"),
+									},
+									{
+										Name:      "foo",
+										Available: resource.MustParse("2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			resources: corev1.ResourceList{
+				"bar": resource.MustParse("3"),
+			},
+			qos:            corev1.PodQOSBestEffort,
+			expectedToPass: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			err := CheckTotalConsumedResources(tc.nrtInitial, tc.nrtUpdated, tc.resources, tc.qos)
+			if err != nil && tc.expectedToPass {
+				t.Errorf("got an error while expected to pass: %v", err)
+			}
+			if err == nil && !tc.expectedToPass {
+				t.Error("test passed while expected to fail")
 			}
 		})
 	}


### PR DESCRIPTION
In the test log it sometimes shows that pod burst test with burstable
pods actually triggers an update on the NRT object, that was reflected at teardown level while
waiting for initial data to be restored, so the test doesn't actually
fail.

```
  STEP: cooldown by verifying NRTs data is settled to the initial state (interval=5s timeout=2m0s) @ 08/27/24 07:28:49.941
I0827 07:28:49.941370  116255 noderesourcetopologies.go:127] Waiting up to 2m0s to have 2 NRT objects restored
I0827 07:28:54.947867  116255 noderesourcetopologies.go:136] checking NRT BEGIN dump current nrt list
cnfdd4.t5g-dev.eng.rdu2.dc.redhat.com policy=single-numa-node, scope=container
- zone: node-0 [Node]: cpu=52/51/21,example.com/deviceA=10/10/10,example.com/deviceB=7/7/7,example.com/deviceC=7/7/7,kni.node/numacell00=15/15/15,memory=49151791104/47973191680/5023518720
- zone: node-1 [Node]: cpu=52/51/39,example.com/deviceA=8/8/8,kni.node/numacell01=15/15/15,memory=50716884992/50716884992/33537015808
cnfdd5.t5g-dev.eng.rdu2.dc.redhat.com policy=single-numa-node, scope=container
- zone: node-0 [Node]: cpu=52/51/51,example.com/deviceA=7/7/7,example.com/deviceB=7/7/7,example.com/deviceC=7/7/7,kni.node/numacell00=15/15/15,memory=49197715456/48019116032/48019116032
- zone: node-1 [Node]: cpu=52/51/51,kni.node/numacell01=15/15/15,memory=50673119232/50673119232/50673119232
NRT END dump
I0827 07:28:54.947910  116255 noderesourcetopologies.go:207] error comparing NRT "cnfdd4.t5g-dev.eng.rdu2.dc.redhat.com": mismatched resource Available initial=cpu=52/51/51 vs updated=cpu=52/51/21
W0827 07:28:54.947921  116255 noderesourcetopologies.go:152] NRT for cnfdd4.t5g-dev.eng.rdu2.dc.redhat.com does not match reference
I0827 07:28:59.948949  116255 noderesourcetopologies.go:136] checking NRT BEGIN dump current nrt list
```

Add a special check to verify the pods' QoS and NRT updates based on it.

Signed-off-by: Shereen Haj <shajmakh@redhat.com>