### PR TITLE
manifests: labels: don't match using new labels

### DIFF
--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -513,7 +513,6 @@ spec:
           replicas: 1
           selector:
             matchLabels:
-              app: numaresources-operator
               control-plane: controller-manager
           strategy: {}
           template:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -18,7 +18,6 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: numaresources-operator
       control-plane: controller-manager
   replicas: 1
   template:


### PR DESCRIPTION
In 055d665ea54a3aeadc24 we added new labels AND we immediately used them to match  components in our deployment. Turns out this breaks upgrades because the old image getting replaced can't possibly have the matching label, for starters. So the proper way is to add labels, let them sit for few releases, then start consuming them. This should work in all the flows, including upgrade.
In this commit we unblock upgrades removing the matching requirement, which will be introduced again later in the future.