### PR TITLE
[release-4.15] internal: align topics version with the branch

### DIFF
--- a/internal/api/features/types.go
+++ b/internal/api/features/types.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	Version = "v4.17.0"
+	Version = "v4.15.0"
 )
 
 type Metadata struct {


### PR DESCRIPTION
Mistakenly backported with 4.17 value, realign it with the 4.15 branch.