### PR TITLE
WIP: nro controller: enable NodeSelector under NodeGroup

### DIFF
--- a/api/numaresourcesoperator/v1/helper/nodegroup/nodegroup.go
+++ b/api/numaresourcesoperator/v1/helper/nodegroup/nodegroup.go
@@ -18,6 +18,7 @@ package nodegroup
 
 import (
 	"fmt"
+	"slices"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -48,37 +49,93 @@ func FindTrees(mcps *mcov1.MachineConfigPoolList, nodeGroups []nropv1.NodeGroup)
 	var result []Tree
 	for idx := range nodeGroups {
 		nodeGroup := &nodeGroups[idx] // shortcut
+		mcpsByMCPSelector, mcpsByNodeSelector := []*mcov1.MachineConfigPool{}, []*mcov1.MachineConfigPool{}
 
-		if nodeGroup.MachineConfigPoolSelector == nil {
-			continue
-		}
-		selector, err := metav1.LabelSelectorAsSelector(nodeGroup.MachineConfigPoolSelector)
-		if err != nil {
-			klog.Errorf("bad node group machine config pool selector %q", nodeGroup.MachineConfigPoolSelector.String())
+		if nodeGroup.MachineConfigPoolSelector == nil && nodeGroup.NodeSelector == nil {
 			continue
 		}
 
-		treeMCPs := []*mcov1.MachineConfigPool{}
-		for i := range mcps.Items {
-			mcp := &mcps.Items[i] // shortcut
-			mcpLabels := labels.Set(mcp.Labels)
-			if !selector.Matches(mcpLabels) {
+		// 3 options:
+		// A. only mcp selector is set -> same as before
+		// B. only node selector is set -> fetch the mcps that match the node selector
+		// C. both are set -> make sure they both are pointing to the same mcp set (on the fly)
+
+		if nodeGroup.MachineConfigPoolSelector != nil {
+			selector, err := metav1.LabelSelectorAsSelector(nodeGroup.MachineConfigPoolSelector)
+			if err != nil {
+				klog.Errorf("bad node group machine config pool selector %q", nodeGroup.MachineConfigPoolSelector.String())
 				continue
 			}
-			treeMCPs = append(treeMCPs, mcp)
+			mcpsByMCPSelector = getMCPsByMatchingLabels(mcps, selector)
 		}
 
-		if len(treeMCPs) == 0 {
-			return nil, fmt.Errorf("failed to find MachineConfigPool for the node group with the selector %q", nodeGroup.MachineConfigPoolSelector.String())
+		if nodeGroup.NodeSelector != nil {
+			selector, err := metav1.LabelSelectorAsSelector(nodeGroup.NodeSelector)
+			if err != nil {
+				klog.Errorf("bad node group node selector %q", nodeGroup.NodeSelector.String())
+				continue
+			}
+			mcpsByNodeSelector = getMCPsByMatchingLabels(mcps, selector)
+		}
+
+		if len(mcpsByMCPSelector) == 0 && len(mcpsByNodeSelector) == 0 {
+			return nil, fmt.Errorf("failed to find MachineConfigPool for the node group with empty selectors; %+v", nodeGroup)
+		}
+
+		if len(mcpsByMCPSelector) != 0 && len(mcpsByNodeSelector) == 0 {
+			result = append(result, Tree{
+				NodeGroup:          nodeGroup,
+				MachineConfigPools: mcpsByMCPSelector,
+			})
+			continue
+		}
+
+		if len(mcpsByMCPSelector) == 0 && len(mcpsByNodeSelector) != 0 {
+			result = append(result, Tree{
+				NodeGroup:          nodeGroup,
+				MachineConfigPools: mcpsByNodeSelector,
+			})
+			continue
+		}
+
+		mcpNamesByMCPSelector := accumulateMCPsNames(mcpsByMCPSelector)
+		slices.Sort(mcpNamesByMCPSelector)
+
+		mcpNamesByNodeSelector := accumulateMCPsNames(mcpsByNodeSelector)
+		slices.Sort(mcpNamesByNodeSelector)
+
+		if !slices.Equal(mcpNamesByMCPSelector, mcpNamesByNodeSelector) {
+			return nil, fmt.Errorf("failed to find MachineConfigPool for the node group with mismatching selectors; node selector matching mcps %v, while mcp selector matching mcps %v", mcpNamesByNodeSelector, mcpNamesByMCPSelector)
 		}
 
 		result = append(result, Tree{
 			NodeGroup:          nodeGroup,
-			MachineConfigPools: treeMCPs,
+			MachineConfigPools: mcpsByNodeSelector,
 		})
 	}
 
 	return result, nil
+}
+
+func accumulateMCPsNames(mcps []*mcov1.MachineConfigPool) []string {
+	names := []string{}
+	for _, mcp := range mcps {
+		names = append(names, mcp.Name)
+	}
+	return names
+}
+
+func getMCPsByMatchingLabels(mcps *mcov1.MachineConfigPoolList, selector labels.Selector) []*mcov1.MachineConfigPool {
+	matchingMCPs := []*mcov1.MachineConfigPool{}
+	for i := range mcps.Items {
+		mcp := &mcps.Items[i] // shortcut
+		mcpLabels := labels.Set(mcp.Labels)
+		if !selector.Matches(mcpLabels) {
+			continue
+		}
+		matchingMCPs = append(matchingMCPs, mcp)
+	}
+	return matchingMCPs
 }
 
 func FindMachineConfigPools(mcps *mcov1.MachineConfigPoolList, nodeGroups []nropv1.NodeGroup) ([]*mcov1.MachineConfigPool, error) {

--- a/api/numaresourcesoperator/v1/helper/nodegroup/nodegroup_test.go
+++ b/api/numaresourcesoperator/v1/helper/nodegroup/nodegroup_test.go
@@ -17,15 +17,11 @@
 package nodegroup
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/klog/v2"
-
 	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
 )
@@ -47,6 +43,7 @@ func TestFindTrees(t *testing.T) {
 					Labels: map[string]string{
 						"mcp-label-2":  "test2",
 						"mcp-label-2a": "test2a",
+						"mcp-label-2b": "test2b",
 					},
 				},
 			},
@@ -185,27 +182,115 @@ func TestFindTrees(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "ng1-nodeSelector1",
+			mcps: &mcpList,
+			ngs: []nropv1.NodeGroup{
+				{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"mcp-label-2a": "test2a",
+						},
+					},
+				},
+			},
+			expected: []Tree{
+				{
+					MachineConfigPools: []*mcov1.MachineConfigPool{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "mcp2",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "ng2-mcp-nodeSelector: different labels but same mcp",
+			mcps: &mcpList,
+			ngs: []nropv1.NodeGroup{
+				{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"mcp-label-2a": "test2a",
+						},
+					},
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"mcp-label-2b": "test2b",
+						},
+					},
+				},
+				{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"mcp-label-3": "test3",
+						},
+					},
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"mcp-label-3": "test3",
+						},
+					},
+				},
+			},
+			expected: []Tree{
+				{
+					MachineConfigPools: []*mcov1.MachineConfigPool{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "mcp2",
+							},
+						},
+					},
+				},
+				{
+					MachineConfigPools: []*mcov1.MachineConfigPool{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "mcp3",
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "mcp5",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "ng2-mcp-nodeSelector: mcps by mcp selector is a subset of mcps by node selector",
+			mcps: &mcpList,
+			ngs: []nropv1.NodeGroup{
+				{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"mcp-label-2a": "test2a",
+						},
+					},
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"mcp-label-2": "test2",
+						},
+					},
+				},
+			},
+			expected: []Tree{},
+		},
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := FindTrees(tt.mcps, tt.ngs)
-			if err != nil {
+			if err != nil && len(tt.expected) != 0 {
 				t.Errorf("unexpected error: %v", err)
 			}
 			gotNames := mcpNamesFromTrees(got)
 			expectedNames := mcpNamesFromTrees(tt.expected)
 			if !reflect.DeepEqual(gotNames, expectedNames) {
 				t.Errorf("Trees mismatch: got=%v expected=%v", gotNames, expectedNames)
-			}
-
-			// backward compat
-			gotMcps, err := findListByNodeGroups(tt.mcps, tt.ngs)
-			if err != nil {
-				t.Errorf("unexpected error checking backward compat: %v", err)
-			}
-			compatNames := mcpNamesFromList(gotMcps)
-			if !reflect.DeepEqual(gotNames, compatNames) {
-				t.Errorf("Trees mismatch (non backward compatible): got=%v compat=%v", gotNames, compatNames)
 			}
 		})
 	}
@@ -382,41 +467,4 @@ func mcpNamesFromList(mcps []*mcov1.MachineConfigPool) []string {
 		result = append(result, mcp.Name)
 	}
 	return result
-}
-
-// old implementation acting as reference for comparisons
-func findListByNodeGroups(mcps *mcov1.MachineConfigPoolList, nodeGroups []nropv1.NodeGroup) ([]*mcov1.MachineConfigPool, error) {
-	var result []*mcov1.MachineConfigPool
-	for idx := range nodeGroups {
-		nodeGroup := &nodeGroups[idx]
-		found := false
-
-		// handled by validation
-		if nodeGroup.MachineConfigPoolSelector == nil {
-			continue
-		}
-
-		for i := range mcps.Items {
-			mcp := &mcps.Items[i]
-
-			selector, err := metav1.LabelSelectorAsSelector(nodeGroup.MachineConfigPoolSelector)
-			// handled by validation
-			if err != nil {
-				klog.Errorf("bad node group machine config pool selector %q", nodeGroup.MachineConfigPoolSelector.String())
-				continue
-			}
-
-			mcpLabels := labels.Set(mcp.Labels)
-			if selector.Matches(mcpLabels) {
-				found = true
-				result = append(result, mcp)
-			}
-		}
-
-		if !found {
-			return nil, fmt.Errorf("failed to find MachineConfigPool for the node group with the selector %q", nodeGroup.MachineConfigPoolSelector.String())
-		}
-	}
-
-	return result, nil
 }

--- a/api/numaresourcesoperator/v1/numaresourcesoperator_types.go
+++ b/api/numaresourcesoperator/v1/numaresourcesoperator_types.go
@@ -117,6 +117,9 @@ type NodeGroup struct {
 	// MachineConfigPoolSelector defines label selector for the machine config pool
 	// +optional
 	MachineConfigPoolSelector *metav1.LabelSelector `json:"machineConfigPoolSelector,omitempty"`
+	// NodeSelector defines the label selector by which a node would be targeted by the RTE daemonset
+	// +optional
+	NodeSelector *metav1.LabelSelector `json:"nodeSelector,omitempty"`
 	// Config defines the RTE behavior for this NodeGroup
 	// +optional
 	Config *NodeGroupConfig `json:"config,omitempty"`

--- a/api/numaresourcesoperator/v1/zz_generated.deepcopy.go
+++ b/api/numaresourcesoperator/v1/zz_generated.deepcopy.go
@@ -340,6 +340,11 @@ func (in *NodeGroup) DeepCopyInto(out *NodeGroup) {
 		*out = new(metav1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
 		*out = new(NodeGroupConfig)

--- a/controllers/kubeletconfig_controller_test.go
+++ b/controllers/kubeletconfig_controller_test.go
@@ -65,9 +65,12 @@ var _ = Describe("Test KubeletConfig Reconcile", func() {
 				"test1": "test1",
 			}
 			mcp1 = testobjs.NewMachineConfigPool("test1", label1, &metav1.LabelSelector{MatchLabels: label1}, &metav1.LabelSelector{MatchLabels: label1})
-			nro = testobjs.NewNUMAResourcesOperator(objectnames.DefaultNUMAResourcesOperatorCrName, []*metav1.LabelSelector{
-				{MatchLabels: label1},
-			})
+			ng := nropv1.NodeGroup{
+				MachineConfigPoolSelector: &metav1.LabelSelector{
+					MatchLabels: label1,
+				},
+			}
+			nro = testobjs.NewNUMAResourcesOperator(objectnames.DefaultNUMAResourcesOperatorCrName, []nropv1.NodeGroup{ng})
 			kubeletConfig := &kubeletconfigv1beta1.KubeletConfiguration{}
 			mcoKc1 = testobjs.NewKubeletConfig("test1", label1, mcp1.Spec.MachineConfigSelector, kubeletConfig)
 		})

--- a/internal/objects/objects.go
+++ b/internal/objects/objects.go
@@ -29,14 +29,7 @@ import (
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
 )
 
-func NewNUMAResourcesOperator(name string, labelSelectors []*metav1.LabelSelector) *nropv1.NUMAResourcesOperator {
-	var nodeGroups []nropv1.NodeGroup
-	for _, selector := range labelSelectors {
-		nodeGroups = append(nodeGroups, nropv1.NodeGroup{
-			MachineConfigPoolSelector: selector,
-		})
-	}
-
+func NewNUMAResourcesOperator(name string, nodeGroups []nropv1.NodeGroup) *nropv1.NUMAResourcesOperator {
 	return &nropv1.NUMAResourcesOperator{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "NUMAResourcesOperator",

--- a/internal/objects/objects_test.go
+++ b/internal/objects/objects_test.go
@@ -17,6 +17,7 @@
 package objects
 
 import (
+	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
 	"testing"
 	"time"
 
@@ -25,15 +26,14 @@ import (
 
 func TestNewNUMAResourcesOperator(t *testing.T) {
 	name := "test-nrop"
-	labelSelectors := []*metav1.LabelSelector{
-		{
+
+	ng := nropv1.NodeGroup{
+		MachineConfigPoolSelector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				"unit-test-nrop-obj": "foobar",
-			},
-		},
+			}},
 	}
-
-	obj := NewNUMAResourcesOperator(name, labelSelectors)
+	obj := NewNUMAResourcesOperator(name, []nropv1.NodeGroup{ng})
 
 	if obj == nil {
 		t.Fatalf("null object")

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -36,7 +36,7 @@ func TestUpdate(t *testing.T) {
 		t.Errorf("nropv1.AddToScheme() failed with: %v", err)
 	}
 
-	nro := testobjs.NewNUMAResourcesOperator("test-nro", nil)
+	nro := testobjs.NewNUMAResourcesOperator("test-nro", []nropv1.NodeGroup{})
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(nro).Build()
 
 	nro.Status.Conditions, _ = GetUpdatedConditions(nro.Status.Conditions, ConditionProgressing, "testReason", "test message")
@@ -64,7 +64,7 @@ func TestUpdateIfNeeded(t *testing.T) {
 		t.Errorf("nropv1.AddToScheme() failed with: %v", err)
 	}
 
-	nro := testobjs.NewNUMAResourcesOperator("test-nro", nil)
+	nro := testobjs.NewNUMAResourcesOperator("test-nro", []nropv1.NodeGroup{})
 
 	var ok bool
 	nro.Status.Conditions, ok = GetUpdatedConditions(nro.Status.Conditions, ConditionAvailable, "", "")


### PR DESCRIPTION
So far the controller configures the operator RTE daemonset on node groups according to the MCP selector provided under NodeGroup[]. The determination of nodes based on that MCP selector boils down to the node selector provided under that MCP spec.

This PR enables configuring the nodeGroups of the NROP CR via NodeSelector directly, while still retaining the MCP selector option.

The only restriction for having these both options configured is that if both are found in the CR they should point to the same MCPs, otherwise the operator's status will be in a degraded condition.