### PR TITLE
gh actions: bump upload-artifact version

### DIFF
--- a/.github/workflows/e2e-tools.yml
+++ b/.github/workflows/e2e-tools.yml
@@ -76,7 +76,7 @@ jobs:
 
     - name: Archive E2E Tests logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: test_e2e_logs
         path: ${LOG_DIR}/
@@ -88,7 +88,7 @@ jobs:
 
     - name: Archive kind logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: kind_logs
         path: /tmp/kind_logs

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,7 +74,7 @@ jobs:
 
     - name: Archive E2E Tests logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: test_e2e_logs
         path: ${LOG_DIR}/
@@ -86,7 +86,7 @@ jobs:
 
     - name: Archive kind logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: kind_logs
         path: /tmp/kind_logs


### PR DESCRIPTION
bump to v4:
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/