### PR TITLE
doc: examples: use ctrreschk releases

### DIFF
--- a/doc/examples/pod.ctrreschk.yaml
+++ b/doc/examples/pod.ctrreschk.yaml
@@ -6,7 +6,7 @@ spec:
   schedulerName: topo-aware-scheduler
   containers:
   - name: ctrreschk
-    image: quay.io/fromani/ctrreschk:v0.0.2024080204
+    image: quay.io/fromani/ctrreschk:v0.0.3
     imagePullPolicy: Always
     command: ["/usr/local/bin/ctrreschk", "-S", "align"]
     resources:

--- a/doc/examples/pod.lshwinfo.yaml
+++ b/doc/examples/pod.lshwinfo.yaml
@@ -6,6 +6,6 @@ spec:
   schedulerName: topo-aware-scheduler
   containers:
   - name: ctrreschk
-    image: quay.io/fromani/ctrreschk:v0.0.2024080204
+    image: quay.io/fromani/ctrreschk:v0.0.3
     imagePullPolicy: Always
     command: ["/usr/local/bin/ctrreschk", "-S", "info"]

--- a/doc/examples/pods.testgroup.yaml
+++ b/doc/examples/pods.testgroup.yaml
@@ -6,11 +6,8 @@ spec:
   schedulerName: topo-aware-scheduler
   containers:
   - name: testcnt1
-    command: ["/usr/local/bin/numalign"]
-    env:
-      - name: NUMALIGN_SLEEP_HOURS
-        value: "127"
-    image: quay.io/fromani/numalign
+    command: ["/usr/local/bin/ctrreschk", "-S", "align"]
+    image: quay.io/fromani/ctrreschk:v0.0.3
     resources:
       limits:
         cpu: '32'
@@ -25,11 +22,8 @@ spec:
   schedulerName: topo-aware-scheduler
   containers:
   - name: testcnt2
-    command: ["/usr/local/bin/numalign"]
-    env:
-      - name: NUMALIGN_SLEEP_HOURS
-        value: "127"
-    image: quay.io/fromani/numalign
+    command: ["/usr/local/bin/ctrreschk", "-S", "align"]
+    image: quay.io/fromani/ctrreschk:v0.0.3
     resources:
       limits:
         cpu: '32'
@@ -44,11 +38,8 @@ spec:
   schedulerName: topo-aware-scheduler
   containers:
   - name: testcnt3
-    command: ["/usr/local/bin/numalign"]
-    env:
-      - name: NUMALIGN_SLEEP_HOURS
-        value: "127"
-    image: quay.io/fromani/numalign
+    command: ["/usr/local/bin/ctrreschk", "-S", "align"]
+    image: quay.io/fromani/ctrreschk:v0.0.3
     resources:
       limits:
         cpu: '32'


### PR DESCRIPTION
let's use releases instead of snapshots, and
the first available release is v0.0.3.