### PR TITLE
 Makefile: bump tooling version

### DIFF
--- a/Dockerfile.bundle
+++ b/Dockerfile.bundle
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=numaresources-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
 LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.25.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.36.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ CONTAINER_ENGINE ?= docker
 
 BIN_DIR="bin"
 
-OPERATOR_SDK_VERSION="v1.25.0"
+OPERATOR_SDK_VERSION="v1.36.1"
 OPERATOR_SDK_BIN="operator-sdk_$(GOOS)_$(GOARCH)"
 OPERATOR_SDK="$(BIN_DIR)/$(OPERATOR_SDK_BIN)"
 
@@ -289,11 +289,11 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0)
+	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.3)
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.4)
+	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5@v5.4.3)
 
 # use the last version before the bump golang 1.20 -> 1.22. We want to avoid the go.mod version format changes - for now.
 ENVTEST = $(shell pwd)/bin/setup-envtest

--- a/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   creationTimestamp: null
   name: numaresourcesoperators.nodetopology.openshift.io
 spec:
@@ -207,16 +207,8 @@ spec:
                 description: Conditions show the current state of the NUMAResourcesOperator
                   Operator
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -257,12 +249,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -591,16 +578,8 @@ spec:
                 description: Conditions show the current state of the NUMAResourcesOperator
                   Operator
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -641,12 +620,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/bundle/manifests/nodetopology.openshift.io_numaresourcesschedulers.yaml
+++ b/bundle/manifests/nodetopology.openshift.io_numaresourcesschedulers.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   creationTimestamp: null
   name: numaresourcesschedulers.nodetopology.openshift.io
 spec:
@@ -128,16 +128,8 @@ spec:
                 description: Conditions show the current state of the NUMAResourcesOperator
                   Operator
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -178,12 +170,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -294,16 +281,8 @@ spec:
                 description: Conditions show the current state of the NUMAResourcesOperator
                   Operator
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -344,12 +323,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -62,8 +62,9 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    createdAt: "2024-09-17T08:34:36Z"
     olm.skipRange: '>=4.17.0 <4.18.0'
-    operators.operatorframework.io/builder: operator-sdk-v1.25.0
+    operators.operatorframework.io/builder: operator-sdk-v1.36.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: numaresources-operator.v4.18.999-snapshot
   namespace: placeholder
@@ -86,8 +87,9 @@ spec:
         path: imageSpec
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: 'Valid values are: "Normal", "Debug", "Trace", "TraceAll". Defaults
-          to "Normal".'
+      - description: |-
+          Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+          Defaults to "Normal".
         displayName: RTE log verbosity
         path: logLevel
       - description: Group of Nodes to enable RTE on
@@ -117,8 +119,8 @@ spec:
         path: nodeGroups[0].config.podsFingerprinting
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Tolerations overrides tolerations to be set into RTE daemonsets
-          for this NodeGroup. If not empty, the tolerations will be the one set here.
+      - description: |-
+          Tolerations overrides tolerations to be set into RTE daemonsets for this NodeGroup. If not empty, the tolerations will be the one set here.
           Leave empty to make the system use the default tolerations.
         displayName: Extra tolerations for the topology updater daemonset
         path: nodeGroups[0].config.tolerations
@@ -166,8 +168,9 @@ spec:
         path: imageSpec
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: 'Valid values are: "Normal", "Debug", "Trace", "TraceAll". Defaults
-          to "Normal".'
+      - description: |-
+          Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+          Defaults to "Normal".
         displayName: RTE log verbosity
         path: logLevel
       - description: Group of Nodes to enable RTE on
@@ -246,8 +249,9 @@ spec:
         path: imageSpec
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: 'Valid values are: "Normal", "Debug", "Trace", "TraceAll". Defaults
-          to "Normal".'
+      - description: |-
+          Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+          Defaults to "Normal".
         displayName: Scheduler log verbosity
         path: logLevel
       - description: Replicas control how many scheduler pods must be configured for
@@ -307,8 +311,9 @@ spec:
         path: imageSpec
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: 'Valid values are: "Normal", "Debug", "Trace", "TraceAll". Defaults
-          to "Normal".'
+      - description: |-
+          Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+          Defaults to "Normal".
         displayName: Scheduler log verbosity
         path: logLevel
       - description: Scheduler name to be used in pod templates
@@ -337,6 +342,7 @@ spec:
           - ""
           resources:
           - configmaps
+          - serviceaccounts
           verbs:
           - '*'
         - apiGroups:
@@ -355,12 +361,6 @@ spec:
           - list
           - watch
         - apiGroups:
-          - ""
-          resources:
-          - serviceaccounts
-          verbs:
-          - '*'
-        - apiGroups:
           - apiextensions.k8s.io
           resources:
           - customresourcedefinitions
@@ -370,11 +370,6 @@ spec:
           - apps
           resources:
           - daemonsets
-          verbs:
-          - '*'
-        - apiGroups:
-          - apps
-          resources:
           - deployments
           verbs:
           - '*'
@@ -394,6 +389,7 @@ spec:
           - machineconfiguration.openshift.io
           resources:
           - kubeletconfigs
+          - machineconfigpools
           verbs:
           - get
           - list
@@ -404,14 +400,6 @@ spec:
           - kubeletconfigs/finalizers
           verbs:
           - update
-        - apiGroups:
-          - machineconfiguration.openshift.io
-          resources:
-          - machineconfigpools
-          verbs:
-          - get
-          - list
-          - watch
         - apiGroups:
           - machineconfiguration.openshift.io
           resources:
@@ -428,12 +416,14 @@ spec:
           - nodetopology.openshift.io
           resources:
           - numaresourcesoperators/finalizers
+          - numaresourcesschedulers/finalizers
           verbs:
           - update
         - apiGroups:
           - nodetopology.openshift.io
           resources:
           - numaresourcesoperators/status
+          - numaresourcesschedulers/status
           verbs:
           - get
           - patch
@@ -451,40 +441,11 @@ spec:
           - update
           - watch
         - apiGroups:
-          - nodetopology.openshift.io
-          resources:
-          - numaresourcesschedulers/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - nodetopology.openshift.io
-          resources:
-          - numaresourcesschedulers/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - clusterrolebindings
-          verbs:
-          - '*'
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
           - clusterroles
-          verbs:
-          - '*'
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
           - rolebindings
-          verbs:
-          - '*'
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
           - roles
           verbs:
           - '*'

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: numaresources-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
   operators.operatorframework.io.bundle.channel.default.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.25.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.36.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: numaresourcesoperators.nodetopology.openshift.io
 spec:
   group: nodetopology.openshift.io
@@ -207,16 +207,8 @@ spec:
                 description: Conditions show the current state of the NUMAResourcesOperator
                   Operator
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -257,12 +249,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -591,16 +578,8 @@ spec:
                 description: Conditions show the current state of the NUMAResourcesOperator
                   Operator
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -641,12 +620,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesschedulers.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesschedulers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: numaresourcesschedulers.nodetopology.openshift.io
 spec:
   group: nodetopology.openshift.io
@@ -128,16 +128,8 @@ spec:
                 description: Conditions show the current state of the NUMAResourcesOperator
                   Operator
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -178,12 +170,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -294,16 +281,8 @@ spec:
                 description: Conditions show the current state of the NUMAResourcesOperator
                   Operator
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -344,12 +323,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,7 +12,7 @@ namePrefix: numaresources-
 #commonLabels:
 #  someName: someValue
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager

--- a/config/kind-ci/kustomization.yaml
+++ b/config/kind-ci/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
   - ../default
 
 patchesStrategicMerge:

--- a/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
@@ -26,8 +26,9 @@ spec:
         path: imageSpec
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: 'Valid values are: "Normal", "Debug", "Trace", "TraceAll". Defaults
-          to "Normal".'
+      - description: |-
+          Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+          Defaults to "Normal".
         displayName: RTE log verbosity
         path: logLevel
       - description: Group of Nodes to enable RTE on
@@ -57,8 +58,8 @@ spec:
         path: nodeGroups[0].config.podsFingerprinting
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Tolerations overrides tolerations to be set into RTE daemonsets
-          for this NodeGroup. If not empty, the tolerations will be the one set here.
+      - description: |-
+          Tolerations overrides tolerations to be set into RTE daemonsets for this NodeGroup. If not empty, the tolerations will be the one set here.
           Leave empty to make the system use the default tolerations.
         displayName: Extra tolerations for the topology updater daemonset
         path: nodeGroups[0].config.tolerations
@@ -106,8 +107,9 @@ spec:
         path: imageSpec
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: 'Valid values are: "Normal", "Debug", "Trace", "TraceAll". Defaults
-          to "Normal".'
+      - description: |-
+          Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+          Defaults to "Normal".
         displayName: RTE log verbosity
         path: logLevel
       - description: Group of Nodes to enable RTE on
@@ -186,8 +188,9 @@ spec:
         path: imageSpec
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: 'Valid values are: "Normal", "Debug", "Trace", "TraceAll". Defaults
-          to "Normal".'
+      - description: |-
+          Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+          Defaults to "Normal".
         displayName: Scheduler log verbosity
         path: logLevel
       - description: Replicas control how many scheduler pods must be configured for
@@ -247,8 +250,9 @@ spec:
         path: imageSpec
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: 'Valid values are: "Normal", "Debug", "Trace", "TraceAll". Defaults
-          to "Normal".'
+      - description: |-
+          Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+          Defaults to "Normal".
         displayName: Scheduler log verbosity
         path: logLevel
       - description: Scheduler name to be used in pod templates

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,6 +8,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - serviceaccounts
   verbs:
   - '*'
 - apiGroups:
@@ -26,12 +27,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - '*'
-- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
@@ -41,11 +36,6 @@ rules:
   - apps
   resources:
   - daemonsets
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
   - deployments
   verbs:
   - '*'
@@ -65,6 +55,7 @@ rules:
   - machineconfiguration.openshift.io
   resources:
   - kubeletconfigs
+  - machineconfigpools
   verbs:
   - get
   - list
@@ -75,14 +66,6 @@ rules:
   - kubeletconfigs/finalizers
   verbs:
   - update
-- apiGroups:
-  - machineconfiguration.openshift.io
-  resources:
-  - machineconfigpools
-  verbs:
-  - get
-  - list
-  - watch
 - apiGroups:
   - machineconfiguration.openshift.io
   resources:
@@ -99,12 +82,14 @@ rules:
   - nodetopology.openshift.io
   resources:
   - numaresourcesoperators/finalizers
+  - numaresourcesschedulers/finalizers
   verbs:
   - update
 - apiGroups:
   - nodetopology.openshift.io
   resources:
   - numaresourcesoperators/status
+  - numaresourcesschedulers/status
   verbs:
   - get
   - patch
@@ -122,40 +107,11 @@ rules:
   - update
   - watch
 - apiGroups:
-  - nodetopology.openshift.io
-  resources:
-  - numaresourcesschedulers/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - nodetopology.openshift.io
-  resources:
-  - numaresourcesschedulers/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
-  verbs:
-  - '*'
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
   - clusterroles
-  verbs:
-  - '*'
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
   - rolebindings
-  verbs:
-  - '*'
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
   - roles
   verbs:
   - '*'

--- a/config/scorecard/kustomization.yaml
+++ b/config/scorecard/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
 - bases/config.yaml
-patchesJson6902:
+patches:
 - path: patches/basic.config.yaml
   target:
     group: scorecard.operatorframework.io

--- a/hack/verify-generated.sh
+++ b/hack/verify-generated.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# compare the CSV file against the latest revision
+# but ignore the createdAt field which is always changing.
+if [[ "$(git diff --quiet -I'^    createdAt: ' bundle)" -eq 0 ]]; then
+  git checkout --quiet bundle
+fi
+
 if [[ -n "$(git status --untracked-files=no --porcelain .)" ]]; then
         echo "uncommitted generated files. run 'make generate bundle manifests' and commit results."
         echo "$(git status --untracked-files=no --porcelain .)"

--- a/hack/verify-generated.sh
+++ b/hack/verify-generated.sh
@@ -8,6 +8,6 @@ fi
 
 if [[ -n "$(git status --untracked-files=no --porcelain .)" ]]; then
         echo "uncommitted generated files. run 'make generate bundle manifests' and commit results."
-        echo "$(git status --untracked-files=no --porcelain .)"
+        git status --untracked-files=no --porcelain .
         exit 1
 fi


### PR DESCRIPTION
Bump the following tooling version to the latest stable:
* `operator-sdk`
* `controller-gen`
* `kustomize`

In addition addressed all deprecation messages and other dependencies that
were resulted from the use of the latest versions of the tools.