### PR TITLE
CNF-11193: controller:hypershift: add support in for Kubelet controller

### DIFF
--- a/controllers/kubeletconfig_controller.go
+++ b/controllers/kubeletconfig_controller.go
@@ -38,6 +38,9 @@ import (
 
 	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
+	"github.com/pkg/errors"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
 	"github.com/openshift-kni/numaresources-operator/internal/machineconfigpools"
 	"github.com/openshift-kni/numaresources-operator/pkg/apply"
@@ -57,6 +60,7 @@ type KubeletConfigReconciler struct {
 	Scheme    *runtime.Scheme
 	Recorder  record.EventRecorder
 	Namespace string
+	Platform  platform.Platform
 }
 
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=*

--- a/controllers/kubeletconfig_controller.go
+++ b/controllers/kubeletconfig_controller.go
@@ -64,6 +64,13 @@ type KubeletConfigReconciler struct {
 	Platform  platform.Platform
 }
 
+type kubeletConfigHandler struct {
+	ownerObject client.Object
+	mcoKc       *mcov1.KubeletConfig
+	// mcp or nodePool name
+	poolName string
+}
+
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=*
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=kubeletconfigs,verbs=get;list;watch

--- a/controllers/kubeletconfig_controller.go
+++ b/controllers/kubeletconfig_controller.go
@@ -195,8 +195,11 @@ func (r *KubeletConfigReconciler) syncConfigMap(ctx context.Context, kubeletConf
 	for _, objState := range existing.State(cfgManifests) {
 		// the owner should be the KubeletConfig object and not the NUMAResourcesOperator CR
 		// this means that when KubeletConfig will get deleted, the ConfigMap gets deleted as well
-		if err := controllerutil.SetControllerReference(kcHandler.ownerObject, objState.Desired, r.Scheme); err != nil {
-			return nil, fmt.Errorf("failed to set controller reference to %s %s: %w", objState.Desired.GetNamespace(), objState.Desired.GetName(), err)
+		// TODO on HyperShift there's a cross-namespaced owner references that need to be fixed.
+		if r.Platform != platform.HyperShift {
+			if err := controllerutil.SetControllerReference(kcHandler.ownerObject, objState.Desired, r.Scheme); err != nil {
+				return nil, fmt.Errorf("failed to set controller reference to %s %s: %w", objState.Desired.GetNamespace(), objState.Desired.GetName(), err)
+			}
 		}
 		if _, _, err := apply.ApplyObject(ctx, r.Client, objState); err != nil {
 			return nil, fmt.Errorf("could not create %s: %w", objState.Desired.GetObjectKind().GroupVersionKind().String(), err)

--- a/controllers/kubeletconfig_controller_test.go
+++ b/controllers/kubeletconfig_controller_test.go
@@ -32,12 +32,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
 	rteconfig "github.com/openshift-kni/numaresources-operator/rte/pkg/config"
 
 	testobjs "github.com/openshift-kni/numaresources-operator/internal/objects"
 )
+
+type reconcilerBuilderFunc func(...runtime.Object) (*KubeletConfigReconciler, error)
 
 const (
 	bufferSize = 1024
@@ -50,15 +53,30 @@ func NewFakeKubeletConfigReconciler(initObjects ...runtime.Object) (*KubeletConf
 		Scheme:    scheme.Scheme,
 		Namespace: testNamespace,
 		Recorder:  record.NewFakeRecorder(bufferSize),
+		Platform:  platform.OpenShift,
+	}, nil
+}
+
+func NewFakeKubeletConfigReconcilerForHyperShift(initObjects ...runtime.Object) (*KubeletConfigReconciler, error) {
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(initObjects...).Build()
+	return &KubeletConfigReconciler{
+		Client:    fakeClient,
+		Scheme:    scheme.Scheme,
+		Namespace: testNamespace,
+		Recorder:  record.NewFakeRecorder(bufferSize),
+		Platform:  platform.HyperShift,
 	}, nil
 }
 
 var _ = Describe("Test KubeletConfig Reconcile", func() {
-	Context("with KubeletConfig objects already present in the cluster", func() {
+	DescribeTableSubtree("On different platforms with KubeletConfig objects already present in the cluster", func(newFakeReconciler reconcilerBuilderFunc, clusterPlatform platform.Platform) {
 		var nro *nropv1.NUMAResourcesOperator
 		var mcp1 *machineconfigv1.MachineConfigPool
 		var mcoKc1 *machineconfigv1.KubeletConfig
 		var label1 map[string]string
+		var key client.ObjectKey
+		var poolName string
+		cmKc1 := &corev1.ConfigMap{}
 
 		BeforeEach(func() {
 			label1 = map[string]string{
@@ -73,23 +91,30 @@ var _ = Describe("Test KubeletConfig Reconcile", func() {
 			nro = testobjs.NewNUMAResourcesOperator(objectnames.DefaultNUMAResourcesOperatorCrName, ng)
 			kubeletConfig := &kubeletconfigv1beta1.KubeletConfiguration{}
 			mcoKc1 = testobjs.NewKubeletConfig("test1", label1, mcp1.Spec.MachineConfigSelector, kubeletConfig)
+			key = client.ObjectKeyFromObject(mcoKc1)
+			poolName = mcp1.Name
+
+			if clusterPlatform == platform.HyperShift {
+				poolName = "test-hostedcluster1"
+				label1[HyperShiftNodePoolLabel] = poolName
+				cmKc1 = testobjs.NewKubeletConfigConfigMap("test1", label1, mcoKc1)
+				key = client.ObjectKeyFromObject(cmKc1)
+			}
 		})
 
 		Context("on the first iteration", func() {
 			It("without NRO present, should wait", func() {
-				reconciler, err := NewFakeKubeletConfigReconciler(mcp1, mcoKc1)
+				reconciler, err := newFakeReconciler(mcp1, mcoKc1, cmKc1)
 				Expect(err).ToNot(HaveOccurred())
 
-				key := client.ObjectKeyFromObject(mcoKc1)
 				result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{RequeueAfter: kubeletConfigRetryPeriod}))
 			})
 			It("with NRO present, should create configmap", func() {
-				reconciler, err := NewFakeKubeletConfigReconciler(nro, mcp1, mcoKc1)
+				reconciler, err := newFakeReconciler(nro, mcp1, mcoKc1, cmKc1)
 				Expect(err).ToNot(HaveOccurred())
 
-				key := client.ObjectKeyFromObject(mcoKc1)
 				result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{}))
@@ -97,15 +122,14 @@ var _ = Describe("Test KubeletConfig Reconcile", func() {
 				cm := &corev1.ConfigMap{}
 				key = client.ObjectKey{
 					Namespace: testNamespace,
-					Name:      objectnames.GetComponentName(nro.Name, mcp1.Name),
+					Name:      objectnames.GetComponentName(nro.Name, poolName),
 				}
 				Expect(reconciler.Client.Get(context.TODO(), key, cm)).ToNot(HaveOccurred())
 			})
 			It("with NRO present, the created configmap should have the linking labels", func() {
-				reconciler, err := NewFakeKubeletConfigReconciler(nro, mcp1, mcoKc1)
+				reconciler, err := newFakeReconciler(nro, mcp1, mcoKc1, cmKc1)
 				Expect(err).ToNot(HaveOccurred())
 
-				key := client.ObjectKeyFromObject(mcoKc1)
 				result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{}))
@@ -113,17 +137,16 @@ var _ = Describe("Test KubeletConfig Reconcile", func() {
 				cm := &corev1.ConfigMap{}
 				key = client.ObjectKey{
 					Namespace: testNamespace,
-					Name:      objectnames.GetComponentName(nro.Name, mcp1.Name),
+					Name:      objectnames.GetComponentName(nro.Name, poolName),
 				}
 				Expect(reconciler.Client.Get(context.TODO(), key, cm)).ToNot(HaveOccurred())
 				Expect(cm.Labels).To(HaveKeyWithValue(rteconfig.LabelOperatorName, nro.Name))
-				Expect(cm.Labels).To(HaveKeyWithValue(rteconfig.LabelNodeGroupName+"/"+rteconfig.LabelNodeGroupKindMachineConfigPool, mcp1.Name))
+				Expect(cm.Labels).To(HaveKeyWithValue(rteconfig.LabelNodeGroupName+"/"+rteconfig.LabelNodeGroupKindMachineConfigPool, poolName))
 			})
-			It("should send events when NRO present and operation succesfull", func() {
-				reconciler, err := NewFakeKubeletConfigReconciler(nro, mcp1, mcoKc1)
+			It("should send events when NRO present and operation successful", func() {
+				reconciler, err := newFakeReconciler(nro, mcp1, mcoKc1, cmKc1)
 				Expect(err).ToNot(HaveOccurred())
 
-				key := client.ObjectKeyFromObject(mcoKc1)
 				result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{}))
@@ -137,7 +160,9 @@ var _ = Describe("Test KubeletConfig Reconcile", func() {
 
 			It("should send events when NRO present and operation failure", func() {
 				brokenMcoKc := testobjs.NewKubeletConfigWithData("broken", label1, mcp1.Spec.MachineConfigSelector, []byte(""))
-				reconciler, err := NewFakeKubeletConfigReconciler(nro, mcp1, brokenMcoKc)
+				// on HyperShift we can mimic this behavior by not having a ConfigMap with a KubeletConfig
+				// present on the cluster at all
+				reconciler, err := newFakeReconciler(nro, mcp1, brokenMcoKc)
 				Expect(err).ToNot(HaveOccurred())
 
 				key := client.ObjectKeyFromObject(brokenMcoKc)
@@ -153,7 +178,9 @@ var _ = Describe("Test KubeletConfig Reconcile", func() {
 
 			It("should skip invalid kubeletconfig", func() {
 				invalidMcoKc := testobjs.NewKubeletConfigWithoutData("payloadless", label1, mcp1.Spec.MachineConfigSelector)
-				reconciler, err := NewFakeKubeletConfigReconciler(nro, mcp1, invalidMcoKc)
+				// adding a CM for when this test emulates HyperShift platform
+				invalidCmMcoKc := testobjs.NewKubeletConfigConfigMap("payloadless", label1, invalidMcoKc)
+				reconciler, err := newFakeReconciler(nro, mcp1, invalidMcoKc, invalidCmMcoKc)
 				Expect(err).ToNot(HaveOccurred())
 
 				key := client.ObjectKeyFromObject(invalidMcoKc)
@@ -170,8 +197,9 @@ var _ = Describe("Test KubeletConfig Reconcile", func() {
 
 			It("should ignore non-matching kubeketconfigs", func() {
 				ctrlPlaneKc := testobjs.NewKubeletConfigAutoresizeControlPlane()
-
-				reconciler, err := NewFakeKubeletConfigReconciler(nro, mcp1, mcoKc1, ctrlPlaneKc)
+				// adding a CM for when this test emulates HyperShift platform
+				ctrlPlaneCmKc := testobjs.NewKubeletConfigConfigMap(ctrlPlaneKc.Name, label1, ctrlPlaneKc)
+				reconciler, err := newFakeReconciler(nro, mcp1, mcoKc1, ctrlPlaneKc, ctrlPlaneCmKc)
 				Expect(err).ToNot(HaveOccurred())
 
 				key := client.ObjectKeyFromObject(ctrlPlaneKc)
@@ -188,16 +216,20 @@ var _ = Describe("Test KubeletConfig Reconcile", func() {
 			})
 
 			It("should process matching kubeletconfig, then ignore non-matching kubeketconfig", func() {
-				reconciler, err := NewFakeKubeletConfigReconciler(nro, mcp1)
+				reconciler, err := newFakeReconciler(nro, mcp1)
 				Expect(err).ToNot(HaveOccurred())
 
 				fakeRecorder, ok := reconciler.Recorder.(*record.FakeRecorder)
 				Expect(ok).To(BeTrue())
 
-				err = reconciler.Client.Create(context.TODO(), mcoKc1)
+				var reconciledObj client.Object
+				reconciledObj = mcoKc1
+				if clusterPlatform == platform.HyperShift {
+					reconciledObj = cmKc1
+				}
+				err = reconciler.Client.Create(context.TODO(), reconciledObj)
 				Expect(err).ToNot(HaveOccurred())
 
-				key := client.ObjectKeyFromObject(mcoKc1)
 				result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{}))
@@ -205,16 +237,21 @@ var _ = Describe("Test KubeletConfig Reconcile", func() {
 				cm := &corev1.ConfigMap{}
 				key = client.ObjectKey{
 					Namespace: testNamespace,
-					Name:      objectnames.GetComponentName(nro.Name, mcp1.Name),
+					Name:      objectnames.GetComponentName(nro.Name, poolName),
 				}
 				Expect(reconciler.Client.Get(context.TODO(), key, cm)).ToNot(HaveOccurred())
 				// verify creation event
 				event := <-fakeRecorder.Events
 				Expect(event).To(ContainSubstring("ProcessOK"))
-				Expect(event).To(ContainSubstring(mcoKc1.Name))
+				Expect(event).To(ContainSubstring(reconciledObj.GetName()))
 
 				ctrlPlaneKc := testobjs.NewKubeletConfigAutoresizeControlPlane()
 				err = reconciler.Client.Create(context.TODO(), ctrlPlaneKc)
+				Expect(err).ToNot(HaveOccurred())
+
+				// adding a CM for when this test emulates HyperShift platform
+				ctrlPlaneCmKc := testobjs.NewKubeletConfigConfigMap(ctrlPlaneKc.Name, label1, ctrlPlaneKc)
+				err = reconciler.Client.Create(context.TODO(), ctrlPlaneCmKc)
 				Expect(err).ToNot(HaveOccurred())
 
 				key = client.ObjectKeyFromObject(ctrlPlaneKc)
@@ -228,5 +265,8 @@ var _ = Describe("Test KubeletConfig Reconcile", func() {
 				Expect(event).To(ContainSubstring(ctrlPlaneKc.Name))
 			})
 		})
-	})
+	},
+		Entry("OpenShift Platform", NewFakeKubeletConfigReconciler, platform.OpenShift),
+		Entry("HyperShift Platform", NewFakeKubeletConfigReconcilerForHyperShift, platform.HyperShift),
+	)
 })

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -560,7 +560,11 @@ func (r *NUMAResourcesOperatorReconciler) SetupWithManager(mgr ctrl.Manager) err
 
 	b := ctrl.NewControllerManagedBy(mgr).For(&nropv1.NUMAResourcesOperator{})
 	if r.Platform == platform.OpenShift {
-		b = b.Owns(&securityv1.SecurityContextConstraints{}).
+		b.Watches(
+			&machineconfigv1.MachineConfigPool{},
+			handler.EnqueueRequestsFromMapFunc(r.mcpToNUMAResourceOperator),
+			builder.WithPredicates(mcpPredicates)).
+			Owns(&securityv1.SecurityContextConstraints{}).
 			Owns(&machineconfigv1.MachineConfig{}, builder.WithPredicates(p))
 	}
 	return b.Owns(&apiextensionv1.CustomResourceDefinition{}).
@@ -568,10 +572,6 @@ func (r *NUMAResourcesOperatorReconciler) SetupWithManager(mgr ctrl.Manager) err
 		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(p)).
 		Owns(&rbacv1.Role{}, builder.WithPredicates(p)).
 		Owns(&appsv1.DaemonSet{}, builder.WithPredicates(p)).
-		Watches(
-			&machineconfigv1.MachineConfigPool{},
-			handler.EnqueueRequestsFromMapFunc(r.mcpToNUMAResourceOperator),
-			builder.WithPredicates(mcpPredicates)).
 		Complete(r)
 }
 

--- a/controllers/numaresourcesoperator_controller_test.go
+++ b/controllers/numaresourcesoperator_controller_test.go
@@ -65,7 +65,6 @@ func NewFakeNUMAResourcesOperatorReconciler(plat platform.Platform, platVersion 
 	if err != nil {
 		return nil, err
 	}
-
 	rteManifests, err := rtemanifests.GetManifests(plat, platVersion, testNamespace, false, true)
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -274,7 +274,7 @@ func main() {
 		Recorder:  mgr.GetEventRecorderFor("kubeletconfig-controller"),
 		Namespace: namespace,
 		Platform:  clusterPlatform,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, clusterPlatform); err != nil {
 		klog.ErrorS(err, "unable to create controller", "controller", "KubeletConfig")
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -273,6 +273,7 @@ func main() {
 		Scheme:    mgr.GetScheme(),
 		Recorder:  mgr.GetEventRecorderFor("kubeletconfig-controller"),
 		Namespace: namespace,
+		Platform:  clusterPlatform,
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create controller", "controller", "KubeletConfig")
 		os.Exit(1)


### PR DESCRIPTION
Kubelet controller is responsible for extracting the TM configuration from the 
`KubeletConfig` object, craft a `ConfigMap` from it so it could be consumed later on
by the RTE workload.

On HyperShift there's no plain `KubeletConfig` object but a `ConfigMap` that encapsulate it instead,

This PR contains all the changes that were needed for the controller to be able to provide
similar functionality when it's running on HyperShift platform.

- [x] Unit tests
- [x] Integration tests
- [ ] E2e tests