### PR TITLE
gh actions: bump more action versions

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up golang
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: 1.22.4
 

--- a/.github/workflows/ciformat.yml
+++ b/.github/workflows/ciformat.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up golang
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: 1.22.4
 

--- a/.github/workflows/cilint-custom.yml
+++ b/.github/workflows/cilint-custom.yml
@@ -17,10 +17,10 @@ jobs:
       GOLANGCI_LINT_VERSION: "1.41.1"
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up golang
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: 1.22.4
 

--- a/.github/workflows/cilint.yml
+++ b/.github/workflows/cilint.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up golang
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: 1.22.4
 

--- a/.github/workflows/civerify-commit.yml
+++ b/.github/workflows/civerify-commit.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.22.4
 

--- a/.github/workflows/e2e-local.yaml
+++ b/.github/workflows/e2e-local.yaml
@@ -21,12 +21,12 @@ jobs:
       LOG_DIR: /tmp/test_e2e_logs
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0 # Fetch all history for all tags and branches
 
     - name: Set up golang
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: 1.22.4
 

--- a/.github/workflows/e2e-tools.yml
+++ b/.github/workflows/e2e-tools.yml
@@ -21,12 +21,12 @@ jobs:
       LOG_DIR: /tmp/test_e2e_logs
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0 # Fetch all history for all tags and branches
 
     - name: Set up golang
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: 1.22.4
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,12 +20,12 @@ jobs:
       LOG_DIR: /tmp/test_e2e_logs
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0 # Fetch all history for all tags and branches
 
     - name: Set up golang
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: 1.22.4
 

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up golang
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: 1.22.4
 

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         id: go
         with:
           go-version: 1.22.4

--- a/.github/workflows/release-testsuite.yaml
+++ b/.github/workflows/release-testsuite.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/support-tools.yml
+++ b/.github/workflows/support-tools.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: setup golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         id: go
         with:
           go-version: 1.22.4


### PR DESCRIPTION
bump to v4:
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/