### PR TITLE
ctrl: HCP adaptations for NodeGroup validation and RTE

### DIFF
--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -146,19 +146,22 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 		return r.degradeStatus(ctx, instance, status.ConditionTypeIncorrectNUMAResourcesOperatorResourceName, err)
 	}
 
-	if err := validation.NodeGroups(instance.Spec.NodeGroups); err != nil {
+	if err := validation.NodeGroups(instance.Spec.NodeGroups, r.Platform); err != nil {
 		return r.degradeStatus(ctx, instance, validation.NodeGroupsError, err)
 	}
 
-	trees, err := getTreesByNodeGroup(ctx, r.Client, instance.Spec.NodeGroups)
+	trees, err := getTreesByNodeGroup(ctx, r.Client, instance.Spec.NodeGroups, r.Platform)
 	if err != nil {
 		return r.degradeStatus(ctx, instance, validation.NodeGroupsError, err)
 	}
 
-	multiMCPsErr := validation.MultipleMCPsPerTree(instance.Annotations, trees)
+	var multiMCPsErr error
+	if r.Platform == platform.OpenShift {
+		multiMCPsErr = validation.MultipleMCPsPerTree(instance.Annotations, trees)
 
-	if err := validation.MachineConfigPoolDuplicates(trees); err != nil {
-		return r.degradeStatus(ctx, instance, validation.NodeGroupsError, err)
+		if err := validation.MachineConfigPoolDuplicates(trees); err != nil {
+			return r.degradeStatus(ctx, instance, validation.NodeGroupsError, err)
+		}
 	}
 
 	for idx := range trees {
@@ -258,19 +261,20 @@ func (r *NUMAResourcesOperatorReconciler) reconcileResourceMachineConfig(ctx con
 }
 
 func (r *NUMAResourcesOperatorReconciler) reconcileResourceDaemonSet(ctx context.Context, instance *nropv1.NUMAResourcesOperator, trees []nodegroupv1.Tree) ([]poolDaemonSet, intreconcile.Step) {
-	daemonSetsInfoPerMCP, err := r.syncNUMAResourcesOperatorResources(ctx, instance, trees)
+	daemonSetsInfoPerPool, err := r.syncNUMAResourcesOperatorResources(ctx, instance, trees)
 	if err != nil {
 		r.Recorder.Eventf(instance, corev1.EventTypeWarning, "FailedRTECreate", "Failed to create Resource-Topology-Exporter DaemonSets: %v", err)
 		err = fmt.Errorf("FailedRTESync: %w", err)
 		return nil, intreconcile.StepFailed(err)
 	}
-	if len(daemonSetsInfoPerMCP) == 0 {
+
+	if len(daemonSetsInfoPerPool) == 0 {
 		return nil, intreconcile.StepSuccess()
 	}
 
 	r.Recorder.Eventf(instance, corev1.EventTypeNormal, "SuccessfulRTECreate", "Created Resource-Topology-Exporter DaemonSets")
 
-	dssWithReadyStatus, allDSsUpdated, err := r.syncDaemonSetsStatuses(ctx, r.Client, daemonSetsInfoPerMCP)
+	dssWithReadyStatus, allDSsUpdated, err := r.syncDaemonSetsStatuses(ctx, r.Client, daemonSetsInfoPerPool)
 	instance.Status.DaemonSets = dssWithReadyStatus
 	instance.Status.RelatedObjects = relatedobjects.ResourceTopologyExporter(r.Namespace, dssWithReadyStatus)
 	if err != nil {
@@ -280,7 +284,7 @@ func (r *NUMAResourcesOperatorReconciler) reconcileResourceDaemonSet(ctx context
 		return nil, intreconcile.StepOngoing(5 * time.Second)
 	}
 
-	return daemonSetsInfoPerMCP, intreconcile.StepSuccess()
+	return daemonSetsInfoPerPool, intreconcile.StepSuccess()
 }
 
 func (r *NUMAResourcesOperatorReconciler) reconcileResource(ctx context.Context, instance *nropv1.NUMAResourcesOperator, trees []nodegroupv1.Tree) intreconcile.Step {
@@ -296,7 +300,7 @@ func (r *NUMAResourcesOperatorReconciler) reconcileResource(ctx context.Context,
 		}
 	}
 
-	dsPerMCP, step := r.reconcileResourceDaemonSet(ctx, instance, trees)
+	dsPerPool, step := r.reconcileResourceDaemonSet(ctx, instance, trees)
 	if step.EarlyStop() {
 		updateStatusConditionsIfNeeded(instance, step.ConditionInfo)
 		return step
@@ -304,7 +308,7 @@ func (r *NUMAResourcesOperatorReconciler) reconcileResource(ctx context.Context,
 
 	// all fields of NodeGroupStatus are required so publish the status only when all daemonset and MCPs are updated which
 	// is a certain thing if we got to this point otherwise the function would have returned already
-	instance.Status.NodeGroups = syncNodeGroupsStatus(instance, dsPerMCP)
+	instance.Status.NodeGroups = syncNodeGroupsStatus(instance, dsPerPool)
 
 	updateStatusConditionsIfNeeded(instance, conditioninfo.Available())
 	return intreconcile.Step{
@@ -489,44 +493,46 @@ func (r *NUMAResourcesOperatorReconciler) syncNUMAResourcesOperatorResources(ctx
 		klog.ErrorS(err, "failed to deleted unused daemonsets")
 	}
 
-	err = dangling.DeleteUnusedMachineConfigs(r.Client, ctx, instance, trees)
-	if err != nil {
-		klog.ErrorS(err, "failed to deleted unused machineconfigs")
+	if r.Platform == platform.OpenShift {
+		err = dangling.DeleteUnusedMachineConfigs(r.Client, ctx, instance, trees)
+		if err != nil {
+			klog.ErrorS(err, "failed to deleted unused machineconfigs")
+		}
 	}
 
 	// using a slice of poolDaemonSet instead of a map because Go maps assignment order is not consistent and non-deterministic
-	dsMCPPairs := []poolDaemonSet{}
+	dsPoolPairs := []poolDaemonSet{}
 	err = rteupdate.DaemonSetUserImageSettings(r.RTEManifests.DaemonSet, instance.Spec.ExporterImage, r.Images.Preferred(), r.ImagePullPolicy)
 	if err != nil {
-		return dsMCPPairs, err
+		return dsPoolPairs, err
 	}
 
 	err = rteupdate.DaemonSetPauseContainerSettings(r.RTEManifests.DaemonSet)
 	if err != nil {
-		return dsMCPPairs, err
+		return dsPoolPairs, err
 	}
 
 	err = loglevel.UpdatePodSpec(&r.RTEManifests.DaemonSet.Spec.Template.Spec, manifests.ContainerNameRTE, instance.Spec.LogLevel)
 	if err != nil {
-		return dsMCPPairs, err
+		return dsPoolPairs, err
 	}
 
 	// ConfigMap should be provided by the kubeletconfig reconciliation loop
 	if r.RTEManifests.ConfigMap != nil {
 		cmHash, err := hash.ComputeCurrentConfigMap(ctx, r.Client, r.RTEManifests.ConfigMap)
 		if err != nil {
-			return dsMCPPairs, err
+			return dsPoolPairs, err
 		}
 		rteupdate.DaemonSetHashAnnotation(r.RTEManifests.DaemonSet, cmHash)
 	}
 	rteupdate.SecurityContextConstraint(r.RTEManifests.SecurityContextConstraint, annotations.IsCustomPolicyEnabled(instance.Annotations))
 
-	processor := func(mcpName string, gdm *rtestate.GeneratedDesiredManifest) error {
-		err := daemonsetUpdater(mcpName, gdm)
+	processor := func(poolName string, gdm *rtestate.GeneratedDesiredManifest) error {
+		err := daemonsetUpdater(poolName, gdm)
 		if err != nil {
 			return err
 		}
-		dsMCPPairs = append(dsMCPPairs, poolDaemonSet{mcpName, nropv1.NamespacedNameFromObject(gdm.DaemonSet)})
+		dsPoolPairs = append(dsPoolPairs, poolDaemonSet{poolName, nropv1.NamespacedNameFromObject(gdm.DaemonSet)})
 		return nil
 	}
 
@@ -550,10 +556,10 @@ func (r *NUMAResourcesOperatorReconciler) syncNUMAResourcesOperatorResources(ctx
 			return nil, fmt.Errorf("failed to apply (%s) %s/%s: %w", objState.Desired.GetObjectKind().GroupVersionKind(), objState.Desired.GetNamespace(), objState.Desired.GetName(), err)
 		}
 	}
-	if len(dsMCPPairs) < len(trees) {
-		klog.Warningf("daemonset and tree size mismatch: expected %d got in daemonsets %d", len(trees), len(dsMCPPairs))
+	if len(dsPoolPairs) < len(trees) {
+		klog.Warningf("daemonset and tree size mismatch: expected %d got in daemonsets %d", len(trees), len(dsPoolPairs))
 	}
-	return dsMCPPairs, nil
+	return dsPoolPairs, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -693,12 +699,12 @@ func validateMachineConfigLabels(mc client.Object, trees []nodegroupv1.Tree) err
 	return nil
 }
 
-func daemonsetUpdater(mcpName string, gdm *rtestate.GeneratedDesiredManifest) error {
+func daemonsetUpdater(poolName string, gdm *rtestate.GeneratedDesiredManifest) error {
 	rteupdate.DaemonSetTolerations(gdm.DaemonSet, gdm.NodeGroup.Config.Tolerations)
 
 	err := rteupdate.DaemonSetArgs(gdm.DaemonSet, *gdm.NodeGroup.Config)
 	if err != nil {
-		klog.V(5).InfoS("DaemonSet update: cannot update arguments", "mcp", mcpName, "daemonset", gdm.DaemonSet.Name, "error", err)
+		klog.V(5).InfoS("DaemonSet update: cannot update arguments", "pool name", poolName, "daemonset", gdm.DaemonSet.Name, "error", err)
 		return err
 	}
 
@@ -707,15 +713,15 @@ func daemonsetUpdater(mcpName string, gdm *rtestate.GeneratedDesiredManifest) er
 	// We cannot do this at GetManifests time because we need to mount
 	// a specific configmap for each daemonset, whose name we know only
 	// when we instantiate the daemonset from the MCP.
-	if gdm.ClusterPlatform != platform.OpenShift {
-		klog.V(5).InfoS("DaemonSet update: unsupported platform", "mcp", mcpName, "platform", gdm.ClusterPlatform)
+	if gdm.ClusterPlatform != platform.OpenShift && gdm.ClusterPlatform != platform.HyperShift {
+		klog.V(5).InfoS("DaemonSet update: unsupported platform", "pool name", poolName, "platform", gdm.ClusterPlatform)
 		// nothing to do!
 		return nil
 	}
 	err = rteupdate.ContainerConfig(gdm.DaemonSet, gdm.DaemonSet.Name)
 	if err != nil {
 		// intentionally info because we want to keep going
-		klog.V(5).InfoS("DaemonSet update: cannot update config", "mcp", mcpName, "daemonset", gdm.DaemonSet.Name, "error", err)
+		klog.V(5).InfoS("DaemonSet update: cannot update config", "pool name", poolName, "daemonset", gdm.DaemonSet.Name, "error", err)
 		return err
 	}
 	if gdm.ClusterPlatform != platform.Kubernetes {
@@ -738,10 +744,17 @@ func isDaemonSetReady(ds *appsv1.DaemonSet) bool {
 	return ds.Status.DesiredNumberScheduled > 0 && ds.Status.DesiredNumberScheduled == ds.Status.NumberReady
 }
 
-func getTreesByNodeGroup(ctx context.Context, cli client.Client, nodeGroups []nropv1.NodeGroup) ([]nodegroupv1.Tree, error) {
-	mcps := &machineconfigv1.MachineConfigPoolList{}
-	if err := cli.List(ctx, mcps); err != nil {
-		return nil, err
+func getTreesByNodeGroup(ctx context.Context, cli client.Client, nodeGroups []nropv1.NodeGroup, platf platform.Platform) ([]nodegroupv1.Tree, error) {
+	switch platf {
+	case platform.OpenShift:
+		mcps := &machineconfigv1.MachineConfigPoolList{}
+		if err := cli.List(ctx, mcps); err != nil {
+			return nil, err
+		}
+		return nodegroupv1.FindTreesOpenshift(mcps, nodeGroups)
+	case platform.HyperShift:
+		return nodegroupv1.FindTreesHypershift(nodeGroups), nil
+	default:
+		return nil, fmt.Errorf("unsupported platform")
 	}
-	return nodegroupv1.FindTrees(mcps, nodeGroups)
 }

--- a/pkg/objectstate/rte/rte.go
+++ b/pkg/objectstate/rte/rte.go
@@ -40,8 +40,11 @@ import (
 	"github.com/openshift-kni/numaresources-operator/pkg/objectstate/merge"
 )
 
-// MachineConfigLabelKey contains the key of generated label for machine config
-const MachineConfigLabelKey = "machineconfiguration.openshift.io/role"
+const (
+	// MachineConfigLabelKey contains the key of generated label for machine config
+	MachineConfigLabelKey   = "machineconfiguration.openshift.io/role"
+	HyperShiftNodePoolLabel = "hypershift.openshift.io/nodePool"
+)
 
 type daemonSetManifest struct {
 	daemonSet      *appsv1.DaemonSet
@@ -257,11 +260,64 @@ func (em *ExistingManifests) State(mf rtemanifests.Manifests, updater GenerateDe
 	}
 
 	for _, tree := range em.trees {
-		for _, mcp := range tree.MachineConfigPools {
+		if em.plat == platform.OpenShift {
+			for _, mcp := range tree.MachineConfigPools {
+				var existingDs client.Object
+				var loadError error
+
+				generatedName := objectnames.GetComponentName(em.instance.Name, mcp.Name)
+				existingDaemonSet, ok := em.daemonSets[generatedName]
+				if ok {
+					existingDs = existingDaemonSet.daemonSet
+					loadError = existingDaemonSet.daemonSetError
+				} else {
+					loadError = fmt.Errorf("failed to find daemon set %s/%s", mf.DaemonSet.Namespace, mf.DaemonSet.Name)
+				}
+
+				desiredDaemonSet := mf.DaemonSet.DeepCopy()
+				desiredDaemonSet.Name = generatedName
+
+				var updateError error
+				if mcp.Spec.NodeSelector != nil {
+					desiredDaemonSet.Spec.Template.Spec.NodeSelector = mcp.Spec.NodeSelector.MatchLabels
+				} else {
+					updateError = fmt.Errorf("the machine config pool %q does not have node selector", mcp.Name)
+				}
+
+				if updater != nil {
+					gdm := GeneratedDesiredManifest{
+						ClusterPlatform:       em.plat,
+						MachineConfigPool:     mcp.DeepCopy(),
+						NodeGroup:             tree.NodeGroup.DeepCopy(),
+						DaemonSet:             desiredDaemonSet,
+						IsCustomPolicyEnabled: isCustomPolicyEnabled,
+					}
+
+					err := updater(mcp.Name, &gdm)
+					if err != nil {
+						updateError = fmt.Errorf("daemonset for MCP %q: update failed: %w", mcp.Name, err)
+					}
+				}
+
+				ret = append(ret,
+					objectstate.ObjectState{
+						Existing:    existingDs,
+						Error:       loadError,
+						UpdateError: updateError,
+						Desired:     desiredDaemonSet,
+						Compare:     compare.Object,
+						Merge:       merge.ObjectForUpdate,
+					},
+				)
+			}
+		}
+		if em.plat == platform.HyperShift {
 			var existingDs client.Object
 			var loadError error
 
-			generatedName := objectnames.GetComponentName(em.instance.Name, mcp.Name)
+			poolName := *tree.NodeGroup.PoolName
+
+			generatedName := objectnames.GetComponentName(em.instance.Name, poolName)
 			existingDaemonSet, ok := em.daemonSets[generatedName]
 			if ok {
 				existingDs = existingDaemonSet.daemonSet
@@ -274,24 +330,22 @@ func (em *ExistingManifests) State(mf rtemanifests.Manifests, updater GenerateDe
 			desiredDaemonSet.Name = generatedName
 
 			var updateError error
-			if mcp.Spec.NodeSelector != nil {
-				desiredDaemonSet.Spec.Template.Spec.NodeSelector = mcp.Spec.NodeSelector.MatchLabels
-			} else {
-				updateError = fmt.Errorf("the machine config pool %q does not have node selector", mcp.Name)
+			desiredDaemonSet.Spec.Template.Spec.NodeSelector = map[string]string{
+				HyperShiftNodePoolLabel: poolName,
 			}
 
 			if updater != nil {
 				gdm := GeneratedDesiredManifest{
 					ClusterPlatform:       em.plat,
-					MachineConfigPool:     mcp.DeepCopy(),
+					MachineConfigPool:     nil,
 					NodeGroup:             tree.NodeGroup.DeepCopy(),
 					DaemonSet:             desiredDaemonSet,
 					IsCustomPolicyEnabled: isCustomPolicyEnabled,
 				}
 
-				err := updater(mcp.Name, &gdm)
+				err := updater(poolName, &gdm)
 				if err != nil {
-					updateError = fmt.Errorf("daemonset for MCP %q: update failed: %w", mcp.Name, err)
+					updateError = fmt.Errorf("daemonset for pool %q: update failed: %w", poolName, err)
 				}
 			}
 
@@ -358,8 +412,35 @@ func FromClient(ctx context.Context, cli client.Client, plat platform.Platform, 
 
 	// should have the amount of resources equals to the amount of node groups
 	for _, tree := range trees {
-		for _, mcp := range tree.MachineConfigPools {
-			generatedName := objectnames.GetComponentName(instance.Name, mcp.Name)
+		if plat == platform.OpenShift {
+			for _, mcp := range tree.MachineConfigPools {
+				generatedName := objectnames.GetComponentName(instance.Name, mcp.Name)
+				key := client.ObjectKey{
+					Name:      generatedName,
+					Namespace: namespace,
+				}
+				ds := &appsv1.DaemonSet{}
+				dsm := daemonSetManifest{}
+				if dsm.daemonSetError = cli.Get(ctx, key, ds); dsm.daemonSetError == nil {
+					dsm.daemonSet = ds
+				}
+				ret.daemonSets[generatedName] = dsm
+
+				mcName := objectnames.GetMachineConfigName(instance.Name, mcp.Name)
+				mckey := client.ObjectKey{
+					Name: mcName,
+				}
+				mc := &machineconfigv1.MachineConfig{}
+				mcm := machineConfigManifest{}
+				if mcm.machineConfigError = cli.Get(ctx, mckey, mc); mcm.machineConfigError == nil {
+					mcm.machineConfig = mc
+				}
+				ret.machineConfigs[mcName] = mcm
+			}
+		}
+
+		if plat == platform.HyperShift {
+			generatedName := objectnames.GetComponentName(instance.Name, *tree.NodeGroup.PoolName)
 			key := client.ObjectKey{
 				Name:      generatedName,
 				Namespace: namespace,
@@ -370,19 +451,6 @@ func FromClient(ctx context.Context, cli client.Client, plat platform.Platform, 
 				dsm.daemonSet = ds
 			}
 			ret.daemonSets[generatedName] = dsm
-
-			if plat == platform.OpenShift {
-				mcName := objectnames.GetMachineConfigName(instance.Name, mcp.Name)
-				key := client.ObjectKey{
-					Name: mcName,
-				}
-				mc := &machineconfigv1.MachineConfig{}
-				mcm := machineConfigManifest{}
-				if mcm.machineConfigError = cli.Get(ctx, key, mc); mcm.machineConfigError == nil {
-					mcm.machineConfig = mc
-				}
-				ret.machineConfigs[mcName] = mcm
-			}
 		}
 	}
 

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -20,8 +20,10 @@ import (
 	"strings"
 	"testing"
 
-	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
 	nodegroupv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1/helper/nodegroup"
@@ -88,10 +90,13 @@ func TestNodeGroupsSanity(t *testing.T) {
 		nodeGroups           []nropv1.NodeGroup
 		expectedError        bool
 		expectedErrorMessage string
+		platf                platform.Platform
 	}
 
 	emptyString := ""
 	poolName := "poolname-test"
+	config := nropv1.DefaultNodeGroupConfig()
+
 	testCases := []testCase{
 		{
 			name: "both source pools are nil",
@@ -110,6 +115,7 @@ func TestNodeGroupsSanity(t *testing.T) {
 			},
 			expectedError:        true,
 			expectedErrorMessage: "missing any pool specifier",
+			platf:                platform.OpenShift,
 		},
 		{
 			name: "both source pools are set",
@@ -125,6 +131,7 @@ func TestNodeGroupsSanity(t *testing.T) {
 			},
 			expectedError:        true,
 			expectedErrorMessage: "must have only a single specifier set",
+			platf:                platform.OpenShift,
 		},
 		{
 			name: "with duplicates - mcp selector",
@@ -146,6 +153,7 @@ func TestNodeGroupsSanity(t *testing.T) {
 			},
 			expectedError:        true,
 			expectedErrorMessage: "has duplicates",
+			platf:                platform.OpenShift,
 		},
 		{
 			name: "with duplicates - pool name",
@@ -159,6 +167,7 @@ func TestNodeGroupsSanity(t *testing.T) {
 			},
 			expectedError:        true,
 			expectedErrorMessage: "has duplicates",
+			platf:                platform.OpenShift,
 		},
 		{
 			name: "bad MCP selector",
@@ -175,9 +184,9 @@ func TestNodeGroupsSanity(t *testing.T) {
 					},
 				},
 			},
-
 			expectedError:        true,
 			expectedErrorMessage: "not a valid label selector operator",
+			platf:                platform.OpenShift,
 		},
 		{
 			name: "correct values",
@@ -200,6 +209,34 @@ func TestNodeGroupsSanity(t *testing.T) {
 					PoolName: &poolName,
 				},
 			},
+			platf: platform.OpenShift,
+		},
+		{
+			name: "MCP selector set on Hypershift platform",
+			nodeGroups: []nropv1.NodeGroup{
+				{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"test": "test",
+						},
+					},
+					PoolName: &poolName,
+				},
+			},
+			expectedError:        true,
+			expectedErrorMessage: "MachineConfigPoolSelector on Hypershift platform",
+			platf:                platform.HyperShift,
+		},
+		{
+			name: "empty PoolName on Hypershift platform",
+			nodeGroups: []nropv1.NodeGroup{
+				{
+					Config: &config,
+				},
+			},
+			expectedError:        true,
+			expectedErrorMessage: "must specify PoolName on Hypershift platform",
+			platf:                platform.HyperShift,
 		},
 		{
 			name: "empty pool name",
@@ -215,7 +252,7 @@ func TestNodeGroupsSanity(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := NodeGroups(tc.nodeGroups)
+			err := NodeGroups(tc.nodeGroups, tc.platf)
 			if err == nil && tc.expectedError {
 				t.Errorf("expected error, succeeded")
 			}


### PR DESCRIPTION
Adapt the possibility of running the operator on Hypershift platform by
replacing MCP context with PoolName where relevant; In addition to extra
NodeGroup validation on hypershift.