### PR TITLE
pkg: use `errors.Join` instead of appending to slice

### DIFF
--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -449,17 +449,16 @@ func (r *NUMAResourcesOperatorReconciler) syncNUMAResourcesOperatorResources(ctx
 	klog.V(4).InfoS("RTESync start", "trees", len(trees))
 	defer klog.V(4).Info("RTESync stop")
 
-	errorList := dangling.DeleteUnusedDaemonSets(r.Client, ctx, instance, trees)
-	if len(errorList) > 0 {
-		klog.ErrorS(fmt.Errorf("failed to delete unused daemonsets"), "errors", errorList)
+	err := dangling.DeleteUnusedDaemonSets(r.Client, ctx, instance, trees)
+	if err != nil {
+		klog.ErrorS(err, "failed to deleted unused daemonsets")
 	}
 
-	errorList = dangling.DeleteUnusedMachineConfigs(r.Client, ctx, instance, trees)
-	if len(errorList) > 0 {
-		klog.ErrorS(fmt.Errorf("failed to delete unused machineconfigs"), "errors", errorList)
+	err = dangling.DeleteUnusedMachineConfigs(r.Client, ctx, instance, trees)
+	if err != nil {
+		klog.ErrorS(err, "failed to deleted unused machineconfigs")
 	}
 
-	var err error
 	// using a slice of poolDaemonSet instead of a map because Go maps assignment order is not consistent and non-deterministic
 	dsMCPPairs := []poolDaemonSet{}
 	err = rteupdate.DaemonSetUserImageSettings(r.RTEManifests.DaemonSet, instance.Spec.ExporterImage, r.Images.Preferred(), r.ImagePullPolicy)

--- a/internal/dangling/dangling.go
+++ b/internal/dangling/dangling.go
@@ -24,6 +24,7 @@ package dangling
 
 import (
 	"context"
+	"errors"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,14 +40,14 @@ import (
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
 )
 
-func DeleteUnusedDaemonSets(cli client.Client, ctx context.Context, instance *nropv1.NUMAResourcesOperator, trees []nodegroupv1.Tree) []error {
+func DeleteUnusedDaemonSets(cli client.Client, ctx context.Context, instance *nropv1.NUMAResourcesOperator, trees []nodegroupv1.Tree) error {
 	klog.V(3).Info("Delete dangling Daemonsets start")
 	defer klog.V(3).Info("Delete dangling Daemonsets end")
-	var errors []error
+
 	var daemonSetList appsv1.DaemonSetList
 	if err := cli.List(ctx, &daemonSetList, &client.ListOptions{Namespace: instance.Namespace}); err != nil {
 		klog.ErrorS(err, "error while getting Daemonset list")
-		return append(errors, err)
+		return err
 	}
 
 	expectedDaemonSetNames := sets.NewString()
@@ -56,6 +57,7 @@ func DeleteUnusedDaemonSets(cli client.Client, ctx context.Context, instance *nr
 		}
 	}
 
+	var errs error
 	deleted := 0
 	for _, ds := range daemonSetList.Items {
 		if !isOwnedBy(ds.GetObjectMeta(), instance) {
@@ -66,7 +68,7 @@ func DeleteUnusedDaemonSets(cli client.Client, ctx context.Context, instance *nr
 		}
 		if err := cli.Delete(ctx, &ds); err != nil {
 			klog.ErrorS(err, "error while deleting dangling daemonset", "DaemonSet", ds.Namespace+"/"+ds.Name)
-			errors = append(errors, err)
+			errs = errors.Join(errs, err)
 			continue
 		}
 		klog.V(3).InfoS("dangling Daemonset deleted", "name", ds.Name)
@@ -75,17 +77,16 @@ func DeleteUnusedDaemonSets(cli client.Client, ctx context.Context, instance *nr
 	if deleted > 0 {
 		klog.V(2).InfoS("Delete dangling Daemonsets", "deletedCount", deleted)
 	}
-	return errors
+	return errs
 }
 
-func DeleteUnusedMachineConfigs(cli client.Client, ctx context.Context, instance *nropv1.NUMAResourcesOperator, trees []nodegroupv1.Tree) []error {
+func DeleteUnusedMachineConfigs(cli client.Client, ctx context.Context, instance *nropv1.NUMAResourcesOperator, trees []nodegroupv1.Tree) error {
 	klog.V(3).Info("Delete dangling Machineconfigs start")
 	defer klog.V(3).Info("Delete dangling Machineconfigs end")
-	var errors []error
 	var machineConfigList machineconfigv1.MachineConfigList
 	if err := cli.List(ctx, &machineConfigList); err != nil {
 		klog.ErrorS(err, "error while getting MachineConfig list")
-		return append(errors, err)
+		return err
 	}
 
 	expectedMachineConfigNames := sets.NewString()
@@ -95,6 +96,7 @@ func DeleteUnusedMachineConfigs(cli client.Client, ctx context.Context, instance
 		}
 	}
 
+	var errs error
 	deleted := 0
 	for _, mc := range machineConfigList.Items {
 		if !isOwnedBy(mc.GetObjectMeta(), instance) {
@@ -105,7 +107,7 @@ func DeleteUnusedMachineConfigs(cli client.Client, ctx context.Context, instance
 		}
 		if err := cli.Delete(ctx, &mc); err != nil {
 			klog.ErrorS(err, "error while deleting dangling machineconfig", "MachineConfig", mc.Name)
-			errors = append(errors, err)
+			errs = errors.Join(errs, err)
 			continue
 		}
 		klog.V(3).InfoS("dangling Machineconfig deleted", "name", mc.Name)
@@ -114,7 +116,7 @@ func DeleteUnusedMachineConfigs(cli client.Client, ctx context.Context, instance
 	if deleted > 0 {
 		klog.V(2).InfoS("Delete dangling Machineconfigs", "deletedCount", deleted)
 	}
-	return errors
+	return errs
 }
 
 func isOwnedBy(element metav1.Object, owner metav1.Object) bool {


### PR DESCRIPTION
Instead of using a slice of error texts and converting it back to error
type or using a slice of errors, use the `errors` go library to `Join`
multiple errors into one.