### PR TITLE
CNF-11234: Enable RTE metrics to be scraped securely  by Prometheus

### DIFF
--- a/bundle/manifests/numaresources-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/numaresources-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: secret-kube-rbac-proxy-tls
+  creationTimestamp: null
+  labels:
+    control-plane: controller-manager
+  name: numaresources-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/bundle/manifests/numaresources-controller-manager_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/numaresources-controller-manager_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: numaresources-controller-manager
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    path: /metrics
+    scheme: https
+    targetPort: 8443
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      insecureSkipVerify: false
+      serverName: numaresources-controller-manager-metrics-service.numaresources.svc
+  selector:
+    matchLabels:
+      control-plane: controller-manager

--- a/bundle/manifests/numaresources-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/numaresources-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: numaresources-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -62,7 +62,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-09-25T14:08:22Z"
+    createdAt: "2024-10-06T18:15:59Z"
     olm.skipRange: '>=4.17.0 <4.18.0'
     operators.operatorframework.io/builder: operator-sdk-v1.36.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -343,6 +343,7 @@ spec:
           resources:
           - configmaps
           - serviceaccounts
+          - services
           verbs:
           - '*'
         - apiGroups:

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -465,6 +465,18 @@ spec:
           - get
           - list
           - update
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
         serviceAccountName: numaresources-controller-manager
       deployments:
       - label:
@@ -528,6 +540,35 @@ spec:
                     memory: 20Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --config-file=/etc/kube-rbac-proxy/config.yaml
+                - --tls-cert-file=/etc/tls/private/tls.crt
+                - --tls-private-key-file=/etc/tls/private/tls.key
+                - --allow-paths=/metrics
+                - --logtostderr=true
+                - -v=10
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources: {}
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                terminationMessagePolicy: FallbackToLogsOnError
+                volumeMounts:
+                - mountPath: /etc/kube-rbac-proxy
+                  name: secret-kube-rbac-proxy-metric
+                  readOnly: true
+                - mountPath: /etc/tls/private
+                  name: secret-kube-rbac-proxy-tls
+                  readOnly: true
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: numaresources-controller-manager
@@ -537,6 +578,13 @@ spec:
                 key: node-role.kubernetes.io/control-plane
               - effect: NoSchedule
                 key: node-role.kubernetes.io/master
+              volumes:
+              - name: secret-kube-rbac-proxy-tls
+                secret:
+                  secretName: secret-kube-rbac-proxy-tls
+              - name: secret-kube-rbac-proxy-metric
+                secret:
+                  secretName: numaresources-secret-kube-rbac-proxy-metric
       permissions:
       - rules:
         - apiGroups:

--- a/bundle/manifests/numaresources-prometheus-k8s_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/numaresources-prometheus-k8s_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: numaresources-prometheus-k8s
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/bundle/manifests/numaresources-prometheus-k8s_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/numaresources-prometheus-k8s_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: numaresources-prometheus-k8s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: numaresources-prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/bundle/manifests/numaresources-secret-kube-rbac-proxy-metric_v1_secret.yaml
+++ b/bundle/manifests/numaresources-secret-kube-rbac-proxy-metric_v1_secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: numaresources-secret-kube-rbac-proxy-metric
+stringData:
+  config.yaml: "\"authorization\":\n  \"static\":\n  - \"path\": \"/metrics\"\n    \"resourceRequest\":
+    false\n    \"user\":\n      \"name\": \"system:serviceaccount:openshift-monitoring:prometheus-k8s\"\n
+    \   \"verb\": \"get\"    "
+type: Opaque

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -22,13 +22,13 @@ resources:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+- ../prometheus
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-#- manager_auth_proxy_patch.yaml
+- manager_auth_proxy_patch.yaml
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -9,20 +9,41 @@ spec:
   template:
     spec:
       containers:
+      - name: manager
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
+        - "--config-file=/etc/kube-rbac-proxy/config.yaml"
+        - "--tls-cert-file=/etc/tls/private/tls.crt"
+        - "--tls-private-key-file=/etc/tls/private/tls.key"
+        - "--allow-paths=/metrics"
         - "--logtostderr=true"
         - "-v=10"
         ports:
         - containerPort: 8443
           protocol: TCP
           name: https
-      - name: manager
-        args:
-        - "--platform=kubernetes"
-        - "--health-probe-bind-address=:8081"
-        - "--metrics-bind-address=127.0.0.1:8080"
-        - "--leader-elect"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/kube-rbac-proxy
+          name: secret-kube-rbac-proxy-metric
+          readOnly: true
+        - mountPath: /etc/tls/private
+          name: secret-kube-rbac-proxy-tls
+          readOnly: true
+      serviceAccountName: controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: secret-kube-rbac-proxy-tls
+        secret:
+          secretName: secret-kube-rbac-proxy-tls
+      - name: secret-kube-rbac-proxy-metric
+        secret:
+          secretName: secret-kube-rbac-proxy-metric

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -5,6 +5,7 @@ metadata:
     workload.openshift.io/allowed: management
   labels:
     control-plane: controller-manager
+    openshift.io/cluster-monitoring: "true"
   name: system
 ---
 apiVersion: apps/v1

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,2 +1,5 @@
 resources:
-- monitor.yaml
+- rbac.yaml
+- secret-kube-rbac-proxy.yaml
+# Please uncomment monitor.yaml to enable prometheus pods to scrape the metrics periodically.
+# - monitor.yaml

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -1,20 +1,24 @@
 
-# Prometheus Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  labels:
-    control-plane: controller-manager
-  name: controller-manager-metrics-monitor
+  name: controller-manager
   namespace: system
 spec:
   endpoints:
-    - path: /metrics
-      port: https
-      scheme: https
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      tlsConfig:
-        insecureSkipVerify: true
+  - interval: 30s
+    # Matches the name of the service's port.
+    targetPort: 8443
+    path: /metrics
+    scheme: https
+    bearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    tlsConfig:
+      # The CA file used by Prometheus to verify the server's certificate.
+      # It's the cluster's CA bundle from the service CA operator.
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      # The name of the server (CN) in the server's certificate.
+      serverName: numaresources-controller-manager-metrics-service.numaresources.svc
+      insecureSkipVerify: false
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/config/prometheus/rbac.yaml
+++ b/config/prometheus/rbac.yaml
@@ -1,0 +1,31 @@
+# creates Role and RoleBinding for prometheus-k8s service account to access our namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/config/prometheus/secret-kube-rbac-proxy.yaml
+++ b/config/prometheus/secret-kube-rbac-proxy.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-kube-rbac-proxy-metric
+  namespace: system
+stringData:
+  config.yaml: |-
+    "authorization":
+      "static":
+      - "path": "/metrics"
+        "resourceRequest": false
+        "user":
+          "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
+        "verb": "get"    
+type: Opaque

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: secret-kube-rbac-proxy-tls
   labels:
     control-plane: controller-manager
   name: controller-manager-metrics-service

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-#- auth_proxy_service.yaml
-#- auth_proxy_role.yaml
-#- auth_proxy_role_binding.yaml
-#- auth_proxy_client_clusterrole.yaml
+- auth_proxy_service.yaml
+- auth_proxy_role.yaml
+- auth_proxy_role_binding.yaml
+- auth_proxy_client_clusterrole.yaml

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - configmaps
   - serviceaccounts
+  - services
   verbs:
   - '*'
 - apiGroups:
@@ -26,18 +27,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - '*'
 - apiGroups:
   - apiextensions.k8s.io
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -27,6 +27,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - '*'
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -750,6 +750,8 @@ func daemonsetUpdater(mcpName string, gdm *rtestate.GeneratedDesiredManifest) er
 		// nothing to do!
 		return nil
 	}
+	rteupdate.SidecarContainerConfig(gdm.DaemonSet)
+	klog.V(5).Info("DaemonSet update: Added daemonset sidecar")
 	err = rteupdate.ContainerConfig(gdm.DaemonSet, gdm.DaemonSet.Name)
 	if err != nil {
 		// intentionally info because we want to keep going

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -57,6 +57,7 @@ import (
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	"github.com/openshift-kni/numaresources-operator/pkg/images"
 	"github.com/openshift-kni/numaresources-operator/pkg/loglevel"
+	rtemetricsmanifests "github.com/openshift-kni/numaresources-operator/pkg/metrics/manifests/monitor"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
 	apistate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/api"
 	rtestate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/rte"
@@ -70,15 +71,16 @@ const numaResourcesRetryPeriod = 1 * time.Minute
 // NUMAResourcesOperatorReconciler reconciles a NUMAResourcesOperator object
 type NUMAResourcesOperatorReconciler struct {
 	client.Client
-	Scheme          *runtime.Scheme
-	Platform        platform.Platform
-	APIManifests    apimanifests.Manifests
-	RTEManifests    rtemanifests.Manifests
-	Namespace       string
-	Images          images.Data
-	ImagePullPolicy corev1.PullPolicy
-	Recorder        record.EventRecorder
-	ForwardMCPConds bool
+	Scheme              *runtime.Scheme
+	Platform            platform.Platform
+	APIManifests        apimanifests.Manifests
+	RTEManifests        rtemanifests.Manifests
+	RTEMetricsManifests rtemetricsmanifests.Manifests
+	Namespace           string
+	Images              images.Data
+	ImagePullPolicy     corev1.PullPolicy
+	Recorder            record.EventRecorder
+	ForwardMCPConds     bool
 }
 
 // TODO: narrow down

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -107,6 +107,7 @@ type NUMAResourcesOperatorReconciler struct {
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesoperators,verbs=*
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesoperators/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesoperators/finalizers,verbs=update
+//+kubebuilder:rbac:groups="",resources=services,verbs=*
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ import (
 	"github.com/openshift-kni/numaresources-operator/internal/api/features"
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	"github.com/openshift-kni/numaresources-operator/pkg/images"
+	rtemetricsmanifests "github.com/openshift-kni/numaresources-operator/pkg/metrics/manifests/monitor"
 	"github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/controlplane"
 	schedmanifests "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/manifests/sched"
 	rteupdate "github.com/openshift-kni/numaresources-operator/pkg/objectupdate/rte"
@@ -254,18 +255,24 @@ func main() {
 		klog.ErrorS(err, "unable to render RTE manifests", "controller", "NUMAResourcesOperator")
 		os.Exit(1)
 	}
+	rteMetricsManifests, err := rtemetricsmanifests.GetManifests(namespace)
+	if err != nil {
+		klog.ErrorS(err, "unable to load the RTE metrics manifests")
+		os.Exit(1)
+	}
 
 	if err = (&controllers.NUMAResourcesOperatorReconciler{
-		Client:          mgr.GetClient(),
-		Scheme:          mgr.GetScheme(),
-		Recorder:        mgr.GetEventRecorderFor("numaresources-controller"),
-		APIManifests:    apiManifests,
-		RTEManifests:    rteManifestsRendered,
-		Platform:        clusterPlatform,
-		Images:          imgs,
-		ImagePullPolicy: pullPolicy,
-		Namespace:       namespace,
-		ForwardMCPConds: params.enableMCPCondsForward,
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
+		Recorder:            mgr.GetEventRecorderFor("numaresources-controller"),
+		APIManifests:        apiManifests,
+		RTEManifests:        rteManifestsRendered,
+		RTEMetricsManifests: rteMetricsManifests,
+		Platform:            clusterPlatform,
+		Images:              imgs,
+		ImagePullPolicy:     pullPolicy,
+		Namespace:           namespace,
+		ForwardMCPConds:     params.enableMCPCondsForward,
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create controller", "controller", "NUMAResourcesOperator")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ const (
 const (
 	defaultWebhookPort = 9443
 	defaultMetricsAddr = ":8080"
+	defaultMetricsEnabled = true
 	defaultProbeAddr   = ":8081"
 	defaultNamespace   = "numaresources-operator"
 )
@@ -129,6 +130,7 @@ func (pa *Params) SetDefaults() {
 	pa.probeAddr = defaultProbeAddr
 	pa.render.Namespace = defaultNamespace
 	pa.enableReplicasDetect = true
+	pa.enableMetrics = defaultMetricsEnabled
 }
 
 func (pa *Params) FromFlags() {

--- a/main.go
+++ b/main.go
@@ -71,11 +71,11 @@ const (
 )
 
 const (
-	defaultWebhookPort = 9443
-	defaultMetricsAddr = ":8080"
+	defaultWebhookPort    = 9443
+	defaultMetricsAddr    = ":8080"
 	defaultMetricsEnabled = true
-	defaultProbeAddr   = ":8081"
-	defaultNamespace   = "numaresources-operator"
+	defaultProbeAddr      = ":8081"
+	defaultNamespace      = "numaresources-operator"
 )
 
 var (

--- a/pkg/images/fetch.go
+++ b/pkg/images/fetch.go
@@ -28,10 +28,11 @@ import (
 )
 
 const (
-	envVarPodNamespace = "NAMESPACE"
-	envVarPodName      = "PODNAME"
-	NullPolicy         = corev1.PullPolicy("")
-	NullImage          = ""
+	envVarPodNamespace         = "NAMESPACE"
+	envVarPodName              = "PODNAME"
+	NullPolicy                 = corev1.PullPolicy("")
+	NullImage                  = ""
+	kubeRbacProxyContainerName = "kube-rbac-proxy"
 )
 
 func GetCurrentImage(ctx context.Context) (string, corev1.PullPolicy, error) {
@@ -44,6 +45,19 @@ func GetCurrentImage(ctx context.Context) (string, corev1.PullPolicy, error) {
 		return NullImage, NullPolicy, fmt.Errorf("environment variable not set: %q", envVarPodName)
 	}
 	return GetImageFromPod(ctx, podNamespace, podName, "")
+}
+
+func GetKubeRbacProxyImage(ctx context.Context) (string, error) {
+	podNamespace, ok := os.LookupEnv(envVarPodNamespace)
+	if !ok {
+		return NullImage, fmt.Errorf("environment variable not set: %q", envVarPodNamespace)
+	}
+	podName, ok := os.LookupEnv(envVarPodName)
+	if !ok {
+		return NullImage, fmt.Errorf("environment variable not set: %q", envVarPodName)
+	}
+	img, _, err := GetImageFromPod(ctx, podNamespace, podName, kubeRbacProxyContainerName)
+	return img, err
 }
 
 func GetImageFromPod(ctx context.Context, namespace, podName, containerName string) (string, corev1.PullPolicy, error) {

--- a/pkg/metrics/manifests/manifests.go
+++ b/pkg/metrics/manifests/manifests.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manifests
+
+import (
+	"embed"
+	"fmt"
+	"path/filepath"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+//go:embed yaml
+var src embed.FS
+
+func Service(namespace string) (*corev1.Service, error) {
+	obj, err := loadObject(filepath.Join("yaml", "service.yaml"))
+	if err != nil {
+		return nil, err
+	}
+
+	service, ok := obj.(*corev1.Service)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type, got %t", obj)
+	}
+
+	if namespace != "" {
+		service.Namespace = namespace
+	}
+	return service, nil
+}
+
+func ClusterRoleBinding(namespace string) (*rbacv1.ClusterRoleBinding, error) {
+	return loadClusterRoleBinding("clusterrolebinding.yaml", namespace)
+}
+
+func loadClusterRoleBinding(crbName, namespace string) (*rbacv1.ClusterRoleBinding, error) {
+	obj, err := loadObject(filepath.Join("yaml", crbName))
+	if err != nil {
+		return nil, err
+	}
+
+	crb, ok := obj.(*rbacv1.ClusterRoleBinding)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type, got %t", obj)
+	}
+	for idx := 0; idx < len(crb.Subjects); idx++ {
+		crb.Subjects[idx].Namespace = namespace
+	}
+	return crb, nil
+}
+
+func deserializeObjectFromData(data []byte) (runtime.Object, error) {
+	decode := scheme.Codecs.UniversalDeserializer().Decode
+	obj, _, err := decode(data, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func loadObject(path string) (runtime.Object, error) {
+	data, err := src.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return deserializeObjectFromData(data)
+}

--- a/pkg/metrics/manifests/manifests_test.go
+++ b/pkg/metrics/manifests/manifests_test.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manifests
+
+import (
+	"testing"
+)
+
+func TestLoad(t *testing.T) {
+	if obj, err := Service(""); obj == nil || err != nil {
+		t.Errorf("Service() failed: err=%v", err)
+	}
+	if obj, err := ClusterRoleBinding(""); obj == nil || err != nil {
+		t.Errorf("ClusterRoleBinding() failed: err=%v", err)
+	}
+}

--- a/pkg/metrics/manifests/monitor/monitor.go
+++ b/pkg/metrics/manifests/monitor/monitor.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sched
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift-kni/numaresources-operator/pkg/metrics/manifests"
+)
+
+type Manifests struct {
+	Service            *corev1.Service
+	ClusterRoleBinding *rbacv1.ClusterRoleBinding
+}
+
+func (mf Manifests) ToObjects() []client.Object {
+	return []client.Object{
+		mf.Service,
+		mf.ClusterRoleBinding,
+	}
+}
+
+func (mf Manifests) Clone() Manifests {
+	return Manifests{
+		Service:            mf.Service.DeepCopy(),
+		ClusterRoleBinding: mf.ClusterRoleBinding.DeepCopy(),
+	}
+}
+
+func GetManifests(namespace string) (Manifests, error) {
+	var err error
+	mf := Manifests{}
+
+	mf.Service, err = manifests.Service(namespace)
+	if err != nil {
+		return mf, err
+	}
+
+	mf.ClusterRoleBinding, err = manifests.ClusterRoleBinding(namespace)
+	if err != nil {
+		return mf, err
+	}
+
+	return mf, nil
+}

--- a/pkg/metrics/manifests/monitor/monitor_test.go
+++ b/pkg/metrics/manifests/monitor/monitor_test.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sched
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetManifests(t *testing.T) {
+	mf, err := GetManifests("")
+	if err != nil {
+		t.Fatalf("GetManifests() failed: err=%v", err)
+	}
+
+	for _, obj := range mf.ToObjects() {
+		if obj == nil {
+			t.Fatalf("GetManifests(): loaded nil manifest")
+		}
+	}
+}
+
+func TestCloneManifests(t *testing.T) {
+	mf, err := GetManifests("")
+	if err != nil {
+		t.Fatalf("GetManifests() failed: err=%v", err)
+	}
+
+	mf2 := mf.Clone()
+	if !reflect.DeepEqual(mf, mf2) {
+		t.Fatalf("Clone() returned manifests failing DeepEqual")
+	}
+
+	for _, obj := range mf2.ToObjects() {
+		if obj == nil {
+			t.Fatalf("Clone(): produced nil manifest")
+		}
+	}
+}

--- a/pkg/metrics/manifests/yaml/clusterrolebinding.yaml
+++ b/pkg/metrics/manifests/yaml/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rte-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: numaresources-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: rte
+  namespace: numaresources

--- a/pkg/metrics/manifests/yaml/service.yaml
+++ b/pkg/metrics/manifests/yaml/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: rte-secret-kube-rbac-proxy-tls
+  labels:
+    name: resource-topology
+  name: rte-metrics-service
+  namespace: numaresources
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    name: resource-topology

--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -273,6 +273,13 @@ func SidecarContainerConfig(ds *appsv1.DaemonSet) {
 
 	// Add the sidecar container to the DaemonSet spec
 	ds.Spec.Template.Spec.Containers = append(ds.Spec.Template.Spec.Containers, sidecarContainer)
+
+	// Pull kube-rbac-proxy image from operator proxy.
+	if sidecarImage, err := images.GetKubeRbacProxyImage(context.TODO()); err != nil {
+		klog.InfoS("unable to find current image, using hardcoded", "error", err)
+	} else {
+		sidecarContainer.Image = sidecarImage
+	}
 }
 
 func AddVolumeMountMemory(podSpec *corev1.PodSpec, cnt *corev1.Container, mountName, dirName string, sizeMiB int64) {

--- a/rte/main.go
+++ b/rte/main.go
@@ -151,7 +151,7 @@ func parseArgs(args ...string) (ProgArgs, error) {
 	flags.StringVar(&pArgs.RTE.PodResourcesSocketPath, "podresources-socket", "unix:///podresources/kubelet.sock", "Pod Resource Socket path to use.")
 	flags.BoolVar(&pArgs.RTE.PodReadinessEnable, "podreadiness", true, "Custom condition injection using Podreadiness.")
 	flags.BoolVar(&pArgs.RTE.AddNRTOwnerEnable, "add-nrt-owner", true, "RTE will inject NRT's related node as OwnerReference to ensure cleanup if the node is deleted.")
-	flags.StringVar(&metricsMode, "metrics-mode", metricssrv.ServingDisabled, fmt.Sprintf("Select the mode to expose metrics endpoint. Valid options: %s", metricssrv.ServingModeSupported()))
+	flags.StringVar(&metricsMode, "metrics-mode", metricssrv.ServingHTTP, fmt.Sprintf("Select the mode to expose metrics endpoint. Valid options: %s", metricssrv.ServingModeSupported()))
 
 	refCnt := flags.String("reference-container", "", "Reference container, used to learn about the shared cpu pool\n See: https://github.com/kubernetes/kubernetes/issues/102190\n format of spec is namespace/podname/containername.\n Alternatively, you can use the env vars REFERENCE_NAMESPACE, REFERENCE_POD_NAME, REFERENCE_CONTAINER_NAME.")
 


### PR DESCRIPTION
This is a follow-up PR for [Enable NROP metrics to be to scraped securely by Prometheus ](https://github.com/openshift-kni/numaresources-operator/pull/1007).

This PR encompasses and integrates all the needed infrastructure to enable secured communication for scraping metrics by Prometheus, now for **RTE**.

A follow-up PR will be posted for e2e tests later.

 To validate that this PR is functioning correctly, please follow these steps:
1. build image of the operator (`make docker-build docker-push`)
2. run: `make deploy` 
3. Attach to one of the prometheus pods `oc exec -it prometheus-k8s-0 -n openshift-monitoring /bin/bash`
4. run:
  ```
 curl -v \
  --cacert /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt \
  -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
  https://rte-metrics-service.numaresources.svc:8443/metrics
```