### PR TITLE
rte: controller: push down machineconfig deletion support into library packages

### DIFF
--- a/pkg/objectstate/objectstate.go
+++ b/pkg/objectstate/objectstate.go
@@ -17,6 +17,8 @@
 package objectstate
 
 import (
+	"reflect"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,4 +38,15 @@ func (obst ObjectState) IsNotFoundError() bool {
 		return false
 	}
 	return apierrors.IsNotFound(obst.Error)
+}
+
+func (obst ObjectState) IsCreateOrUpdate() bool {
+	if obst.Desired == nil {
+		return false
+	}
+	// this should not be required, but removes a footgun
+	if vobj := reflect.ValueOf(obst.Desired); vobj.IsNil() {
+		return false
+	}
+	return true
 }

--- a/test/utils/deploy/deploy.go
+++ b/test/utils/deploy/deploy.go
@@ -19,11 +19,12 @@ package deploy
 import (
 	"context"
 	"fmt"
-	"github.com/openshift-kni/numaresources-operator/internal/api/annotations"
-	"golang.org/x/sync/errgroup"
 	"os"
 	"sync"
 	"time"
+
+	"github.com/openshift-kni/numaresources-operator/internal/api/annotations"
+	"golang.org/x/sync/errgroup"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
@@ -36,9 +37,9 @@ import (
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
-	"github.com/openshift-kni/numaresources-operator/controllers"
 	nropmcp "github.com/openshift-kni/numaresources-operator/internal/machineconfigpools"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
+	rtestate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/rte"
 	"github.com/openshift-kni/numaresources-operator/pkg/status"
 
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
@@ -217,7 +218,7 @@ func isMachineConfigPoolsUpdatedAfterDeletion(nro *nropv1.NUMAResourcesOperator)
 	}
 
 	for _, mcp := range mcps {
-		if !controllers.IsMachineConfigPoolUpdatedAfterDeletion(nro.Name, mcp) {
+		if !rtestate.IsMachineConfigPoolUpdatedAfterDeletion(nro.Name, mcp) {
 			return false, nil
 		}
 	}


### PR DESCRIPTION
Push down the logic to manage the deletion of machineconfig into library packages, streamlining the controller.

This PR is meant to do code movement and reorganize the packages, no intended changes in behavior