### PR TITLE
tree: stop using `errors.Wrapf`

### DIFF
--- a/controllers/kubeletconfig_controller.go
+++ b/controllers/kubeletconfig_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -36,8 +37,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
-
-	"github.com/pkg/errors"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
 	"github.com/openshift-kni/numaresources-operator/internal/machineconfigpools"
@@ -197,10 +196,10 @@ func (r *KubeletConfigReconciler) syncConfigMap(ctx context.Context, mcoKc *mcov
 		// the owner should be the KubeletConfig object and not the NUMAResourcesOperator CR
 		// this means that when KubeletConfig will get deleted, the ConfigMap gets deleted as well
 		if err := controllerutil.SetControllerReference(mcoKc, objState.Desired, r.Scheme); err != nil {
-			return nil, errors.Wrapf(err, "Failed to set controller reference to %s %s", objState.Desired.GetNamespace(), objState.Desired.GetName())
+			return nil, fmt.Errorf("failed to set controller reference to %s %s: %w", objState.Desired.GetNamespace(), objState.Desired.GetName(), err)
 		}
 		if _, _, err := apply.ApplyObject(ctx, r.Client, objState); err != nil {
-			return nil, errors.Wrapf(err, "could not create %s", objState.Desired.GetObjectKind().GroupVersionKind().String())
+			return nil, fmt.Errorf("could not create %s: %w", objState.Desired.GetObjectKind().GroupVersionKind().String(), err)
 		}
 	}
 	return rendered, nil

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/openshift/api v0.0.0-20240422085825-2624175e9673
 	github.com/openshift/cluster-node-tuning-operator v0.0.0-20240611064827-2bd8891ead93
 	github.com/openshift/machine-config-operator v0.0.1-0.20230724174830-7b54f1dcce4e
-	github.com/pkg/errors v0.9.1
 	github.com/sergi/go-diff v1.1.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/sync v0.7.0
@@ -82,6 +81,7 @@ require (
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/openshift/client-go v0.0.0-20240415214935-be70f772f157 // indirect
 	github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.19.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect

--- a/pkg/hash/configmap.go
+++ b/pkg/hash/configmap.go
@@ -25,8 +25,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/pkg/errors"
 )
 
 // hash package purpose is to compute a ConfigMap hash
@@ -45,7 +43,7 @@ func ComputeCurrentConfigMap(ctx context.Context, cli client.Client, cm *corev1.
 		if apierrors.IsNotFound(err) {
 			updatedConfigMap = cm
 		} else {
-			return "", errors.Wrapf(err, "could not calculate ConfigMap %q hash", key.String())
+			return "", fmt.Errorf("could not calculate ConfigMap %q hash: %w", key.String(), err)
 		}
 	}
 	cmHash := ConfigMapData(updatedConfigMap)


### PR DESCRIPTION
we can just use the `%w` format specifier in `fmt.Errorf` and in the stdlib in general. One less (direct) dependency, no expected changes in behavior, even though some error messages can have been slightly changed.