### PR TITLE
[release-4.17][manual] api: fix v1alpha1 backward compatibility

### DIFF
--- a/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_types.go
+++ b/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_types.go
@@ -43,21 +43,24 @@ type NUMAResourcesOperatorSpec struct {
 	PodExcludes []NamespacedName `json:"podExcludes,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=Enabled;Disabled
+// +kubebuilder:validation:Enum=Disabled;Enabled;EnabledExclusiveResources
 type PodsFingerprintingMode string
 
-var (
+const (
 	// PodsFingerprintingDisabled disables the pod fingerprinting reporting.
 	PodsFingerprintingDisabled PodsFingerprintingMode = "Disabled"
 
 	// PodsFingerprintingEnabled enables the pod fingerprint considering all the pods running on nodes. It is the default.
 	PodsFingerprintingEnabled PodsFingerprintingMode = "Enabled"
+
+	// PodsFingerprintingEnabledExclusiveResources enables the pod fingerprint considering only pods which have exclusive resources assigned.
+	PodsFingerprintingEnabledExclusiveResources PodsFingerprintingMode = "EnabledExclusiveResources"
 )
 
 // +kubebuilder:validation:Enum=Periodic;Events;PeriodicAndEvents
 type InfoRefreshMode string
 
-var (
+const (
 	// InfoRefreshPeriodic is the default. Periodically polls the state and reports it.
 	InfoRefreshPeriodic InfoRefreshMode = "Periodic"
 

--- a/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -512,8 +512,9 @@ spec:
                             should be reported for the machines belonging to this
                             group
                           enum:
-                          - Enabled
                           - Disabled
+                          - Enabled
+                          - EnabledExclusiveResources
                           type: string
                       type: object
                     disablePodsFingerprinting:
@@ -738,8 +739,9 @@ spec:
                             should be reported for the machines belonging to this
                             group
                           enum:
-                          - Enabled
                           - Disabled
+                          - Enabled
+                          - EnabledExclusiveResources
                           type: string
                       type: object
                     name:

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -512,8 +512,9 @@ spec:
                             should be reported for the machines belonging to this
                             group
                           enum:
-                          - Enabled
                           - Disabled
+                          - Enabled
+                          - EnabledExclusiveResources
                           type: string
                       type: object
                     disablePodsFingerprinting:
@@ -738,8 +739,9 @@ spec:
                             should be reported for the machines belonging to this
                             group
                           enum:
-                          - Enabled
                           - Disabled
+                          - Enabled
+                          - EnabledExclusiveResources
                           type: string
                       type: object
                     name:


### PR DESCRIPTION
Back in 4.16.0 we changed defaults and added options to both operator and scheduler objects. Due to the sharing of the config objects between spec and status and due to the fact we still serve v1alpha1, we may end up with fields values in the status which are not declared in the API definition.

The most obvious offender is the enum values, but this actually affects all the values we set explicit defaults for and we expose in the status.

This is what OLM complained about.
To fix this, we align the status definition from v1 to v1alpha1, until we deprecate the v1alpha1 and we stop serving it.

xref: https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/dependency-resolution.md

Manual backport of #1040