### PR TITLE
e2e: review CI lanes

### DIFF
--- a/hack/run-test-e2e.sh
+++ b/hack/run-test-e2e.sh
@@ -5,6 +5,7 @@ set -e
 source hack/common.sh
 
 ENABLE_SCHED_TESTS="${ENABLE_SCHED_TESTS:-true}"
+ENABLE_CLEANUP="${ENABLE_CLEANUP:-false}"
 
 NO_COLOR=""
 if ! which tput &> /dev/null 2>&1 || [[ $(tput -T$TERM colors) -lt 8 ]]; then
@@ -51,12 +52,16 @@ if [ "$ENABLE_SCHED_TESTS" = true ]; then
   # -requireSuite: fail if tests are not executed because of missing suite
   ${BIN_DIR}/e2e-nrop-sched.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.flake-attempts=2 --ginkgo.junit-report=${REPORT_DIR}/e2e-sched.xml
 
-  echo "Running NROScheduler uninstall test suite";
-  ${BIN_DIR}/e2e-nrop-sched-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/sched-uninstall.xml
+  if [ "$ENABLE_CLEANUP" = true ]; then
+    echo "Running NROScheduler uninstall test suite";
+    ${BIN_DIR}/e2e-nrop-sched-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/sched-uninstall.xml
+  fi
 fi
 
-echo "Undeploying sample devices for RTE tests"
-rte/hack/undeploy-devices.sh
+if [ "$ENABLE_CLEANUP" = true ]; then
+  echo "Undeploying sample devices for RTE tests"
+  rte/hack/undeploy-devices.sh
 
-echo "Running NRO uninstall test suite";
-${BIN_DIR}/e2e-nrop-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/uninstall.xml
+  echo "Running NRO uninstall test suite";
+  ${BIN_DIR}/e2e-nrop-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/uninstall.xml
+fi

--- a/hack/run-test-install-e2e.sh
+++ b/hack/run-test-install-e2e.sh
@@ -16,3 +16,6 @@ trap '{ echo "Running NRO uninstall test suite"; ${BIN_DIR}/e2e-nrop-uninstall.t
 # Run install test suite
 echo "Running NRO install test suite"
 ${BIN_DIR}/e2e-nrop-install.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.junit-report=${REPORT_DIR}/install.xml --ginkgo.focus='\[Install\] durability'
+  
+echo "Running NRO uninstall test suite";
+${BIN_DIR}/e2e-nrop-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/uninstall.xml

--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -52,6 +52,9 @@ import (
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 )
 
+// tests here are not interruptible, so they should not accept contexts.
+// See: https://onsi.github.io/ginkgo/#interruptible-nodes-and-speccontext
+
 const (
 	containerNameRTE = "resource-topology-exporter"
 )
@@ -144,7 +147,7 @@ var _ = Describe("[Install] continuousIntegration", func() {
 	})
 })
 
-var _ = Describe("[Install] durability", func() {
+var _ = Describe("[Install] durability", Serial, func() {
 	var initialized bool
 
 	BeforeEach(func() {
@@ -198,7 +201,6 @@ var _ = Describe("[Install] durability", func() {
 		})
 
 		It("[test_id:47587][tier1] should restart RTE DaemonSet when image is updated in NUMAResourcesOperator", func() {
-
 			By("getting up-to-date NRO object")
 			nroKey := client.ObjectKeyFromObject(deployedObj.NroObj)
 			Expect(nroKey.Name).NotTo(BeEmpty())

--- a/test/e2e/uninstall/uninstall_test.go
+++ b/test/e2e/uninstall/uninstall_test.go
@@ -39,7 +39,7 @@ import (
 	e2epause "github.com/openshift-kni/numaresources-operator/test/utils/objects/pause"
 )
 
-var _ = Describe("[Uninstall]", func() {
+var _ = Describe("[Uninstall] clusterCleanup", Serial, func() {
 	var (
 		initialized bool
 	)


### PR DESCRIPTION
this cleanup spawned from #1029.

the idea is to review and streamline what we do in the e2e lanes.
In the main e2e lane the uninstall test(s) don't make much sense, but they make a lot of sense in the (un)install lane.
So let's move code around.

Overall, running wall clock time should not increase, hopefully actually decrease.