### PR TITLE
api: deprecate v1alpha1

### DIFF
--- a/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_types.go
+++ b/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_types.go
@@ -133,6 +133,7 @@ type MachineConfigPool struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:shortName=numaresop,path=numaresourcesoperators,scope=Cluster
+//+kubebuilder:deprecatedversion
 
 // NUMAResourcesOperator is the Schema for the numaresourcesoperators API
 // +operator-sdk:csv:customresourcedefinitions:displayName="NUMA Resources Operator",resources={{DaemonSet,v1,rte-daemonset,ConfigMap,v1,rte-configmap}}

--- a/api/numaresourcesoperator/v1alpha1/numaresourcesscheduler_types.go
+++ b/api/numaresourcesoperator/v1alpha1/numaresourcesscheduler_types.go
@@ -59,6 +59,7 @@ type NUMAResourcesSchedulerStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:shortName=numaressched,path=numaresourcesschedulers,scope=Cluster
+//+kubebuilder:deprecatedversion
 
 // NUMAResourcesScheduler is the Schema for the numaresourcesschedulers API
 // +operator-sdk:csv:customresourcedefinitions:displayName="NUMA Aware Scheduler",resources={{Deployment,v1,secondary-scheduler-deployment}}

--- a/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -544,7 +544,8 @@ spec:
     storage: true
     subresources:
       status: {}
-  - name: v1alpha1
+  - deprecated: true
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NUMAResourcesOperator is the Schema for the numaresourcesoperators

--- a/bundle/manifests/nodetopology.openshift.io_numaresourcesschedulers.yaml
+++ b/bundle/manifests/nodetopology.openshift.io_numaresourcesschedulers.yaml
@@ -223,7 +223,8 @@ spec:
     storage: true
     subresources:
       status: {}
-  - name: v1alpha1
+  - deprecated: true
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NUMAResourcesScheduler is the Schema for the numaresourcesschedulers

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -62,7 +62,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-10-16T11:10:10Z"
+    createdAt: "2024-10-17T06:42:27Z"
     olm.skipRange: '>=4.17.0 <4.18.0'
     operators.operatorframework.io/builder: operator-sdk-v1.36.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -544,7 +544,8 @@ spec:
     storage: true
     subresources:
       status: {}
-  - name: v1alpha1
+  - deprecated: true
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NUMAResourcesOperator is the Schema for the numaresourcesoperators

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesschedulers.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesschedulers.yaml
@@ -223,7 +223,8 @@ spec:
     storage: true
     subresources:
       status: {}
-  - name: v1alpha1
+  - deprecated: true
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NUMAResourcesScheduler is the Schema for the numaresourcesschedulers


### PR DESCRIPTION
The API v1alpha1 was not only deprecated before GA, but never advertised. It's time to deprecate. Later we will stop servingf it in 4.18, and remove in 4.19/20.

This change can and should be backported back to 4.16 or perhaps even below

Key references:
- https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#version-deprecation
- https://book.kubebuilder.io/reference/markers/crd
- https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/dependency-resolution.md#deprecateremove-a-version-of-crd