### PR TITLE
Report created RTE daemonsets in operator status and fix status sync issue

### DIFF
--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -769,9 +769,11 @@ func daemonsetUpdater(mcpName string, gdm *rtestate.GeneratedDesiredManifest) er
 }
 
 func isDaemonSetReady(ds *appsv1.DaemonSet) bool {
-	ok := (ds.Status.DesiredNumberScheduled > 0 && ds.Status.DesiredNumberScheduled == ds.Status.NumberReady)
 	klog.V(5).InfoS("daemonset", "namespace", ds.Namespace, "name", ds.Name, "desired", ds.Status.DesiredNumberScheduled, "current", ds.Status.CurrentNumberScheduled, "ready", ds.Status.NumberReady)
-	return ok
+	if ds.Status.DesiredNumberScheduled == 0 {
+		return true
+	}
+	return ds.Status.DesiredNumberScheduled > 0 && ds.Status.DesiredNumberScheduled == ds.Status.NumberReady
 }
 
 func getTreesByNodeGroup(ctx context.Context, cli client.Client, nodeGroups []nropv1.NodeGroup) ([]nodegroupv1.Tree, error) {

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -177,11 +177,11 @@ func (r *NUMAResourcesOperatorReconciler) updateStatus(ctx context.Context, inst
 
 func updateStatus(ctx context.Context, cli client.Client, instance *nropv1.NUMAResourcesOperator, condition string, reason string, message string) (bool, error) {
 	conditions, ok := status.GetUpdatedConditions(instance.Status.Conditions, condition, reason, message)
-	if !ok {
-		return false, nil
+	if ok {
+		instance.Status.Conditions = conditions
 	}
-	instance.Status.Conditions = conditions
 
+	// in case of a 2 similar successive conditions happen we still want to update the status to get latest status updates
 	if err := cli.Status().Update(ctx, instance); err != nil {
 		return false, fmt.Errorf("could not update status for object %s: %w", client.ObjectKeyFromObject(instance), err)
 	}

--- a/controllers/numaresourcesoperator_controller_test.go
+++ b/controllers/numaresourcesoperator_controller_test.go
@@ -261,7 +261,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 			secondLoopResult, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(secondLoopResult).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
+			Expect(secondLoopResult).To(Equal(reconcile.Result{RequeueAfter: 0}))
 
 			By("Check DaemonSets are created")
 			mcp1DSKey := client.ObjectKey{
@@ -330,7 +330,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 				thirdLoopResult, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(thirdLoopResult).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
+				Expect(thirdLoopResult).To(Equal(reconcile.Result{RequeueAfter: 0}))
 			})
 			It("should delete also the corresponding DaemonSet", func() {
 
@@ -587,7 +587,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 					})
 					It("should continue with creation of additional components", func() {
 						// check reconcile second loop result
-						Expect(secondLoopResult).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
+						Expect(secondLoopResult).To(Equal(reconcile.Result{RequeueAfter: 0}))
 
 						By("Check All the additional components are created")
 						rteKey := client.ObjectKey{
@@ -1017,7 +1017,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 			thirdLoopResult, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(thirdLoopResult).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
+			Expect(thirdLoopResult).To(Equal(reconcile.Result{RequeueAfter: 0}))
 
 			dsUpdated := &appsv1.DaemonSet{}
 			Expect(reconciler.Client.Get(context.TODO(), mcpDSKey, dsUpdated)).ToNot(HaveOccurred())
@@ -1069,7 +1069,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 			thirdLoopResult, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(thirdLoopResult).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
+			Expect(thirdLoopResult).To(Equal(reconcile.Result{RequeueAfter: 0}))
 
 			dsUpdated := &appsv1.DaemonSet{}
 			Expect(reconciler.Client.Get(context.TODO(), mcpDSKey, dsUpdated)).ToNot(HaveOccurred())
@@ -1321,7 +1321,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 			secondLoopResult, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(secondLoopResult).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
+			Expect(secondLoopResult).To(Equal(reconcile.Result{RequeueAfter: 0}))
 
 			By("Check DaemonSets are created")
 			mcp1DSKey := client.ObjectKey{
@@ -1412,6 +1412,6 @@ func reconcileObjects(nro *nropv1.NUMAResourcesOperator, mcp *machineconfigv1.Ma
 	secondLoopResult, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 	Expect(err).ToNot(HaveOccurred())
 
-	Expect(secondLoopResult).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
+	Expect(secondLoopResult).To(Equal(reconcile.Result{RequeueAfter: 0}))
 	return reconciler
 }

--- a/controllers/numaresourcesoperator_controller_test.go
+++ b/controllers/numaresourcesoperator_controller_test.go
@@ -18,26 +18,17 @@ package controllers
 
 import (
 	"context"
-	"github.com/openshift-kni/numaresources-operator/internal/api/annotations"
 	"time"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-
-	configv1 "github.com/openshift/api/config/v1"
-	securityv1 "github.com/openshift/api/security/v1"
-	appsv1 "k8s.io/api/apps/v1"
-
-	rbacv1 "k8s.io/api/rbac/v1"
-
-	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
-	apimanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/api"
-	rtemanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
+	securityv1 "github.com/openshift/api/security/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -46,14 +37,21 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+	apimanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/api"
+	rtemanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte"
+
+	configv1 "github.com/openshift/api/config/v1"
+	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
+	"github.com/openshift-kni/numaresources-operator/internal/api/annotations"
+	testobjs "github.com/openshift-kni/numaresources-operator/internal/objects"
 	"github.com/openshift-kni/numaresources-operator/pkg/images"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectstate/rte"
 	"github.com/openshift-kni/numaresources-operator/pkg/status"
 	"github.com/openshift-kni/numaresources-operator/pkg/validation"
-
-	testobjs "github.com/openshift-kni/numaresources-operator/internal/objects"
 )
 
 const (
@@ -225,6 +223,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			key := client.ObjectKeyFromObject(nro)
+			// on the first iteration we expect the CRDs and MCPs to be created, yet, it will wait one minute to update MC, thus RTE daemonsets and complete status update is not going to be achieved at this point
 			firstLoopResult, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(firstLoopResult).To(Equal(reconcile.Result{RequeueAfter: time.Minute}))
@@ -259,9 +258,10 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 			}
 			Expect(reconciler.Client.Update(context.TODO(), mcp2)).To(Succeed())
 
+			// triggering a second reconcile will create the RTEs and fully update the statuses making the operator in Available condition -> no more reconciliation needed thus the result is clean
 			secondLoopResult, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(secondLoopResult).To(Equal(reconcile.Result{RequeueAfter: 0}))
+			Expect(secondLoopResult).To(Equal(reconcile.Result{}))
 
 			By("Check DaemonSets are created")
 			mcp1DSKey := client.ObjectKey{
@@ -290,6 +290,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 				nro.Annotations = map[string]string{}
 				Expect(reconciler.Client.Update(context.TODO(), nro)).NotTo(HaveOccurred())
 
+				// removing the annotation will trigger reboot which requires resync after 1 min
 				thirdLoopResult, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(thirdLoopResult).To(Equal(reconcile.Result{RequeueAfter: time.Minute}))
@@ -328,9 +329,10 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 				nro.Annotations = map[string]string{annotations.SELinuxPolicyConfigAnnotation: annotations.SELinuxPolicyCustom}
 				Expect(reconciler.Client.Update(context.TODO(), nro)).NotTo(HaveOccurred())
 
+				// immediate update reflection with no reboot needed -> no need to reconcileafter this
 				thirdLoopResult, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(thirdLoopResult).To(Equal(reconcile.Result{RequeueAfter: 0}))
+				Expect(thirdLoopResult).To(Equal(reconcile.Result{}))
 			})
 			It("should delete also the corresponding DaemonSet", func() {
 
@@ -419,7 +421,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 	})
 
 	Context("with correct NRO and PoolName set", func() {
-		It("should create RTE daemonset", func(ctx context.Context) {
+		It("should create RTE daemonset and report the status", func(ctx context.Context) {
 			mcpName := "test1"
 			label := map[string]string{
 				"test1": "test1",
@@ -446,7 +448,136 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 			Expect(len(nroUpdated.Status.MachineConfigPools)).To(Equal(1))
 			Expect(nroUpdated.Status.MachineConfigPools[0].Name).To(Equal(mcp.Name))
-			// TODO check the actual returned config and the daemonset in status, we need to force the NRO condition as Available for this.
+
+			conf := nropv1.DefaultNodeGroupConfig()
+			Expect(nroUpdated.Status.NodeGroups[0].Config).To(Equal(conf), "node group config was not updated in the operator status")
+		})
+
+		When("multiple node groups are configured with different config", func() {
+			It("should create all RTE daemonsets and report the status respectively per node group", func(ctx context.Context) {
+				mcp1Name := "test1"
+				mcp2Name := "test2"
+				label1 := map[string]string{
+					"test1": "test1",
+				}
+				label2 := map[string]string{
+					"test2": "test2",
+				}
+
+				defaultConf := nropv1.DefaultNodeGroupConfig()
+
+				conf1 := defaultConf.DeepCopy()
+				pfpModeDisabled := nropv1.PodsFingerprintingDisabled
+				rteMode := nropv1.InfoRefreshPauseEnabled
+				conf1.PodsFingerprinting = &pfpModeDisabled
+				conf1.InfoRefreshPause = &rteMode
+
+				conf2 := defaultConf.DeepCopy()
+				pfpModeEnabled := nropv1.PodsFingerprintingEnabled
+				refMode := nropv1.InfoRefreshPeriodicAndEvents
+				conf2.PodsFingerprinting = &pfpModeEnabled
+				conf2.InfoRefreshMode = &refMode
+				conf2.Tolerations = []corev1.Toleration{
+					{
+						Key:    "foo",
+						Value:  "1",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+				}
+
+				ng1 := nropv1.NodeGroup{
+					PoolName: &mcp1Name,
+					Config:   conf1,
+				}
+				ng2 := nropv1.NodeGroup{
+					PoolName: &mcp2Name,
+					Config:   conf2,
+				}
+
+				mcp1 := testobjs.NewMachineConfigPool(mcp1Name, label1, &metav1.LabelSelector{MatchLabels: label1}, &metav1.LabelSelector{MatchLabels: label1})
+				mcp2 := testobjs.NewMachineConfigPool(mcp2Name, label2, &metav1.LabelSelector{MatchLabels: label2}, &metav1.LabelSelector{MatchLabels: label2})
+				nro := testobjs.NewNUMAResourcesOperator(objectnames.DefaultNUMAResourcesOperatorCrName, ng1, ng2)
+				nro.Annotations = map[string]string{annotations.SELinuxPolicyConfigAnnotation: annotations.SELinuxPolicyCustom}
+
+				reconciler, err := NewFakeNUMAResourcesOperatorReconciler(platform.OpenShift, defaultOCPVersion, nro, mcp1, mcp2)
+				Expect(err).ToNot(HaveOccurred())
+
+				key := client.ObjectKeyFromObject(nro)
+				// on the first iteration we expect the CRDs and MCPs to be created, yet, it will wait one minute to update MC, thus RTE daemonsets and complete status update is not going to be achieved at this point
+				result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{RequeueAfter: 1 * time.Minute}))
+
+				By("ensure MachineConfigPools are ready")
+				Expect(reconciler.Client.Get(context.TODO(), client.ObjectKeyFromObject(mcp1), mcp1)).ToNot(HaveOccurred())
+				mcp1.Status.Configuration.Source = []corev1.ObjectReference{
+					{
+						Name: objectnames.GetMachineConfigName(nro.Name, mcp1.Name),
+					},
+				}
+				mcp1.Status.Conditions = []machineconfigv1.MachineConfigPoolCondition{
+					{
+						Type:   machineconfigv1.MachineConfigPoolUpdated,
+						Status: corev1.ConditionTrue,
+					},
+				}
+				Expect(reconciler.Client.Update(context.TODO(), mcp1)).Should(Succeed())
+				Expect(reconciler.Client.Get(context.TODO(), client.ObjectKeyFromObject(mcp1), mcp1)).ToNot(HaveOccurred())
+
+				Expect(reconciler.Client.Get(context.TODO(), client.ObjectKeyFromObject(mcp2), mcp2)).ToNot(HaveOccurred())
+				mcp2.Status.Configuration.Source = []corev1.ObjectReference{
+					{
+						Name: objectnames.GetMachineConfigName(nro.Name, mcp2.Name),
+					},
+				}
+				mcp2.Status.Conditions = []machineconfigv1.MachineConfigPoolCondition{
+					{
+						Type:   machineconfigv1.MachineConfigPoolUpdated,
+						Status: corev1.ConditionTrue,
+					},
+				}
+				Expect(reconciler.Client.Update(context.TODO(), mcp2)).Should(Succeed())
+				Expect(reconciler.Client.Get(context.TODO(), client.ObjectKeyFromObject(mcp2), mcp2)).ToNot(HaveOccurred())
+
+				// triggering a second reconcile will create the RTEs and fully update the statuses making the operator in Available condition -> no more reconciliation needed thus the result is clean
+				var secondLoopResult reconcile.Result
+				secondLoopResult, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(secondLoopResult).To(Equal(reconcile.Result{}))
+
+				ds := &appsv1.DaemonSet{}
+				mcpDSKey1 := client.ObjectKey{
+					Name:      objectnames.GetComponentName(nro.Name, mcp1.Name),
+					Namespace: testNamespace,
+				}
+				Expect(reconciler.Client.Get(context.TODO(), mcpDSKey1, ds)).ToNot(HaveOccurred())
+
+				mcpDSKey2 := client.ObjectKey{
+					Name:      objectnames.GetComponentName(nro.Name, mcp2.Name),
+					Namespace: testNamespace,
+				}
+				Expect(reconciler.Client.Get(context.TODO(), mcpDSKey2, ds)).ToNot(HaveOccurred())
+
+				nroUpdated := &nropv1.NUMAResourcesOperator{}
+				Expect(reconciler.Client.Get(context.TODO(), client.ObjectKeyFromObject(nro), nroUpdated)).ToNot(HaveOccurred())
+
+				Expect(len(nroUpdated.Status.MachineConfigPools)).To(Equal(2))
+				Expect(len(nroUpdated.Status.DaemonSets)).To(Equal(2))
+
+				// the order of the NodeGroups also preserved under the operator status
+				Expect(nroUpdated.Status.MachineConfigPools[0].Name).To(Equal(mcp1.Name))
+				Expect(nroUpdated.Status.NodeGroups[0].PoolName).To(Equal(mcp1.Name))
+				Expect(nroUpdated.Status.MachineConfigPools[0].Config).To(Equal(conf1))
+				Expect(nroUpdated.Status.NodeGroups[0].Config).To(Equal(*conf1))
+				Expect(nroUpdated.Status.NodeGroups[0].DaemonSet).To(Equal(nroUpdated.Status.DaemonSets[0]))
+
+				Expect(nroUpdated.Status.MachineConfigPools[1].Name).To(Equal(mcp2.Name))
+				Expect(nroUpdated.Status.NodeGroups[1].PoolName).To(Equal(mcp2.Name))
+				Expect(nroUpdated.Status.MachineConfigPools[1].Config).To(Equal(conf2))
+				Expect(nroUpdated.Status.NodeGroups[1].Config).To(Equal(*conf2))
+				Expect(nroUpdated.Status.NodeGroups[1].DaemonSet).To(Equal(nroUpdated.Status.DaemonSets[1]))
+
+			})
 		})
 	})
 
@@ -502,6 +633,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 				})
 				It("should create CRD, machine configs and wait for MCPs updates", func() {
 					// check reconcile loop result
+					// wait one minute to update MCP, thus RTE daemonsets and complete status update is not going to be achieved at this point
 					Expect(firstLoopResult).To(Equal(reconcile.Result{RequeueAfter: time.Minute}))
 
 					// check CRD is created
@@ -526,18 +658,19 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 			})
 			Context("on the second iteration", func() {
-				var secondLoopResult reconcile.Result
+				var result reconcile.Result
 				When("machine config pools still are not ready", func() {
 					BeforeEach(func() {
 						var err error
 
 						key := client.ObjectKeyFromObject(nro)
-						secondLoopResult, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
+						result, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 						Expect(err).ToNot(HaveOccurred())
 					})
 					It("should wait", func() {
-						//check reconcile second loop result
-						Expect(secondLoopResult).To(Equal(reconcile.Result{RequeueAfter: time.Minute}))
+						// check reconcile first loop result
+						// wait one minute to update MCP, thus RTE daemonsets and complete status update is not going to be achieved at this point
+						Expect(result).To(Equal(reconcile.Result{RequeueAfter: time.Minute}))
 
 						key := client.ObjectKeyFromObject(nro)
 						Expect(reconciler.Client.Get(context.TODO(), key, nro)).ToNot(HaveOccurred())
@@ -582,12 +715,13 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 						Expect(reconciler.Client.Update(context.TODO(), mcp2))
 
 						key := client.ObjectKeyFromObject(nro)
-						secondLoopResult, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
+						result, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 						Expect(err).ToNot(HaveOccurred())
 					})
 					It("should continue with creation of additional components", func() {
 						// check reconcile second loop result
-						Expect(secondLoopResult).To(Equal(reconcile.Result{RequeueAfter: 0}))
+						//	triggering a second reconcile will create the RTEs and fully update the statuses making the operator in Available condition -> no more reconciliation needed thus the result is clean
+						Expect(result).To(Equal(reconcile.Result{}))
 
 						By("Check All the additional components are created")
 						rteKey := client.ObjectKey{
@@ -739,6 +873,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 				It("should create the machine config", func() {
 					key := client.ObjectKeyFromObject(nro)
+					// on the first iteration we expect the CRDs and MCPs to be created, yet, it will wait one minute to update MC, thus RTE daemonsets and complete status update is not going to be achieved at this point
 					firstLoopResult, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 					Expect(err).ToNot(HaveOccurred())
 					Expect(firstLoopResult).To(Equal(reconcile.Result{RequeueAfter: time.Minute}))
@@ -770,6 +905,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 				It("should not create the machine config and set the degraded condition", func() {
 					key := client.ObjectKeyFromObject(nro)
+					// degraded condition doesn't require reconciliation thus expect empty reconcile result
 					firstLoopResult, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 					Expect(err).To(HaveOccurred())
 					Expect(firstLoopResult).To(Equal(reconcile.Result{}))
@@ -850,7 +986,9 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 			Expect(len(nroUpdated.Status.MachineConfigPools)).To(Equal(1))
 			Expect(nroUpdated.Status.MachineConfigPools[0].Name).To(Equal(mcp.Name))
-			// TODO check the actual returned config. We need to force the condition as Available for this.
+			Expect(*nroUpdated.Status.MachineConfigPools[0].Config).To(Equal(conf), "operator status was not updated")
+			Expect(nroUpdated.Status.NodeGroups[0].Config).To(Equal(conf), "operator status was not updated under NodeGroupStatus field")
+
 		})
 
 		It("should allow to alter all the settings of the DS objects", func() {
@@ -906,6 +1044,11 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 			args := ds.Spec.Template.Spec.Containers[0].Args
 			Expect(args).ToNot(ContainElement("--pods-fingerprint"), "malformed args: %v", args)
+
+			nroUpdated := &nropv1.NUMAResourcesOperator{}
+			Expect(reconciler.Client.Get(context.TODO(), client.ObjectKeyFromObject(nro), nroUpdated)).ToNot(HaveOccurred())
+			Expect(*nroUpdated.Status.MachineConfigPools[0].Config.PodsFingerprinting).To(Equal(pfpMode), "node group config was not updated in the operator status")
+			Expect(*nroUpdated.Status.NodeGroups[0].Config.PodsFingerprinting).To(Equal(pfpMode), "node group config was not updated under NodeGroupStatus field")
 		})
 
 		It("should allow to tune the update period", func() {
@@ -931,6 +1074,11 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 			args := ds.Spec.Template.Spec.Containers[0].Args
 			Expect(args).To(ContainElement("--sleep-interval=42s"), "malformed args: %v", args)
+
+			nroUpdated := &nropv1.NUMAResourcesOperator{}
+			Expect(reconciler.Client.Get(context.TODO(), client.ObjectKeyFromObject(nro), nroUpdated)).ToNot(HaveOccurred())
+			Expect(*nroUpdated.Status.MachineConfigPools[0].Config.InfoRefreshPeriod).To(Equal(period), "node group config was not updated in the operator status")
+			Expect(*nroUpdated.Status.NodeGroups[0].Config.InfoRefreshPeriod).To(Equal(period), "node group config was not updated under NodeGroupStatus field")
 		})
 
 		It("should allow to tune the update mechanism", func() {
@@ -952,6 +1100,11 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 			args := ds.Spec.Template.Spec.Containers[0].Args
 			Expect(args).ToNot(ContainElement(ContainSubstring("--notify-file")), "malformed args: %v", args)
+
+			nroUpdated := &nropv1.NUMAResourcesOperator{}
+			Expect(reconciler.Client.Get(context.TODO(), client.ObjectKeyFromObject(nro), nroUpdated)).ToNot(HaveOccurred())
+			Expect(*nroUpdated.Status.MachineConfigPools[0].Config.InfoRefreshMode).To(Equal(refMode), "node group config was not updated in the operator status")
+			Expect(*nroUpdated.Status.NodeGroups[0].Config.InfoRefreshMode).To(Equal(refMode), "node group config was not updated under NodeGroupStatus field")
 		})
 
 		It("should find default behavior to update NRT data", func() {
@@ -985,13 +1138,15 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 			}
 			nro := testobjs.NewNUMAResourcesOperatorWithNodeGroupConfig(objectnames.DefaultNUMAResourcesOperatorCrName, &labSel, &conf)
 
+			// first and second reconcile loops are done inside
 			reconciler := reconcileObjects(nro, mcp)
 
 			key := client.ObjectKeyFromObject(nro)
 
 			nroCurrent := &nropv1.NUMAResourcesOperator{}
 			Expect(reconciler.Client.Get(context.TODO(), key, nroCurrent)).NotTo(HaveOccurred())
-			Expect(nroCurrent.Spec.NodeGroups[0].Config.InfoRefreshPause).To(Equal(&rteMode))
+			Expect(*nroCurrent.Status.MachineConfigPools[0].Config.InfoRefreshPause).To(Equal(rteMode), "node group config was not updated in the operator status")
+			Expect(*nroCurrent.Status.NodeGroups[0].Config.InfoRefreshPause).To(Equal(rteMode), "node group config was not updated under NodeGroupStatus field")
 
 			mcpDSKey := client.ObjectKey{
 				Name:      objectnames.GetComponentName(nro.Name, mcp.Name),
@@ -1015,21 +1170,28 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 				return reconciler.Client.Update(context.TODO(), nroUpdated)
 			}).WithPolling(1 * time.Second).WithTimeout(30 * time.Second).ShouldNot(HaveOccurred())
 
-			thirdLoopResult, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
+			// immediate update reflection with no reboot needed -> no need to reconcile after this
+			result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(thirdLoopResult).To(Equal(reconcile.Result{RequeueAfter: 0}))
+			Expect(result).To(Equal(reconcile.Result{}))
 
 			dsUpdated := &appsv1.DaemonSet{}
 			Expect(reconciler.Client.Get(context.TODO(), mcpDSKey, dsUpdated)).ToNot(HaveOccurred())
 
 			argsUpdated := dsUpdated.Spec.Template.Spec.Containers[0].Args
 			Expect(argsUpdated).ToNot(ContainElement(ContainSubstring("--no-publish")), "malformed args: %v", argsUpdated)
+
+			nroUpdated := &nropv1.NUMAResourcesOperator{}
+			Expect(reconciler.Client.Get(context.TODO(), key, nroUpdated)).ToNot(HaveOccurred())
+			Expect(*nroUpdated.Status.MachineConfigPools[0].Config.InfoRefreshPause).To(Equal(rteModeOpp), "node group config was not updated in the operator status")
+			Expect(*nroUpdated.Status.NodeGroups[0].Config.InfoRefreshPause).To(Equal(rteModeOpp), "node group config was not updated under NodeGroupStatus field")
 		})
 
 		It("should allow to update all the settings of the DS objects", func() {
 			conf := nropv1.DefaultNodeGroupConfig()
 			nro := testobjs.NewNUMAResourcesOperatorWithNodeGroupConfig(objectnames.DefaultNUMAResourcesOperatorCrName, &labSel, &conf)
 
+			// first and second reconcile loops are done inside
 			reconciler := reconcileObjects(nro, mcp)
 
 			mcpDSKey := client.ObjectKey{
@@ -1047,15 +1209,17 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 			d, err := time.ParseDuration("12s")
 			Expect(err).ToNot(HaveOccurred())
 
+			pfpMode := nropv1.PodsFingerprintingEnabled
 			period := metav1.Duration{
 				Duration: d,
 			}
 			refMode := nropv1.InfoRefreshPeriodic
 			rteMode := nropv1.InfoRefreshPauseEnabled
 			confUpdated := nropv1.NodeGroupConfig{
-				InfoRefreshPeriod: &period,
-				InfoRefreshMode:   &refMode,
-				InfoRefreshPause:  &rteMode,
+				PodsFingerprinting: &pfpMode,
+				InfoRefreshPeriod:  &period,
+				InfoRefreshMode:    &refMode,
+				InfoRefreshPause:   &rteMode,
 			}
 
 			key := client.ObjectKeyFromObject(nro)
@@ -1067,9 +1231,10 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 				return reconciler.Client.Update(context.TODO(), nroUpdated)
 			}).WithPolling(1 * time.Second).WithTimeout(30 * time.Second).ShouldNot(HaveOccurred())
 
+			// immediate update reflection with no reboot needed -> no need to reconcile after this
 			thirdLoopResult, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(thirdLoopResult).To(Equal(reconcile.Result{RequeueAfter: 0}))
+			Expect(thirdLoopResult).To(Equal(reconcile.Result{}))
 
 			dsUpdated := &appsv1.DaemonSet{}
 			Expect(reconciler.Client.Get(context.TODO(), mcpDSKey, dsUpdated)).ToNot(HaveOccurred())
@@ -1079,6 +1244,11 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 			Expect(argsUpdated).ToNot(ContainElement(ContainSubstring("--notify-file=")), "malformed updated args: %v", argsUpdated)
 			Expect(argsUpdated).To(ContainElement("--pods-fingerprint"), "malformed updated args: %v", argsUpdated)
 			Expect(argsUpdated).To(ContainElement(ContainSubstring("--no-publish")), "malformed args: %v", argsUpdated)
+
+			nroUpdated := &nropv1.NUMAResourcesOperator{}
+			Expect(reconciler.Client.Get(context.TODO(), client.ObjectKeyFromObject(nro), nroUpdated)).ToNot(HaveOccurred())
+			Expect(*nroUpdated.Status.MachineConfigPools[0].Config).To(Equal(confUpdated), "node group config was not updated in the operator status")
+			Expect(nroUpdated.Status.NodeGroups[0].Config).To(Equal(confUpdated), "node group config was not updated under NodeGroupStatus field")
 		})
 
 		It("should allow to change the PFP method dynamically", func() {
@@ -1102,12 +1272,16 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 			Expect(args).To(ContainElement("--pods-fingerprint-method=with-exclusive-resources"), "malformed args: %v", args)
 
 			key := client.ObjectKeyFromObject(nro)
+			nroUpdated := &nropv1.NUMAResourcesOperator{}
+			Expect(reconciler.Client.Get(context.TODO(), key, nroUpdated)).ToNot(HaveOccurred())
+			Expect(*nroUpdated.Status.MachineConfigPools[0].Config.PodsFingerprinting).To(Equal(pfpMode), "node group config was not updated in the operator status")
+			Expect(*nroUpdated.Status.NodeGroups[0].Config.PodsFingerprinting).To(Equal(pfpMode), "node group config was not updated under NodeGroupStatus field")
 
+			updatedPFPMode := nropv1.PodsFingerprintingEnabled
 			Eventually(func() error {
 				nroUpdated := &nropv1.NUMAResourcesOperator{}
 				Expect(reconciler.Client.Get(context.TODO(), key, nroUpdated)).NotTo(HaveOccurred())
-				pfpMode := nropv1.PodsFingerprintingEnabled
-				nroUpdated.Spec.NodeGroups[0].Config.PodsFingerprinting = &pfpMode
+				nroUpdated.Spec.NodeGroups[0].Config.PodsFingerprinting = &updatedPFPMode
 				return reconciler.Client.Update(context.TODO(), nroUpdated)
 			}).WithPolling(1 * time.Second).WithTimeout(30 * time.Second).ShouldNot(HaveOccurred())
 
@@ -1119,6 +1293,10 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 			args = ds.Spec.Template.Spec.Containers[0].Args
 			Expect(args).To(ContainElement("--pods-fingerprint-method=all"), "malformed args: %v", args)
+
+			Expect(reconciler.Client.Get(context.TODO(), key, nroUpdated)).ToNot(HaveOccurred())
+			Expect(*nroUpdated.Status.MachineConfigPools[0].Config.PodsFingerprinting).To(Equal(updatedPFPMode), "node group config was not updated in the operator status")
+			Expect(*nroUpdated.Status.NodeGroups[0].Config.PodsFingerprinting).To(Equal(updatedPFPMode), "node group config was not updated under NodeGroupStatus field")
 		})
 
 		It("should keep the manifest tolerations if not set", func() {
@@ -1159,6 +1337,11 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 			Expect(reconciler.Client.Get(context.TODO(), mcpDSKey, ds)).To(Succeed())
 
 			Expect(ds.Spec.Template.Spec.Tolerations).To(Equal(conf.Tolerations), "mismatched DS tolerations")
+
+			nroUpdated := &nropv1.NUMAResourcesOperator{}
+			Expect(reconciler.Client.Get(context.TODO(), client.ObjectKeyFromObject(nro), nroUpdated)).ToNot(HaveOccurred())
+			Expect(nroUpdated.Status.MachineConfigPools[0].Config.Tolerations).To(Equal(conf.Tolerations), "node group config was not updated in the operator status")
+			Expect(nroUpdated.Status.NodeGroups[0].Config.Tolerations).To(Equal(conf.Tolerations), "node group config was not updated under NodeGroupStatus field")
 		})
 
 		It("should replace the extra tolerations in the DS objects", func() {
@@ -1185,21 +1368,22 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 			key := client.ObjectKeyFromObject(nro)
 
+			newTols := []corev1.Toleration{
+				{
+					Key:    "bar",
+					Value:  "2",
+					Effect: corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "baz",
+					Value:  "3",
+					Effect: corev1.TaintEffectNoSchedule,
+				},
+			}
 			nroUpdated := &nropv1.NUMAResourcesOperator{}
 			Eventually(func() error {
 				Expect(reconciler.Client.Get(context.TODO(), key, nroUpdated)).To(Succeed())
-				nroUpdated.Spec.NodeGroups[0].Config.Tolerations = []corev1.Toleration{
-					{
-						Key:    "bar",
-						Value:  "2",
-						Effect: corev1.TaintEffectNoSchedule,
-					},
-					{
-						Key:    "baz",
-						Value:  "3",
-						Effect: corev1.TaintEffectNoSchedule,
-					},
-				}
+				nroUpdated.Spec.NodeGroups[0].Config.Tolerations = newTols
 				return reconciler.Client.Update(context.TODO(), nroUpdated)
 			}).WithPolling(1 * time.Second).WithTimeout(30 * time.Second).Should(Succeed())
 
@@ -1208,6 +1392,10 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 			Expect(reconciler.Client.Get(context.TODO(), mcpDSKey, ds)).To(Succeed())
 			Expect(ds.Spec.Template.Spec.Tolerations).To(Equal(nroUpdated.Spec.NodeGroups[0].Config.Tolerations), "mismatched DS tolerations (round 2)")
+
+			Expect(reconciler.Client.Get(context.TODO(), client.ObjectKeyFromObject(nro), nroUpdated)).ToNot(HaveOccurred())
+			Expect(nroUpdated.Status.MachineConfigPools[0].Config.Tolerations).To(Equal(newTols), "node group config was not updated in the operator status")
+			Expect(nroUpdated.Status.NodeGroups[0].Config.Tolerations).To(Equal(newTols), "node group config was not updated under NodeGroupStatus field")
 		})
 
 		It("should remove the extra tolerations in the DS objects", func() {
@@ -1246,6 +1434,11 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 			Expect(reconciler.Client.Get(context.TODO(), mcpDSKey, ds)).To(Succeed())
 			Expect(ds.Spec.Template.Spec.Tolerations).To(Equal(reconciler.RTEManifests.DaemonSet.Spec.Template.Spec.Tolerations), "DS tolerations not restored to defaults")
+
+			nroUpdated := &nropv1.NUMAResourcesOperator{}
+			Expect(reconciler.Client.Get(context.TODO(), client.ObjectKeyFromObject(nro), nroUpdated)).ToNot(HaveOccurred())
+			Expect(nroUpdated.Status.MachineConfigPools[0].Config.Tolerations).To(BeNil(), "node group config was not updated in the operator status")
+			Expect(nroUpdated.Status.NodeGroups[0].Config.Tolerations).To(BeNil(), "node group config was not updated under NodeGroupStatus field")
 		})
 	})
 	Context("emulating upgrade from 4.1X to 4.18 which has a built-in selinux policy for RTE pods", func() {
@@ -1285,6 +1478,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			key := client.ObjectKeyFromObject(nro)
+			// on the first iteration we expect the CRDs and MCPs to be created, yet, it will wait one minute to update MC, thus RTE daemonsets and complete status update is not going to be achieved at this point
 			firstLoopResult, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(firstLoopResult).To(Equal(reconcile.Result{RequeueAfter: time.Minute}))
@@ -1319,6 +1513,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 			}
 			Expect(reconciler.Client.Update(context.TODO(), mcp2)).To(Succeed())
 
+			// triggering a second reconcile will create the RTEs and fully update the statuses making the operator in Available condition -> no more reconciliation needed thus the result is clean
 			secondLoopResult, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(secondLoopResult).To(Equal(reconcile.Result{RequeueAfter: 0}))
@@ -1342,6 +1537,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 			nro.Annotations = map[string]string{}
 			Expect(reconciler.Client.Update(context.TODO(), nro)).To(Succeed())
 
+			// removing the annotation will trigger reboot which requires resync after 1 min
 			thirdLoopResult, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(thirdLoopResult).To(Equal(reconcile.Result{RequeueAfter: time.Minute}))
@@ -1383,8 +1579,9 @@ func reconcileObjects(nro *nropv1.NUMAResourcesOperator, mcp *machineconfigv1.Ma
 	key := client.ObjectKeyFromObject(nro)
 
 	// we need to do the first iteration here because the DS object is created in the second
-	_, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
+	firstLoopResult, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 	Expect(err).ToNot(HaveOccurred())
+	Expect(firstLoopResult).To(Equal(reconcile.Result{RequeueAfter: 1 * time.Minute}))
 
 	By("Ensure MachineConfigPools is ready")
 	Expect(reconciler.Client.Get(context.TODO(), client.ObjectKeyFromObject(mcp), mcp)).ToNot(HaveOccurred())
@@ -1408,10 +1605,10 @@ func reconcileObjects(nro *nropv1.NUMAResourcesOperator, mcp *machineconfigv1.Ma
 	Expect(mcp.Status.Conditions[0].Status).To(Equal(corev1.ConditionTrue))
 	Expect(mcp.Status.Configuration.Source[0].Name).To(Equal(mcName))
 
-	var secondLoopResult reconcile.Result
-	secondLoopResult, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
+	// triggering a second reconcile will create the RTEs and fully update the statuses making the operator in Available condition -> no more reconciliation needed thus the result is clean
+	secondLoopResult, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 	Expect(err).ToNot(HaveOccurred())
+	Expect(secondLoopResult).To(Equal(reconcile.Result{}))
 
-	Expect(secondLoopResult).To(Equal(reconcile.Result{RequeueAfter: 0}))
 	return reconciler
 }


### PR DESCRIPTION
Complementary unit tests coverage for #1018 in addition to fixing other deficient behaviors; see the commits messages for more info.