### PR TITLE
[release-4.17][manual]  api: deprecate v1alpha1

### DIFF
--- a/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_types.go
+++ b/api/numaresourcesoperator/v1alpha1/numaresourcesoperator_types.go
@@ -133,6 +133,7 @@ type MachineConfigPool struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:shortName=numaresop,path=numaresourcesoperators,scope=Cluster
+//+kubebuilder:deprecatedversion
 
 // NUMAResourcesOperator is the Schema for the numaresourcesoperators API
 // +operator-sdk:csv:customresourcedefinitions:displayName="NUMA Resources Operator",resources={{DaemonSet,v1,rte-daemonset,ConfigMap,v1,rte-configmap}}

--- a/api/numaresourcesoperator/v1alpha1/numaresourcesscheduler_types.go
+++ b/api/numaresourcesoperator/v1alpha1/numaresourcesscheduler_types.go
@@ -59,6 +59,7 @@ type NUMAResourcesSchedulerStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:shortName=numaressched,path=numaresourcesschedulers,scope=Cluster
+//+kubebuilder:deprecatedversion
 
 // NUMAResourcesScheduler is the Schema for the numaresourcesschedulers API
 // +operator-sdk:csv:customresourcedefinitions:displayName="NUMA Aware Scheduler",resources={{Deployment,v1,secondary-scheduler-deployment}}

--- a/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -444,7 +444,8 @@ spec:
     storage: true
     subresources:
       status: {}
-  - name: v1alpha1
+  - deprecated: true
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NUMAResourcesOperator is the Schema for the numaresourcesoperators

--- a/bundle/manifests/nodetopology.openshift.io_numaresourcesschedulers.yaml
+++ b/bundle/manifests/nodetopology.openshift.io_numaresourcesschedulers.yaml
@@ -236,7 +236,8 @@ spec:
     storage: true
     subresources:
       status: {}
-  - name: v1alpha1
+  - deprecated: true
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NUMAResourcesScheduler is the Schema for the numaresourcesschedulers

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -444,7 +444,8 @@ spec:
     storage: true
     subresources:
       status: {}
-  - name: v1alpha1
+  - deprecated: true
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NUMAResourcesOperator is the Schema for the numaresourcesoperators

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesschedulers.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesschedulers.yaml
@@ -236,7 +236,8 @@ spec:
     storage: true
     subresources:
       status: {}
-  - name: v1alpha1
+  - deprecated: true
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NUMAResourcesScheduler is the Schema for the numaresourcesschedulers


### PR DESCRIPTION
use kube mechanism to make it really loud and obvious this API version is deprecated

xref: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#version-deprecation