### PR TITLE
nrop: cleanup dangling objects removal

### DIFF
--- a/internal/dangling/dangling.go
+++ b/internal/dangling/dangling.go
@@ -57,15 +57,17 @@ func DeleteUnusedDaemonSets(cli client.Client, ctx context.Context, instance *nr
 	}
 
 	for _, ds := range daemonSetList.Items {
-		if !expectedDaemonSetNames.Has(ds.Name) {
-			if isOwnedBy(ds.GetObjectMeta(), instance) {
-				if err := cli.Delete(ctx, &ds); err != nil {
-					klog.ErrorS(err, "error while deleting daemonset", "DaemonSet", ds.Name)
-					errors = append(errors, err)
-				} else {
-					klog.V(3).InfoS("Daemonset deleted", "name", ds.Name)
-				}
-			}
+		if expectedDaemonSetNames.Has(ds.Name) {
+			continue
+		}
+		if !isOwnedBy(ds.GetObjectMeta(), instance) {
+			continue
+		}
+		if err := cli.Delete(ctx, &ds); err != nil {
+			klog.ErrorS(err, "error while deleting daemonset", "DaemonSet", ds.Name)
+			errors = append(errors, err)
+		} else {
+			klog.V(3).InfoS("Daemonset deleted", "name", ds.Name)
 		}
 	}
 	return errors
@@ -89,15 +91,17 @@ func DeleteUnusedMachineConfigs(cli client.Client, ctx context.Context, instance
 	}
 
 	for _, mc := range machineConfigList.Items {
-		if !expectedMachineConfigNames.Has(mc.Name) {
-			if isOwnedBy(mc.GetObjectMeta(), instance) {
-				if err := cli.Delete(ctx, &mc); err != nil {
-					klog.ErrorS(err, "error while deleting machineconfig", "MachineConfig", mc.Name)
-					errors = append(errors, err)
-				} else {
-					klog.V(3).InfoS("Machineconfig deleted", "name", mc.Name)
-				}
-			}
+		if expectedMachineConfigNames.Has(mc.Name) {
+			continue
+		}
+		if !isOwnedBy(mc.GetObjectMeta(), instance) {
+			continue
+		}
+		if err := cli.Delete(ctx, &mc); err != nil {
+			klog.ErrorS(err, "error while deleting machineconfig", "MachineConfig", mc.Name)
+			errors = append(errors, err)
+		} else {
+			klog.V(3).InfoS("Machineconfig deleted", "name", mc.Name)
 		}
 	}
 	return errors

--- a/internal/dangling/dangling.go
+++ b/internal/dangling/dangling.go
@@ -56,6 +56,7 @@ func DeleteUnusedDaemonSets(cli client.Client, ctx context.Context, instance *nr
 		}
 	}
 
+	deleted := 0
 	for _, ds := range daemonSetList.Items {
 		if !isOwnedBy(ds.GetObjectMeta(), instance) {
 			continue
@@ -69,6 +70,10 @@ func DeleteUnusedDaemonSets(cli client.Client, ctx context.Context, instance *nr
 			continue
 		}
 		klog.V(3).InfoS("dangling Daemonset deleted", "name", ds.Name)
+		deleted += 1
+	}
+	if deleted > 0 {
+		klog.V(2).InfoS("Delete dangling Daemonsets", "deletedCount", deleted)
 	}
 	return errors
 }
@@ -90,6 +95,7 @@ func DeleteUnusedMachineConfigs(cli client.Client, ctx context.Context, instance
 		}
 	}
 
+	deleted := 0
 	for _, mc := range machineConfigList.Items {
 		if !isOwnedBy(mc.GetObjectMeta(), instance) {
 			continue
@@ -103,6 +109,10 @@ func DeleteUnusedMachineConfigs(cli client.Client, ctx context.Context, instance
 			continue
 		}
 		klog.V(3).InfoS("dangling Machineconfig deleted", "name", mc.Name)
+		deleted += 1
+	}
+	if deleted > 0 {
+		klog.V(2).InfoS("Delete dangling Machineconfigs", "deletedCount", deleted)
 	}
 	return errors
 }

--- a/internal/dangling/dangling.go
+++ b/internal/dangling/dangling.go
@@ -40,8 +40,8 @@ import (
 )
 
 func DeleteUnusedDaemonSets(cli client.Client, ctx context.Context, instance *nropv1.NUMAResourcesOperator, trees []nodegroupv1.Tree) []error {
-	klog.V(3).Info("Delete Daemonsets start")
-	defer klog.V(3).Info("Delete Daemonsets end")
+	klog.V(3).Info("Delete dangling Daemonsets start")
+	defer klog.V(3).Info("Delete dangling Daemonsets end")
 	var errors []error
 	var daemonSetList appsv1.DaemonSetList
 	if err := cli.List(ctx, &daemonSetList, &client.ListOptions{Namespace: instance.Namespace}); err != nil {
@@ -64,18 +64,18 @@ func DeleteUnusedDaemonSets(cli client.Client, ctx context.Context, instance *nr
 			continue
 		}
 		if err := cli.Delete(ctx, &ds); err != nil {
-			klog.ErrorS(err, "error while deleting daemonset", "DaemonSet", ds.Name)
+			klog.ErrorS(err, "error while deleting dangling daemonset", "DaemonSet", ds.Namespace+"/"+ds.Name)
 			errors = append(errors, err)
-		} else {
-			klog.V(3).InfoS("Daemonset deleted", "name", ds.Name)
+			continue
 		}
+		klog.V(3).InfoS("dangling Daemonset deleted", "name", ds.Name)
 	}
 	return errors
 }
 
 func DeleteUnusedMachineConfigs(cli client.Client, ctx context.Context, instance *nropv1.NUMAResourcesOperator, trees []nodegroupv1.Tree) []error {
-	klog.V(3).Info("Delete Machineconfigs start")
-	defer klog.V(3).Info("Delete Machineconfigs end")
+	klog.V(3).Info("Delete dangling Machineconfigs start")
+	defer klog.V(3).Info("Delete dangling Machineconfigs end")
 	var errors []error
 	var machineConfigList machineconfigv1.MachineConfigList
 	if err := cli.List(ctx, &machineConfigList); err != nil {
@@ -98,11 +98,11 @@ func DeleteUnusedMachineConfigs(cli client.Client, ctx context.Context, instance
 			continue
 		}
 		if err := cli.Delete(ctx, &mc); err != nil {
-			klog.ErrorS(err, "error while deleting machineconfig", "MachineConfig", mc.Name)
+			klog.ErrorS(err, "error while deleting dangling machineconfig", "MachineConfig", mc.Name)
 			errors = append(errors, err)
-		} else {
-			klog.V(3).InfoS("Machineconfig deleted", "name", mc.Name)
+			continue
 		}
+		klog.V(3).InfoS("dangling Machineconfig deleted", "name", mc.Name)
 	}
 	return errors
 }

--- a/internal/dangling/dangling.go
+++ b/internal/dangling/dangling.go
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package dangling takes care of detecting and removing dangling object from removed NodeGroups.
+// If we edit nodegroups in such a way that a set of nodes previously managed is no longer managed, the related MachineConfig is left lingering.
+// We need to explicit cleanup objects with are 1:1 with NodeGroups because NodeGroups are not a separate object, and the main NRO object is set as
+// the owner of all the generated object. But in this scenario (NodeGroup no longer managed), the main NRO object is NOT deleted, so the dependant
+// objects are left unnecessarily lingering. In hindsight, we should probably have set a NUMAResourcesOperator own NodeGroups, or just allow more than
+// a NUMAResourcesOperator object, but that ship as sailed and now a NUMAResourcesOperator object is 1:N to NodeGroups (and the latter are not K8S objects).
+package dangling

--- a/internal/dangling/dangling.go
+++ b/internal/dangling/dangling.go
@@ -57,10 +57,10 @@ func DeleteUnusedDaemonSets(cli client.Client, ctx context.Context, instance *nr
 	}
 
 	for _, ds := range daemonSetList.Items {
-		if expectedDaemonSetNames.Has(ds.Name) {
+		if !isOwnedBy(ds.GetObjectMeta(), instance) {
 			continue
 		}
-		if !isOwnedBy(ds.GetObjectMeta(), instance) {
+		if expectedDaemonSetNames.Has(ds.Name) {
 			continue
 		}
 		if err := cli.Delete(ctx, &ds); err != nil {
@@ -91,10 +91,10 @@ func DeleteUnusedMachineConfigs(cli client.Client, ctx context.Context, instance
 	}
 
 	for _, mc := range machineConfigList.Items {
-		if expectedMachineConfigNames.Has(mc.Name) {
+		if !isOwnedBy(mc.GetObjectMeta(), instance) {
 			continue
 		}
-		if !isOwnedBy(mc.GetObjectMeta(), instance) {
+		if expectedMachineConfigNames.Has(mc.Name) {
 			continue
 		}
 		if err := cli.Delete(ctx, &mc); err != nil {


### PR DESCRIPTION
Move the dangling object removal code in its own package. This is useful because
- we have now a clear recorded explicit rationale about why we need this code
- this code is in essence a workaround for a questionable design choice, and we now isolate from the regular controller code.
- [future] we enable future reuse (maybe) in the validator.

The main benefit is the added `doc.go`.

this PR salvages the good parts of #1029 
Adding validation support is also a nice idea, but is deferred for later.