### PR TITLE
controller: use slice instead of map to conserve consistent order

### DIFF
--- a/api/numaresourcesoperator/v1/namespacedname.go
+++ b/api/numaresourcesoperator/v1/namespacedname.go
@@ -16,6 +16,10 @@
 
 package v1
 
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
 // This is borrowed from the kubernetes source, because controller-gen
 // complains about the kube native type:
 // encountered struct field "Namespace" without JSON tag in type "NamespacedName"
@@ -35,4 +39,11 @@ const (
 // String returns the general purpose string representation
 func (n NamespacedName) String() string {
 	return n.Namespace + string(Separator) + n.Name
+}
+
+func NamespacedNameFromObject(obj metav1.Object) NamespacedName {
+	return NamespacedName{
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}
 }

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -1125,10 +1125,7 @@ func createTAEDeployment(fxt *e2efixture.Fixture, ctx context.Context, name, sch
 func daemonSetListToNamespacedNameList(dss []*appsv1.DaemonSet) []nropv1.NamespacedName {
 	ret := make([]nropv1.NamespacedName, 0, len(dss))
 	for _, ds := range dss {
-		ret = append(ret, nropv1.NamespacedName{
-			Namespace: ds.Namespace,
-			Name:      ds.Name,
-		})
+		ret = append(ret, (nropv1.NamespacedNameFromObject(ds)))
 	}
 	return ret
 }


### PR DESCRIPTION
Using map to store the daemonset of the targeted MCPs turned out to be a not the best data structure especially when we would like to conserve a consistent order of the elements that aligns with the rest of the slices in the operator status.
The problem with map is that it cannot be guaranteed that the elements will be ordered in the same order they were placed. To fix that, define a new struct of an MCP and its respective created RTE daemonset and replace the map with a slice of this struct which ensures that same data will produce same output every time.

ref: https://groups.google.com/g/golang-nuts/c/YfDxpkI34hY/m/4pktJI2ytusJ