### PR TITLE
OCPBUGS-42523: allow single MCP match per node group by default

### DIFF
--- a/internal/api/annotations/annotations.go
+++ b/internal/api/annotations/annotations.go
@@ -1,12 +1,39 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package annotations
 
 const (
 	SELinuxPolicyConfigAnnotation = "config.node.openshift-kni.io/selinux-policy"
 	SELinuxPolicyCustom           = "custom"
+	// MultiplePoolsPerTreeAnnotation an annotation used to re-enable the support of multiple node pools per tree; starting 4.18 it is disabled by default
+	// the annotation is on when it's set to "enabled", every other value is equivalent to disabled
+	MultiplePoolsPerTreeAnnotation = "config.node.openshift-kni.io/multiple-pools-per-tree"
+	MultiplePoolsPerTreeEnabled    = "enabled"
 )
 
 func IsCustomPolicyEnabled(annot map[string]string) bool {
 	if v, ok := annot[SELinuxPolicyConfigAnnotation]; ok && v == SELinuxPolicyCustom {
+		return true
+	}
+	return false
+}
+
+func IsMultiplePoolsPerTreeEnabled(annot map[string]string) bool {
+	if v, ok := annot[MultiplePoolsPerTreeAnnotation]; ok && v == MultiplePoolsPerTreeEnabled {
 		return true
 	}
 	return false

--- a/internal/api/annotations/annotations_test.go
+++ b/internal/api/annotations/annotations_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import "testing"
+
+func TestIsCustomPolicyEnabled(t *testing.T) {
+	testcases := []struct {
+		description string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			description: "empty map",
+			annotations: map[string]string{},
+			expected:    false,
+		},
+		{
+			description: "annotation set but not to anything except \"custom\" value means the default",
+			annotations: map[string]string{
+				SELinuxPolicyConfigAnnotation: "true",
+			},
+			expected: false,
+		},
+		{
+			description: "enabled custom policy",
+			annotations: map[string]string{
+				SELinuxPolicyConfigAnnotation: "custom",
+			},
+			expected: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			if got := IsCustomPolicyEnabled(tc.annotations); got != tc.expected {
+				t.Errorf("expected %v got %v", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestIsMultiplePoolsPerTreeEnabled(t *testing.T) {
+	testcases := []struct {
+		description string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			description: "empty map",
+			annotations: map[string]string{},
+			expected:    false,
+		},
+		{
+			description: "annotation set to anything but not \"enabled\" means it's disabled",
+			annotations: map[string]string{
+				MultiplePoolsPerTreeAnnotation: "true",
+			},
+			expected: false,
+		},
+		{
+			description: "enabled multiple pools per tree",
+			annotations: map[string]string{
+				MultiplePoolsPerTreeAnnotation: MultiplePoolsPerTreeEnabled,
+			},
+			expected: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			if got := IsMultiplePoolsPerTreeEnabled(tc.annotations); got != tc.expected {
+				t.Errorf("expected %v got %v", tc.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -25,6 +25,7 @@ import (
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
 	nodegroupv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1/helper/nodegroup"
+	"github.com/openshift-kni/numaresources-operator/internal/api/annotations"
 )
 
 const (
@@ -162,4 +163,19 @@ func nodeGroupMachineConfigPoolSelector(nodeGroups []nropv1.NodeGroup) error {
 	}
 
 	return nil
+}
+
+func MultipleMCPsPerTree(annot map[string]string, trees []nodegroupv1.Tree) error {
+	multiMCPsPerTree := annotations.IsMultiplePoolsPerTreeEnabled(annot)
+	if multiMCPsPerTree {
+		return nil
+	}
+
+	var err error
+	for _, tree := range trees {
+		if len(tree.MachineConfigPools) > 1 {
+			err = errors.Join(err, fmt.Errorf("found multiple pools matches for node group %v but expected one. Pools found %+v", &tree.NodeGroup, tree.MachineConfigPools))
+		}
+	}
+	return err
 }


### PR DESCRIPTION
Because of historical accident we have a 1:N mapping between NodeGroup and MCPs (MachineConfigPool*s* is a slice!). One of the key design assumptions in NROP is the 1:1 mapping between NodeGroups and MCPs.

Since we want to conserve the backward compatibility we still need to support multiple MCP matches per tree; however, since by design the intention was to have a single matching MCP per node group, make this the default behavior. To re-enable the old behavior permitting multiple pools matches, use the following annotation: `experimental.multiple-pools-per-tree: enabled`

Experiment the effects of the new default for the next 2 releases. If there are no complaints, we shall remove the multiple MCP match logic.