### PR TITLE
Prepare for cleaning up status computation

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import "errors"
+
+func reasonFromError(err error) string {
+	if err == nil {
+		return "AsExpected"
+	}
+	return "InternalError"
+}
+
+func messageFromError(err error) string {
+	if err == nil {
+		return ""
+	}
+	unwErr := errors.Unwrap(err)
+	if unwErr == nil {
+		return ""
+	}
+	return unwErr.Error()
+}

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -181,7 +181,7 @@ func (r *NUMAResourcesOperatorReconciler) updateStatus(ctx context.Context, inst
 }
 
 func updateStatus(ctx context.Context, cli client.Client, instance *nropv1.NUMAResourcesOperator, condition string, reason string, message string) (bool, error) {
-	conditions, ok := status.GetUpdatedConditions(instance.Status.Conditions, condition, reason, message)
+	conditions, ok := status.UpdateConditions(instance.Status.Conditions, condition, reason, message)
 	if ok {
 		instance.Status.Conditions = conditions
 	}

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -164,9 +163,7 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 
 	result, condition, err := r.reconcileResource(ctx, instance, trees)
 	if condition != "" {
-		// TODO: use proper reason
-		reason, message := condition, messageFromError(err)
-		_, _ = r.updateStatus(ctx, instance, condition, reason, message)
+		_, _ = r.updateStatus(ctx, instance, condition, reasonFromError(err), messageFromError(err))
 	}
 	return result, err
 }
@@ -194,17 +191,6 @@ func updateStatus(ctx context.Context, cli client.Client, instance *nropv1.NUMAR
 		return false, fmt.Errorf("could not update status for object %s: %w", client.ObjectKeyFromObject(instance), err)
 	}
 	return true, nil
-}
-
-func messageFromError(err error) string {
-	if err == nil {
-		return ""
-	}
-	unwErr := errors.Unwrap(err)
-	if unwErr == nil {
-		return ""
-	}
-	return unwErr.Error()
 }
 
 func (r *NUMAResourcesOperatorReconciler) reconcileResourceAPI(ctx context.Context, instance *nropv1.NUMAResourcesOperator, trees []nodegroupv1.Tree) (bool, ctrl.Result, string, error) {

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -139,21 +139,21 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	if req.Name != objectnames.DefaultNUMAResourcesOperatorCrName {
-		message := fmt.Sprintf("incorrect NUMAResourcesOperator resource name: %s", instance.Name)
-		return r.updateStatus(ctx, instance, status.ConditionDegraded, status.ConditionTypeIncorrectNUMAResourcesOperatorResourceName, message)
+		err := fmt.Errorf("incorrect NUMAResourcesOperator resource name: %s", instance.Name)
+		return r.updateStatus(ctx, instance, status.ConditionDegraded, status.ConditionTypeIncorrectNUMAResourcesOperatorResourceName, err)
 	}
 
 	if err := validation.NodeGroups(instance.Spec.NodeGroups); err != nil {
-		return r.updateStatus(ctx, instance, status.ConditionDegraded, validation.NodeGroupsError, err.Error())
+		return r.updateStatus(ctx, instance, status.ConditionDegraded, validation.NodeGroupsError, err)
 	}
 
 	trees, err := getTreesByNodeGroup(ctx, r.Client, instance.Spec.NodeGroups)
 	if err != nil {
-		return r.updateStatus(ctx, instance, status.ConditionDegraded, validation.NodeGroupsError, err.Error())
+		return r.updateStatus(ctx, instance, status.ConditionDegraded, validation.NodeGroupsError, err)
 	}
 
 	if err := validation.MachineConfigPoolDuplicates(trees); err != nil {
-		return r.updateStatus(ctx, instance, status.ConditionDegraded, validation.NodeGroupsError, err.Error())
+		return r.updateStatus(ctx, instance, status.ConditionDegraded, validation.NodeGroupsError, err)
 	}
 
 	for idx := range trees {
@@ -163,34 +163,35 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 
 	result, condition, err := r.reconcileResource(ctx, instance, trees)
 	if condition != "" {
-		_, _ = r.updateStatus(ctx, instance, condition, reasonFromError(err), messageFromError(err))
+		_, _ = r.updateStatus(ctx, instance, condition, reasonFromError(err), err)
 	}
 	return result, err
 }
 
-func (r *NUMAResourcesOperatorReconciler) updateStatus(ctx context.Context, instance *nropv1.NUMAResourcesOperator, condition string, reason string, message string) (ctrl.Result, error) {
+// updateStatusConditionsIfNeeded returns true if conditions were updated.
+func updateStatusConditionsIfNeeded(instance *nropv1.NUMAResourcesOperator, condition string, reason string, message string) bool {
 	klog.InfoS("updateStatus", "condition", condition, "reason", reason, "message", message)
-
-	if _, err := updateStatus(ctx, r.Client, instance, condition, reason, message); err != nil {
-		klog.InfoS("Failed to update numaresourcesoperator status", "Desired condition", status.ConditionDegraded, "error", err)
-		return ctrl.Result{}, err
-	}
-	// we do not return an error here because to pass the validation error a user will need to update NRO CR
-	// that will anyway initiate to reconcile loop
-	return ctrl.Result{}, nil
-}
-
-func updateStatus(ctx context.Context, cli client.Client, instance *nropv1.NUMAResourcesOperator, condition string, reason string, message string) (bool, error) {
 	conditions, ok := status.UpdateConditions(instance.Status.Conditions, condition, reason, message)
 	if ok {
 		instance.Status.Conditions = conditions
 	}
+	return ok
+}
 
-	// in case of a 2 similar successive conditions happen we still want to update the status to get latest status updates
-	if err := cli.Status().Update(ctx, instance); err != nil {
-		return false, fmt.Errorf("could not update status for object %s: %w", client.ObjectKeyFromObject(instance), err)
+func (r *NUMAResourcesOperatorReconciler) updateStatus(ctx context.Context, instance *nropv1.NUMAResourcesOperator, condition string, reason string, stErr error) (ctrl.Result, error) {
+	message := messageFromError(stErr)
+
+	_ = updateStatusConditionsIfNeeded(instance, condition, reason, message)
+
+	err := r.Client.Status().Update(ctx, instance)
+	if err != nil {
+		klog.InfoS("Failed to update numaresourcesoperator status", "error", err)
+		return ctrl.Result{}, fmt.Errorf("could not update status for object %s: %w", client.ObjectKeyFromObject(instance), err)
 	}
-	return true, nil
+
+	// we do not return an error here because to pass the validation error a user will need to update NRO CR
+	// that will anyway initiate to reconcile loop
+	return ctrl.Result{}, nil
 }
 
 func (r *NUMAResourcesOperatorReconciler) reconcileResourceAPI(ctx context.Context, instance *nropv1.NUMAResourcesOperator, trees []nodegroupv1.Tree) (bool, ctrl.Result, string, error) {

--- a/controllers/numaresourcesscheduler_controller.go
+++ b/controllers/numaresourcesscheduler_controller.go
@@ -111,9 +111,7 @@ func (r *NUMAResourcesSchedulerReconciler) Reconcile(ctx context.Context, req ct
 	}
 
 	result, condition, err := r.reconcileResource(ctx, instance)
-
-	reason := condition // TODO: use proper reason
-	if err := r.updateStatus(ctx, instance, condition, reason, messageFromError(err)); err != nil {
+	if err := r.updateStatus(ctx, instance, condition, reasonFromError(err), messageFromError(err)); err != nil {
 		klog.InfoS("Failed to update numaresourcesscheduler status", "Desired condition", condition, "error", err)
 	}
 

--- a/controllers/numaresourcesscheduler_controller.go
+++ b/controllers/numaresourcesscheduler_controller.go
@@ -249,7 +249,7 @@ func (r *NUMAResourcesSchedulerReconciler) syncNUMASchedulerResources(ctx contex
 }
 
 func (r *NUMAResourcesSchedulerReconciler) updateStatus(ctx context.Context, sched *nropv1.NUMAResourcesScheduler, condition string, reason string, message string) error {
-	sched.Status.Conditions, _ = status.GetUpdatedConditions(sched.Status.Conditions, condition, reason, message)
+	sched.Status.Conditions, _ = status.UpdateConditions(sched.Status.Conditions, condition, reason, message)
 	if err := r.Client.Status().Update(ctx, sched); err != nil {
 		return fmt.Errorf("could not update status for object %s: %w", client.ObjectKeyFromObject(sched), err)
 	}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -37,7 +37,10 @@ const (
 	ConditionTypeIncorrectNUMAResourcesOperatorResourceName = "IncorrectNUMAResourcesOperatorResourceName"
 )
 
-func GetUpdatedConditions(currentConditions []metav1.Condition, condition string, reason string, message string) ([]metav1.Condition, bool) {
+// UpdateConditions compute new conditions based on arguments, and then compare with given current conditions.
+// Returns the conditions to use, either current or newly computed, and a boolean flag which is `true` if conditions need
+// update - so if they are updated since the current conditions.
+func UpdateConditions(currentConditions []metav1.Condition, condition string, reason string, message string) ([]metav1.Condition, bool) {
 	conditions := NewConditions(condition, reason, message)
 
 	options := []cmp.Option{

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -39,7 +39,7 @@ func TestUpdate(t *testing.T) {
 	nro := testobjs.NewNUMAResourcesOperator("test-nro")
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(nro).Build()
 
-	nro.Status.Conditions, _ = GetUpdatedConditions(nro.Status.Conditions, ConditionProgressing, "testReason", "test message")
+	nro.Status.Conditions, _ = UpdateConditions(nro.Status.Conditions, ConditionProgressing, "testReason", "test message")
 	err = fakeClient.Update(context.TODO(), nro)
 	if err != nil {
 		t.Errorf("Update() failed with: %v", err)
@@ -67,13 +67,13 @@ func TestUpdateIfNeeded(t *testing.T) {
 	nro := testobjs.NewNUMAResourcesOperator("test-nro")
 
 	var ok bool
-	nro.Status.Conditions, ok = GetUpdatedConditions(nro.Status.Conditions, ConditionAvailable, "", "")
+	nro.Status.Conditions, ok = UpdateConditions(nro.Status.Conditions, ConditionAvailable, "", "")
 	if !ok {
 		t.Errorf("Update did not change status, but it should")
 	}
 
 	// same status twice in a row. We should not overwrite identical status to save transactions.
-	_, ok = GetUpdatedConditions(nro.Status.Conditions, ConditionAvailable, "", "")
+	_, ok = UpdateConditions(nro.Status.Conditions, ConditionAvailable, "", "")
 	if ok {
 		t.Errorf("Update did change status, but it should not")
 	}


### PR DESCRIPTION
Simple and safe cleanup/refactoring preparation to the real upcoming cleanup of how controllers compute the status of their objects.

These changes have some (little, admittedly) value on their own and simplify the main PR (#1032).
