### PR TITLE
CNF-14050: csv:operator: lax affinity constraints

### DIFF
--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -502,9 +502,10 @@ spec:
             spec:
               affinity:
                 nodeAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    nodeSelectorTerms:
-                    - matchExpressions:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 1
+                    preference:
+                      matchExpressions:
                       - key: node-role.kubernetes.io/control-plane
                         operator: Exists
               containers:


### PR DESCRIPTION
On HyperShift, the operator is supposed to be running on the worker nodes and not on the control planes which are located at the MNG cluster.

For that we should make the affinity constraints less restrict, and replace `requiredDuringSchedulingIgnoredDuringExecution` with `preferredDuringSchedulingIgnoredDuringExecution`.

There are other possibilities like overriding the CSV from the `subscription`:
https://olm.operatorframework.io/docs/advanced-tasks/overriding-operator-pod-affinity-configuration/#example-overridingdefining-node-affinity

but that requires creation of a `subscription` on the targeted cluster, by the admin or another controller.

In addition the creation of the `subscription` varries based on the environment.
For exmaple it would be a different procedure for production and CI.

So after a careful investigation we find the former way more suitable and convenient.