### PR TITLE
e2e: fix padder allocationTarget to ensure unfeasible nodes

### DIFF
--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -116,14 +116,14 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			numOfNodeToBePadded := len(nrts) - 1
 
 			rl := corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("3"),
-				corev1.ResourceMemory: resource.MustParse("8G"),
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("4G"),
 			}
 			By("padding the nodes before test start")
 			labSel, err := labels.Parse(serialconfig.MultiNUMALabel + "=2")
 			Expect(err).ToNot(HaveOccurred())
 
-			err = padder.Nodes(numOfNodeToBePadded).UntilAvailableIsResourceList(rl).Pad(timeout, e2epadder.PaddingOptions{
+			err = padder.Nodes(numOfNodeToBePadded).UntilAvailableIsResourceListPerZone(rl).Pad(timeout, e2epadder.PaddingOptions{
 				LabelSelector: labSel,
 			})
 			Expect(err).ToNot(HaveOccurred())
@@ -161,7 +161,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			cnt := &testPod.Spec.Containers[0]
 			requiredRes := corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceCPU:    resource.MustParse("4"),
 				corev1.ResourceMemory: resource.MustParse("100Mi"),
 			}
 			cnt.Resources.Requests = requiredRes

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -128,14 +128,14 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			numOfNodeToBePadded := len(nrts) - 1
 
 			rl := corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("3"),
-				corev1.ResourceMemory: resource.MustParse("8G"),
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("4G"),
 			}
 			By("padding the nodes before test start")
 			labSel, err := labels.Parse(serialconfig.MultiNUMALabel + "=2")
 			Expect(err).ToNot(HaveOccurred())
 
-			err = padder.Nodes(numOfNodeToBePadded).UntilAvailableIsResourceList(rl).Pad(timeout, e2epadder.PaddingOptions{
+			err = padder.Nodes(numOfNodeToBePadded).UntilAvailableIsResourceListPerZone(rl).Pad(timeout, e2epadder.PaddingOptions{
 				LabelSelector: labSel,
 			})
 			Expect(err).ToNot(HaveOccurred())
@@ -355,11 +355,11 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			rl = corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("2"),
-				corev1.ResourceMemory: resource.MustParse("8G"),
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("4G"),
 			}
 
-			err = padder.Nodes(1).UntilAvailableIsResourceList(rl).Pad(timeout, e2epadder.PaddingOptions{LabelSelector: sel})
+			err = padder.Nodes(1).UntilAvailableIsResourceListPerZone(rl).Pad(timeout, e2epadder.PaddingOptions{LabelSelector: sel})
 			Expect(err).ToNot(HaveOccurred())
 
 			// we reorganize the cluster state, so we need to get an updated NRTs which will be treated as the initial ones
@@ -518,14 +518,14 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			numOfNodeToBePadded := len(nrts) - 1
 
 			rl := corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("3"),
-				corev1.ResourceMemory: resource.MustParse("8G"),
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("4G"),
 			}
 			By("padding the nodes before test start")
 			labSel, err := labels.Parse(serialconfig.MultiNUMALabel + "=2")
 			Expect(err).ToNot(HaveOccurred())
 
-			err = padder.Nodes(numOfNodeToBePadded).UntilAvailableIsResourceList(rl).Pad(timeout, e2epadder.PaddingOptions{
+			err = padder.Nodes(numOfNodeToBePadded).UntilAvailableIsResourceListPerZone(rl).Pad(timeout, e2epadder.PaddingOptions{
 				LabelSelector: labSel,
 			})
 			Expect(err).ToNot(HaveOccurred())
@@ -764,7 +764,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			labSel, err := labels.Parse(serialconfig.MultiNUMALabel + "=2")
 			Expect(err).ToNot(HaveOccurred())
 
-			err = padder.Nodes(numOfNodeToBePadded).UntilAvailableIsResourceList(rl).Pad(timeout, e2epadder.PaddingOptions{
+			err = padder.Nodes(numOfNodeToBePadded).UntilAvailableIsResourceListPerZone(rl).Pad(timeout, e2epadder.PaddingOptions{
 				LabelSelector: labSel,
 			})
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/serial/tests/workload_placement_taint.go
+++ b/test/e2e/serial/tests/workload_placement_taint.go
@@ -110,14 +110,14 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			numOfNodeToBePadded := len(nrts) - 1
 
 			rl := corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("3"),
-				corev1.ResourceMemory: resource.MustParse("8G"),
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("4G"),
 			}
 			By("padding the nodes before test start")
 			labSel, err := labels.Parse(serialconfig.MultiNUMALabel + "=2")
 			Expect(err).ToNot(HaveOccurred())
 
-			err = padder.Nodes(numOfNodeToBePadded).UntilAvailableIsResourceList(rl).Pad(timeout, e2epadder.PaddingOptions{
+			err = padder.Nodes(numOfNodeToBePadded).UntilAvailableIsResourceListPerZone(rl).Pad(timeout, e2epadder.PaddingOptions{
 				LabelSelector: labSel,
 			})
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -633,13 +633,13 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			}
 
 			padUntilRes := corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("3"),
-				corev1.ResourceMemory: resource.MustParse("8Gi"),
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
 			}
 
 			labSel, err := labels.Parse(serialconfig.MultiNUMALabel + "=2")
 			Expect(err).ToNot(HaveOccurred())
-			err = padder.Nodes(len(nrts)).UntilAvailableIsResourceList(padUntilRes).Pad(time.Minute*2, e2epadder.PaddingOptions{
+			err = padder.Nodes(len(nrts)).UntilAvailableIsResourceListPerZone(padUntilRes).Pad(time.Minute*2, e2epadder.PaddingOptions{
 				LabelSelector: labSel,
 			})
 			Expect(err).ToNot(HaveOccurred())

--- a/test/utils/padder/padder.go
+++ b/test/utils/padder/padder.go
@@ -98,14 +98,14 @@ func (p *Padder) Nodes(n int) *Padder {
 }
 
 // UntilAvailableIsResource will pad pods into nodes until reach the desired available allocationTarget
-func (p *Padder) UntilAvailableIsResource(resName corev1.ResourceName, quantity string) *Padder {
+func (p *Padder) UntilAvailableIsResourcePerZone(resName corev1.ResourceName, quantity string) *Padder {
 	quan := resource.MustParse(quantity)
 	p.allocationTarget[resName] = quan
 	return p
 }
 
 // UntilAvailableIsResourceList is like UntilAvailableIsResource but with a complete ResourceList as a parameter
-func (p *Padder) UntilAvailableIsResourceList(resources corev1.ResourceList) *Padder {
+func (p *Padder) UntilAvailableIsResourceListPerZone(resources corev1.ResourceList) *Padder {
 	p.allocationTarget = resources
 	return p
 }


### PR DESCRIPTION
The test 47591 is expecting the testing pod to land on the target node that is unpadded. The problem is with the CPU request amount of 2, which is available on the target node but also on the other nodes although they are padded. Thus, the test fails because the pod landed on a node other than the target when TMScope is a container.

Ultimately, the reason is the way the padding function works. It creates a guaranteed pod on each numa zone and each pod with the same allocation resources that were set in the Padder field. This means the whole compute the node will have available resources equivalent to `<# numa cells per node> * p.allocationTarget`.

This is a quick fix for this test flakiness and other possible instances
 to reduce the amount of resources forwarded as the allocation target to
 guarantee that non target nodes are truely unfeasible.
Adjust the function name reflect that the padding is done per numa zone.