### PR TITLE
manifests: relax node affinity for hypershift

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -37,11 +37,12 @@ spec:
         key: node-role.kubernetes.io/master
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: node-role.kubernetes.io/control-plane
-                operator: Exists
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       containers:
       - command:
         - /bin/numaresources-operator

--- a/pkg/numaresourcesscheduler/manifests/yaml/deployment.yaml
+++ b/pkg/numaresourcesscheduler/manifests/yaml/deployment.yaml
@@ -23,11 +23,12 @@ spec:
           type: RuntimeDefault
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node-role.kubernetes.io/control-plane
-                    operator: Exists
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+                - key: node-role.kubernetes.io/control-plane
+                  operator: Exists
       volumes:
         - name: "etckubernetes"
           configMap:


### PR DESCRIPTION
For local deployment (not via OLM), we configure the controller manager using yaml files instead of CSV. These yamls use requiredDuringSchedulingIgnoredDuringExecution affinity but on hypershift it was agreed that controller and scheduler be scheduled on the hosted cluster which contains worker nodes only.

related to
https://github.com/openshift-kni/numaresources-operator/pull/1059.