### PR TITLE
mustgather: Dockerfile: use ocp CLI base image

### DIFF
--- a/Dockerfile.must-gather
+++ b/Dockerfile.must-gather
@@ -1,16 +1,4 @@
-FROM quay.io/openshift/origin-must-gather:4.18.0 AS builder
-
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
-RUN microdnf install -y procps-ng tar rsync
-RUN microdnf clean all
-
-# Copy must-gather required binaries
-COPY --from=builder /usr/bin/openshift-must-gather /usr/bin/openshift-must-gather
-COPY --from=builder /usr/bin/oc /usr/bin/oc
-
-# Save original gather script
-COPY --from=builder /usr/bin/gather* /usr/bin/
-RUN mv /usr/bin/gather /usr/bin/gather_original
+FROM quay.io/openshift/origin-cli:4.18
 
 COPY must-gather/collection-scripts/* /usr/bin/
 


### PR DESCRIPTION
Initially, must-gather for NROP was built by grabbing the latest openshift-ose-must-gather image, copying the required binaries for running must gather and override the collection scripts and base that on rhel-minimal.

While this works, there is no need for extra dependencies on images when all we need is the openshift clients to gather the must-gather collection which is available in the CLI image.