### PR TITLE
hack:ci: remove trap

### DIFF
--- a/hack/run-test-install-e2e.sh
+++ b/hack/run-test-install-e2e.sh
@@ -10,12 +10,15 @@ fi
 
 setupreport
 
-# Make sure that we always properly clean the environment
-trap '{ echo "Running NRO uninstall test suite"; ${BIN_DIR}/e2e-nrop-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/uninstall.xml; }' EXIT SIGINT SIGTERM SIGSTOP
-
 # Run install test suite
 echo "Running NRO install test suite"
-${BIN_DIR}/e2e-nrop-install.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.junit-report=${REPORT_DIR}/install.xml --ginkgo.focus='\[Install\] durability'
-  
+if ! "${BIN_DIR}"/e2e-nrop-install.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.junit-report=${REPORT_DIR}/install.xml --ginkgo.focus='\[Install\] durability'; then
+  echo "Failed to run NRO install test suite"
+  exit 1
+fi
+
 echo "Running NRO uninstall test suite";
-${BIN_DIR}/e2e-nrop-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/uninstall.xml
+if ! "${BIN_DIR}"/e2e-nrop-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/uninstall.xml; then
+  echo "Failed to run NRO install test suite"
+  exit 2
+fi

--- a/hack/run-test-serial-e2e.sh
+++ b/hack/run-test-serial-e2e.sh
@@ -200,9 +200,13 @@ function runtests() {
 trap 'teardown' EXIT SIGINT SIGTERM SIGSTOP
 
 setupreport
-setup
-if [ $? -ne 0 ]; then
+
+if ! setup; then
     echo "Failed to install NRO"
     exit 1
 fi
-runtests
+
+if ! runtests; then
+  echo "Failed to run tests"
+  exit 2
+fi

--- a/hack/run-test-serial-e2e.sh
+++ b/hack/run-test-serial-e2e.sh
@@ -197,7 +197,7 @@ function runtests() {
 }
 
 # Make sure that we always properly clean the environment
-trap 'teardown' EXIT SIGINT SIGTERM SIGSTOP
+trap 'teardown' EXIT SIGINT SIGTERM
 
 setupreport
 


### PR DESCRIPTION
The run-test-install-e2e.sh script is usually running as part of the u/s CI tests.
We don't want to catch the signal in trap because it's
masking the error which makes the test a false positive.

We want to check the error explicitly and fail loud instead,
because on CI there's no bother to revert the cluster back
to its initial state.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>