### PR TITLE
validation: ensure non-empty poolName

### DIFF
--- a/internal/dangling/dangling.go
+++ b/internal/dangling/dangling.go
@@ -126,8 +126,9 @@ func isOwnedBy(element metav1.Object, owner metav1.Object) bool {
 func buildDaemonSetNames(instance *nropv1.NUMAResourcesOperator, trees []nodegroupv1.Tree) sets.Set[string] {
 	expectedDaemonSetNames := sets.New[string]()
 	for _, tree := range trees {
-		poolName := tree.NodeGroup.PoolName
-		if poolName != nil && *poolName != "" {
+		// the earlier validation step ensures that if poolName is not nil, then it's not empty either
+		poolName := tree.NodeGroup.PoolName // shortcut
+		if poolName != nil {
 			expectedDaemonSetNames.Insert(objectnames.GetComponentName(instance.Name, *poolName))
 			continue
 		}

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -61,6 +61,10 @@ func NodeGroups(nodeGroups []nropv1.NodeGroup) error {
 		return err
 	}
 
+	if err := nodeGroupsValidPoolName(nodeGroups); err != nil {
+		return err
+	}
+
 	if err := nodeGroupsDuplicatesByPoolName(nodeGroups); err != nil {
 		return err
 	}
@@ -83,6 +87,20 @@ func nodeGroupPools(nodeGroups []nropv1.NodeGroup) error {
 	}
 
 	return nil
+}
+
+func nodeGroupsValidPoolName(nodeGroups []nropv1.NodeGroup) error {
+	var err error
+	for idx, nodeGroup := range nodeGroups {
+		if nodeGroup.PoolName == nil {
+			continue
+		}
+		if *nodeGroup.PoolName != "" {
+			continue
+		}
+		err = errors.Join(err, fmt.Errorf("pool name for pool #%d cannot be empty", idx))
+	}
+	return err
 }
 
 func nodeGroupsDuplicatesByMCPSelector(nodeGroups []nropv1.NodeGroup) error {

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -90,6 +90,7 @@ func TestNodeGroupsSanity(t *testing.T) {
 		expectedErrorMessage string
 	}
 
+	emptyString := ""
 	poolName := "poolname-test"
 	testCases := []testCase{
 		{
@@ -199,6 +200,16 @@ func TestNodeGroupsSanity(t *testing.T) {
 					PoolName: &poolName,
 				},
 			},
+		},
+		{
+			name: "empty pool name",
+			nodeGroups: []nropv1.NodeGroup{
+				{
+					PoolName: &emptyString,
+				},
+			},
+			expectedError:        true,
+			expectedErrorMessage: "cannot be empty",
 		},
 	}
 


### PR DESCRIPTION
We wanted to have this validation, but we didn't actually add it yet :)

So, if the user supplies a PoolName, it must be non-empty string: the rest of our code expects
it that way, and it's a pretty reasonable restriction anyway.

Add validation to enforce this, and simplify code after the validation.