### PR TITLE
deploy-mco-crds.sh: do not install mco crds on hypershift

### DIFF
--- a/hack/deploy-mco-crds.sh
+++ b/hack/deploy-mco-crds.sh
@@ -14,5 +14,10 @@ if ${REPO_DIR}/bin/lsplatform -is-platform openshift; then
 	exit 0
 fi
 
+if ${REPO_DIR}/bin/lsplatform -is-platform HyperShift; then
+	echo "detected HyperShift platform - nothing to do"
+	exit 0
+fi
+
 runcmd kubectl apply -f ${CRD_MACHINE_CONFIG_POOL_URL}
 runcmd kubectl apply -f ${CRD_KUBELET_CONFIG_URL}


### PR DESCRIPTION
On HyperShift hostedcluster, the concepts MCO and KubeletConfig do not exist.
Henec, we should not install their CRDs while using calling `make deploy`