### PR TITLE
sched: manifests: disable leader election by default

### DIFF
--- a/pkg/numaresourcesscheduler/manifests/yaml/configmap.nrt.yaml
+++ b/pkg/numaresourcesscheduler/manifests/yaml/configmap.nrt.yaml
@@ -8,7 +8,7 @@ data:
     apiVersion: kubescheduler.config.k8s.io/v1
     kind: KubeSchedulerConfiguration
     leaderElection:
-      leaderElect: true
+      leaderElect: false
     profiles:
       - schedulerName: topo-aware-scheduler
         plugins:


### PR DESCRIPTION
Defaults for leader election are questionable at best and likely harmful. So, we should default the leader election to off and enable it only if user sets so, because this will make us to tune all the leader election parameters and set sane values.