### PR TITLE
sched: always set the leader election parameters

### DIFF
--- a/pkg/numaresourcesscheduler/consts.go
+++ b/pkg/numaresourcesscheduler/consts.go
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package numaresourcesscheduler
+
+const (
+	LeaderElectionResourceName = "numa-scheduler-leader"
+	SchedulerPriorityClassName = "system-node-critical"
+)

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -46,6 +46,10 @@ const (
 	ConditionTypeIncorrectNUMAResourcesOperatorResourceName = "IncorrectNUMAResourcesOperatorResourceName"
 )
 
+const (
+	ConditionTypeIncorrectNUMAResourcesSchedulerResourceName = "IncorrectNUMAResourcesSchedulerResourceName"
+)
+
 func IsUpdatedNUMAResourcesOperator(oldStatus, newStatus *nropv1.NUMAResourcesOperatorStatus) bool {
 	options := []cmp.Option{
 		cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),


### PR DESCRIPTION
Because of a overlook, we used to set the leader election
params only if replicas > 1 was requested. This left the key *and default* corner case of replicas=1 with
compiled in defaults, which are questionable at best and most likely harmful for our use case.

Make sure to always set sane parameters, obviously taking into account the user desires from the spec
(Replicas field).

Add more logs to make troubleshooting easier