### PR TITLE
e2e: more robust wait for MCP updates

### DIFF
--- a/internal/wait/kubeletconfig.go
+++ b/internal/wait/kubeletconfig.go
@@ -32,3 +32,14 @@ func (wt Waiter) ForMCOKubeletConfigDeleted(ctx context.Context, kcName string) 
 		return deletionStatusFromError("MCOKubeletConfig", key, err)
 	})
 }
+
+func (wt Waiter) ForKubeletConfigDeleted(ctx context.Context, kc *machineconfigv1.KubeletConfig) error {
+	immediate := false
+	err := k8swait.PollUntilContextTimeout(ctx, wt.PollInterval, wt.PollTimeout, immediate, func(aContext context.Context) (bool, error) {
+		updatedKc := machineconfigv1.KubeletConfig{}
+		key := ObjectKeyFromObject(kc)
+		err := wt.Cli.Get(aContext, key.AsKey(), &updatedKc)
+		return deletionStatusFromError("KubeletConfig", key, err)
+	})
+	return err
+}

--- a/internal/wait/machineconfigpool.go
+++ b/internal/wait/machineconfigpool.go
@@ -52,6 +52,11 @@ func (wt Waiter) ForMachineConfigPoolCondition(ctx context.Context, mcp *machine
 		if err != nil {
 			return false, err
 		}
+		klog.Infof("mcp: updated resourceversion %q (reference: %q)", updatedMcp.ResourceVersion, mcp.ResourceVersion)
+		if updatedMcp.ResourceVersion == mcp.ResourceVersion {
+			// nothing yet changed, need to recheck later
+			return false, nil
+		}
 		for _, cond := range updatedMcp.Status.Conditions {
 			if cond.Type == condType {
 				if cond.Status == corev1.ConditionTrue {

--- a/internal/wait/machineconfigpool.go
+++ b/internal/wait/machineconfigpool.go
@@ -34,10 +34,10 @@ const (
 
 func (wt Waiter) ForMachineConfigPoolDeleted(ctx context.Context, mcp *machineconfigv1.MachineConfigPool) error {
 	immediate := false
-	err := k8swait.PollUntilContextTimeout(ctx, wt.PollInterval, wt.PollTimeout, immediate, func(aContext context.Context) (bool, error) {
+	err := k8swait.PollUntilContextTimeout(ctx, wt.PollInterval, wt.PollTimeout, immediate, func(ctx context.Context) (bool, error) {
 		updatedMcp := machineconfigv1.MachineConfigPool{}
 		key := ObjectKeyFromObject(mcp)
-		err := wt.Cli.Get(aContext, key.AsKey(), &updatedMcp)
+		err := wt.Cli.Get(ctx, key.AsKey(), &updatedMcp)
 		return deletionStatusFromError("MachineConfigPool", key, err)
 	})
 	return err
@@ -45,10 +45,10 @@ func (wt Waiter) ForMachineConfigPoolDeleted(ctx context.Context, mcp *machineco
 
 func (wt Waiter) ForMachineConfigPoolCondition(ctx context.Context, mcp *machineconfigv1.MachineConfigPool, condType machineconfigv1.MachineConfigPoolConditionType) error {
 	immediate := false
-	err := k8swait.PollUntilContextTimeout(ctx, wt.PollInterval, wt.PollTimeout, immediate, func(aContext context.Context) (bool, error) {
+	err := k8swait.PollUntilContextTimeout(ctx, wt.PollInterval, wt.PollTimeout, immediate, func(ctx context.Context) (bool, error) {
 		updatedMcp := machineconfigv1.MachineConfigPool{}
 		key := ObjectKeyFromObject(mcp)
-		err := wt.Cli.Get(aContext, key.AsKey(), &updatedMcp)
+		err := wt.Cli.Get(ctx, key.AsKey(), &updatedMcp)
 		if err != nil {
 			return false, err
 		}

--- a/internal/wait/machineconfigpool.go
+++ b/internal/wait/machineconfigpool.go
@@ -43,17 +43,6 @@ func (wt Waiter) ForMachineConfigPoolDeleted(ctx context.Context, mcp *machineco
 	return err
 }
 
-func (wt Waiter) ForKubeletConfigDeleted(ctx context.Context, kc *machineconfigv1.KubeletConfig) error {
-	immediate := false
-	err := k8swait.PollUntilContextTimeout(ctx, wt.PollInterval, wt.PollTimeout, immediate, func(aContext context.Context) (bool, error) {
-		updatedKc := machineconfigv1.KubeletConfig{}
-		key := ObjectKeyFromObject(kc)
-		err := wt.Cli.Get(aContext, key.AsKey(), &updatedKc)
-		return deletionStatusFromError("KubeletConfig", key, err)
-	})
-	return err
-}
-
 func (wt Waiter) ForMachineConfigPoolCondition(ctx context.Context, mcp *machineconfigv1.MachineConfigPool, condType machineconfigv1.MachineConfigPoolConditionType) error {
 	immediate := false
 	err := k8swait.PollUntilContextTimeout(ctx, wt.PollInterval, wt.PollTimeout, immediate, func(aContext context.Context) (bool, error) {

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -91,7 +91,7 @@ const (
 )
 
 type mcpInfo struct {
-	obj           *machineconfigv1.MachineConfigPool
+	mcpObj        *machineconfigv1.MachineConfigPool
 	initialConfig string
 	sampleNode    corev1.Node
 }
@@ -195,12 +195,12 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			}()
 			//so far 0 machine count for mcp-test -> no nodes -> no updates status
 			newMcpInfo := mcpInfo{
-				obj:           mcp,
+				mcpObj:        mcp,
 				initialConfig: mcp.Status.Configuration.Name,
 				sampleNode:    targetedNode,
 			}
 			initialMcpInfo := mcpInfo{
-				obj:           initialMcp,
+				mcpObj:        initialMcp,
 				initialConfig: initialMcp.Status.Configuration.Name,
 				sampleNode:    initialMcpSampleNode,
 			}
@@ -212,7 +212,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			defer func() {
 				By(fmt.Sprintf("CLEANUP: restore initial labels of node %q with %q", targetedNode.Name, getLabelRoleWorker()))
 				var updatedMcp machineconfigv1.MachineConfigPool
-				Expect(fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(initialMcpInfo.obj), &updatedMcp)).To(Succeed())
+				Expect(fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(initialMcpInfo.mcpObj), &updatedMcp)).To(Succeed())
 				initialMcpInfo.initialConfig = updatedMcp.Status.Configuration.Name
 				initialMcpInfo.sampleNode = targetedNode
 
@@ -241,7 +241,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			defer func() {
 				By("CLEANUP: reverting the changes under the NUMAResourcesOperator object")
 				var updatedMcp machineconfigv1.MachineConfigPool
-				Expect(fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(initialMcpInfo.obj), &updatedMcp)).To(Succeed())
+				Expect(fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(initialMcpInfo.mcpObj), &updatedMcp)).To(Succeed())
 				initialMcpInfo.initialConfig = updatedMcp.Status.Configuration.Name
 
 				// see https://pkg.go.dev/github.com/onsi/gomega#Eventually category 3

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -536,7 +536,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 					By("delete current NROP CR from the cluster")
 					mcpsInfo, err := buildMCPsInfo(fxt.Client, ctx, nroOperObj)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(len(mcpsInfo)).To(BeNumerically(">", 0))
+					Expect(mcpsInfo).ToNot(BeEmpty())
 
 					err = fxt.Client.Delete(ctx, &nroOperObj)
 					Expect(err).ToNot(HaveOccurred())
@@ -578,7 +578,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 
 						mcpsInfo, err := buildMCPsInfo(fxt.Client, ctx, *nropNewObj)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(len(mcpsInfo)).To(BeNumerically(">", 0))
+						Expect(mcpsInfo).ToNot(BeEmpty())
 
 						waitForMcpUpdate(fxt.Client, ctx, mcpsInfo, MachineCount)
 					} else {
@@ -610,7 +610,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 
 					mcpsInfo, err := buildMCPsInfo(fxt.Client, ctx, *nropNewObj)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(len(mcpsInfo)).To(BeNumerically(">", 0))
+					Expect(mcpsInfo).ToNot(BeEmpty())
 
 					waitForMcpUpdate(fxt.Client, ctx, mcpsInfo, MachineCount)
 
@@ -654,7 +654,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 
 					mcpsInfo, err := buildMCPsInfo(fxt.Client, ctx, *nropNewObj)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(len(mcpsInfo)).To(BeNumerically(">", 0))
+					Expect(mcpsInfo).ToNot(BeEmpty())
 
 					waitForMcpUpdate(fxt.Client, ctx, mcpsInfo, MachineCount)
 

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -755,7 +755,7 @@ func buildMCPsInfo(cli client.Client, ctx context.Context, nroObj nropv1.NUMARes
 		// TODO: support correlated labels on nodes for different MCPs
 
 		mcpInfo := mcpInfo{
-			obj:           mcp,
+			mcpObj:        mcp,
 			initialConfig: mcp.Status.Configuration.Name,
 			sampleNode:    nodes.Items[0],
 		}
@@ -854,7 +854,7 @@ func waitForMcpUpdate(cli client.Client, ctx context.Context, mcpsInfo []mcpInfo
 		Expect(deploy.WaitForMCPsCondition(cli, ctx, []*machineconfigv1.MachineConfigPool{info.obj}, machineconfigv1.MachineConfigPoolUpdated)).To(Succeed())
 
 		var updatedMcp machineconfigv1.MachineConfigPool
-		Expect(cli.Get(ctx, client.ObjectKeyFromObject(info.obj), &updatedMcp)).To(Succeed())
+		Expect(cli.Get(ctx, client.ObjectKeyFromObject(info.mcpObj), &updatedMcp)).To(Succeed())
 		// Note: when update type is MachineCount, don't check for difference between initial config and current config
 		// on the updated mcp because mcp going into an update doesn't always it goes into a configuration update and
 		// thus associated to different MC, it could be because new nodes are joining the pool so the MC update is

--- a/test/e2e/uninstall/uninstall_test.go
+++ b/test/e2e/uninstall/uninstall_test.go
@@ -82,8 +82,9 @@ var _ = Describe("[Uninstall] clusterCleanup", Serial, func() {
 				klog.Warningf("failed to delete the kubeletconfigs %q", kcObj.Name)
 			}
 
-			err = unpause()
-			Expect(err).NotTo(HaveOccurred())
+			timeout := configuration.MachineConfigPoolUpdateTimeout   // shortcut
+			interval := configuration.MachineConfigPoolUpdateInterval // shortcut
+			Eventually(unpause).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
 
 			if configuration.Plat == platform.Kubernetes {
 				mcpObj := objects.TestMCP()

--- a/test/utils/deploy/deploy.go
+++ b/test/utils/deploy/deploy.go
@@ -168,25 +168,15 @@ func TeardownNROScheduler(nroSched *nropv1.NUMAResourcesScheduler, timeout time.
 }
 
 func WaitForMCPsCondition(cli client.Client, ctx context.Context, mcps []*machineconfigv1.MachineConfigPool, condition machineconfigv1.MachineConfigPoolConditionType) error {
+	interval := configuration.MachineConfigPoolUpdateInterval // shortcut
+	timeout := configuration.MachineConfigPoolUpdateTimeout   // timeout
 	var eg errgroup.Group
-	interval := configuration.MachineConfigPoolUpdateInterval
-	if condition == machineconfigv1.MachineConfigPoolUpdating {
-		// the transition from updated to updating to updated can be very fast sometimes. so if
-		// the status changed to updating and then to updated while on wait it will miss the updating
-		// status, and it will keep waiting and lastly fail the test. to avoid that decrease the interval
-		// to allow more often checks for the status
-		interval = 2 * time.Second
-	}
 	for _, mcp := range mcps {
 		klog.Infof("wait for mcp %q to meet condition %q", mcp.Name, condition)
 		mcp := mcp
 		eg.Go(func() error {
 			defer GinkgoRecover()
-			err := wait.With(cli).
-				Interval(interval).
-				Timeout(configuration.MachineConfigPoolUpdateTimeout).
-				ForMachineConfigPoolCondition(ctx, mcp, condition)
-			return err
+			return wait.With(cli).Interval(interval).Timeout(timeout).ForMachineConfigPoolCondition(ctx, mcp, condition)
 		})
 	}
 	return eg.Wait()


### PR DESCRIPTION
instead of chasing the MCP status transition updated -> updating -> updated, which is fragile and hard to get right both in theory and in practice, let's try a different approach.

When we change a MCP status (e.g. sending a new MachineConfig and/or pausing/unpausing)
1. we record the current MCP resourceversion
2. we ask for our desired state
3. we wait for the MCP desired state to be `updated` again *but with
   different resourceversion*

this should allow us to capture the conditions which describe our desired state while waiting for a stable state in a more robust way.

Add minorish cleanups along the way.