### PR TITLE
controller: nrop: always populate reason (progressing)

### DIFF
--- a/internal/reconcile/step.go
+++ b/internal/reconcile/step.go
@@ -43,6 +43,26 @@ func (rs Step) EarlyStop() bool {
 	return rs.ConditionInfo.Type != status.ConditionAvailable
 }
 
+// WithReason set the existing reason with the given value,
+// if not set already and returns a new updated Step
+func (rs Step) WithReason(reason string) Step {
+	return Step{
+		Result:        rs.Result,
+		ConditionInfo: rs.ConditionInfo.WithReason(reason),
+		Error:         rs.Error,
+	}
+}
+
+// WithMessage override the existing message with the given value,
+// if not set already, and returns a new updated ConditionInfo
+func (rs Step) WithMessage(message string) Step {
+	return Step{
+		Result:        rs.Result,
+		ConditionInfo: rs.ConditionInfo.WithMessage(message),
+		Error:         rs.Error,
+	}
+}
+
 // StepSuccess returns a Step which tells the caller
 // the reconciliation attempt was completed successfully
 func StepSuccess() Step {

--- a/pkg/status/conditioninfo/conditioninfo.go
+++ b/pkg/status/conditioninfo/conditioninfo.go
@@ -27,8 +27,8 @@ type ConditionInfo struct {
 	Message string
 }
 
-// WithReason override the ConditionInfo reason with the given value,
-// and returns a new updated ConditionInfo
+// WithReason override the ConditionInfo reason with the given value
+// if not set already and returns a new updated ConditionInfo
 func (ci ConditionInfo) WithReason(reason string) ConditionInfo {
 	ret := ci
 	if ret.Reason == "" {
@@ -37,8 +37,8 @@ func (ci ConditionInfo) WithReason(reason string) ConditionInfo {
 	return ret
 }
 
-// WithMessage override the ConditionInfo message with the given value,
-// and returns a new updated ConditionInfo
+// WithMessage override the ConditionInfo message with the given value
+// if not set already and returns a new updated ConditionInfo
 func (ci ConditionInfo) WithMessage(message string) ConditionInfo {
 	ret := ci
 	if ret.Message == "" {


### PR DESCRIPTION
The API spec requires the condition.Reason to always contain a non-empty CamelCase string. We added the infra to do so but we forgot for the Progressing case.

This change fixes that.
This becomes evident if RTEs fail to start, otherwise it's easy to miss, like it probably happened till now.