### PR TITLE
Separated NROP uninstall from install script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,9 @@ test-e2e: build-e2e-all
 test-install-e2e: build-e2e-all
 	hack/run-test-install-e2e.sh
 
+test-uninstall-e2e: build-e2e-all
+	hack/run-test-uninstall-e2e.sh
+
 test-must-gather-e2e: build-must-gather-e2e
 	hack/run-test-must-gather-e2e.sh
 

--- a/hack/run-test-install-e2e.sh
+++ b/hack/run-test-install-e2e.sh
@@ -16,9 +16,3 @@ if ! "${BIN_DIR}"/e2e-nrop-install.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=
   echo "Failed to run NRO install test suite"
   exit 1
 fi
-
-echo "Running NRO uninstall test suite";
-if ! "${BIN_DIR}"/e2e-nrop-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/uninstall.xml; then
-  echo "Failed to run NRO install test suite"
-  exit 2
-fi

--- a/hack/run-test-uninstall-e2e.sh
+++ b/hack/run-test-uninstall-e2e.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+source hack/common.sh
+
+NO_COLOR=""
+if ! which tput &> /dev/null 2>&1 || [[ $(tput -T$TERM colors) -lt 8 ]]; then
+  echo "Terminal does not seem to support colored output, disabling it"
+  NO_COLOR="-ginkgo.no-color"
+fi
+
+setupreport
+
+# Run uninstall test suite
+echo "Running NRO uninstall test suite";
+if ! "${BIN_DIR}"/e2e-nrop-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/uninstall.xml; then
+  echo "Failed to run NRO uninstall test suite"
+  exit 2
+fi


### PR DESCRIPTION
Invoking make test-install-e2e currently handles both the installation and uninstallation of NROP and its components. We propose separating this into two distinct suites, introducing a dedicated script for the uninstallation process. This separation would be beneficial in scenarios where we need to install and test the operator, upgrade it, and only then proceed with its deletion.

For example, this work will be needed in the [NROP upgrade test lane](https://github.com/openshift/release/pull/58457),
As we wish to:
Install the operator with 4.17 version, run e2e install suite, upgrade to 4.18 and only then uninstall. 

Note, after merging this PR I'll create a PR in the release repo to ensure both calls ([first](https://github.com/openshift/release/blob/master/ci-operator/config/openshift-kni/numaresources-operator/openshift-kni-numaresources-operator-main.yaml#L102) and [second](https://github.com/openshift/release/blob/master/ci-operator/config/openshift-kni/numaresources-operator/openshift-kni-numaresources-operator-main.yaml#L181)) of `make test-install-e2e` will be replaced with make `test-install-e2e test-uninstall-e2e`