### PR TITLE
gosec: initial scaffolding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,9 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+gosec:
+	gosec ./pkg/... ./rte/pkg/... ./internal/... ./nrovalidate/validator/...
+
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 

--- a/pkg/objectupdate/sched/fakeconfs.go
+++ b/pkg/objectupdate/sched/fakeconfs.go
@@ -161,11 +161,11 @@ func yamlCompare(t *testing.T, testName, got, expected string) {
 	}
 	if diffCount > 0 {
 		var err error
-		err = os.WriteFile(testName+"-got.yaml", []byte(got), 0644)
+		err = os.WriteFile(testName+"-got.yaml", []byte(got), 0600)
 		if err != nil {
 			t.Fatalf("cannot write got.yaml")
 		}
-		err = os.WriteFile(testName+"-exp.yaml", []byte(expected), 0644)
+		err = os.WriteFile(testName+"-exp.yaml", []byte(expected), 0600)
 		if err != nil {
 			t.Fatalf("cannot write exp.yaml")
 		}

--- a/rte/pkg/config/config.go
+++ b/rte/pkg/config/config.go
@@ -17,13 +17,10 @@
 package config
 
 import (
-	"errors"
 	"fmt"
-	"os"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 
 	"sigs.k8s.io/yaml"
@@ -52,22 +49,6 @@ type Config struct {
 	Kubelet         KubeletParams                   `json:"kubelet,omitempty"`
 	ResourceExclude resourcemonitor.ResourceExclude `json:"resourceExclude,omitempty"`
 	PodExclude      podexclude.List                 `json:"podExclude,omitempty"`
-}
-
-func ReadFile(configPath string) (Config, error) {
-	conf := Config{}
-	// TODO modernize using os.ReadFile
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		// config is optional
-		if errors.Is(err, os.ErrNotExist) {
-			klog.Warningf("Info: couldn't find configuration in %q", configPath)
-			return conf, nil
-		}
-		return conf, err
-	}
-	err = yaml.Unmarshal(data, &conf)
-	return conf, err
 }
 
 func Render(klConfig *kubeletconfigv1beta1.KubeletConfiguration, podExcludes []nropv1.NamespacedName) (string, error) {


### PR DESCRIPTION
initial support to run gosec scanning over the source tree

notes:
1. no automated download yet - assume is present. This will be implemented when we make the flow mandatory
2. add the minimal set of fixes found running the `gosec` tool.