### PR TITLE
add static buildinfo information

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal
 COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/manager /bin/numaresources-operator
 # bundle the operand, and use a backward compatible name for RTE
 COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/exporter /bin/resource-topology-exporter
+COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/buildinfo.json /usr/local/share
 RUN mkdir /etc/resource-topology-exporter/ && \
     touch /etc/resource-topology-exporter/config.yaml
 RUN microdnf install -y hwdata && \

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -2,6 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal
 COPY manager /bin/numaresources-operator
 # bundle the operand, and use a backward compatible name for RTE
 COPY exporter /bin/resource-topology-exporter
+COPY buildinfo.json /usr/local/share
 RUN mkdir /etc/resource-topology-exporter/ && \
     touch /etc/resource-topology-exporter/config.yaml
 RUN microdnf install -y hwdata && \

--- a/Dockerfile.openshift.rte
+++ b/Dockerfile.openshift.rte
@@ -1,5 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 COPY exporter /bin/resource-topology-exporter
+COPY buildinfo.json /usr/local/share
 RUN mkdir /etc/resource-topology-exporter/ && \
     touch /etc/resource-topology-exporter/config.yaml
 RUN microdnf install -y hwdata && \

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,11 @@ binary-numacell: build-tools
 	LDFLAGS="-s -w" \
 	CGO_ENABLED=0 go build -mod=vendor -o bin/numacell -ldflags "$$LDFLAGS" test/deviceplugin/cmd/numacell/main.go
 
-binary-all: binary binary-rte binary-nrovalidate
+binary-all: goversion \
+	binary \
+	binary-rte \
+	binary-nrovalidate \
+	introspect-data
 
 binary-e2e-rte-local:
 	go test -c -v -o bin/e2e-nrop-rte-local.test ./test/e2e/rte/local
@@ -215,14 +219,20 @@ binary-e2e-all: goversion \
 	binary-e2e-tools \
 	binary-e2e-must-gather \
 	runner-e2e-serial \
-	build-pause
+	build-pause \
+	introspect-data
 
 runner-e2e-serial: bin/envsubst
 	hack/render-e2e-runner.sh
 	hack/test-e2e-runner.sh
 
+introspect-data: build-topics build-buildinfo
+
 build-topics:
 	mkdir -p bin && go run tools/lstopics/lstopics.go > bin/topics.json
+
+build-buildinfo: bin/buildhelper
+	bin/buildhelper inspect > bin/buildinfo.json
 
 build: generate fmt vet binary
 

--- a/main.go
+++ b/main.go
@@ -172,7 +172,7 @@ func main() {
 	params.FromFlags()
 
 	if params.showVersion {
-		fmt.Printf("%s %s %s %s\n", version.ProgramName(), version.Get(), version.GetGitCommit(), runtime.Version())
+		fmt.Printf("%s %s %s %s\n", version.OperatorProgramName(), version.Get(), version.GetGitCommit(), runtime.Version())
 		os.Exit(0)
 	}
 
@@ -189,7 +189,7 @@ func main() {
 	config := textlogger.NewConfig(textlogger.Verbosity(int(klogV)))
 	ctrl.SetLogger(textlogger.NewLogger(config))
 
-	klog.InfoS("starting", "program", version.ProgramName(), "version", version.Get(), "gitcommit", version.GetGitCommit(), "golang", runtime.Version(), "vl", klogV, "auxv", config.Verbosity().String())
+	klog.InfoS("starting", "program", version.OperatorProgramName(), "version", version.Get(), "gitcommit", version.GetGitCommit(), "golang", runtime.Version(), "vl", klogV, "auxv", config.Verbosity().String())
 
 	ctx := context.Background()
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -55,3 +55,11 @@ func ProgramName() string {
 	}
 	return filepath.Base(os.Args[0])
 }
+
+func OperatorProgramName() string {
+	return "numaresources-operator"
+}
+
+func ExporterProgramName() string {
+	return "resource-topology-exporter"
+}

--- a/rte/main.go
+++ b/rte/main.go
@@ -45,14 +45,15 @@ const (
 )
 
 func main() {
-	klog.Infof("starting %s %s %s %s\n", version.ProgramName(), version.Get(), version.GetGitCommit(), runtime.Version())
+	klog.Infof("starting %s %s %s %s\n", version.ExporterProgramName(), version.Get(), version.GetGitCommit(), runtime.Version())
+
 	parsedArgs, err := parseArgs(os.Args[1:]...)
 	if err != nil {
 		klog.Fatalf("failed to parse args: %v", err)
 	}
 
 	if parsedArgs.Version {
-		fmt.Printf("%s %s %s %s\n", version.ProgramName(), version.Get(), version.GetGitCommit(), runtime.Version())
+		fmt.Printf("%s %s %s %s\n", version.ExporterProgramName(), version.Get(), version.GetGitCommit(), runtime.Version())
 		os.Exit(0)
 	}
 

--- a/tools/buildhelper/buildhelper.go
+++ b/tools/buildhelper/buildhelper.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -26,39 +27,117 @@ import (
 	"github.com/mdomke/git-semver/version"
 )
 
-func showVersion() int {
+const (
+	develBranchName     = "devel"
+	releaseBranchPrefix = "release-"
+)
+
+type buildInfo struct {
+	Branch  string `json:"branch"`
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+}
+
+func getVersion() (string, error) {
 	if ver, ok := os.LookupEnv("NRO_BUILD_VERSION"); ok {
-		fmt.Println(ver)
-		return 0
+		return ver, nil
 	}
 
 	v, err := version.Derive()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
-		return 1
-	}
-	fmt.Println(v)
-	return 0
+	return v.String(), err
 }
 
-func showCommit() int {
+func getCommit() (string, error) {
 	if cm, ok := os.LookupEnv("NRO_BUILD_COMMIT"); ok {
-		fmt.Println(cm)
-		return 0
+		return cm, nil
 	}
 
 	cmd := exec.Command("git", "log", "-1", "--pretty=format:%h")
 	out, err := cmd.Output()
 	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func getBranch() (string, error) {
+	if cm, ok := os.LookupEnv("NRO_BUILD_BRANCH"); ok {
+		return cm, nil
+	}
+
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	branchName := strings.TrimSpace(string(out))
+	if !strings.HasPrefix(branchName, releaseBranchPrefix) {
+		return develBranchName, nil
+	}
+	return strings.TrimPrefix(branchName, releaseBranchPrefix), nil
+}
+
+func showVersion() int {
+	ver, err := getVersion()
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		return 1
 	}
-	fmt.Println(strings.TrimSpace(string(out)))
+	fmt.Println(ver)
+	return 0
+}
+
+func showCommit() int {
+	cm, err := getCommit()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		return 1
+	}
+	fmt.Println(cm)
+	return 0
+}
+
+func showBranch() int {
+	br, err := getBranch()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		return 1
+	}
+	fmt.Println(br)
+	return 0
+}
+
+func inspect() int {
+	var bi buildInfo
+	var err error
+
+	bi.Version, err = getVersion()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		return 1
+	}
+
+	bi.Branch, err = getBranch()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		return 1
+	}
+
+	bi.Commit, err = getCommit()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		return 1
+	}
+
+	if err := json.NewEncoder(os.Stdout).Encode(&bi); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		return 1
+	}
 	return 0
 }
 
 func help() {
-	fmt.Fprintf(os.Stderr, "usage: %s [version|commit]\n", filepath.Base(os.Args[0]))
+	fmt.Fprintf(os.Stderr, "usage: %s [inspect|version|commit|branch]\n", filepath.Base(os.Args[0]))
 	os.Exit(1)
 }
 
@@ -68,10 +147,14 @@ func main() {
 	}
 
 	switch os.Args[1] {
+	case "inspect":
+		inspect()
 	case "version":
 		showVersion()
 	case "commit":
 		showCommit()
+	case "branch":
+		showBranch()
 	default:
 		help()
 	}


### PR DESCRIPTION
add static buildinfo rather than determine that at last stage of the build process. This data is expected to be frozen when we build our artifacts, so collect all the infos when we start and add this to our artifacts is actually simpler and safe.
shipping `buildinfo.json` alongside `topics.json` in our test images would also enable better tests introspection, yet to be implemented.