### PR TITLE
NO-JIRA: controller:annotation: introduce pause annotation

### DIFF
--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -146,6 +146,11 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 		return r.degradeStatus(ctx, instance, status.ConditionTypeIncorrectNUMAResourcesOperatorResourceName, err)
 	}
 
+	if annotations.IsPauseReconciliationEnabled(instance.Annotations) {
+		klog.V(2).InfoS("Pause reconciliation enabled", "object", req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+
 	if err := validation.NodeGroups(instance.Spec.NodeGroups, r.Platform); err != nil {
 		return r.degradeStatus(ctx, instance, validation.NodeGroupsError, err)
 	}

--- a/controllers/numaresourcesscheduler_controller.go
+++ b/controllers/numaresourcesscheduler_controller.go
@@ -41,6 +41,7 @@ import (
 	k8swgrbacupdate "github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate/rbac"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
+	"github.com/openshift-kni/numaresources-operator/internal/api/annotations"
 	"github.com/openshift-kni/numaresources-operator/internal/relatedobjects"
 	"github.com/openshift-kni/numaresources-operator/pkg/apply"
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
@@ -100,6 +101,11 @@ func (r *NUMAResourcesSchedulerReconciler) Reconcile(ctx context.Context, req ct
 	if req.Name != objectnames.DefaultNUMAResourcesSchedulerCrName {
 		message := fmt.Sprintf("incorrect NUMAResourcesScheduler resource name: %s", instance.Name)
 		return ctrl.Result{}, r.updateStatus(ctx, instance, status.ConditionDegraded, status.ConditionTypeIncorrectNUMAResourcesSchedulerResourceName, message)
+	}
+
+	if annotations.IsPauseReconciliationEnabled(instance.Annotations) {
+		klog.InfoS("Pause reconciliation enabled", "object", req.NamespacedName)
+		return ctrl.Result{}, nil
 	}
 
 	result, condition, err := r.reconcileResource(ctx, instance)

--- a/internal/api/annotations/annotations.go
+++ b/internal/api/annotations/annotations.go
@@ -23,6 +23,9 @@ const (
 	// the annotation is on when it's set to "enabled", every other value is equivalent to disabled
 	MultiplePoolsPerTreeAnnotation = "config.node.openshift-kni.io/multiple-pools-per-tree"
 	MultiplePoolsPerTreeEnabled    = "enabled"
+
+	PauseReconciliationAnnotation        = "config.numa-operator.openshift.io/pause-reconciliation"
+	PauseReconciliationAnnotationEnabled = "enabled"
 )
 
 func IsCustomPolicyEnabled(annot map[string]string) bool {
@@ -34,6 +37,13 @@ func IsCustomPolicyEnabled(annot map[string]string) bool {
 
 func IsMultiplePoolsPerTreeEnabled(annot map[string]string) bool {
 	if v, ok := annot[MultiplePoolsPerTreeAnnotation]; ok && v == MultiplePoolsPerTreeEnabled {
+		return true
+	}
+	return false
+}
+
+func IsPauseReconciliationEnabled(annot map[string]string) bool {
+	if v, ok := annot[PauseReconciliationAnnotation]; ok && v == PauseReconciliationAnnotationEnabled {
 		return true
 	}
 	return false

--- a/internal/api/annotations/annotations_test.go
+++ b/internal/api/annotations/annotations_test.go
@@ -87,3 +87,38 @@ func TestIsMultiplePoolsPerTreeEnabled(t *testing.T) {
 		})
 	}
 }
+
+func TestIsPauseReconciliationEnabled(t *testing.T) {
+	testcases := []struct {
+		description string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			description: "empty map",
+			annotations: map[string]string{},
+			expected:    false,
+		},
+		{
+			description: "annotation set to anything but not \"enabled\" means it's disabled",
+			annotations: map[string]string{
+				PauseReconciliationAnnotation: "true",
+			},
+			expected: false,
+		},
+		{
+			description: "enabled multiple pools per tree",
+			annotations: map[string]string{
+				PauseReconciliationAnnotation: PauseReconciliationAnnotationEnabled,
+			},
+			expected: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			if got := IsPauseReconciliationEnabled(tc.annotations); got != tc.expected {
+				t.Errorf("expected %v got %v", tc.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Allowing the operator to pause reconciliation of specific CR.
This is useful for experiment,debug and development process.

For example when a contributor would like to test some changes
done to the owned object, without having those
object overwritten by the operator.