### PR TITLE
build: buildinfo: move buildinfo struct in internal api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ testbin/*
 *~
 
 coverage.out
+
+pkg/version/_buildinfo.json

--- a/internal/api/buildinfo/types.go
+++ b/internal/api/buildinfo/types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Red Hat, Inc.
+ * Copyright 2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,14 @@
  * limitations under the License.
  */
 
-package version
+package buildinfo
 
-import "testing"
-
-func TestGet(t *testing.T) {
-	if Get() == "" {
-		t.Errorf("empty version")
-	}
+type BuildInfo struct {
+	Branch  string `json:"branch"`
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
 }
 
-func TestGetGitCommit(t *testing.T) {
-	if GetGitCommit() == "" {
-		t.Errorf("empty gitcommit")
-	}
-}
-
-func TestProgramName(t *testing.T) {
-	if ProgramName() == "undefined" {
-		t.Errorf("program name should always be defined")
-	}
+func (bi BuildInfo) String() string {
+	return bi.Version + " " + bi.Commit + " (" + bi.Branch + ")"
 }

--- a/main.go
+++ b/main.go
@@ -171,8 +171,9 @@ func main() {
 	params.SetDefaults()
 	params.FromFlags()
 
+	bi := version.GetBuildInfo()
 	if params.showVersion {
-		fmt.Printf("%s %s %s %s\n", version.OperatorProgramName(), version.Get(), version.GetGitCommit(), runtime.Version())
+		fmt.Printf("%s %s %s\n", version.OperatorProgramName(), bi.String(), runtime.Version())
 		os.Exit(0)
 	}
 
@@ -189,7 +190,7 @@ func main() {
 	config := textlogger.NewConfig(textlogger.Verbosity(int(klogV)))
 	ctrl.SetLogger(textlogger.NewLogger(config))
 
-	klog.InfoS("starting", "program", version.OperatorProgramName(), "version", version.Get(), "gitcommit", version.GetGitCommit(), "golang", runtime.Version(), "vl", klogV, "auxv", config.Verbosity().String())
+	klog.InfoS("starting", "program", version.OperatorProgramName(), "version", bi.Version, "branch", bi.Branch, "gitcommit", bi.Commit, "golang", runtime.Version(), "vl", klogV, "auxv", config.Verbosity().String())
 
 	ctx := context.Background()
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,36 +17,32 @@
 package version
 
 import (
+	_ "embed"
+	"encoding/json"
 	"os"
 	"path/filepath"
+
+	"github.com/openshift-kni/numaresources-operator/internal/api/buildinfo"
 )
 
-const (
-	undefined string = "undefined"
-)
+//go:embed _buildinfo.json
+var buildInfo string
 
-// version Must not be const, supposed to be set using ldflags at build time
-var version = undefined
-
-// gitcommit Must not be const, supposed to be set using ldflags at build time
-var gitcommit = undefined
+func GetBuildInfo() buildinfo.BuildInfo {
+	var bi buildinfo.BuildInfo
+	_ = json.Unmarshal([]byte(buildInfo), &bi)
+	return bi
+}
 
 // Get returns the version as a string
 func Get() string {
-	return version
-}
-
-// Undefined returns if version is at it's default value
-func Undefined() bool {
-	return version == undefined
+	bi := GetBuildInfo()
+	return bi.Version
 }
 
 func GetGitCommit() string {
-	return gitcommit
-}
-
-func UndefinedGitCommit() bool {
-	return gitcommit == undefined
+	bi := GetBuildInfo()
+	return bi.Commit
 }
 
 func ProgramName() string {

--- a/rte/main.go
+++ b/rte/main.go
@@ -45,7 +45,8 @@ const (
 )
 
 func main() {
-	klog.Infof("starting %s %s %s %s\n", version.ExporterProgramName(), version.Get(), version.GetGitCommit(), runtime.Version())
+	bi := version.GetBuildInfo()
+	klog.Infof("starting %s %s %s\n", version.ExporterProgramName(), bi.String(), runtime.Version())
 
 	parsedArgs, err := parseArgs(os.Args[1:]...)
 	if err != nil {
@@ -53,7 +54,7 @@ func main() {
 	}
 
 	if parsedArgs.Version {
-		fmt.Printf("%s %s %s %s\n", version.ExporterProgramName(), version.Get(), version.GetGitCommit(), runtime.Version())
+		fmt.Printf("%s %s %s\n", version.ExporterProgramName(), bi.String(), runtime.Version())
 		os.Exit(0)
 	}
 

--- a/tools/buildhelper/buildhelper.go
+++ b/tools/buildhelper/buildhelper.go
@@ -25,18 +25,14 @@ import (
 	"strings"
 
 	"github.com/mdomke/git-semver/version"
+
+	"github.com/openshift-kni/numaresources-operator/internal/api/buildinfo"
 )
 
 const (
 	develBranchName     = "devel"
 	releaseBranchPrefix = "release-"
 )
-
-type buildInfo struct {
-	Branch  string `json:"branch"`
-	Version string `json:"version"`
-	Commit  string `json:"commit"`
-}
 
 func getVersion() (string, error) {
 	if ver, ok := os.LookupEnv("NRO_BUILD_VERSION"); ok {
@@ -108,7 +104,7 @@ func showBranch() int {
 }
 
 func inspect() int {
-	var bi buildInfo
+	var bi buildinfo.BuildInfo
 	var err error
 
 	bi.Version, err = getVersion()


### PR DESCRIPTION
use the buildinfo.json data for `pkg/version` instead of injecting the values at link time.
This simplifies the builds and enables better introspection capabilities.