### PR TITLE
controllers: kubelet: cleanup platform code

### DIFF
--- a/main.go
+++ b/main.go
@@ -281,7 +281,7 @@ func main() {
 		Recorder:  mgr.GetEventRecorderFor("kubeletconfig-controller"),
 		Namespace: namespace,
 		Platform:  clusterPlatform,
-	}).SetupWithManager(mgr, clusterPlatform); err != nil {
+	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create controller", "controller", "KubeletConfig")
 		os.Exit(1)
 	}


### PR DESCRIPTION
move platform-specific code as much as possible at initialization stage vs peppering the code with `if platform == `.
In addition, remove small repetitions.