### PR TITLE
[release-4.18][manual] e2e: must-gather: fix the setup process

### DIFF
--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -77,7 +77,7 @@ var _ = Describe("[Install] continuousIntegration", Serial, func() {
 	Context("with a running cluster with all the components", func() {
 		It("[test_id:47574][tier0] should perform overall deployment and verify the condition is reported as available", func() {
 			deployer := deploy.NewForPlatform(configuration.Plat)
-			nroObj := deployer.Deploy(context.TODO())
+			nroObj := deployer.Deploy(context.TODO(), configuration.MachineConfigPoolUpdateTimeout)
 			nname := client.ObjectKeyFromObject(nroObj)
 			Expect(nname.Name).ToNot(BeEmpty())
 
@@ -205,7 +205,7 @@ var _ = Describe("[Install] durability", Serial, func() {
 
 		BeforeEach(func() {
 			deployer = deploy.NewForPlatform(configuration.Plat)
-			nroObj = deployer.Deploy(context.TODO())
+			nroObj = deployer.Deploy(context.TODO(), configuration.MachineConfigPoolUpdateTimeout)
 		})
 
 		AfterEach(func() {

--- a/test/e2e/must-gather/must_gather_suite_test.go
+++ b/test/e2e/must-gather/must_gather_suite_test.go
@@ -25,8 +25,11 @@ import (
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 
+	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
+	e2eclient "github.com/openshift-kni/numaresources-operator/test/utils/clients"
 	"github.com/openshift-kni/numaresources-operator/test/utils/configuration"
 	"github.com/openshift-kni/numaresources-operator/test/utils/deploy"
+	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -41,7 +44,9 @@ const (
 )
 
 var (
-	deployment deploy.NroDeploymentWithSched
+	deployment deploy.Deployer
+
+	nroSchedObj *nropv1.NUMAResourcesScheduler
 
 	mustGatherImage string
 	mustGatherTag   string
@@ -62,17 +67,23 @@ var _ = ginkgo.BeforeSuite(func() {
 	mustGatherTag = getStringValueFromEnv(envVarMustGatherTag, defaultMustGatherTag)
 	ginkgo.By(fmt.Sprintf("Using must-gather image %q tag %q", mustGatherImage, mustGatherTag))
 
+	ctx := context.Background()
+
 	if _, ok := os.LookupEnv("E2E_NROP_INFRA_SETUP_SKIP"); ok {
 		ginkgo.By("Fetching up cluster data")
 
-		var err error
-		deployment, err = deploy.GetDeploymentWithSched(context.TODO())
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		// assume cluster is set up correctly, so just fetch what we have already;
+		// fail loudly if we can't get, this means the assumption was wrong
+		nroSchedObj = &nropv1.NUMAResourcesScheduler{}
+		gomega.Expect(e2eclient.Client.Get(ctx, objects.NROSchedObjectKey(), nroSchedObj)).To(gomega.Succeed())
 		return
 	}
+
 	ginkgo.By("Setting up the cluster")
-	deployment.Deploy(context.TODO())
-	deployment.NroSchedObj = deploy.DeployNROScheduler()
+
+	deployment = deploy.NewForPlatform(configuration.Plat)
+	_ = deployment.Deploy(ctx) // we don't care about the nrop instance
+	nroSchedObj = deploy.DeployNROScheduler()
 })
 
 var _ = ginkgo.AfterSuite(func() {
@@ -81,8 +92,9 @@ var _ = ginkgo.AfterSuite(func() {
 		return
 	}
 	ginkgo.By("tearing down the cluster")
-	deploy.TeardownNROScheduler(deployment.NroSchedObj, 5*time.Minute)
-	deployment.Teardown(context.TODO(), 5*time.Minute)
+	ctx := context.Background()
+	deploy.TeardownNROScheduler(nroSchedObj, 5*time.Minute)
+	deployment.Teardown(ctx, 5*time.Minute)
 })
 
 func getStringValueFromEnv(envVar, fallback string) string {

--- a/test/e2e/must-gather/must_gather_suite_test.go
+++ b/test/e2e/must-gather/must_gather_suite_test.go
@@ -41,6 +41,8 @@ const (
 
 	defaultMustGatherImage = "quay.io/openshift-kni/numaresources-must-gather"
 	defaultMustGatherTag   = "4.18.999-snapshot"
+
+	nroSchedTimeout = 5 * time.Minute
 )
 
 var (
@@ -82,8 +84,8 @@ var _ = ginkgo.BeforeSuite(func() {
 	ginkgo.By("Setting up the cluster")
 
 	deployment = deploy.NewForPlatform(configuration.Plat)
-	_ = deployment.Deploy(ctx) // we don't care about the nrop instance
-	nroSchedObj = deploy.DeployNROScheduler()
+	_ = deployment.Deploy(ctx, configuration.MachineConfigPoolUpdateTimeout) // we don't care about the nrop instance
+	nroSchedObj = deploy.DeployNROScheduler(ctx, nroSchedTimeout)
 })
 
 var _ = ginkgo.AfterSuite(func() {
@@ -93,7 +95,7 @@ var _ = ginkgo.AfterSuite(func() {
 	}
 	ginkgo.By("tearing down the cluster")
 	ctx := context.Background()
-	deploy.TeardownNROScheduler(nroSchedObj, 5*time.Minute)
+	deploy.TeardownNROScheduler(ctx, nroSchedObj, nroSchedTimeout)
 	deployment.Teardown(ctx, 5*time.Minute)
 })
 

--- a/test/e2e/must-gather/must_gather_test.go
+++ b/test/e2e/must-gather/must_gather_test.go
@@ -45,6 +45,8 @@ var _ = Describe("[must-gather] NRO data collected", func() {
 		var destDir string
 
 		BeforeEach(func() {
+			Expect(nroSchedObj).ToNot(BeNil(), "missing scheduler object reference")
+
 			var err error
 			destDir, err = os.MkdirTemp("", "*-e2e-data")
 			Expect(err).ToNot(HaveOccurred())
@@ -106,7 +108,7 @@ var _ = Describe("[must-gather] NRO data collected", func() {
 
 				By("Looking for resources instances")
 				nropInstanceFileName := fmt.Sprintf("%s.yaml", filepath.Join("cluster-scoped-resources/nodetopology.openshift.io/numaresourcesoperators", objects.NROObjectKey().Name))
-				nroschedInstanceFileName := fmt.Sprintf("%s.yaml", filepath.Join("cluster-scoped-resources/nodetopology.openshift.io/numaresourcesschedulers", deployment.NroSchedObj.Name))
+				nroschedInstanceFileName := fmt.Sprintf("%s.yaml", filepath.Join("cluster-scoped-resources/nodetopology.openshift.io/numaresourcesschedulers", nroSchedObj.Name))
 
 				collectedMCPs, err := getMachineConfigPools(filepath.Join(mgContentFolder, "cluster-scoped-resources/machineconfiguration.openshift.io/machineconfigpools"))
 				Expect(err).ToNot(HaveOccurred())

--- a/test/utils/deploy/deploy.go
+++ b/test/utils/deploy/deploy.go
@@ -43,10 +43,14 @@ import (
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 )
 
+const (
+	NROSchedulerPollingInterval = 10 * time.Second
+)
+
 type Deployer interface {
 	// Deploy deploys NUMAResourcesOperator object create other dependencies
 	// per the platform that implements it
-	Deploy(ctx context.Context) *nropv1.NUMAResourcesOperator
+	Deploy(ctx context.Context, timeout time.Duration) *nropv1.NUMAResourcesOperator
 	// Teardown Teardowns NUMAResourcesOperator object delete other dependencies
 	// per the platform that implements it
 	Teardown(ctx context.Context, timeout time.Duration)
@@ -104,20 +108,16 @@ func isMachineConfigPoolsUpdatedAfterDeletion(nro *nropv1.NUMAResourcesOperator)
 // or a timeout happens (5 min right now).
 //
 // see: `TestNROScheduler` to see the specific object characteristics.
-func DeployNROScheduler() *nropv1.NUMAResourcesScheduler {
+func DeployNROScheduler(ctx context.Context, timeout time.Duration) *nropv1.NUMAResourcesScheduler {
 	GinkgoHelper()
 
 	nroSchedObj := objects.TestNROScheduler()
 
-	err := e2eclient.Client.Create(context.TODO(), nroSchedObj)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroSchedObj), nroSchedObj)
-	Expect(err).NotTo(HaveOccurred())
-
+	Expect(e2eclient.Client.Create(ctx, nroSchedObj)).To(Succeed())
+	Expect(e2eclient.Client.Get(ctx, client.ObjectKeyFromObject(nroSchedObj), nroSchedObj)).To(Succeed())
 	Eventually(func() bool {
 		updatedNROObj := &nropv1.NUMAResourcesScheduler{}
-		err := e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroSchedObj), updatedNROObj)
+		err := e2eclient.Client.Get(ctx, client.ObjectKeyFromObject(nroSchedObj), updatedNROObj)
 		if err != nil {
 			klog.Warningf("failed to get the NRO Scheduler resource: %v", err)
 			return false
@@ -133,20 +133,15 @@ func DeployNROScheduler() *nropv1.NUMAResourcesScheduler {
 		klog.Infof("condition: %v", cond)
 
 		return cond.Status == metav1.ConditionTrue
-	}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).Should(BeTrue(), "NRO Scheduler condition did not become available")
+	}).WithTimeout(timeout).WithPolling(NROSchedulerPollingInterval).Should(BeTrue(), "NRO Scheduler condition did not become available")
 	return nroSchedObj
 }
 
-func TeardownNROScheduler(nroSched *nropv1.NUMAResourcesScheduler, timeout time.Duration) {
+func TeardownNROScheduler(ctx context.Context, nroSched *nropv1.NUMAResourcesScheduler, timeout time.Duration) {
 	GinkgoHelper()
-
-	if nroSched != nil {
-		err := e2eclient.Client.Delete(context.TODO(), nroSched)
-		Expect(err).ToNot(HaveOccurred())
-
-		err = wait.With(e2eclient.Client).Interval(10*time.Second).Timeout(timeout).ForNUMAResourcesSchedulerDeleted(context.TODO(), nroSched)
-		Expect(err).ToNot(HaveOccurred(), "NROScheduler %q failed to be deleted", nroSched.Name)
-	}
+	Expect(nroSched).ToNot(BeNil())
+	Expect(e2eclient.Client.Delete(ctx, nroSched)).To(Succeed())
+	Expect(wait.With(e2eclient.Client).Interval(NROSchedulerPollingInterval).Timeout(timeout).ForNUMAResourcesSchedulerDeleted(ctx, nroSched)).To(Succeed(), "NROScheduler %q failed to be deleted", nroSched.Name)
 }
 
 func WaitForMCPsCondition(cli client.Client, ctx context.Context, mcps []*machineconfigv1.MachineConfigPool, condition machineconfigv1.MachineConfigPoolConditionType) error {

--- a/test/utils/deploy/deploy.go
+++ b/test/utils/deploy/deploy.go
@@ -52,11 +52,6 @@ type Deployer interface {
 	Teardown(ctx context.Context, timeout time.Duration)
 }
 
-type NroDeploymentWithSched struct {
-	Deployer
-	NroSchedObj *nropv1.NUMAResourcesScheduler
-}
-
 func NewForPlatform(plat platform.Platform) Deployer {
 	switch plat {
 	case platform.OpenShift:
@@ -68,19 +63,6 @@ func NewForPlatform(plat platform.Platform) Deployer {
 	default:
 		return nil
 	}
-}
-
-func GetDeploymentWithSched(ctx context.Context) (NroDeploymentWithSched, error) {
-	sd := NroDeploymentWithSched{}
-	nroSchedKey := objects.NROSchedObjectKey()
-	nroSchedObj := nropv1.NUMAResourcesScheduler{}
-	err := e2eclient.Client.Get(ctx, nroSchedKey, &nroSchedObj)
-	if err != nil {
-		return sd, err
-	}
-	sd.NroSchedObj = &nroSchedObj
-
-	return sd, nil
 }
 
 func WaitForMCPUpdatedAfterNRODeleted(nroObj *nropv1.NUMAResourcesOperator) {

--- a/test/utils/deploy/hypershift.go
+++ b/test/utils/deploy/hypershift.go
@@ -39,7 +39,7 @@ const (
 	ConfigDataKey               = "config"
 )
 
-func (h *HyperShiftNRO) Deploy(ctx context.Context) *nropv1.NUMAResourcesOperator {
+func (h *HyperShiftNRO) Deploy(ctx context.Context, _ time.Duration) *nropv1.NUMAResourcesOperator {
 	GinkgoHelper()
 
 	hostedClusterName, err := hypershift.GetHostedClusterName()
@@ -105,7 +105,7 @@ func (h *HyperShiftNRO) Teardown(ctx context.Context, timeout time.Duration) {
 			Namespace: h.NroObj.Status.DaemonSets[0].Namespace,
 		}
 		Eventually(func() bool {
-			if err := e2eclient.Client.Get(context.TODO(), key, cm); !errors.IsNotFound(err) {
+			if err := e2eclient.Client.Get(ctx, key, cm); !errors.IsNotFound(err) {
 				if err == nil {
 					klog.Warningf("configmap %s still exists", key.String())
 				} else {
@@ -114,7 +114,7 @@ func (h *HyperShiftNRO) Teardown(ctx context.Context, timeout time.Duration) {
 				return false
 			}
 			return true
-		}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(BeTrue())
+		}).WithTimeout(timeout).WithPolling(10 * time.Second).Should(BeTrue())
 	}
 	Expect(e2eclient.Client.Delete(ctx, h.NroObj)).To(Succeed())
 }

--- a/test/utils/deploy/kubernetes.go
+++ b/test/utils/deploy/kubernetes.go
@@ -21,7 +21,7 @@ type KubernetesNRO struct {
 
 // Deploy returns a struct containing all the deployed objects,
 // so it will be easier to introspect and delete them later.
-func (k *KubernetesNRO) Deploy(ctx context.Context) *v1.NUMAResourcesOperator {
+func (k *KubernetesNRO) Deploy(ctx context.Context, timeout time.Duration) *v1.NUMAResourcesOperator {
 	GinkgoHelper()
 
 	mcpObj := objects.TestMCP()
@@ -31,7 +31,7 @@ func (k *KubernetesNRO) Deploy(ctx context.Context) *v1.NUMAResourcesOperator {
 	k.McpObj = mcpObj
 	matchLabels := map[string]string{"test": "test"}
 
-	return k.OpenShiftNRO.deployWithLabels(ctx, matchLabels)
+	return k.OpenShiftNRO.deployWithLabels(ctx, timeout, matchLabels)
 }
 
 func (k *KubernetesNRO) Teardown(ctx context.Context, timeout time.Duration) {

--- a/test/utils/deploy/openshift.go
+++ b/test/utils/deploy/openshift.go
@@ -35,13 +35,13 @@ type OpenShiftNRO struct {
 // Deploy deploys NUMAResourcesOperator object and
 // other dependencies, so the controller will be able to install TAS
 // stack properly
-func (o *OpenShiftNRO) Deploy(ctx context.Context) *nropv1.NUMAResourcesOperator {
+func (o *OpenShiftNRO) Deploy(ctx context.Context, timeout time.Duration) *nropv1.NUMAResourcesOperator {
 	GinkgoHelper()
 
-	return o.deployWithLabels(ctx, objects.OpenshiftMatchLabels())
+	return o.deployWithLabels(ctx, timeout, objects.OpenshiftMatchLabels())
 }
 
-func (o *OpenShiftNRO) deployWithLabels(ctx context.Context, matchLabels map[string]string) *nropv1.NUMAResourcesOperator {
+func (o *OpenShiftNRO) deployWithLabels(ctx context.Context, timeout time.Duration, matchLabels map[string]string) *nropv1.NUMAResourcesOperator {
 	GinkgoHelper()
 	nroObj := objects.TestNRO(objects.NROWithMCPSelector(matchLabels))
 	kcObj, err := objects.TestKC(matchLabels)
@@ -72,7 +72,7 @@ func (o *OpenShiftNRO) deployWithLabels(ctx context.Context, matchLabels map[str
 	o.NroObj = nroObj
 
 	By("unpausing the target MCPs")
-	Eventually(unpause).WithTimeout(configuration.MachineConfigPoolUpdateTimeout).WithPolling(configuration.MachineConfigPoolUpdateInterval).Should(Succeed())
+	Eventually(unpause).WithTimeout(timeout).WithPolling(configuration.MachineConfigPoolUpdateInterval).Should(Succeed())
 
 	By("updating the target NRO object")
 	Expect(e2eclient.Client.Get(ctx, client.ObjectKeyFromObject(nroObj), nroObj)).To(Succeed())


### PR DESCRIPTION
In case we are skipping the setup, make sure to fetch the existing scheduler data, failing loudly if that resource is not actually present.

Along the way, cleanup the deploy API and package to make sure context and timeout are properly passed down the call chain.

manual backport of #1120 