### PR TITLE
buildhelper: try harder to get version

### DIFF
--- a/internal/api/buildinfo/types.go
+++ b/internal/api/buildinfo/types.go
@@ -17,9 +17,14 @@
 package buildinfo
 
 type BuildInfo struct {
-	Branch  string `json:"branch"`
+	// GitBranch is the raw git branch from which the artifacts are built
+	GitBranch string `json:"gitbranch"`
+	// Branch is the parsed git branch from which the artifacts are built
+	Branch string `json:"branch"`
+	// Version is the MAJOR.MINOR version of the artifacts being built
 	Version string `json:"version"`
-	Commit  string `json:"commit"`
+	// Commit is the parsed git commit from which the artifacts are built
+	Commit string `json:"commit"`
 }
 
 func (bi BuildInfo) String() string {

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package buildinfo
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"strings"
+
+	goversion "github.com/aquasecurity/go-version/pkg/version"
+)
+
+const (
+	versionFileName  = "Makefile"
+	versionTagPrefix = `VERSION`
+	// ok, this is an abuse. What we would really need is to parse the full
+	// raw version and emit MAJOR.MINOR but the version parsing package
+	// we are currently using doesn't allow this easily, so we leverage
+	// our versioning convention.
+	versionTagSuffix = `.999-snapshot`
+)
+
+// ParseVersionFromFile find an annotation like
+// `VERSION ?= 4.19.999-snapshot`
+// intentionally swallows any error
+func ParseVersionFromFile(srcFile string) string {
+	data, err := os.ReadFile(srcFile)
+	if err != nil {
+		return ""
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, versionTagPrefix) {
+			continue
+		}
+		ver := findVersionValueInLine(line)
+		if !strings.HasSuffix(ver, versionTagSuffix) {
+			continue
+		}
+		ver = strings.TrimSuffix(ver, versionTagSuffix)
+		if _, err := goversion.Parse(ver); err != nil {
+			return "" // no point in continuing
+		}
+		return ver
+	}
+	return ""
+}
+
+func findVersionValueInLine(line string) string {
+	// if we are here we know the line starts with `VERSION`
+	fields := strings.FieldsFunc(line, func(c rune) bool {
+		return c == '='
+	})
+	if len(fields) < 2 {
+		return ""
+	}
+	// inline comments are not supported (yet?)
+	return strings.TrimSpace(fields[1])
+}


### PR DESCRIPTION
try first to fetch the version from the master location (Makefile) before to deduce from the branch name.
The immediate benefit is we have a much higher chance to always report a version number, because we must have a version number in the master location in the Makefile.

Also: report git raw branch name