### PR TITLE
security: rte: narrow down SCC volumes

### DIFF
--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -228,6 +228,14 @@ func SecurityContextConstraint(scc *securityv1.SecurityContextConstraints, legac
 		return
 	}
 	scc.SELinuxContext.SELinuxOptions.Type = selinux.RTEContextType
+	scc.Volumes = []securityv1.FSType{
+		securityv1.FSTypeHostPath,
+		securityv1.FSTypeEmptyDir,
+		securityv1.FSTypeSecret,
+		securityv1.FSTypeDownwardAPI,
+		securityv1.FSTypeConfigMap,
+		securityv1.FSProjected,
+	}
 }
 
 func isPodFingerprintEnabled(conf *nropv1.NodeGroupConfig) (bool, string) {


### PR DESCRIPTION
narrow down the list of allowed volumes for the security context contraints RTE use.
We only allowlist the volumes we already use or which we will reasonnably use.