### PR TITLE
rte: metrics: merge manifests into existing manifests handling

### DIFF
--- a/controllers/numaresourcesoperator_controller_test.go
+++ b/controllers/numaresourcesoperator_controller_test.go
@@ -83,10 +83,10 @@ func NewFakeNUMAResourcesOperatorReconciler(plat platform.Platform, platVersion 
 		Platform:     plat,
 		APIManifests: apiManifests,
 		RTEManifests: rte.Manifests{
-			Core: rteManifests,
+			Core:    rteManifests,
+			Metrics: rtemetricsmanifests,
 		},
-		RTEMetricsManifests: rtemetricsmanifests,
-		Namespace:           testNamespace,
+		Namespace: testNamespace,
 		Images: images.Data{
 			Builtin: testImageSpec,
 		},
@@ -1483,16 +1483,13 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 								}
 								Expect(reconciler.Client.Get(context.TODO(), mcp2DSKey, ds)).ToNot(HaveOccurred())
 
-								By("Check All RTE metrics components are created")
-								for _, obj := range reconciler.RTEMetricsManifests.ToObjects() {
-									objectKey := client.ObjectKeyFromObject(obj)
-									switch obj.(type) {
-									case *corev1.Service:
-										service := &corev1.Service{}
-										Expect(reconciler.Client.Get(context.TODO(), objectKey, service)).ToNot(HaveOccurred())
-									default:
-									}
+								serKey := client.ObjectKey{
+									Name:      "numaresources-rte-metrics-service", // TODO: staticize
+									Namespace: testNamespace,
 								}
+								ser := &corev1.Service{}
+								By("Check All RTE metrics components are created")
+								Expect(reconciler.Client.Get(context.TODO(), serKey, ser)).ToNot(HaveOccurred())
 							})
 							When("daemonsets are ready", func() {
 								var dsDesiredNumberScheduled int32

--- a/controllers/numaresourcesoperator_controller_test.go
+++ b/controllers/numaresourcesoperator_controller_test.go
@@ -78,11 +78,13 @@ func NewFakeNUMAResourcesOperatorReconciler(plat platform.Platform, platVersion 
 	recorder := record.NewFakeRecorder(bufferSize)
 
 	return &NUMAResourcesOperatorReconciler{
-		Client:              fakeClient,
-		Scheme:              scheme.Scheme,
-		Platform:            plat,
-		APIManifests:        apiManifests,
-		RTEManifests:        rteManifests,
+		Client:       fakeClient,
+		Scheme:       scheme.Scheme,
+		Platform:     plat,
+		APIManifests: apiManifests,
+		RTEManifests: rte.Manifests{
+			Core: rteManifests,
+		},
 		RTEMetricsManifests: rtemetricsmanifests,
 		Namespace:           testNamespace,
 		Images: images.Data{
@@ -361,7 +363,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 						BeforeEach(func() {
 							By("Create a new Daemonset with correct name but not owner reference")
 
-							ds := reconciler.RTEManifests.DaemonSet.DeepCopy()
+							ds := reconciler.RTEManifests.Core.DaemonSet.DeepCopy()
 							ds.Name = objectnames.GetComponentName(nro.Name, pn2)
 							ds.Namespace = testNamespace
 
@@ -902,7 +904,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 					ds := &appsv1.DaemonSet{}
 					Expect(reconciler.Client.Get(context.TODO(), dsKey, ds)).To(Succeed())
 
-					Expect(ds.Spec.Template.Spec.Tolerations).To(Equal(reconciler.RTEManifests.DaemonSet.Spec.Template.Spec.Tolerations), "mismatched DS default tolerations")
+					Expect(ds.Spec.Template.Spec.Tolerations).To(Equal(reconciler.RTEManifests.Core.DaemonSet.Spec.Template.Spec.Tolerations), "mismatched DS default tolerations")
 				})
 
 				It("should add the extra tolerations in the DS objects", func() {
@@ -1041,7 +1043,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(reconciler.Client.Get(context.TODO(), dsKey, ds)).To(Succeed())
-					Expect(ds.Spec.Template.Spec.Tolerations).To(Equal(reconciler.RTEManifests.DaemonSet.Spec.Template.Spec.Tolerations), "DS tolerations not restored to defaults")
+					Expect(ds.Spec.Template.Spec.Tolerations).To(Equal(reconciler.RTEManifests.Core.DaemonSet.Spec.Template.Spec.Tolerations), "DS tolerations not restored to defaults")
 
 					nroUpdated := &nropv1.NUMAResourcesOperator{}
 					Expect(reconciler.Client.Get(context.TODO(), client.ObjectKeyFromObject(nro), nroUpdated)).ToNot(HaveOccurred())
@@ -1496,18 +1498,18 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 								var dsDesiredNumberScheduled int32
 								var dsNumReady int32
 								BeforeEach(func() {
-									dsDesiredNumberScheduled = reconciler.RTEManifests.DaemonSet.Status.DesiredNumberScheduled
-									dsNumReady = reconciler.RTEManifests.DaemonSet.Status.NumberReady
+									dsDesiredNumberScheduled = reconciler.RTEManifests.Core.DaemonSet.Status.DesiredNumberScheduled
+									dsNumReady = reconciler.RTEManifests.Core.DaemonSet.Status.NumberReady
 
-									reconciler.RTEManifests.DaemonSet.Status.DesiredNumberScheduled = int32(len(nro.Spec.NodeGroups))
-									reconciler.RTEManifests.DaemonSet.Status.NumberReady = reconciler.RTEManifests.DaemonSet.Status.DesiredNumberScheduled
+									reconciler.RTEManifests.Core.DaemonSet.Status.DesiredNumberScheduled = int32(len(nro.Spec.NodeGroups))
+									reconciler.RTEManifests.Core.DaemonSet.Status.NumberReady = reconciler.RTEManifests.Core.DaemonSet.Status.DesiredNumberScheduled
 
 									_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 									Expect(err).ToNot(HaveOccurred())
 								})
 								AfterEach(func() {
-									reconciler.RTEManifests.DaemonSet.Status.DesiredNumberScheduled = dsDesiredNumberScheduled
-									reconciler.RTEManifests.DaemonSet.Status.NumberReady = dsNumReady
+									reconciler.RTEManifests.Core.DaemonSet.Status.DesiredNumberScheduled = dsDesiredNumberScheduled
+									reconciler.RTEManifests.Core.DaemonSet.Status.NumberReady = dsNumReady
 
 									_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
 									Expect(err).ToNot(HaveOccurred())

--- a/main.go
+++ b/main.go
@@ -229,8 +229,19 @@ func main() {
 	}
 	klog.InfoS("manifests loaded", "component", "RTE")
 
+	rteMetricsManifests, err := rtemetricsmanifests.GetManifests(namespace)
+	if err != nil {
+		klog.ErrorS(err, "unable to load the RTE metrics manifests")
+		os.Exit(1)
+	}
+	klog.InfoS("manifests loaded", "component", "RTEMetrics")
+
 	if params.renderMode {
-		os.Exit(manageRendering(params.render, clusterPlatform, apiManifests, rteManifests, namespace, params.enableScheduler))
+		rteMf := rtestate.Manifests{
+			Core:    rteManifests,
+			Metrics: rteMetricsManifests,
+		}
+		os.Exit(manageRendering(params.render, clusterPlatform, apiManifests, rteMf, namespace, params.enableScheduler))
 	}
 
 	klog.InfoS("metrics server", "enabled", params.enableMetrics, "addr", params.metricsAddr)
@@ -262,11 +273,6 @@ func main() {
 	rteManifestsRendered, err := renderRTEManifests(rteManifests, namespace, imgs)
 	if err != nil {
 		klog.ErrorS(err, "unable to render RTE manifests", "controller", "NUMAResourcesOperator")
-		os.Exit(1)
-	}
-	rteMetricsManifests, err := rtemetricsmanifests.GetManifests(namespace)
-	if err != nil {
-		klog.ErrorS(err, "unable to load the RTE metrics manifests")
 		os.Exit(1)
 	}
 
@@ -360,7 +366,7 @@ func manageIntrospection() int {
 	return 0
 }
 
-func manageRendering(render RenderParams, clusterPlatform platform.Platform, apiMf apimanifests.Manifests, rteMf rtemanifests.Manifests, namespace string, enableScheduler bool) int {
+func manageRendering(render RenderParams, clusterPlatform platform.Platform, apiMf apimanifests.Manifests, rteMf rtestate.Manifests, namespace string, enableScheduler bool) int {
 	if render.NRTCRD {
 		if err := renderObjects(apiMf.ToObjects()); err != nil {
 			klog.ErrorS(err, "unable to render manifests")
@@ -395,12 +401,13 @@ func manageRendering(render RenderParams, clusterPlatform platform.Platform, api
 		User:    render.Image.Exporter,
 		Builtin: images.SpecPath(),
 	}
-	mf, err := renderRTEManifests(rteMf, render.Namespace, imgs)
+	mf, err := renderRTEManifests(rteMf.Core, render.Namespace, imgs)
 	if err != nil {
 		klog.ErrorS(err, "unable to render RTE manifests")
 		return 1
 	}
 	objs = append(objs, mf.ToObjects()...)
+	objs = append(objs, rteMf.Metrics.ToObjects()...) // no rendering needed
 
 	if err := renderObjects(objs); err != nil {
 		klog.ErrorS(err, "unable to render manifests")

--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ import (
 	rtemetricsmanifests "github.com/openshift-kni/numaresources-operator/pkg/metrics/manifests/monitor"
 	"github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/controlplane"
 	schedmanifests "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/manifests/sched"
+	rtestate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/rte"
 	rteupdate "github.com/openshift-kni/numaresources-operator/pkg/objectupdate/rte"
 	schedupdate "github.com/openshift-kni/numaresources-operator/pkg/objectupdate/sched"
 	"github.com/openshift-kni/numaresources-operator/pkg/version"
@@ -270,11 +271,13 @@ func main() {
 	}
 
 	if err = (&controllers.NUMAResourcesOperatorReconciler{
-		Client:              mgr.GetClient(),
-		Scheme:              mgr.GetScheme(),
-		Recorder:            mgr.GetEventRecorderFor("numaresources-controller"),
-		APIManifests:        apiManifests,
-		RTEManifests:        rteManifestsRendered,
+		Client:       mgr.GetClient(),
+		Scheme:       mgr.GetScheme(),
+		Recorder:     mgr.GetEventRecorderFor("numaresources-controller"),
+		APIManifests: apiManifests,
+		RTEManifests: rtestate.Manifests{
+			Core: rteManifestsRendered,
+		},
 		RTEMetricsManifests: rteMetricsManifests,
 		Platform:            clusterPlatform,
 		Images:              imgs,

--- a/main.go
+++ b/main.go
@@ -276,14 +276,14 @@ func main() {
 		Recorder:     mgr.GetEventRecorderFor("numaresources-controller"),
 		APIManifests: apiManifests,
 		RTEManifests: rtestate.Manifests{
-			Core: rteManifestsRendered,
+			Core:    rteManifestsRendered,
+			Metrics: rteMetricsManifests,
 		},
-		RTEMetricsManifests: rteMetricsManifests,
-		Platform:            clusterPlatform,
-		Images:              imgs,
-		ImagePullPolicy:     pullPolicy,
-		Namespace:           namespace,
-		ForwardMCPConds:     params.enableMCPCondsForward,
+		Platform:        clusterPlatform,
+		Images:          imgs,
+		ImagePullPolicy: pullPolicy,
+		Namespace:       namespace,
+		ForwardMCPConds: params.enableMCPCondsForward,
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create controller", "controller", "NUMAResourcesOperator")
 		os.Exit(1)


### PR DESCRIPTION
instead of having very custom processing of RTE metrics manifests, generalize the current RTE manifests handling and merge the metrics manifests in this flow. Benefits are more common code and less special cases. No expected changes in the operator behavior.