### PR TITLE
Remove cluster role service RBAC permission leftover

### DIFF
--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -62,7 +62,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-01-07T08:34:09Z"
+    createdAt: "2025-01-09T10:45:35Z"
     olm.skipRange: '>=4.17.0 <4.18.0'
     operatorframework.io/cluster-monitoring: "true"
     operators.operatorframework.io/builder: operator-sdk-v1.36.1
@@ -359,7 +359,6 @@ spec:
           resources:
           - configmaps
           - serviceaccounts
-          - services
           verbs:
           - '*'
         - apiGroups:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,7 +9,6 @@ rules:
   resources:
   - configmaps
   - serviceaccounts
-  - services
   verbs:
   - '*'
 - apiGroups:

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -117,7 +117,6 @@ type NUMAResourcesOperatorReconciler struct {
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesoperators,verbs=*
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesoperators/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesoperators/finalizers,verbs=update
-//+kubebuilder:rbac:groups="",resources=services,verbs=*
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
This PR removes the Service-related RBAC permissions previously granted in the ClusterRole.
This should have been removed as part of the #1140 backport, but it seems to have been unintentionally left behind, likely due to rebase issues.
@ffromani @Tal-or 

