### PR TITLE
ghactions: use `kubectl` instead of `oc`

### DIFF
--- a/.github/workflows/e2e-tools.yaml
+++ b/.github/workflows/e2e-tools.yaml
@@ -71,8 +71,8 @@ jobs:
         mkdir -p ${LOG_DIR}
         for pod in $(kubectl get pods -n $E2E_NAMESPACE_NAME --no-headers=true -o custom-columns=NAME:.metadata.name)
         do
-          oc logs $pod -n $E2E_NAMESPACE_NAME --all-containers=true > ${LOG_DIR}/${pod}.log
-          oc describe pod $pod -n $E2E_NAMESPACE_NAME > ${LOG_DIR}/${pod}.describe.log
+          kubectl logs $pod -n $E2E_NAMESPACE_NAME --all-containers=true > ${LOG_DIR}/${pod}.log
+          kubectl describe pod $pod -n $E2E_NAMESPACE_NAME > ${LOG_DIR}/${pod}.describe.log
         done
 
     - name: Archive E2E Tests logs

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -73,8 +73,8 @@ jobs:
         mkdir -p ${LOG_DIR}
         for pod in $(kubectl get pods -n $E2E_NAMESPACE_NAME --no-headers=true -o custom-columns=NAME:.metadata.name)
         do
-          oc logs $pod -n $E2E_NAMESPACE_NAME --all-containers=true > ${LOG_DIR}/${pod}.log
-          oc describe pod $pod -n $E2E_NAMESPACE_NAME > ${LOG_DIR}/${pod}.describe.log
+          kubectl logs $pod -n $E2E_NAMESPACE_NAME --all-containers=true > ${LOG_DIR}/${pod}.log
+          kubectl describe pod $pod -n $E2E_NAMESPACE_NAME > ${LOG_DIR}/${pod}.describe.log
         done
 
     - name: Archive E2E Tests logs


### PR DESCRIPTION
oc binary seems to missing under the runner:
https://github.com/openshift-kni/numaresources-operator/actions/runs/12930090387/job/36060828252\?pr\=1155

It probably removed in one of the vm's distro update. Let's use kubectl instead.