### PR TITLE
go.mod: go 1.22.8->1.23.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/openshift-kni/numaresources-operator
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.8
+toolchain go1.23.5
 
 require (
 	github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492


### PR DESCRIPTION
1.23.5 introduce security fixes, bump to that build.