### PR TITLE
api: validate rules using CEL

### DIFF
--- a/api/v1/numaresourcesoperator_types.go
+++ b/api/v1/numaresourcesoperator_types.go
@@ -125,6 +125,7 @@ const (
 
 // NodeGroup defines group of nodes that will run resource topology exporter daemon set
 // You can choose the group of node by MachineConfigPoolSelector or by PoolName
+// +kubebuilder:validation:XValidation:rule="has(self.poolName) ? !has(self.machineConfigPoolSelector) : has(self.machineConfigPoolSelector)",message="Exactly one of 'PoolName' or 'MachineConfigPoolSelector' must be set for NodeGroup."
 type NodeGroup struct {
 	// MachineConfigPoolSelector defines label selector for the machine config pool
 	// +optional

--- a/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -198,6 +198,11 @@ spec:
                         to
                       type: string
                   type: object
+                  x-kubernetes-validations:
+                  - message: Exactly one of 'PoolName' or 'MachineConfigPoolSelector'
+                      must be set for NodeGroup.
+                    rule: 'has(self.poolName) ? !has(self.machineConfigPoolSelector)
+                      : has(self.machineConfigPoolSelector)'
                 type: array
               podExcludes:
                 description: Optional Namespace/Name glob patterns of pod to ignore

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -198,6 +198,11 @@ spec:
                         to
                       type: string
                   type: object
+                  x-kubernetes-validations:
+                  - message: Exactly one of 'PoolName' or 'MachineConfigPoolSelector'
+                      must be set for NodeGroup.
+                    rule: 'has(self.poolName) ? !has(self.machineConfigPoolSelector)
+                      : has(self.machineConfigPoolSelector)'
                 type: array
               podExcludes:
                 description: Optional Namespace/Name glob patterns of pod to ignore


### PR DESCRIPTION
Later versions of k8s introduce a new way for validating api fields
using CEL.
[https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/\#validation-rules](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions//#validation-rules)

This PR suggests using CEL validation for
validating that `PoolName` and `MachineConfigPoolSelector`
are configured correctly for the `NodeGroup`.

This method has several advantages:
1. It stops users from making mistakes at the manifest applying stage,
but doesn't involve with any preparation like validation webhooks.

2. It saves the operator from performing those validation, which
in turns save coding and maintaing less code.

3. Reporting configuration errors in status is less restrict
and might be missed by unexperienced user.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>