### PR TITLE
linter: enable checks for ginkgo and gomega

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,7 @@ linters:
     - bodyclose
 #    - copyloopvar
     - depguard
+    - ginkgolinter
     - gosimple
     - govet
     - ineffassign
@@ -78,3 +79,6 @@ linters-settings:
         deny:
           - pkg: "k8s.io/kubernetes"
             desc: Importing k8s.io/kubernetes as library is not supported
+  ginkgolinter:
+    # Trigger warning for ginkgo focus containers like `FDescribe`, `FContext`, `FWhen` or `FIt`
+    forbid-focus-container: true

--- a/internal/controller/numaresourcesscheduler_controller_test.go
+++ b/internal/controller/numaresourcesscheduler_controller_test.go
@@ -181,7 +181,7 @@ var _ = ginkgo.Describe("Test NUMAResourcesScheduler Reconcile", func() {
 			}
 
 			gomega.Expect(nrs.Status.RelatedObjects).ToNot(gomega.BeEmpty())
-			gomega.Expect(len(nrs.Status.RelatedObjects)).To(gomega.Equal(len(expected)))
+			gomega.Expect(nrs.Status.RelatedObjects).To(gomega.HaveLen(len(expected)))
 			gomega.Expect(nrs.Status.RelatedObjects).To(gomega.ContainElements(expected))
 		})
 
@@ -594,7 +594,7 @@ var _ = ginkgo.Describe("Test NUMAResourcesScheduler Reconcile", func() {
 		ginkgo.DescribeTable("should set the leader election resource parameters depending on replica count", func(replicas int32, expectedEnabled bool) {
 			nrs := nrs.DeepCopy()
 			nrs.Spec.Replicas = &replicas
-			gomega.Eventually(reconciler.Client.Update(context.TODO(), nrs)).WithPolling(30 * time.Second).WithTimeout(5 * time.Minute).Should(gomega.Succeed())
+			gomega.Eventually(reconciler.Client.Update).WithArguments(context.TODO(), nrs).WithPolling(30 * time.Second).WithTimeout(5 * time.Minute).Should(gomega.Succeed())
 
 			key := client.ObjectKeyFromObject(nrs)
 			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})

--- a/test/e2e/sched/sched_test.go
+++ b/test/e2e/sched/sched_test.go
@@ -227,7 +227,7 @@ var _ = Describe("[Scheduler] imageReplacement", func() {
 			podList, err := podlist.With(e2eclient.Client).ByDeployment(context.TODO(), *deployment)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(podList).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
-			uid := &podList[0].UID
+			uid := podList[0].UID
 
 			var t time.Duration
 			if nroSchedObj.Spec.CacheResyncPeriod != nil {

--- a/test/e2e/serial/tests/metrics.go
+++ b/test/e2e/serial/tests/metrics.go
@@ -77,7 +77,7 @@ var _ = Describe("metrics exposed securely", Serial, func() {
 			pods, err := e2eclient.K8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 				LabelSelector: labelSelector,
 			})
-			Expect(err).To(BeNil(), "Error listing worker pods: %v", err)
+			Expect(err).ToNot(HaveOccurred(), "Error listing worker pods: %v", err)
 			Expect(pods.Items).ToNot(BeEmpty(), "There should be at least one worker pod")
 			workerPod := &pods.Items[0]
 			stdout := fetchMetricsFromPod(ctx, workerPod, metricsAddress, metricsPort)

--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -262,7 +262,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *updatedDp)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(pods)).To(Equal(1))
+			Expect(pods).To(HaveLen(1))
 
 			updatedPod := pods[0]
 

--- a/test/e2e/serial/tests/scheduler_cache.go
+++ b/test/e2e/serial/tests/scheduler_cache.go
@@ -201,7 +201,7 @@ var _ = Describe("[serial][scheduler][cache][tier0] scheduler cache", Serial, La
 				// but that would be the most correct and stricter testing.
 				failedPods, updatedPods := wait.With(fxt.Client).Timeout(3*time.Minute).ForPodListAllRunning(context.TODO(), testPods)
 				dumpFailedPodInfo(fxt, failedPods)
-				Expect(len(failedPods)).To(BeZero(), "unexpected failed pods: %q", accumulatePodNamespacedNames(failedPods))
+				Expect(failedPods).To(BeEmpty(), "unexpected failed pods: %q", accumulatePodNamespacedNames(failedPods))
 
 				for _, updatedPod := range updatedPods {
 					schedOK, err := nrosched.CheckPODWasScheduledWith(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
@@ -298,7 +298,7 @@ var _ = Describe("[serial][scheduler][cache][tier0] scheduler cache", Serial, La
 					dumpFailedPodInfo(fxt, failedPods)
 					elapsed := time.Since(startTime)
 					klog.Infof("test pods (payload + interference) gone running in %v", elapsed)
-					Expect(len(failedPods)).To(BeZero(), "unexpected failed pods: %q", accumulatePodNamespacedNames(failedPods))
+					Expect(failedPods).To(BeEmpty(), "unexpected failed pods: %q", accumulatePodNamespacedNames(failedPods))
 
 					By("checking the test pods once running")
 					for _, updatedPod := range updatedPods {
@@ -429,8 +429,8 @@ var _ = Describe("[serial][scheduler][cache][tier0] scheduler cache", Serial, La
 				// So we wait a bit too much unnecessarily, but wetake this chance to ensure the pod(s) which are supposed to be pending
 				// stay pending at least up until timeout
 				failedPods, updatedPods := wait.With(fxt.Client).Timeout(time.Minute).ForPodListAllRunning(context.TODO(), testPods)
-				Expect(len(updatedPods)).To(Equal(hostsRequired))
-				Expect(len(failedPods)).To(Equal(expectedPending))
+				Expect(updatedPods).To(HaveLen(hostsRequired))
+				Expect(failedPods).To(HaveLen(expectedPending))
 				Expect(len(updatedPods) + len(failedPods)).To(Equal(desiredPods))
 
 				var usedNodes []string
@@ -549,8 +549,8 @@ var _ = Describe("[serial][scheduler][cache][tier0] scheduler cache", Serial, La
 				// So we wait a bit too much unnecessarily, but wetake this chance to ensure the pod(s) which are supposed to be pending
 				// stay pending at least up until timeout
 				failedPods, updatedPods := wait.With(fxt.Client).Timeout(time.Minute).ForPodListAllRunning(context.TODO(), testPods)
-				Expect(len(updatedPods)).To(Equal(hostsRequired))
-				Expect(len(failedPods)).To(Equal(expectedPending))
+				Expect(updatedPods).To(HaveLen(hostsRequired))
+				Expect(failedPods).To(HaveLen(expectedPending))
 
 				var usedNodes []string
 				for _, updatedPod := range updatedPods {
@@ -597,7 +597,7 @@ var _ = Describe("[serial][scheduler][cache][tier0] scheduler cache", Serial, La
 				// NRT updater, resync loop, scheduler retry loop.
 				failedPods, updatedPods = wait.With(fxt.Client).Timeout(5*time.Minute).ForPodListAllRunning(context.TODO(), expectedRunningPods)
 				dumpFailedPodInfo(fxt, failedPods)
-				Expect(len(updatedPods)).To(Equal(hostsRequired))
+				Expect(updatedPods).To(HaveLen(hostsRequired))
 				Expect(failedPods).To(BeEmpty())
 			})
 		})

--- a/test/e2e/serial/tests/scheduler_cache_stall.go
+++ b/test/e2e/serial/tests/scheduler_cache_stall.go
@@ -221,7 +221,7 @@ var _ = Describe("[serial][scheduler][cache] scheduler cache stall", Label("sche
 						_ = objects.LogEventsForPod(fxt.K8sClient, failedPod.Namespace, failedPod.Name)
 					}
 				}
-				Expect(len(failedPods)).To(BeZero(), "unexpected failed pods: %q", accumulatePodNamespacedNames(failedPods))
+				Expect(failedPods).To(BeEmpty(), "unexpected failed pods: %q", accumulatePodNamespacedNames(failedPods))
 
 				for _, updatedPod := range updatedPods {
 					schedOK, err := nrosched.CheckPODWasScheduledWith(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -454,7 +454,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 				pods, err := podlist.With(fxt.Client).ByDaemonset(ctx, *updatedDs)
 				Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset pods %s: %v", dsKey.String(), err)
 				By(fmt.Sprintf("ensuring the RTE DS is running with the same pods count (expected pods=%d)", len(workers)))
-				Expect(len(pods)).To(Equal(len(workers)), "updated DS ready=%v original worker nodes=%d", len(pods), len(workers))
+				Expect(pods).To(HaveLen(len(workers)), "updated DS ready=%v original worker nodes=%d", len(pods), len(workers))
 
 				By("applying the taint 2 - NoExecute")
 				applyTaintToNode(ctx, fxt.Client, targetNode, &tntNoExec[0])
@@ -501,7 +501,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 				klog.Info("verify RTE pods before triggering the restart still include the pod on the tainted node")
 				pods, err := podlist.With(fxt.Client).ByDaemonset(ctx, ds)
 				Expect(err).NotTo(HaveOccurred(), "Unable to get pods from daemonset %q: %v", ds.Name, err)
-				Expect(len(pods)).To(Equal(len(workers)), "pods number is not as expected for RTE daemonset: expected %d found %d", len(workers), len(pods))
+				Expect(pods).To(HaveLen(len(workers)), "pods number is not as expected for RTE daemonset: expected %d found %d", len(workers), len(pods))
 
 				var podToDelete corev1.Pod
 				for _, pod := range pods {

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -218,7 +218,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *updatedDp)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(pods)).To(Equal(1))
+			Expect(pods).To(HaveLen(1))
 
 			updatedPod := pods[0]
 			By(fmt.Sprintf("checking the pod landed on the target node %q vs %q", updatedPod.Spec.NodeName, targetNodeName))
@@ -607,7 +607,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *updatedDp)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(pods)).To(Equal(2))
+			Expect(pods).To(HaveLen(2))
 
 			updatedPod0 := pods[0]
 			checkReplica(updatedPod0, targetNodeName, fxt.K8sClient)

--- a/test/e2e/serial/tests/workload_placement_no_nrt.go
+++ b/test/e2e/serial/tests/workload_placement_no_nrt.go
@@ -199,7 +199,7 @@ func updateInfoRefreshPause(fxt *e2efixture.Fixture, newVal nropv1.InfoRefreshPa
 			return false
 		}
 		return true
-	}).WithTimeout(2*time.Minute).WithPolling(9*time.Second).Should(Equal(true), "Status of NROP failed to get updated")
+	}).WithTimeout(2*time.Minute).WithPolling(9*time.Second).Should(BeTrue(), "Status of NROP failed to get updated")
 
 	dsKey := wait.ObjectKey{
 		Namespace: updatedObj.Status.DaemonSets[0].Namespace,

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -390,7 +390,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				e2efixture.Skipf(fxt, "not enough nodes with policy %q - found %d", policyFuncs.policyName(), len(nrts))
 			}
 
-			Expect(len(unsuitableFreeRes)).To(Equal(hostsRequired), "mismatch unsuitable resource declarations expected %d items, but found %d", hostsRequired, len(unsuitableFreeRes))
+			Expect(unsuitableFreeRes).To(HaveLen(hostsRequired), "mismatch unsuitable resource declarations expected %d items, but found %d", hostsRequired, len(unsuitableFreeRes))
 
 			pod := objects.NewTestPodPause(fxt.Namespace.Name, "testpod")
 			pod.Spec.SchedulerName = serialconfig.Config.SchedulerName
@@ -1316,7 +1316,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				e2efixture.Skipf(fxt, "not enough nodes with policy %q - found %d", policyFuncs.policyName(), len(nrts))
 			}
 
-			Expect(len(unsuitableFreeRes)).To(Equal(hostsRequired), "mismatch unsuitable resource declarations expected %d items, but found %d", hostsRequired, len(unsuitableFreeRes))
+			Expect(unsuitableFreeRes).To(HaveLen(hostsRequired), "mismatch unsuitable resource declarations expected %d items, but found %d", hostsRequired, len(unsuitableFreeRes))
 
 			for _, nrt := range nrts {
 				for _, zone := range nrt.Zones {

--- a/test/e2e/tools/nrovalidate_test.go
+++ b/test/e2e/tools/nrovalidate_test.go
@@ -77,7 +77,7 @@ var _ = Describe("[tools][validation] nrovalidate tools", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(rep.Succeeded).To(BeFalse())
-			Expect(len(rep.Errors)).ToNot(BeZero())
+			Expect(rep.Errors).ToNot(BeEmpty())
 			for _, ve := range rep.Errors {
 				fmt.Fprintf(GinkgoWriter, "reported expected validation error: %v\n", ve)
 			}
@@ -134,7 +134,7 @@ var _ = Describe("[tools][validation] nrovalidate tools", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(rep.Succeeded).To(BeFalse())
-			Expect(len(rep.Errors)).ToNot(BeZero())
+			Expect(rep.Errors).ToNot(BeEmpty())
 			for _, ve := range rep.Errors {
 				fmt.Fprintf(GinkgoWriter, "reported expected validation error: %v\n", ve)
 			}

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Upgrade", Label("upgrade"), func() {
 				}
 
 				err := e2eclient.Client.Get(context.TODO(), mcKey, mc)
-				Expect(err).ToNot(BeNil(), "MachineConfig %s is not expected to to be present", mcKey.String())
+				Expect(err).To(HaveOccurred(), "MachineConfig %s is not expected to to be present", mcKey.String())
 				Expect(errors.IsNotFound(err)).To(BeTrue(), "Unexpected error occurred while getting MachineConfig %s: %v", mcKey.String(), err)
 			}
 		})

--- a/test/internal/deploy/hypershift.go
+++ b/test/internal/deploy/hypershift.go
@@ -97,7 +97,7 @@ func (h *HyperShiftNRO) Teardown(ctx context.Context, timeout time.Duration) {
 		Expect(e2eclient.MNGClient.Delete(ctx, h.KcConfigMapObj)).To(Succeed())
 
 		By("checking that generated configmap has been deleted")
-		Expect(e2eclient.Client.Get(ctx, client.ObjectKeyFromObject(h.NroObj), h.NroObj))
+		Expect(e2eclient.Client.Get(ctx, client.ObjectKeyFromObject(h.NroObj), h.NroObj)).To(Succeed())
 		Expect(h.NroObj.Status.DaemonSets).ToNot(BeEmpty())
 		cm := &corev1.ConfigMap{}
 		key := client.ObjectKey{


### PR DESCRIPTION
enable the ginkgo linter and address the first batch of complaints.