### PR TITLE
api: helper: fix NodeGroup Name

### DIFF
--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -72,7 +72,7 @@ func MultipleMCPsPerTree(annot map[string]string, trees []nodegroupv1.Tree) erro
 	var err error
 	for _, tree := range trees {
 		if len(tree.MachineConfigPools) > 1 {
-			err = errors.Join(err, fmt.Errorf("found multiple pools matches for node group %s but expected one. Pools found %v", tree.NodeGroup.ToString(), nodegroupv1.GetTreePoolsNames(tree)))
+			err = errors.Join(err, fmt.Errorf("found multiple pools matches for node group %s but expected one. Pools found %v", tree.NodeGroup.GetName(), nodegroupv1.GetTreePoolsNames(tree)))
 		}
 	}
 	return err


### PR DESCRIPTION
Problems with the current `NodeGroup.ToString()` method:
1. string representation of annotations, being them maps, is not stable, and we had no test coverage
2. the string representation can be very long, and in some places (e.g. conditions) we need a much more concise representation.

Fix both issues:
1. make representation of annotations stable
2. shorten a tiny bit `ToString()` but most notably add a concise `GetName()` method; use it on validation.