### PR TITLE
[release-4.17][manual]: e2e:install: deflake install suite

### DIFF
--- a/hack/run-test-e2e.sh
+++ b/hack/run-test-e2e.sh
@@ -5,6 +5,7 @@ set -e
 source hack/common.sh
 
 ENABLE_SCHED_TESTS="${ENABLE_SCHED_TESTS:-true}"
+ENABLE_CLEANUP="${ENABLE_CLEANUP:-false}"
 
 NO_COLOR=""
 if ! which tput &> /dev/null 2>&1 || [[ $(tput -T$TERM colors) -lt 8 ]]; then
@@ -51,12 +52,16 @@ if [ "$ENABLE_SCHED_TESTS" = true ]; then
   # -requireSuite: fail if tests are not executed because of missing suite
   ${BIN_DIR}/e2e-nrop-sched.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.flake-attempts=2 --ginkgo.junit-report=${REPORT_DIR}/e2e-sched.xml
 
-  echo "Running NROScheduler uninstall test suite";
-  ${BIN_DIR}/e2e-nrop-sched-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/sched-uninstall.xml
+  if [ "$ENABLE_CLEANUP" = true ]; then
+    echo "Running NROScheduler uninstall test suite";
+    ${BIN_DIR}/e2e-nrop-sched-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/sched-uninstall.xml
+  fi
 fi
 
-echo "Undeploying sample devices for RTE tests"
-rte/hack/undeploy-devices.sh
+if [ "$ENABLE_CLEANUP" = true ]; then
+  echo "Undeploying sample devices for RTE tests"
+  rte/hack/undeploy-devices.sh
 
-echo "Running NRO uninstall test suite";
-${BIN_DIR}/e2e-nrop-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/uninstall.xml
+  echo "Running NRO uninstall test suite";
+  ${BIN_DIR}/e2e-nrop-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/uninstall.xml
+fi

--- a/hack/run-test-install-e2e.sh
+++ b/hack/run-test-install-e2e.sh
@@ -16,3 +16,6 @@ trap '{ echo "Running NRO uninstall test suite"; ${BIN_DIR}/e2e-nrop-uninstall.t
 # Run install test suite
 echo "Running NRO install test suite"
 ${BIN_DIR}/e2e-nrop-install.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.junit-report=${REPORT_DIR}/install.xml --ginkgo.focus='\[Install\] durability'
+  
+echo "Running NRO uninstall test suite";
+${BIN_DIR}/e2e-nrop-uninstall.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/uninstall.xml

--- a/internal/wait/kubeletconfig.go
+++ b/internal/wait/kubeletconfig.go
@@ -32,3 +32,14 @@ func (wt Waiter) ForMCOKubeletConfigDeleted(ctx context.Context, kcName string) 
 		return deletionStatusFromError("MCOKubeletConfig", key, err)
 	})
 }
+
+func (wt Waiter) ForKubeletConfigDeleted(ctx context.Context, kc *machineconfigv1.KubeletConfig) error {
+	immediate := false
+	err := k8swait.PollUntilContextTimeout(ctx, wt.PollInterval, wt.PollTimeout, immediate, func(aContext context.Context) (bool, error) {
+		updatedKc := machineconfigv1.KubeletConfig{}
+		key := ObjectKeyFromObject(kc)
+		err := wt.Cli.Get(aContext, key.AsKey(), &updatedKc)
+		return deletionStatusFromError("KubeletConfig", key, err)
+	})
+	return err
+}

--- a/internal/wait/machineconfigpool.go
+++ b/internal/wait/machineconfigpool.go
@@ -34,10 +34,10 @@ const (
 
 func (wt Waiter) ForMachineConfigPoolDeleted(ctx context.Context, mcp *machineconfigv1.MachineConfigPool) error {
 	immediate := false
-	err := k8swait.PollUntilContextTimeout(ctx, wt.PollInterval, wt.PollTimeout, immediate, func(aContext context.Context) (bool, error) {
+	err := k8swait.PollUntilContextTimeout(ctx, wt.PollInterval, wt.PollTimeout, immediate, func(ctx context.Context) (bool, error) {
 		updatedMcp := machineconfigv1.MachineConfigPool{}
 		key := ObjectKeyFromObject(mcp)
-		err := wt.Cli.Get(aContext, key.AsKey(), &updatedMcp)
+		err := wt.Cli.Get(ctx, key.AsKey(), &updatedMcp)
 		return deletionStatusFromError("MachineConfigPool", key, err)
 	})
 	return err
@@ -45,10 +45,10 @@ func (wt Waiter) ForMachineConfigPoolDeleted(ctx context.Context, mcp *machineco
 
 func (wt Waiter) ForMachineConfigPoolCondition(ctx context.Context, mcp *machineconfigv1.MachineConfigPool, condType machineconfigv1.MachineConfigPoolConditionType) error {
 	immediate := false
-	err := k8swait.PollUntilContextTimeout(ctx, wt.PollInterval, wt.PollTimeout, immediate, func(aContext context.Context) (bool, error) {
+	err := k8swait.PollUntilContextTimeout(ctx, wt.PollInterval, wt.PollTimeout, immediate, func(ctx context.Context) (bool, error) {
 		updatedMcp := machineconfigv1.MachineConfigPool{}
 		key := ObjectKeyFromObject(mcp)
-		err := wt.Cli.Get(aContext, key.AsKey(), &updatedMcp)
+		err := wt.Cli.Get(ctx, key.AsKey(), &updatedMcp)
 		if err != nil {
 			return false, err
 		}

--- a/internal/wait/machineconfigpool.go
+++ b/internal/wait/machineconfigpool.go
@@ -43,17 +43,6 @@ func (wt Waiter) ForMachineConfigPoolDeleted(ctx context.Context, mcp *machineco
 	return err
 }
 
-func (wt Waiter) ForKubeletConfigDeleted(ctx context.Context, kc *machineconfigv1.KubeletConfig) error {
-	immediate := false
-	err := k8swait.PollUntilContextTimeout(ctx, wt.PollInterval, wt.PollTimeout, immediate, func(aContext context.Context) (bool, error) {
-		updatedKc := machineconfigv1.KubeletConfig{}
-		key := ObjectKeyFromObject(kc)
-		err := wt.Cli.Get(aContext, key.AsKey(), &updatedKc)
-		return deletionStatusFromError("KubeletConfig", key, err)
-	})
-	return err
-}
-
 func (wt Waiter) ForMachineConfigPoolCondition(ctx context.Context, mcp *machineconfigv1.MachineConfigPool, condType machineconfigv1.MachineConfigPoolConditionType) error {
 	immediate := false
 	err := k8swait.PollUntilContextTimeout(ctx, wt.PollInterval, wt.PollTimeout, immediate, func(aContext context.Context) (bool, error) {

--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -48,6 +48,9 @@ import (
 	"github.com/openshift-kni/numaresources-operator/test/utils/objects"
 )
 
+// tests here are not interruptible, so they should not accept contexts.
+// See: https://onsi.github.io/ginkgo/#interruptible-nodes-and-speccontext
+
 const (
 	containerNameRTE = "resource-topology-exporter"
 )
@@ -133,7 +136,7 @@ var _ = Describe("[Install] continuousIntegration", func() {
 	})
 })
 
-var _ = Describe("[Install] durability", func() {
+var _ = Describe("[Install] durability", Serial, func() {
 	var initialized bool
 
 	BeforeEach(func() {
@@ -187,7 +190,6 @@ var _ = Describe("[Install] durability", func() {
 		})
 
 		It("[test_id:47587][tier1] should restart RTE DaemonSet when image is updated in NUMAResourcesOperator", func() {
-
 			By("getting up-to-date NRO object")
 			nroKey := client.ObjectKeyFromObject(deployedObj.NroObj)
 			Expect(nroKey.Name).NotTo(BeEmpty())

--- a/test/e2e/uninstall/uninstall_test.go
+++ b/test/e2e/uninstall/uninstall_test.go
@@ -39,7 +39,7 @@ import (
 	e2epause "github.com/openshift-kni/numaresources-operator/test/utils/objects/pause"
 )
 
-var _ = Describe("[Uninstall]", func() {
+var _ = Describe("[Uninstall] clusterCleanup", Serial, func() {
 	var (
 		initialized bool
 	)


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift-kni/numaresources-operator/pull/1043 
and partial cherry-pick of: https://github.com/openshift-kni/numaresources-operator/pull/1091 

These backports should deflake the install suite failures we're facing during the develop of the[ upgrade lane:](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/60423/rehearse-60423-pull-ci-openshift-kni-numaresources-operator-release-4.18-4.18-upgrade-from-stable-4.17-e2e-operator-upgrade/1888880635452329984)


```
  [FAILED] Unexpected error:
      <*errors.StatusError | 0xc000368960>: 
      kubeletconfigs.machineconfiguration.openshift.io "kc-test" already exists
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "kubeletconfigs.machineconfiguration.openshift.io \"kc-test\" already exists",
              Reason: "AlreadyExists",
              Details: {
                  Name: "kc-test",
                  Group: "machineconfiguration.openshift.io",
                  Kind: "kubeletconfigs",
                  UID: "",
                  Causes: nil,
                  RetryAfterSeconds: 0,
              },
              Code: 409,
          },
      }
```