### PR TITLE
internal: include `metrics` in active topics

### DIFF
--- a/internal/api/features/_topics.json
+++ b/internal/api/features/_topics.json
@@ -18,6 +18,7 @@
     "tmpol",
     "schedattrwatch",
     "ngpoolname",
-    "nganns"
+    "nganns",
+    "metrics"
   ]
 }

--- a/test/e2e/serial/tests/metrics.go
+++ b/test/e2e/serial/tests/metrics.go
@@ -41,7 +41,7 @@ import (
 const metricsAddress = "127.0.0.1"
 
 // This test verifies that the HTTPS metrics endpoints, are accessible and serving metrics.
-var _ = Describe("metrics exposed securely", Serial, func() {
+var _ = Describe("metrics exposed securely", Serial, Label("feature:metrics"), func() {
 	ctx := context.Background()
 	var namespace string
 	var nropObj *nropv1.NUMAResourcesOperator


### PR DESCRIPTION
exposing metrics is supported on 4.18 and forward, label the relevant specs that cover this topic and add it to the list of actiuve topics for this branch.