### PR TITLE
e2e: serial: minor usability improvements

### DIFF
--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -337,7 +337,7 @@ var _ = Describe("[Install] durability", Serial, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			if inthelper.IsCustomPolicyEnabled(nroObj) {
-				Expect(deploy.WaitForMCPsCondition(e2eclient.Client, context.TODO(), mcps, machineconfigv1.MachineConfigPoolUpdated)).To(Succeed())
+				Expect(deploy.WaitForMCPsCondition(e2eclient.Client, context.TODO(), machineconfigv1.MachineConfigPoolUpdated, mcps...)).To(Succeed())
 			}
 
 			Eventually(func() bool {

--- a/test/e2e/serial/README.md
+++ b/test/e2e/serial/README.md
@@ -21,6 +21,7 @@ they found it before they run.
 
 ### configuring using the environment variables
 
+- `E2E_NROP_VERBOSE` (accepts integer, e.g 2,4) sets the logger verbosity. Same rules about klog verbosity apply.
 - `E2E_NROP_INSTALL_SKIP_KC` (accepts boolean, e.g. `true`) instructs the suite to NOT deploy the builtin
   `kubeletconfig`. With this enabled, the suite will expect a `kubeletconfig` already deployed (and consumed)
   in the cluster against it is running.

--- a/test/e2e/serial/config/config.go
+++ b/test/e2e/serial/config/config.go
@@ -45,9 +45,13 @@ import (
 )
 
 const (
-	MultiNUMALabel                   = "numa.hardware.openshift-kni.io/cell-count"
+	MultiNUMALabel    = "numa.hardware.openshift-kni.io/cell-count"
+	SchedulerTestName = "test-topology-scheduler"
+	DefaultVerbosity  = 4
+)
+
+const (
 	nropTestCIImage                  = "quay.io/openshift-kni/resource-topology-exporter:test-ci"
-	SchedulerTestName                = "test-topology-scheduler"
 	minNumberOfNodesWithSameTopology = 2
 )
 

--- a/test/e2e/serial/config/envs.go
+++ b/test/e2e/serial/config/envs.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+func DumpEnvironment(w io.Writer) {
+	fmt.Fprintf(w, "E2E NROP environment variables dump BEGIN\n")
+	defer fmt.Fprintf(w, "E2E NROP environment variables dump END\n")
+	for _, keyVal := range os.Environ() {
+		if !looksLikeE2ENROPEnv(keyVal) {
+			continue
+		}
+		fmt.Fprintf(w, "- %s\n", keyVal)
+	}
+}
+
+func looksLikeE2ENROPEnv(s string) bool {
+	return strings.HasPrefix(s, "E2E_NROP_") || strings.HasPrefix(s, "E2E_RTE_")
+}

--- a/test/e2e/serial/e2e_serial_test.go
+++ b/test/e2e/serial/e2e_serial_test.go
@@ -18,6 +18,7 @@ package serial
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -38,6 +39,7 @@ func TestSerial(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	ctx := context.Background()
+	serialconfig.DumpEnvironment(os.Stderr) // logging is not fully setup yet, we need to bruteforce
 	Expect(serialconfig.CheckNodesTopology(ctx)).Should(Succeed())
 	serialconfig.Setup()
 	setupExecuted = true

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -221,10 +221,10 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 				Expect(err).ToNot(HaveOccurred())
 
 				//this will trigger node reboot as the NROP settings will be reapplied to the unlabelled node, so new node is added under the old mcp hence the MachineCount update type
-				waitForMcpUpdate(fxt.Client, context.TODO(), []mcpInfo{initialMcpInfo}, MachineCount)
+				waitForMcpUpdate(fxt.Client, context.TODO(), MachineCount, initialMcpInfo)
 			}()
 
-			waitForMcpUpdate(fxt.Client, context.TODO(), []mcpInfo{newMcpInfo}, MachineConfig)
+			waitForMcpUpdate(fxt.Client, context.TODO(), MachineConfig, newMcpInfo)
 
 			By(fmt.Sprintf("modifying the NUMAResourcesOperator nodeGroups field to match new mcp: %q labels %q", mcp.Name, mcp.Labels))
 			Eventually(func(g Gomega) {
@@ -260,12 +260,12 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 				By("waiting for mcps to start updating")
 				// this will trigger mcp update only for the initial mcps because the mcp-test nodes are still labeled
 				// with the old labels, so worker mcp will switch back to the NROP mc
-				waitForMcpUpdate(fxt.Client, context.TODO(), []mcpInfo{initialMcpInfo}, MachineConfig)
+				waitForMcpUpdate(fxt.Client, context.TODO(), MachineConfig, initialMcpInfo)
 			}() //end of defer
 
 			By("waiting for the mcps to update")
 			// on old mcp because the ds will no longer include the worker node that is not labeled with mcp-test, so returning to MC without NROP settings
-			waitForMcpUpdate(fxt.Client, context.TODO(), []mcpInfo{initialMcpInfo}, MachineConfig)
+			waitForMcpUpdate(fxt.Client, context.TODO(), MachineConfig, initialMcpInfo)
 
 			By(fmt.Sprintf("Verify RTE daemonsets have the updated node selector matching to the new mcp %q", mcp.Name))
 			Eventually(func() (bool, error) {
@@ -564,12 +564,12 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 						)).ToNot(HaveOccurred())
 					}
 					By("waiting for mcp to update")
-					waitForMcpUpdate(fxt.Client, context.TODO(), mcpsInfo, MachineConfig)
+					waitForMcpUpdate(fxt.Client, context.TODO(), MachineConfig, mcpsInfo...)
 				}
 			}()
 
 			By("waiting for mcp to update")
-			waitForMcpUpdate(fxt.Client, context.TODO(), mcpsInfo, MachineConfig)
+			waitForMcpUpdate(fxt.Client, context.TODO(), MachineConfig, mcpsInfo...)
 
 			By("checking that NUMAResourcesOperator's ConfigMap has changed")
 			cmList := &corev1.ConfigMapList{}
@@ -987,12 +987,12 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 					}
 
 					By("waiting for mcp to update")
-					waitForMcpUpdate(fxt.Client, ctx, mcpsInfo, MachineConfig)
+					waitForMcpUpdate(fxt.Client, ctx, MachineConfig, mcpsInfo...)
 				}
 			}()
 
 			By("waiting for mcp to update")
-			waitForMcpUpdate(fxt.Client, ctx, mcpsInfo, MachineConfig)
+			waitForMcpUpdate(fxt.Client, ctx, MachineConfig, mcpsInfo...)
 
 			var schedulerName string
 			var nroSchedObj nropv1.NUMAResourcesScheduler
@@ -1069,7 +1069,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			}
 
 			By("waiting for mcp to update")
-			waitForMcpUpdate(fxt.Client, ctx, mcpsInfo, MachineConfig)
+			waitForMcpUpdate(fxt.Client, ctx, MachineConfig, mcpsInfo...)
 
 			By("creating a Topology Affinity Error deployment and check if the pod status is pending")
 			deployment := createTAEDeployment(fxt, ctx, "testdp", serialconfig.Config.SchedulerName, cpuResources)

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -542,7 +542,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 					err = fxt.Client.Delete(ctx, &nroOperObj)
 					Expect(err).ToNot(HaveOccurred())
 
-					waitForMcpUpdate(fxt.Client, ctx, mcpsInfo, MachineConfig)
+					waitForMcpUpdate(fxt.Client, ctx, MachineConfig, mcpsInfo...)
 
 					By("taint one worker node")
 					workers, err = nodes.GetWorkers(fxt.DEnv())
@@ -581,7 +581,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 						Expect(err).ToNot(HaveOccurred())
 						Expect(mcpsInfo).ToNot(BeEmpty())
 
-						waitForMcpUpdate(fxt.Client, ctx, mcpsInfo, MachineCount)
+						waitForMcpUpdate(fxt.Client, ctx, MachineCount, mcpsInfo...)
 					} else {
 						Eventually(func(g Gomega) {
 							err := fxt.Client.Get(ctx, nroKey, nropNewObj)
@@ -613,7 +613,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 					Expect(err).ToNot(HaveOccurred())
 					Expect(mcpsInfo).ToNot(BeEmpty())
 
-					waitForMcpUpdate(fxt.Client, ctx, mcpsInfo, MachineCount)
+					waitForMcpUpdate(fxt.Client, ctx, MachineCount, mcpsInfo...)
 
 					klog.Info("waiting for DaemonSet to be ready")
 					ds, err := wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDaemonsetPodsCreation(ctx, dsKey, len(workers)-1)
@@ -657,7 +657,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 					Expect(err).ToNot(HaveOccurred())
 					Expect(mcpsInfo).ToNot(BeEmpty())
 
-					waitForMcpUpdate(fxt.Client, ctx, mcpsInfo, MachineCount)
+					waitForMcpUpdate(fxt.Client, ctx, MachineCount, mcpsInfo...)
 
 					klog.Info("waiting for DaemonSet to be ready")
 					ds, err := wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDaemonsetPodsCreation(ctx, dsKey, len(workers))
@@ -840,12 +840,12 @@ func sriovToleration() corev1.Toleration {
 	}
 }
 
-func waitForMcpUpdate(cli client.Client, ctx context.Context, mcpsInfo []mcpInfo, updateType MCPUpdateType) {
+func waitForMcpUpdate(cli client.Client, ctx context.Context, updateType MCPUpdateType, mcpsInfo ...mcpInfo) {
 	mcps := make([]*machineconfigv1.MachineConfigPool, 0, len(mcpsInfo))
 	for _, info := range mcpsInfo {
 		mcps = append(mcps, info.mcpObj)
 	}
-	Expect(deploy.WaitForMCPsCondition(cli, ctx, mcps, machineconfigv1.MachineConfigPoolUpdated)).To(Succeed())
+	Expect(deploy.WaitForMCPsCondition(cli, ctx, machineconfigv1.MachineConfigPoolUpdated, mcps...)).To(Succeed())
 
 	for _, info := range mcpsInfo {
 		// check the sample node is updated with new config in its annotations, both for desired and current, is a must

--- a/test/internal/deploy/deploy.go
+++ b/test/internal/deploy/deploy.go
@@ -144,7 +144,7 @@ func TeardownNROScheduler(ctx context.Context, nroSched *nropv1.NUMAResourcesSch
 	Expect(wait.With(e2eclient.Client).Interval(NROSchedulerPollingInterval).Timeout(timeout).ForNUMAResourcesSchedulerDeleted(ctx, nroSched)).To(Succeed(), "NROScheduler %q failed to be deleted", nroSched.Name)
 }
 
-func WaitForMCPsCondition(cli client.Client, ctx context.Context, mcps []*machineconfigv1.MachineConfigPool, condition machineconfigv1.MachineConfigPoolConditionType) error {
+func WaitForMCPsCondition(cli client.Client, ctx context.Context, condition machineconfigv1.MachineConfigPoolConditionType, mcps ...*machineconfigv1.MachineConfigPool) error {
 	interval := configuration.MachineConfigPoolUpdateInterval // shortcut
 	timeout := configuration.MachineConfigPoolUpdateTimeout   // timeout
 	var eg errgroup.Group

--- a/test/internal/deploy/openshift.go
+++ b/test/internal/deploy/openshift.go
@@ -83,7 +83,7 @@ func (o *OpenShiftNRO) deployWithLabels(ctx context.Context, timeout time.Durati
 
 	if createKubelet || inthelper.IsCustomPolicyEnabled(nroObj) {
 		By("waiting for MCP to get updated")
-		Expect(WaitForMCPsCondition(e2eclient.Client, ctx, mcps, machineconfigv1.MachineConfigPoolUpdated)).To(Succeed())
+		Expect(WaitForMCPsCondition(e2eclient.Client, ctx, machineconfigv1.MachineConfigPoolUpdated, mcps...)).To(Succeed())
 	}
 	return nroObj
 }


### PR DESCRIPTION
another grab bag of internal (dev UX) and external (user UX) improvements:
- make sure to init logger, and let it be configured using env vars
- dump environs at startup
- simplify a bit the waitForMcpUpdate API (no change in behavior)