### PR TITLE
README: recover pods from `CrashLoopBackOff` after upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,16 @@ PRs fixing issues may link either
    Please link the PR using the `OCPBUGS-12345: ` or `RFE-9876: ` prefix in the PR description.
 
 we currently don't support other issue trackers.
+
+## Troubleshooting
+
+In case RTE pods are stuck in `CrashLoopBackOff` state after upgrade, and the following message shown in the logs:
+```
+ error while updating node allocatable: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial unix /host-podresources/kubelet.sock: connect: permission denied"
+```
+
+Try the following steps to recover the pod's state:
+1. Upgrade the operator to latest minor release (x.y → x.z)
+2. Run [restore-selinux-context.sh](hack/restore-selinux-context.sh) script to restore the right security context.
+
+

--- a/hack/restore-selinux-context.sh
+++ b/hack/restore-selinux-context.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Get the list of all worker nodes
+nodes=$(oc get nodes -l node-role.kubernetes.io/worker= -o jsonpath='{.items[*].metadata.name}')
+
+# Loop through each node and create a Job
+for node in $nodes; do
+        echo "execute job on node: ${node}"
+        cat <<EOF | oc create -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: openshift-infra
+  generateName: selinux-restorecon-
+spec:
+  template:
+    spec:
+      nodeName: $node
+      containers:
+        - name: selinux-context-restoration-cnt
+          image: registry.redhat.io/ubi9/ubi
+          command: ["/usr/sbin/chroot", "/host", "/usr/sbin/restorecon", "-R", "/var/lib/kubelet/pod-resources"]
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          volumeMounts:
+            - mountPath: /host
+              name: host
+      restartPolicy: Never
+      volumes:
+        - hostPath:
+            path: /
+            type: Directory
+          name: host
+      securityContext:
+        runAsUser: 0
+      serviceAccountName: build-controller
+EOF
+done


### PR DESCRIPTION
Add a simple guide to help recover
RTE pods from `CrashLoopBackOff` state after upgrade.