### PR TITLE
api: allow to skip reconciliation of NRT CRD 

### DIFF
--- a/internal/api/annotations/annotations.go
+++ b/internal/api/annotations/annotations.go
@@ -26,6 +26,9 @@ const (
 
 	PauseReconciliationAnnotation        = "config.numa-operator.openshift.io/pause-reconciliation"
 	PauseReconciliationAnnotationEnabled = "enabled"
+
+	NRTAPIDefinitionAnnotation = "config.numa-operator.openshift.io/nrt-api-definition"
+	NRTAPIFromCluster          = "cluster" // trust whatever it is already in the cluster, if at all
 )
 
 func IsCustomPolicyEnabled(annot map[string]string) bool {
@@ -44,6 +47,13 @@ func IsMultiplePoolsPerTreeEnabled(annot map[string]string) bool {
 
 func IsPauseReconciliationEnabled(annot map[string]string) bool {
 	if v, ok := annot[PauseReconciliationAnnotation]; ok && v == PauseReconciliationAnnotationEnabled {
+		return true
+	}
+	return false
+}
+
+func IsNRTAPIDefinitionCluster(annot map[string]string) bool {
+	if v, ok := annot[NRTAPIDefinitionAnnotation]; ok && v == NRTAPIFromCluster {
 		return true
 	}
 	return false

--- a/internal/api/annotations/annotations_test.go
+++ b/internal/api/annotations/annotations_test.go
@@ -122,3 +122,38 @@ func TestIsPauseReconciliationEnabled(t *testing.T) {
 		})
 	}
 }
+
+func TestIsNRTAPIDefinitionCluster(t *testing.T) {
+	testcases := []struct {
+		description string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			description: "empty map",
+			annotations: map[string]string{},
+			expected:    false,
+		},
+		{
+			description: "annotation set to anything but not \"cluster\" means the source is the operator",
+			annotations: map[string]string{
+				NRTAPIDefinitionAnnotation: "operator",
+			},
+			expected: false,
+		},
+		{
+			description: "skipping NRT CRD reconciliation",
+			annotations: map[string]string{
+				NRTAPIDefinitionAnnotation: NRTAPIFromCluster,
+			},
+			expected: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			if got := IsNRTAPIDefinitionCluster(tc.annotations); got != tc.expected {
+				t.Errorf("expected %v got %v", tc.expected, got)
+			}
+		})
+	}
+}

--- a/internal/api/features/_topics.json
+++ b/internal/api/features/_topics.json
@@ -19,6 +19,7 @@
     "schedattrwatch",
     "ngpoolname",
     "nganns",
-    "metrics"
+    "metrics",
+    "nrtcrdanns"
   ]
 }

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -224,6 +224,11 @@ func (r *NUMAResourcesOperatorReconciler) degradeStatus(ctx context.Context, ins
 }
 
 func (r *NUMAResourcesOperatorReconciler) reconcileResourceAPI(ctx context.Context, instance *nropv1.NUMAResourcesOperator, trees []nodegroupv1.Tree) intreconcile.Step {
+	if annotations.IsNRTAPIDefinitionCluster(instance.Annotations) {
+		// should never happen, so let's be vocal. Very vocal.
+		r.Recorder.Eventf(instance, corev1.EventTypeWarning, "SkipCRDInstall", "Skipped to install Node Resource Topology CRD: caused by annotation")
+		return intreconcile.StepSuccess()
+	}
 	applied, err := r.syncNodeResourceTopologyAPI(ctx)
 	if err != nil {
 		r.Recorder.Eventf(instance, corev1.EventTypeWarning, "FailedCRDInstall", "Failed to install Node Resource Topology CRD: %v", err)


### PR DESCRIPTION
Add custom annotation to stop reconciling the NRT API.
This annotation is semi-public and will be used strictly on a case-by-case way if there are multiple operators which
claim ownership of the NRT CRD.

With this annotation, NROP goes above and beyond and trusts blindly whatever NRT CRD is found in the cluster instead of owning the API.

Stop owning the NRT CRD greatly weakens the stability of the NUMA-aware scheduling and it is dangerous and definitely NOT recommended. But can be necessary in circumstances on which other operator claim ownership of the CRD, and we can't reconcile the differences.