### PR TITLE
OCPBUGS-51261:controller: track rte configmap state

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -458,9 +458,6 @@ func renderRTEManifests(rteManifests rtemanifests.Manifests, namespace string, i
 	if err != nil {
 		return mf, err
 	}
-	if mf.ConfigMap != nil {
-		rteupdate.DaemonSetHashAnnotation(mf.DaemonSet, hash.ConfigMapData(mf.ConfigMap))
-	}
 	return mf, err
 }
 

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -58,7 +58,6 @@ import (
 	"github.com/openshift-kni/numaresources-operator/internal/dangling"
 	"github.com/openshift-kni/numaresources-operator/internal/relatedobjects"
 	"github.com/openshift-kni/numaresources-operator/pkg/apply"
-	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	"github.com/openshift-kni/numaresources-operator/pkg/images"
 	"github.com/openshift-kni/numaresources-operator/pkg/loglevel"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
@@ -535,15 +534,6 @@ func (r *NUMAResourcesOperatorReconciler) syncNUMAResourcesOperatorResources(ctx
 		return dsPoolPairs, err
 	}
 
-	// ConfigMap should be provided by the kubeletconfig reconciliation loop
-	if r.RTEManifests.Core.ConfigMap != nil {
-		cmHash, err := hash.ComputeCurrentConfigMap(ctx, r.Client, r.RTEManifests.Core.ConfigMap)
-		if err != nil {
-			return dsPoolPairs, err
-		}
-		rteupdate.DaemonSetHashAnnotation(r.RTEManifests.Core.DaemonSet, cmHash)
-	}
-
 	rteupdate.SecurityContextConstraint(r.RTEManifests.Core.SecurityContextConstraint, true) // force to legacy context
 	// SCC v2 needs no updates
 
@@ -753,6 +743,8 @@ func daemonsetUpdater(poolName string, gdm *rtestate.GeneratedDesiredManifest) e
 			klog.V(5).InfoS("DaemonSet update: selinux options", "container", manifests.ContainerNameRTE, "context", selinux.RTEContextType)
 		}
 	}
+	// it's possible that the hash will be empty if kubelet controller hasn't created a configmap
+	rteupdate.DaemonSetHashAnnotation(gdm.DaemonSet, gdm.RTEConfigHash)
 	return nil
 }
 

--- a/internal/objects/objects.go
+++ b/internal/objects/objects.go
@@ -217,3 +217,21 @@ func GetDaemonSetListFromNodeGroupStatuses(groups []nropv1.NodeGroupStatus) []nr
 	}
 	return dss
 }
+
+// NewRTEConfigMap create a configmap similar to one created by KubeletController
+func NewRTEConfigMap(name, ns, policy, scope string) *corev1.ConfigMap {
+	data := fmt.Sprintf("kubelet:\n\t\ttopologyManagerPolicy: %s\ntopologyManagerScope: %s", policy, scope)
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Data: map[string]string{
+			"config.yaml": data,
+		},
+	}
+}

--- a/pkg/hash/configmap.go
+++ b/pkg/hash/configmap.go
@@ -17,39 +17,18 @@
 package hash
 
 import (
-	"context"
 	"crypto/sha256"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // hash package purpose is to compute a ConfigMap hash
 // that will be attached as an annotation to workload resources (DaemonSet, Deployment, etc.)
-// in order to allow them to track ConfigMap changes
+//  to allow them to track ConfigMap changes
 // more about this technique here: https://blog.questionable.services/article/kubernetes-deployments-configmap-change/
 
 const ConfigMapAnnotation = "configmap.hash"
-
-func ComputeCurrentConfigMap(ctx context.Context, cli client.Reader, cm *corev1.ConfigMap) (string, error) {
-	updatedConfigMap := &corev1.ConfigMap{}
-	key := client.ObjectKeyFromObject(cm)
-
-	if err := cli.Get(ctx, key, updatedConfigMap); err != nil {
-		// ConfigMap not created yet, use the data from the manifests
-		if apierrors.IsNotFound(err) {
-			updatedConfigMap = cm
-		} else {
-			return "", fmt.Errorf("could not calculate ConfigMap %q hash: %w", key.String(), err)
-		}
-	}
-	cmHash := ConfigMapData(updatedConfigMap)
-	klog.InfoS("configmap hash calculated", "hash", cmHash)
-	return cmHash, nil
-}
 
 func ConfigMapData(cm *corev1.ConfigMap) string {
 	var dataAsString string

--- a/pkg/hash/configmap_test.go
+++ b/pkg/hash/configmap_test.go
@@ -17,49 +17,13 @@
 package hash
 
 import (
-	"context"
 	"regexp"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	"github.com/openshift-kni/numaresources-operator/internal/objects"
 )
-
-func TestComputeCurrentConfigMap(t *testing.T) {
-	testCases := []struct {
-		name        string
-		cli         client.Client
-		cm          *corev1.ConfigMap
-		expectedOut string
-		expectedErr bool
-	}{
-		{
-			name: "map not created",
-			cli:  fake.NewFakeClient(),
-			cm:   objects.NewKubeletConfigConfigMap("test", map[string]string{}, objects.NewKubeletConfigAutoresizeControlPlane()),
-			// verified manually
-			expectedOut: "SHA256:93909e569a15b6e4a5eefdcac4153f2c8179bf155143d10dac589f62ddcdf742",
-			expectedErr: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		out, err := ComputeCurrentConfigMap(context.TODO(), tc.cli, tc.cm.DeepCopy())
-		gotErr := (err != nil)
-		if gotErr != tc.expectedErr {
-			t.Fatalf("got error %v expected error=%v", err, tc.expectedErr)
-		}
-		if out != tc.expectedOut {
-			t.Fatalf("got output %q expected %q", out, tc.expectedOut)
-		}
-	}
-}
 
 func TestConfigMapData(t *testing.T) {
 	cm := &corev1.ConfigMap{

--- a/pkg/objectstate/rte/machineconfigpool.go
+++ b/pkg/objectstate/rte/machineconfigpool.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
@@ -28,6 +29,7 @@ import (
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
 	nodegroupv1 "github.com/openshift-kni/numaresources-operator/api/v1/helper/nodegroup"
 	"github.com/openshift-kni/numaresources-operator/internal/api/annotations"
+	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectstate"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectstate/compare"
@@ -56,6 +58,12 @@ func (obj machineConfigPoolFinder) UpdateFromClient(ctx context.Context, cli cli
 		if dsm.daemonSetError = cli.Get(ctx, key, ds); dsm.daemonSetError == nil {
 			dsm.daemonSet = ds
 		}
+
+		cm := &corev1.ConfigMap{}
+		if err := cli.Get(ctx, key, cm); err == nil {
+			// we're storing the updated hash only in the case that kubelet controller created a configmap
+			dsm.rteConfigHash = hash.ConfigMapData(cm)
+		}
 		obj.em.daemonSets[generatedName] = dsm
 
 		mcName := objectnames.GetMachineConfigName(obj.instance.Name, mcp.Name)
@@ -76,12 +84,14 @@ func (obj machineConfigPoolFinder) FindState(mf Manifests, tree nodegroupv1.Tree
 	for _, mcp := range tree.MachineConfigPools {
 		var existingDs client.Object
 		var loadError error
+		var rteComputedConfigHash string
 
 		generatedName := objectnames.GetComponentName(obj.instance.Name, mcp.Name)
 		existingDaemonSet, ok := obj.em.daemonSets[generatedName]
 		if ok {
 			existingDs = existingDaemonSet.daemonSet
 			loadError = existingDaemonSet.daemonSetError
+			rteComputedConfigHash = existingDaemonSet.rteConfigHash
 		} else {
 			loadError = fmt.Errorf("failed to find daemon set %s/%s", mf.Core.DaemonSet.Namespace, mf.Core.DaemonSet.Name)
 		}
@@ -101,6 +111,7 @@ func (obj machineConfigPoolFinder) FindState(mf Manifests, tree nodegroupv1.Tree
 			MachineConfigPool:     mcp.DeepCopy(),
 			NodeGroup:             tree.NodeGroup.DeepCopy(),
 			DaemonSet:             desiredDaemonSet,
+			RTEConfigHash:         rteComputedConfigHash,
 			IsCustomPolicyEnabled: annotations.IsCustomPolicyEnabled(tree.NodeGroup.Annotations),
 		}
 

--- a/pkg/objectstate/rte/nodegroup.go
+++ b/pkg/objectstate/rte/nodegroup.go
@@ -21,11 +21,13 @@ import (
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
 	nodegroupv1 "github.com/openshift-kni/numaresources-operator/api/v1/helper/nodegroup"
 	"github.com/openshift-kni/numaresources-operator/internal/api/annotations"
+	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectstate"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectstate/compare"
@@ -53,6 +55,11 @@ func (obj nodeGroupFinder) UpdateFromClient(ctx context.Context, cli client.Clie
 	if dsm.daemonSetError = cli.Get(ctx, key, ds); dsm.daemonSetError == nil {
 		dsm.daemonSet = ds
 	}
+	cm := &corev1.ConfigMap{}
+	if err := cli.Get(ctx, key, cm); err == nil {
+		// we're storing the updated hash only in the case that kubelet controller created a configmap
+		dsm.rteConfigHash = hash.ConfigMapData(cm)
+	}
 	obj.em.daemonSets[generatedName] = dsm
 }
 
@@ -60,6 +67,7 @@ func (obj nodeGroupFinder) FindState(mf Manifests, tree nodegroupv1.Tree) []obje
 	var ret []objectstate.ObjectState
 	var existingDs client.Object
 	var loadError error
+	var rteConfigHash string
 
 	poolName := *tree.NodeGroup.PoolName
 
@@ -68,6 +76,7 @@ func (obj nodeGroupFinder) FindState(mf Manifests, tree nodegroupv1.Tree) []obje
 	if ok {
 		existingDs = existingDaemonSet.daemonSet
 		loadError = existingDaemonSet.daemonSetError
+		rteConfigHash = existingDaemonSet.rteConfigHash
 	} else {
 		loadError = fmt.Errorf("failed to find daemon set %s/%s", mf.Core.DaemonSet.Namespace, mf.Core.DaemonSet.Name)
 	}
@@ -85,6 +94,7 @@ func (obj nodeGroupFinder) FindState(mf Manifests, tree nodegroupv1.Tree) []obje
 		MachineConfigPool:     nil,
 		NodeGroup:             tree.NodeGroup.DeepCopy(),
 		DaemonSet:             desiredDaemonSet,
+		RTEConfigHash:         rteConfigHash,
 		IsCustomPolicyEnabled: annotations.IsCustomPolicyEnabled(tree.NodeGroup.Annotations),
 	}
 

--- a/pkg/objectstate/rte/rte.go
+++ b/pkg/objectstate/rte/rte.go
@@ -56,6 +56,7 @@ type rteHelper interface {
 type daemonSetManifest struct {
 	daemonSet      *appsv1.DaemonSet
 	daemonSetError error
+	rteConfigHash  string
 }
 
 type machineConfigManifest struct {
@@ -227,6 +228,8 @@ type GeneratedDesiredManifest struct {
 	NodeGroup         *nropv1.NodeGroup
 	// generated manifests
 	DaemonSet             *appsv1.DaemonSet
+	RTEConfigHash         string
+	ConfigMap             *corev1.ConfigMap
 	IsCustomPolicyEnabled bool
 }
 

--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -127,6 +127,7 @@ func DaemonSetHashAnnotation(ds *appsv1.DaemonSet, cmHash string) {
 		template.Annotations = map[string]string{}
 	}
 	template.Annotations[hash.ConfigMapAnnotation] = cmHash
+	klog.V(4).InfoS("DaemonSet RTE ConfigMap hash annotation updated", "namespace", ds.Namespace, "DaemonSetName", ds.Name, "hash", cmHash)
 }
 
 const _MiB = 1024 * 1024


### PR DESCRIPTION
Kubelet controller is responsible to track `KubeletConfig` objects and
generate a `ConfigMap` data from them that will be served to RTE.

NROP controller is responsible to track the `ConfigMap` creation,
feed it to RTE and restart RTE in case the `ConfigMap` data has changed.

The latter is broken, and this PR is fixing it.

In addition the `ConfigMap` should be per `DaemonSet`/`NodeGroup`, while
previously it was common at the CR level which is wrong.

Because cluster might have multiple node groups which are configured
slightly different.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>