### PR TITLE
cleanup: remove hash computation from shceduler's deployment

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -471,7 +471,7 @@ func renderSchedulerManifests(schedManifests schedmanifests.Manifests, imageSpec
 	// empty string is fine. Will be handled as "disabled".
 	// We only care about setting the environ variable to declare it exists,
 	// the best setting is "present, but disabled" vs "missing, thus implicitly disabled"
-	schedupdate.DeploymentConfigMapSettings(mf.Deployment, schedManifests.ConfigMap.Name, hash.ConfigMapData(schedManifests.ConfigMap))
+	schedupdate.DeploymentConfigMapSettings(mf.Deployment, schedManifests.ConfigMap.Name)
 	return mf, nil
 }
 

--- a/internal/controller/numaresourcesscheduler_controller.go
+++ b/internal/controller/numaresourcesscheduler_controller.go
@@ -44,7 +44,6 @@ import (
 	"github.com/openshift-kni/numaresources-operator/internal/api/annotations"
 	"github.com/openshift-kni/numaresources-operator/internal/relatedobjects"
 	"github.com/openshift-kni/numaresources-operator/pkg/apply"
-	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	"github.com/openshift-kni/numaresources-operator/pkg/loglevel"
 	nrosched "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler"
 	schedmanifests "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/manifests/sched"
@@ -216,8 +215,7 @@ func (r *NUMAResourcesSchedulerReconciler) syncNUMASchedulerResources(ctx contex
 	r.SchedulerManifests.Deployment.Spec.Template.Spec.PriorityClassName = nrosched.SchedulerPriorityClassName
 
 	schedupdate.DeploymentImageSettings(r.SchedulerManifests.Deployment, schedSpec.SchedulerImage)
-	cmHash := hash.ConfigMapData(r.SchedulerManifests.ConfigMap)
-	schedupdate.DeploymentConfigMapSettings(r.SchedulerManifests.Deployment, r.SchedulerManifests.ConfigMap.Name, cmHash)
+	schedupdate.DeploymentConfigMapSettings(r.SchedulerManifests.Deployment, r.SchedulerManifests.ConfigMap.Name)
 	if err := loglevel.UpdatePodSpec(&r.SchedulerManifests.Deployment.Spec.Template.Spec, "", schedSpec.LogLevel); err != nil {
 		return schedStatus, err
 	}

--- a/internal/controller/numaresourcesscheduler_controller_test.go
+++ b/internal/controller/numaresourcesscheduler_controller_test.go
@@ -40,7 +40,6 @@ import (
 	depmanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
 	depobjupdate "github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate"
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
-	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	nrosched "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler"
 	schedmanifests "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/manifests/sched"
 	"github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/objectstate/sched"
@@ -237,10 +236,6 @@ var _ = ginkgo.Describe("Test NUMAResourcesScheduler Reconcile", func() {
 			dp := &appsv1.Deployment{}
 			gomega.Expect(reconciler.Client.Get(context.TODO(), key, dp)).ToNot(gomega.HaveOccurred())
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-			val, ok := dp.Spec.Template.Annotations[hash.ConfigMapAnnotation]
-			gomega.Expect(ok).To(gomega.BeTrue())
-			gomega.Expect(val).ToNot(gomega.BeEmpty())
 		})
 
 		ginkgo.It("should react to owned objects changes", func() {

--- a/pkg/objectupdate/sched/sched.go
+++ b/pkg/objectupdate/sched/sched.go
@@ -28,7 +28,6 @@ import (
 	k8swgschedupdate "github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate/sched"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
-	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	schedstate "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/objectstate/sched"
 )
 
@@ -106,16 +105,12 @@ func FindEnvVarByName(envs []corev1.EnvVar, name string) *corev1.EnvVar {
 	return nil
 }
 
-func DeploymentConfigMapSettings(dp *appsv1.Deployment, cmName, cmHash string) {
+func DeploymentConfigMapSettings(dp *appsv1.Deployment, cmName string) {
 	template := &dp.Spec.Template // shortcut
 	// CAUTION HERE! the deployment template has a placeholder for volumes[0].
 	// we should clean up and clarify what we expect from the deployment template
 	// and what we manage programmatically, because there's hidden context here.
 	template.Spec.Volumes[0] = schedstate.NewSchedConfigVolume(schedstate.SchedulerConfigMapVolumeName, cmName)
-	if template.Annotations == nil {
-		template.Annotations = map[string]string{}
-	}
-	template.Annotations[hash.ConfigMapAnnotation] = cmHash
 }
 
 func SchedulerConfig(cm *corev1.ConfigMap, name string, params *k8swgmanifests.ConfigParams) error {


### PR DESCRIPTION
In contrary to nrop controller where the configmap is generated by a different controller, on the sheduler side we're fully control the configmap which is static and not configurable, so we don't need to keep the configmap hash in the deployment.

We do change the API of one of the functions, but as of now, we're not aware of anyone using it but this flow.