### PR TITLE
go: bump package to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/openshift-kni/numaresources-operator
 
-go 1.22.0
-
-toolchain go1.22.8
+go 1.23.0
 
 require (
 	github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492


### PR DESCRIPTION
we are a top-level package, so we can require a more recent version wrt our deps, until the go 1 backward promise is respected. This will help with next dep bumps.

We build already with golang 1.23 anyway