### PR TITLE
serial: add openshift labels

### DIFF
--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -143,8 +143,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 
 	Context("cluster has at least one suitable node", func() {
 		timeout := 5 * time.Minute
-
-		It("[test_id:47674] should be able to modify the configurable values under the NUMAResourcesOperator CR", Label("reboot_required", label.Slow, "images", label.Tier2), func() {
+		It("[test_id:47674] should be able to modify the configurable values under the NUMAResourcesOperator CR", Label("reboot_required", label.Slow, "images", label.Tier2, label.OpenShift), func() {
 			fxt.IsRebootTest = true
 			nroOperObj := &nropv1.NUMAResourcesOperator{}
 			nroKey := objects.NROObjectKey()
@@ -451,7 +450,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.SchedulerTestName)
 		})
 
-		It("[test_id:47585] can change kubeletconfig and controller should adapt", Label("reboot_required", label.Slow, label.Tier2), func() {
+		It("[test_id:47585] can change kubeletconfig and controller should adapt", Label("reboot_required", label.Slow, label.Tier2, label.OpenShift), func() {
 			fxt.IsRebootTest = true
 			var performanceProfile perfprof.PerformanceProfile
 			var targetedKC *machineconfigv1.KubeletConfig
@@ -683,7 +682,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			expectNRTConsumedResources(fxt, *nrtPreCreate, rl, testPod)
 		})
 
-		It("should report the NodeGroupConfig in the status", func() {
+		It("should report the NodeGroupConfig in the status", Label("tier2", "openshift"), func() {
 			nroKey := objects.NROObjectKey()
 			nroOperObj := nropv1.NUMAResourcesOperator{}
 
@@ -803,7 +802,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			Expect(nrsGot).To(Equal(nrsExpected), "mismatching related objects for NUMAResourcesScheduler")
 		})
 
-		It("ignores non-matching kubeletconfigs", Label(label.Slow, label.Tier1), func(ctx context.Context) {
+		It("ignores non-matching kubeletconfigs", Label(label.Slow, label.Tier1, label.OpenShift), func(ctx context.Context) {
 			By("getting the NROP object")
 			nroOperObj := &nropv1.NUMAResourcesOperator{}
 			nroKey := objects.NROObjectKey()
@@ -838,7 +837,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			}).WithContext(ctx).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Equal(kcCmNamesPre))
 		})
 
-		It("[test_id:75354] should be able to correctly identify topology manager policy without scheduler restarting", Label("reboot_required", label.Slow, "unsched", "schedrst", label.Tier2), Label("feature:schedattrwatch", "feature:schedrst"), func(ctx context.Context) {
+		It("[test_id:75354]should be able to correctly identify topology manager policy without scheduler restarting", Label("reboot_required", label.Slow, "unsched", "schedrst", label.Tier2, label.OpenShift), Label("feature:schedattrwatch", "feature:schedrst"), func(ctx context.Context) {
 			// https://issues.redhat.com/browse/OCPBUGS-34583
 			fxt.IsRebootTest = true
 			By("getting the number of cpus that is required for a numa zone to create a Topology Affinity Error deployment")

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -451,7 +451,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.SchedulerTestName)
 		})
 
-		It("[test_id:47585] can change kubeletconfig and controller should adapt", Label("reboot_required", label.Slow), func() {
+		It("[test_id:47585] can change kubeletconfig and controller should adapt", Label("reboot_required", label.Slow, label.Tier2), func() {
 			fxt.IsRebootTest = true
 			var performanceProfile perfprof.PerformanceProfile
 			var targetedKC *machineconfigv1.KubeletConfig

--- a/test/e2e/serial/tests/scheduler_cache.go
+++ b/test/e2e/serial/tests/scheduler_cache.go
@@ -86,7 +86,7 @@ var _ = Describe("scheduler cache", Serial, Label(label.Tier0, "scheduler", "cac
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	Context("using a NodeGroup with periodic unevented updates", Label("periodic_update"), func() {
+	Context("using a NodeGroup with periodic unevented updates", Label("periodic_update", label.OpenShift), func() {
 		var nroKey client.ObjectKey
 		var nroOperObj nropv1.NUMAResourcesOperator
 		var nrtCandidates []nrtv1alpha2.NodeResourceTopology

--- a/test/e2e/serial/tests/scheduler_cache_stall.go
+++ b/test/e2e/serial/tests/scheduler_cache_stall.go
@@ -68,7 +68,7 @@ var _ = Describe("[serial][scheduler][cache] scheduler cache stall", Label("sche
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	Context("using a NodeGroup with periodic unevented updates", Label("periodic_update"), func() {
+	Context("using a NodeGroup with periodic unevented updates", Label("periodic_update", label.OpenShift), func() {
 		var nroKey client.ObjectKey
 		var nroOperObj nropv1.NUMAResourcesOperator
 		var nroSchedKey client.ObjectKey

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -531,7 +531,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 				Expect(found).To(BeFalse(), "RTE pod was found on node %q while expected not to be found", taintedNode.Name)
 			})
 
-			When("RTE pods are not running yet", func() {
+			When("RTE pods are not running yet", Label(label.OpenShift), func() {
 				var taintedNode *corev1.Node
 
 				BeforeEach(func(ctx context.Context) {


### PR DESCRIPTION
The suite is running on hypershift and some tests that involves MCP
checks fails because MCO is not supported on HCP. Mark these tests with
the `openshift` label so they can be skipped when running the suite on
hypershift for now.
Note that part of these tests with slight adjustments can run on both
platforms; adapting this should be handled in later PRs.