### PR TITLE
serial: fix comma typo under Label

### DIFF
--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -666,7 +666,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			},
 		),
 		Entry("should make a pod with three gu cnt land on a node with enough resources, containers should be spread on a different zone",
-			Label(label.Tier1, "tmscope:cnt, testtype4"),
+			Label(label.Tier1, "tmscope:cnt", "testtype4"),
 			tmSingleNUMANodeFuncsHandler[intnrt.Container],
 			podResourcesRequest{
 				appCnt: []corev1.ResourceList{


### PR DESCRIPTION
This PR addresses a correction for a typo involving the incorrect placement of a comma within a Ginkgo label.