### PR TITLE
CNF-18350: Enforce Network Policies 

### DIFF
--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -610,6 +610,12 @@ spec:
           - services
           verbs:
           - '*'
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - '*'
         serviceAccountName: numaresources-controller-manager
     strategy: deployment
   installModes:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
+- ../networkpolicy
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook

--- a/config/networkpolicy/deny-all.yaml
+++ b/config/networkpolicy/deny-all.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: operator-default-deny-all
+spec:
+  podSelector:
+    matchLabels:
+      app: numaresources-operator
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rte-default-deny-all
+spec:
+  podSelector:
+    matchLabels:
+      name: resource-topology  
+  policyTypes:
+  - Ingress
+  - Egress
+

--- a/config/networkpolicy/egress-to-api-server.yaml
+++ b/config/networkpolicy/egress-to-api-server.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: operator-egress-to-api-server
+spec:
+  podSelector:
+    matchLabels:
+      app: numaresources-operator 
+  egress:
+  - ports:
+    - protocol: TCP
+      port: 6443 
+  policyTypes:
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rte-egress-to-api-server
+spec:
+  podSelector:
+    matchLabels:
+      name: resource-topology  
+  egress:
+  - ports:
+    - protocol: TCP
+      port: 6443 
+  policyTypes:
+  - Egress

--- a/config/networkpolicy/ingress-to-metrics.yaml
+++ b/config/networkpolicy/ingress-to-metrics.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ingress-to-operator-metrics
+spec:
+  podSelector:
+    matchLabels:
+      app: numaresources-operator
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 8080
+  policyTypes:
+    - Ingress

--- a/config/networkpolicy/kustomization.yaml
+++ b/config/networkpolicy/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- deny-all.yaml
+- egress-to-api-server.yaml
+- ingress-to-metrics.yaml

--- a/config/networkpolicy/kustomization.yaml
+++ b/config/networkpolicy/kustomization.yaml
@@ -2,3 +2,4 @@ resources:
 - deny-all.yaml
 - egress-to-api-server.yaml
 - ingress-to-metrics.yaml
+- webhook-server.yaml

--- a/config/networkpolicy/webhook-server.yaml
+++ b/config/networkpolicy/webhook-server.yaml
@@ -1,0 +1,15 @@
+# Allow access to the webhook server.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-webhook-traffic
+spec:
+  ingress:
+    - ports:
+        - port: 9443
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: numaresources-operator
+  policyTypes:
+    - Ingress

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -151,3 +151,9 @@ rules:
   - services
   verbs:
   - '*'
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - '*'

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -97,6 +97,7 @@ type NUMAResourcesOperatorReconciler struct {
 
 // Namespace Scoped
 //+kubebuilder:rbac:groups="",resources=services,verbs=*,namespace="numaresources"
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=*,namespace="numaresources"
 
 // Cluster Scoped
 //+kubebuilder:rbac:groups=topology.node.k8s.io,resources=noderesourcetopologies,verbs=get;list;create;update

--- a/pkg/metrics/manifests/manifests.go
+++ b/pkg/metrics/manifests/manifests.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 )
@@ -44,6 +45,22 @@ func Service(namespace string) (*corev1.Service, error) {
 		service.Namespace = namespace
 	}
 	return service, nil
+}
+
+func NetworkPolicy(namespace string) (*networkingv1.NetworkPolicy, error) {
+	obj, err := loadObject(filepath.Join("yaml", "networkpolicy.yaml"))
+	if err != nil {
+		return nil, err
+	}
+
+	np, ok := obj.(*networkingv1.NetworkPolicy)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type, got %t", obj)
+	}
+	if namespace != "" {
+		np.Namespace = namespace
+	}
+	return np, nil
 }
 
 func deserializeObjectFromData(data []byte) (runtime.Object, error) {

--- a/pkg/metrics/manifests/monitor/monitor.go
+++ b/pkg/metrics/manifests/monitor/monitor.go
@@ -18,24 +18,28 @@ package sched
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift-kni/numaresources-operator/pkg/metrics/manifests"
 )
 
 type Manifests struct {
-	Service *corev1.Service
+	Service       *corev1.Service
+	NetworkPolicy *networkingv1.NetworkPolicy
 }
 
 func (mf Manifests) ToObjects() []client.Object {
 	return []client.Object{
 		mf.Service,
+		mf.NetworkPolicy,
 	}
 }
 
 func (mf Manifests) Clone() Manifests {
 	return Manifests{
-		Service: mf.Service.DeepCopy(),
+		Service:       mf.Service.DeepCopy(),
+		NetworkPolicy: mf.NetworkPolicy.DeepCopy(),
 	}
 }
 
@@ -44,6 +48,11 @@ func GetManifests(namespace string) (Manifests, error) {
 	mf := Manifests{}
 
 	mf.Service, err = manifests.Service(namespace)
+	if err != nil {
+		return mf, err
+	}
+
+	mf.NetworkPolicy, err = manifests.NetworkPolicy(namespace)
 	if err != nil {
 		return mf, err
 	}

--- a/pkg/metrics/manifests/yaml/networkpolicy.yaml
+++ b/pkg/metrics/manifests/yaml/networkpolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ingress-to-rte-metrics
+spec:
+  podSelector:
+    matchLabels:
+      name: resource-topology
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: metrics-port
+  policyTypes:
+    - Ingress

--- a/pkg/numaresourcesscheduler/manifests/manifests.go
+++ b/pkg/numaresourcesscheduler/manifests/manifests.go
@@ -23,6 +23,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -115,6 +116,30 @@ func Deployment(namespace string) (*appsv1.Deployment, error) {
 		dp.Namespace = namespace
 	}
 	return dp, nil
+}
+
+func NetworkPolicy(policyType, namespace string) (*networkingv1.NetworkPolicy, error) {
+	var fileName string
+
+	if policyType == "" || policyType == "default" {
+		fileName = "networkpolicy.yaml"
+	} else {
+		fileName = fmt.Sprintf("networkpolicy.%s.yaml", policyType)
+	}
+
+	obj, err := loadObject(filepath.Join("yaml", fileName))
+	if err != nil {
+		return nil, err
+	}
+
+	np, ok := obj.(*networkingv1.NetworkPolicy)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type, got %t", obj)
+	}
+	if namespace != "" {
+		np.Namespace = namespace
+	}
+	return np, nil
 }
 
 func deserializeObjectFromData(data []byte) (runtime.Object, error) {

--- a/pkg/numaresourcesscheduler/manifests/manifests_test.go
+++ b/pkg/numaresourcesscheduler/manifests/manifests_test.go
@@ -39,4 +39,10 @@ func TestLoad(t *testing.T) {
 	if obj, err := Deployment(""); obj == nil || err != nil {
 		t.Errorf("Deployment() failed: err=%v", err)
 	}
+	if obj, err := NetworkPolicy("default", ""); obj == nil || err != nil {
+		t.Errorf("NetworkPolicy() failed: err=%v", err)
+	}
+	if obj, err := NetworkPolicy("apiserver", ""); obj == nil || err != nil {
+		t.Errorf("NetworkPolicy() failed: err=%v", err)
+	}
 }

--- a/pkg/numaresourcesscheduler/manifests/sched/sched.go
+++ b/pkg/numaresourcesscheduler/manifests/sched/sched.go
@@ -19,6 +19,7 @@ package sched
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -28,14 +29,16 @@ import (
 )
 
 type Manifests struct {
-	ServiceAccount        *corev1.ServiceAccount
-	ConfigMap             *corev1.ConfigMap
-	ClusterRole           *rbacv1.ClusterRole
-	ClusterRoleBindingK8S *rbacv1.ClusterRoleBinding
-	ClusterRoleBindingNRT *rbacv1.ClusterRoleBinding
-	Role                  *rbacv1.Role
-	RoleBinding           *rbacv1.RoleBinding
-	Deployment            *appsv1.Deployment
+	ServiceAccount         *corev1.ServiceAccount
+	ConfigMap              *corev1.ConfigMap
+	ClusterRole            *rbacv1.ClusterRole
+	ClusterRoleBindingK8S  *rbacv1.ClusterRoleBinding
+	ClusterRoleBindingNRT  *rbacv1.ClusterRoleBinding
+	Role                   *rbacv1.Role
+	RoleBinding            *rbacv1.RoleBinding
+	Deployment             *appsv1.Deployment
+	DefaultNetworkPolicy   *networkingv1.NetworkPolicy
+	APIserverNetworkPolicy *networkingv1.NetworkPolicy
 }
 
 func (mf Manifests) ToObjects() []client.Object {
@@ -48,19 +51,23 @@ func (mf Manifests) ToObjects() []client.Object {
 		mf.Role,
 		mf.RoleBinding,
 		mf.Deployment,
+		mf.DefaultNetworkPolicy,
+		mf.APIserverNetworkPolicy,
 	}
 }
 
 func (mf Manifests) Clone() Manifests {
 	return Manifests{
-		ServiceAccount:        mf.ServiceAccount.DeepCopy(),
-		ConfigMap:             mf.ConfigMap.DeepCopy(),
-		ClusterRole:           mf.ClusterRole.DeepCopy(),
-		ClusterRoleBindingK8S: mf.ClusterRoleBindingK8S.DeepCopy(),
-		ClusterRoleBindingNRT: mf.ClusterRoleBindingNRT.DeepCopy(),
-		Role:                  mf.Role.DeepCopy(),
-		RoleBinding:           mf.RoleBinding.DeepCopy(),
-		Deployment:            mf.Deployment.DeepCopy(),
+		ServiceAccount:         mf.ServiceAccount.DeepCopy(),
+		ConfigMap:              mf.ConfigMap.DeepCopy(),
+		ClusterRole:            mf.ClusterRole.DeepCopy(),
+		ClusterRoleBindingK8S:  mf.ClusterRoleBindingK8S.DeepCopy(),
+		ClusterRoleBindingNRT:  mf.ClusterRoleBindingNRT.DeepCopy(),
+		Role:                   mf.Role.DeepCopy(),
+		RoleBinding:            mf.RoleBinding.DeepCopy(),
+		Deployment:             mf.Deployment.DeepCopy(),
+		DefaultNetworkPolicy:   mf.DefaultNetworkPolicy.DeepCopy(),
+		APIserverNetworkPolicy: mf.APIserverNetworkPolicy.DeepCopy(),
 	}
 }
 
@@ -103,6 +110,16 @@ func GetManifests(namespace string) (Manifests, error) {
 	}
 
 	mf.Deployment, err = manifests.Deployment(namespace)
+	if err != nil {
+		return mf, err
+	}
+
+	mf.DefaultNetworkPolicy, err = manifests.NetworkPolicy("default", namespace)
+	if err != nil {
+		return mf, err
+	}
+
+	mf.APIserverNetworkPolicy, err = manifests.NetworkPolicy("apiserver", namespace)
 	if err != nil {
 		return mf, err
 	}

--- a/pkg/numaresourcesscheduler/manifests/yaml/networkpolicy.apiserver.yaml
+++ b/pkg/numaresourcesscheduler/manifests/yaml/networkpolicy.apiserver.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: scheduler-egress-to-api-server
+spec:
+  podSelector:
+    matchLabels:
+      app: secondary-scheduler 
+  egress:
+  - ports:
+    - protocol: TCP
+      port: 6443 
+  policyTypes:
+  - Egress

--- a/pkg/numaresourcesscheduler/manifests/yaml/networkpolicy.yaml
+++ b/pkg/numaresourcesscheduler/manifests/yaml/networkpolicy.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: scheduler-default-deny-all
+spec:
+  podSelector:
+    matchLabels:
+      app: secondary-scheduler
+  policyTypes:
+  - Ingress
+  - Egress

--- a/pkg/numaresourcesscheduler/objectstate/sched/sched.go
+++ b/pkg/numaresourcesscheduler/objectstate/sched/sched.go
@@ -21,6 +21,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,15 +43,17 @@ const (
 )
 
 type ExistingManifests struct {
-	Existing                   schedmanifests.Manifests
-	serviceAccountError        error
-	configMapError             error
-	clusterRoleError           error
-	clusterRoleBindingK8SError error
-	clusterRoleBindingNRTError error
-	roleError                  error
-	roleBindingError           error
-	deploymentError            error
+	Existing                    schedmanifests.Manifests
+	serviceAccountError         error
+	configMapError              error
+	clusterRoleError            error
+	clusterRoleBindingK8SError  error
+	clusterRoleBindingNRTError  error
+	roleError                   error
+	roleBindingError            error
+	deploymentError             error
+	DefaultNetworkPolicyError   error
+	APIserverNetworkPolicyError error
 }
 
 func (em ExistingManifests) State(mf schedmanifests.Manifests) []objectstate.ObjectState {
@@ -111,6 +114,20 @@ func (em ExistingManifests) State(mf schedmanifests.Manifests) []objectstate.Obj
 			Compare:  compare.Object,
 			Merge:    merge.ObjectForUpdate,
 		},
+		{
+			Existing: em.Existing.DefaultNetworkPolicy,
+			Error:    em.DefaultNetworkPolicyError,
+			Desired:  mf.DefaultNetworkPolicy.DeepCopy(),
+			Compare:  compare.Object,
+			Merge:    merge.MetadataForUpdate,
+		},
+		{
+			Existing: em.Existing.APIserverNetworkPolicy,
+			Error:    em.APIserverNetworkPolicyError,
+			Desired:  mf.APIserverNetworkPolicy.DeepCopy(),
+			Compare:  compare.Object,
+			Merge:    merge.MetadataForUpdate,
+		},
 	}
 }
 
@@ -156,6 +173,16 @@ func FromClient(ctx context.Context, cli client.Client, mf schedmanifests.Manife
 	dp := &appsv1.Deployment{}
 	if ret.deploymentError = cli.Get(ctx, client.ObjectKeyFromObject(mf.Deployment), dp); ret.deploymentError == nil {
 		ret.Existing.Deployment = dp
+	}
+
+	np := &networkingv1.NetworkPolicy{}
+	if ret.DefaultNetworkPolicyError = cli.Get(ctx, client.ObjectKeyFromObject(mf.DefaultNetworkPolicy), np); ret.DefaultNetworkPolicyError == nil {
+		ret.Existing.DefaultNetworkPolicy = np
+	}
+
+	npAPI := &networkingv1.NetworkPolicy{}
+	if ret.APIserverNetworkPolicyError = cli.Get(ctx, client.ObjectKeyFromObject(mf.APIserverNetworkPolicy), npAPI); ret.APIserverNetworkPolicyError == nil {
+		ret.Existing.APIserverNetworkPolicy = npAPI
 	}
 	return ret
 }

--- a/test/e2e/serial/tests/network_policy.go
+++ b/test/e2e/serial/tests/network_policy.go
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	e2etestenv "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/testenv"
+	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
+	"github.com/openshift-kni/numaresources-operator/internal/remoteexec"
+	e2eclient "github.com/openshift-kni/numaresources-operator/test/internal/clients"
+	"github.com/openshift-kni/numaresources-operator/test/internal/deploy"
+	"github.com/openshift-kni/numaresources-operator/test/internal/objects"
+)
+
+// This test suite verifies that the correct network policies are applied and enforced.
+// Specifically, it checks the following:
+// - All ingress and egress traffic is denied by default for the NUMAResources operator.
+// - Egress traffic from the operator, RTE, and scheduler pods to the Kubernetes API server is allowed.
+// - Ingress and egress traffic to/from other pods in the cluster is restricted.
+// - Ingress traffic to the metrics endpoints is allowed.
+//
+// Full coverage for inter-pod communication is challenging, so we include basic tests to validate the expected behavior.
+
+var _ = Describe("network policies are applied", Ordered, Label("feature:network_policies"), func() {
+	ctx := context.Background()
+	var namespace string
+	var nropObj *nropv1.NUMAResourcesOperator
+	var nroSchedObj *nropv1.NUMAResourcesScheduler
+	var operatorPod, schedulerPod, rteWorkerPod, prometheusPod *corev1.Pod
+
+	BeforeAll(func() {
+		nropObj = objects.TestNRO()
+		Expect(e2eclient.Client.Get(ctx, client.ObjectKeyFromObject(nropObj), nropObj)).To(Succeed())
+
+		nroSchedObj = objects.TestNROScheduler()
+		Expect(e2eclient.Client.Get(ctx, client.ObjectKeyFromObject(nroSchedObj), nroSchedObj)).To(Succeed())
+
+		Expect(nropObj.Status.NodeGroups).ToNot(BeEmpty())
+		namespace = nropObj.Status.NodeGroups[0].DaemonSet.Namespace
+
+		var err error
+		operatorPod, err = deploy.FindNUMAResourcesOperatorPod(ctx, e2eclient.Client, nropObj)
+		Expect(err).ToNot(HaveOccurred())
+
+		schedulerPod, err = deploy.FindNUMAResourcesSchedulerPod(ctx, e2eclient.Client, nroSchedObj)
+		Expect(err).ToNot(HaveOccurred())
+
+		pods, err := e2eclient.K8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("name=%s", e2etestenv.RTELabelName),
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pods.Items).ToNot(BeEmpty())
+		rteWorkerPod = &pods.Items[0]
+
+		prometheusPods, err := e2eclient.K8sClient.CoreV1().Pods("openshift-monitoring").List(ctx, metav1.ListOptions{
+			LabelSelector: labels.SelectorFromSet(map[string]string{
+				"app.kubernetes.io/name": "prometheus",
+			}).String(),
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(prometheusPods.Items).ToNot(BeEmpty())
+		prometheusPod = &prometheusPods.Items[0]
+	})
+
+	type trafficCase struct {
+		FromPod     func() *corev1.Pod
+		ToHost      func() string
+		ToPort      string
+		ShouldAllow bool
+		Description string
+	}
+
+	DescribeTable("traffic behavior",
+		func(tc trafficCase) {
+			Expect(tc.FromPod).ToNot(BeNil(), "source pod should not be nil")
+			klog.InfoS("Running traffic test", "description", tc.Description)
+			reachable := trafficTest(e2eclient.K8sClient, ctx, tc.FromPod(), tc.ToHost(), tc.ToPort)
+			klog.InfoS("reachable", "reachable", reachable)
+
+			if tc.ShouldAllow {
+				Expect(reachable).To(BeTrue(), tc.Description)
+			} else {
+				Expect(reachable).To(BeFalse(), tc.Description)
+			}
+		},
+		// Testing operator and operands egress traffic to API server
+		Entry("operator -> API server", trafficCase{
+			FromPod:     func() *corev1.Pod { return operatorPod },
+			ToHost:      func() string { return "$KUBERNETES_SERVICE_HOST" },
+			ToPort:      "$KUBERNETES_SERVICE_PORT",
+			ShouldAllow: true,
+			Description: "operator should access API server",
+		}),
+		Entry("scheduler -> API server", trafficCase{
+			FromPod:     func() *corev1.Pod { return schedulerPod },
+			ToHost:      func() string { return "$KUBERNETES_SERVICE_HOST" },
+			ToPort:      "$KUBERNETES_SERVICE_PORT",
+			ShouldAllow: true,
+			Description: "scheduler should access API server",
+		}),
+		Entry("rte worker -> API server", trafficCase{
+			FromPod:     func() *corev1.Pod { return rteWorkerPod },
+			ToHost:      func() string { return "$KUBERNETES_SERVICE_HOST" },
+			ToPort:      "$KUBERNETES_SERVICE_PORT",
+			ShouldAllow: true,
+			Description: "rte worker should access API server",
+		}),
+
+		// Testing operator and RTE metrics endpoints
+		Entry("prometheus operator -> numaresouces operator metrics endpoint", trafficCase{
+			FromPod:     func() *corev1.Pod { return prometheusPod },
+			ToHost:      func() string { return operatorPod.Status.PodIP },
+			ToPort:      "8080",
+			ShouldAllow: true,
+			Description: "prometheus operator pod should access numaresources operator metrics endpoint",
+		}),
+
+		Entry("prometheus operator -> numaresouces rte worker endpoint", trafficCase{
+			FromPod:     func() *corev1.Pod { return prometheusPod },
+			ToHost:      func() string { return rteWorkerPod.Status.PodIP },
+			ToPort:      "2112",
+			ShouldAllow: true,
+			Description: "prometheus operator pod should access rte worker metrics endpoint",
+		}),
+
+		// Testing traffic restrictions between pods in the numaresources namespace
+		Entry("scheduler -> operator", trafficCase{
+			FromPod:     func() *corev1.Pod { return schedulerPod },
+			ToHost:      func() string { return operatorPod.Status.PodIP },
+			ToPort:      "8081",
+			ShouldAllow: false,
+			Description: "scheduler should NOT access operator",
+		}),
+
+		// Testing network traffic restrictions between pods cross namespaces (numaresouces and openshift-monitoring)
+		Entry("numaresouces operator -> prometheus operator", trafficCase{
+			FromPod:     func() *corev1.Pod { return operatorPod },
+			ToHost:      func() string { return prometheusPod.Status.PodIP },
+			ToPort:      "8081",
+			ShouldAllow: false,
+			Description: "numaresources operator should NOT access prometheus operator pod",
+		}),
+
+		Entry("prometheus operator -> numaresouces operator", trafficCase{
+			FromPod:     func() *corev1.Pod { return prometheusPod },
+			ToHost:      func() string { return operatorPod.Status.PodIP },
+			ToPort:      "8081", // readinessProbe!
+			ShouldAllow: false,
+			Description: "prometheus operator pod should NOT access numaresources operator pod's readiness probe endpoint)",
+		}),
+	)
+})
+
+// trafficTest returns true if the sourcePod can connect to the given destination IP and port over HTTP.
+// It is used to validate network connectivity (e.g., for testing networkPolicy behavior).
+func trafficTest(cli *kubernetes.Clientset, ctx context.Context, sourcePod *corev1.Pod, destinationIP, destinationPort string) bool {
+	GinkgoHelper()
+	endpoint := net.JoinHostPort(destinationIP, destinationPort)
+
+	key := client.ObjectKeyFromObject(sourcePod)
+	By(fmt.Sprintf("verifying HTTP egress connectivity from pod %q to endpoint %s", key.String(), endpoint))
+
+	cmd := []string{"sh", "-c", fmt.Sprintf("curl --connect-timeout 5 http://%s", endpoint)}
+
+	stdout, stderr, err := remoteexec.CommandOnPod(ctx, cli, sourcePod, cmd...)
+
+	if err != nil {
+		GinkgoWriter.Printf("curl failed: stdout=%q, stderr=%q, err=%v\n", stdout, stderr, err)
+	}
+	return err == nil
+}


### PR DESCRIPTION
This PR introduces the baseline network policies that deny all traffic and selectively allow only the necessary communication paths identified above.

**Motivation:**

To improve the security posture of the cluster, we are introducing default-deny network policies for Day-2 operators starting with OCP 4.20. By default, Kubernetes allows unrestricted communication between pods, which may lead to unintended exposure. These network policies are designed to restrict all ingress and egress traffic by default and allow only explicitly permitted communication.

Implementation Overview:
As part of this initiative, we examined the network behavior of the following components:

* The operator pod

* The scheduler pod

* The RTE pods

Based on this analysis, we identified the following requirements:

* API Server Access: All three pod types require egress access to the Kubernetes API server. This access will be explicitly allowed in the network policies.

* Metrics Access: Network policies will also allow traffic to and from metrics endpoints to support observability.

* Webhook server - ingress traffic to the webhook service port will be permitted.

* Kubelet Probes: Liveness probes, readiness probes originate from the Kubelet. These communications are handled outside the scope of standard Kubernetes NetworkPolicies and are permitted by default.

Needs to be done:
- [ ] Wait for the OLM RFE to support network policies and rerun make bundle