### PR TITLE
deps: reduce MCO dependencies

### DIFF
--- a/pkg/objectstate/rte/machineconfigpool.go
+++ b/pkg/objectstate/rte/machineconfigpool.go
@@ -22,6 +22,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
@@ -139,4 +140,116 @@ func MatchMachineConfigPoolCondition(conditions []machineconfigv1.MachineConfigP
 		}
 	}
 	return false
+}
+
+type MCPWaitForUpdatedFunc func(string, *machineconfigv1.MachineConfigPool) bool
+
+func (em *ExistingManifests) MachineConfigsState(mf Manifests) ([]objectstate.ObjectState, MCPWaitForUpdatedFunc) {
+	var ret []objectstate.ObjectState
+	if mf.Core.MachineConfig == nil {
+		return ret, nullMachineConfigPoolUpdated
+	}
+	enabledMCCount := 0
+	for _, tree := range em.trees {
+		for _, mcp := range tree.MachineConfigPools {
+			mcName := objectnames.GetMachineConfigName(em.instance.Name, mcp.Name)
+			if mcp.Spec.MachineConfigSelector == nil {
+				klog.Warningf("the machine config pool %q does not have machine config selector", mcp.Name)
+				continue
+			}
+
+			existingMachineConfig, ok := em.machineConfigs[mcName]
+			if !ok {
+				klog.Warningf("failed to find machine config %q in namespace %q", mcName, em.namespace)
+				continue
+			}
+
+			if !annotations.IsCustomPolicyEnabled(tree.NodeGroup.Annotations) {
+				// caution here: we want a *nil interface value*, not an *interface which points to nil*.
+				// the latter would lead to apparently correct code leading to runtime panics. See:
+				// https://trstringer.com/go-nil-interface-and-interface-with-nil-concrete-value/
+				// (and many other docs like this)
+				ret = append(ret,
+					objectstate.ObjectState{
+						Existing: existingMachineConfig.machineConfig,
+						Error:    existingMachineConfig.machineConfigError,
+						Desired:  nil,
+					},
+				)
+				continue
+			}
+
+			desiredMachineConfig := mf.Core.MachineConfig.DeepCopy()
+			// prefix machine config name to guarantee that we will have an option to override it
+			desiredMachineConfig.Name = mcName
+			desiredMachineConfig.Labels = GetMachineConfigLabel(mcp)
+
+			ret = append(ret,
+				objectstate.ObjectState{
+					Existing: existingMachineConfig.machineConfig,
+					Error:    existingMachineConfig.machineConfigError,
+					Desired:  desiredMachineConfig,
+					Compare:  compare.Object,
+					Merge:    merge.ObjectForUpdate,
+				},
+			)
+			enabledMCCount++
+		}
+	}
+
+	klog.V(4).InfoS("machineConfigsState", "enabledMachineConfigs", enabledMCCount)
+	if enabledMCCount > 0 {
+		return ret, IsMachineConfigPoolUpdated
+	}
+	return ret, IsMachineConfigPoolUpdatedAfterDeletion
+}
+
+func nullMachineConfigPoolUpdated(instanceName string, mcp *machineconfigv1.MachineConfigPool) bool {
+	return true
+}
+
+func IsMachineConfigPoolUpdated(instanceName string, mcp *machineconfigv1.MachineConfigPool) bool {
+	if !existsMachineConfig(instanceName, mcp) {
+		return false
+	}
+	if MatchMachineConfigPoolCondition(mcp.Status.Conditions, machineconfigv1.MachineConfigPoolUpdated, corev1.ConditionFalse) {
+		return false
+	}
+	return true
+}
+
+func IsMachineConfigPoolUpdatedAfterDeletion(instanceName string, mcp *machineconfigv1.MachineConfigPool) bool {
+	if existsMachineConfig(instanceName, mcp) {
+		return false
+	}
+	if MatchMachineConfigPoolCondition(mcp.Status.Conditions, machineconfigv1.MachineConfigPoolUpdated, corev1.ConditionFalse) {
+		return false
+	}
+	return true
+}
+
+func existsMachineConfig(instanceName string, mcp *machineconfigv1.MachineConfigPool) bool {
+	mcName := objectnames.GetMachineConfigName(instanceName, mcp.Name)
+	for _, s := range mcp.Status.Configuration.Source {
+		if s.Name == mcName {
+			return true
+		}
+	}
+	return false
+}
+
+// GetMachineConfigLabel returns machine config labels that should be used under the machine config pool
+// machine config selector
+func GetMachineConfigLabel(mcp *machineconfigv1.MachineConfigPool) map[string]string {
+	if len(mcp.Spec.MachineConfigSelector.MatchLabels) > 0 {
+		return mcp.Spec.MachineConfigSelector.MatchLabels
+	}
+
+	// true only for custom machine config pools
+	klog.Warningf("no match labels was found under the machine config pool %q machine config selector", mcp.Name)
+	labels := map[string]string{
+		"machineconfiguration.openshift.io/role": mcp.Name,
+	}
+	klog.Warningf("generated labels %v, make sure the label is selected by the machine config pool %q", labels, mcp.Name)
+	return labels
 }

--- a/pkg/objectstate/rte/machineconfigpool.go
+++ b/pkg/objectstate/rte/machineconfigpool.go
@@ -131,3 +131,12 @@ func (obj machineConfigPoolFinder) FindState(mf Manifests, tree nodegroupv1.Tree
 	}
 	return ret
 }
+
+func MatchMachineConfigPoolCondition(conditions []machineconfigv1.MachineConfigPoolCondition, conditionType machineconfigv1.MachineConfigPoolConditionType, status corev1.ConditionStatus) bool {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return condition.Status == status
+		}
+	}
+	return false
+}

--- a/pkg/objectstate/rte/rte.go
+++ b/pkg/objectstate/rte/rte.go
@@ -174,28 +174,26 @@ func nullMachineConfigPoolUpdated(instanceName string, mcp *machineconfigv1.Mach
 }
 
 func IsMachineConfigPoolUpdated(instanceName string, mcp *machineconfigv1.MachineConfigPool) bool {
-	existing := isMachineConfigExists(instanceName, mcp)
-
-	// the Machine Config Pool still did not apply the machine config wait for one minute
-	if !existing || machineconfigv1.IsMachineConfigPoolConditionFalse(mcp.Status.Conditions, machineconfigv1.MachineConfigPoolUpdated) {
+	if !existsMachineConfig(instanceName, mcp) {
 		return false
 	}
-
+	if MatchMachineConfigPoolCondition(mcp.Status.Conditions, machineconfigv1.MachineConfigPoolUpdated, corev1.ConditionFalse) {
+		return false
+	}
 	return true
 }
 
 func IsMachineConfigPoolUpdatedAfterDeletion(instanceName string, mcp *machineconfigv1.MachineConfigPool) bool {
-	existing := isMachineConfigExists(instanceName, mcp)
-
-	// the Machine Config Pool still has the machine config return false
-	if existing || machineconfigv1.IsMachineConfigPoolConditionFalse(mcp.Status.Conditions, machineconfigv1.MachineConfigPoolUpdated) {
+	if existsMachineConfig(instanceName, mcp) {
 		return false
 	}
-
+	if MatchMachineConfigPoolCondition(mcp.Status.Conditions, machineconfigv1.MachineConfigPoolUpdated, corev1.ConditionFalse) {
+		return false
+	}
 	return true
 }
 
-func isMachineConfigExists(instanceName string, mcp *machineconfigv1.MachineConfigPool) bool {
+func existsMachineConfig(instanceName string, mcp *machineconfigv1.MachineConfigPool) bool {
 	mcName := objectnames.GetMachineConfigName(instanceName, mcp.Name)
 	for _, s := range mcp.Status.Configuration.Source {
 		if s.Name == mcName {

--- a/test/e2e/uninstall/uninstall_test.go
+++ b/test/e2e/uninstall/uninstall_test.go
@@ -19,8 +19,10 @@ package uninstall
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -32,6 +34,7 @@ import (
 
 	nropmcp "github.com/openshift-kni/numaresources-operator/internal/machineconfigpools"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
+	rtestate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/rte"
 
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/internal/clients"
 	"github.com/openshift-kni/numaresources-operator/test/internal/configuration"
@@ -110,7 +113,7 @@ var _ = Describe("[Uninstall] clusterCleanup", Serial, func() {
 							}
 						}
 
-						if machineconfigv1.IsMachineConfigPoolConditionFalse(mcp.Status.Conditions, machineconfigv1.MachineConfigPoolUpdated) {
+						if rtestate.MatchMachineConfigPoolCondition(mcp.Status.Conditions, machineconfigv1.MachineConfigPoolUpdated, corev1.ConditionFalse) {
 							return false
 						}
 					}


### PR DESCRIPTION
In order to facilitate the transition to the MCO APIs after the merge in `openshift/api`, reduce where it is cheap our usage of the MCO types. Less dep surface, less porting effort.

No intended changes in behavior.