### PR TITLE
OCPBUGS-51261: controller: RTE `ConfigMap` predicate

### DIFF
--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -66,6 +66,7 @@ import (
 	"github.com/openshift-kni/numaresources-operator/pkg/status"
 	"github.com/openshift-kni/numaresources-operator/pkg/status/conditioninfo"
 	"github.com/openshift-kni/numaresources-operator/pkg/validation"
+	"github.com/openshift-kni/numaresources-operator/rte/pkg/config"
 
 	intreconcile "github.com/openshift-kni/numaresources-operator/internal/reconcile"
 )
@@ -608,6 +609,14 @@ func (r *NUMAResourcesOperatorReconciler) SetupWithManager(mgr ctrl.Manager) err
 		},
 	}
 
+	configMapPredicates := predicate.NewPredicateFuncs(func(object client.Object) bool {
+		cm := object.(*corev1.ConfigMap)
+		cmLabels := cm.GetLabels()
+		// return only configmap with the operator name label
+		_, ok := cmLabels[config.LabelOperatorName]
+		return ok
+	})
+
 	b := ctrl.NewControllerManagedBy(mgr).For(&nropv1.NUMAResourcesOperator{})
 	if r.Platform == platform.OpenShift {
 		b.Watches(
@@ -617,7 +626,10 @@ func (r *NUMAResourcesOperatorReconciler) SetupWithManager(mgr ctrl.Manager) err
 			Owns(&securityv1.SecurityContextConstraints{}).
 			Owns(&machineconfigv1.MachineConfig{}, builder.WithPredicates(p))
 	}
-	return b.Owns(&apiextensionv1.CustomResourceDefinition{}).
+	return b.Watches(&corev1.ConfigMap{},
+		handler.EnqueueRequestsFromMapFunc(r.configMapToNUMAResourceOperator),
+		builder.WithPredicates(configMapPredicates)).
+		Owns(&apiextensionv1.CustomResourceDefinition{}).
 		Owns(&corev1.ServiceAccount{}, builder.WithPredicates(p)).
 		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(p)).
 		Owns(&rbacv1.Role{}, builder.WithPredicates(p)).
@@ -670,6 +682,36 @@ func (r *NUMAResourcesOperatorReconciler) mcpToNUMAResourceOperator(ctx context.
 	}
 
 	return requests
+}
+
+func (r *NUMAResourcesOperatorReconciler) configMapToNUMAResourceOperator(ctx context.Context, cmObj client.Object) []reconcile.Request {
+	cm := &corev1.ConfigMap{}
+
+	key := client.ObjectKey{
+		Namespace: cmObj.GetNamespace(),
+		Name:      cmObj.GetName(),
+	}
+
+	if err := r.Get(ctx, key, cm); err != nil {
+		klog.Errorf("failed to get configmap %+v; %v", key, err)
+		return nil
+	}
+	name, ok := cm.Labels[config.LabelOperatorName]
+	if !ok {
+		return nil
+	}
+	key = client.ObjectKey{
+		Name: name,
+	}
+	nro := &nropv1.NUMAResourcesOperator{}
+	if err := r.Get(ctx, key, nro); err != nil {
+		klog.Error("failed to get numa-resources operator")
+		return nil
+	}
+
+	return []reconcile.Request{{NamespacedName: client.ObjectKey{
+		Name: nro.Name,
+	}}}
 }
 
 func validateUpdateEvent(e *event.UpdateEvent) bool {

--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -28,30 +28,33 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/assets/selinux"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte"
-	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
-	"github.com/openshift-kni/numaresources-operator/pkg/status"
+	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+
 	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
 
+	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
 	inthelper "github.com/openshift-kni/numaresources-operator/internal/api/annotations/helper"
 	nropmcp "github.com/openshift-kni/numaresources-operator/internal/machineconfigpools"
 	nrowait "github.com/openshift-kni/numaresources-operator/internal/wait"
-
+	"github.com/openshift-kni/numaresources-operator/pkg/status"
+	rteconfig "github.com/openshift-kni/numaresources-operator/rte/pkg/config"
+	"github.com/openshift-kni/numaresources-operator/test/e2e/label"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/internal/clients"
 	"github.com/openshift-kni/numaresources-operator/test/internal/configuration"
 	"github.com/openshift-kni/numaresources-operator/test/internal/crds"
 	"github.com/openshift-kni/numaresources-operator/test/internal/deploy"
 	e2eimages "github.com/openshift-kni/numaresources-operator/test/internal/images"
 	"github.com/openshift-kni/numaresources-operator/test/internal/objects"
-
-	"github.com/openshift-kni/numaresources-operator/test/e2e/label"
 )
 
 // tests here are not interruptible, so they should not accept contexts.
@@ -357,8 +360,79 @@ var _ = Describe("[Install] durability", Serial, func() {
 				return ds.Spec.Template.Spec.Containers[0].Image == e2eimages.RTETestImageCI
 			}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(BeTrue())
 		})
+		It("should have the desired topology manager configuration under the NRT object", func() {
+			rteConfigMap := &corev1.ConfigMap{}
+			Eventually(func() bool {
+				updatedConfigMaps := &corev1.ConfigMapList{}
+				opts := client.ListOptions{LabelSelector: labels.SelectorFromSet(map[string]string{rteconfig.LabelOperatorName: nroObj.Name})}
+				err := e2eclient.Client.List(context.TODO(), updatedConfigMaps, &opts)
+				Expect(err).ToNot(HaveOccurred())
+
+				if len(updatedConfigMaps.Items) != 1 {
+					klog.Warningf("expected exactly 1 RTE configmap, got: %d", len(updatedConfigMaps.Items))
+					return false
+				}
+				rteConfigMap = &updatedConfigMaps.Items[0]
+				return true
+			}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(BeTrue())
+			klog.InfoS("found RTE configmap", "rteConfigMap", rteConfigMap)
+
+			cfg, err := validateAndExtractRTEConfigData(rteConfigMap)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("checking that NRT reflects the correct data from RTE configmap")
+			Eventually(func() bool {
+				updatedNrtObjs := &nrtv1alpha2.NodeResourceTopologyList{}
+				err := e2eclient.Client.List(context.TODO(), updatedNrtObjs)
+				Expect(err).ToNot(HaveOccurred())
+
+				for i := range updatedNrtObjs.Items {
+					nrt := &updatedNrtObjs.Items[i]
+					// in this specific test deployment,
+					// the same configuration should apply to all NRT objects
+					matchingErr := checkTopologyManagerConfigMatching(nrt, &cfg)
+					if matchingErr != "" {
+						klog.Warningf("NRT %q doesn't match topologyManager configuration: %s", nrt.Name, matchingErr)
+						return false
+					}
+				}
+				return true
+			}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(BeTrue())
+		})
 	})
 })
+
+// validateAndExtractRTEConfigData extracts and validates the RTE config from the given ConfigMap
+func validateAndExtractRTEConfigData(cm *corev1.ConfigMap) (rteconfig.Config, error) {
+	var cfg rteconfig.Config
+	raw, ok := cm.Data[rteconfig.Key]
+	if !ok {
+		return cfg, fmt.Errorf("config.yaml not found in ConfigMap %s/%s", cm.Namespace, cm.Name)
+	}
+
+	if err := yaml.Unmarshal([]byte(raw), &cfg); err != nil {
+		return cfg, fmt.Errorf("failed to unmarshal config.yaml: %w", err)
+	}
+
+	if cfg.Kubelet.TopologyManagerPolicy != "single-numa-node" {
+		return cfg, fmt.Errorf("invalid topologyManagerPolicy: got %q, want \"single-numa-node\"", cfg.Kubelet.TopologyManagerPolicy)
+	}
+
+	return cfg, nil
+}
+
+func checkTopologyManagerConfigMatching(nrt *nrtv1alpha2.NodeResourceTopology, cfg *rteconfig.Config) string {
+	var matchingErr string
+	for _, attr := range nrt.Attributes {
+		if attr.Name == "topologyManagerPolicy" && attr.Value != cfg.Kubelet.TopologyManagerPolicy {
+			matchingErr += fmt.Sprintf("%q value is different; want: %s got: %s\n", attr.Name, cfg.Kubelet.TopologyManagerPolicy, attr.Value)
+		}
+		if attr.Name == "topologyManagerScope" && cfg.Kubelet.TopologyManagerScope != "" && attr.Value != cfg.Kubelet.TopologyManagerScope {
+			matchingErr += fmt.Sprintf("%q value is different; want: %s got: %s\n", attr.Name, cfg.Kubelet.TopologyManagerScope, attr.Value)
+		}
+	}
+	return matchingErr
+}
 
 func findContainerByName(daemonset appsv1.DaemonSet, containerName string) (*corev1.Container, error) {
 	//shortcut


### PR DESCRIPTION
A continuation of #1216 which turns out to solve the problem only partially.

The ConfigMap generated by Kubelet controller
should be watched by NUMAResourceoperator controller,
so it will be able to act upon a ConfigMap change.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>