### PR TITLE
internal: make function backward compatible

### DIFF
--- a/test/internal/deploy/find.go
+++ b/test/internal/deploy/find.go
@@ -31,11 +31,11 @@ import (
 )
 
 func FindNUMAResourcesOperatorPod(ctx context.Context, cli client.Client, nrop *nropv1.NUMAResourcesOperator) (*corev1.Pod, error) {
-	if len(nrop.Status.NodeGroups) < 1 {
+	if len(nrop.Status.DaemonSets) < 1 {
 		return nil, errors.New("node groups not reported, nothing to do")
 	}
 	// nrop places all daemonsets in the same namespace on which it resides, so any group is fine
-	namespace := nrop.Status.NodeGroups[0].DaemonSet.Namespace // shortcut
+	namespace := nrop.Status.DaemonSets[0].Namespace // shortcut
 	klog.InfoS("NROP pod", "namespace", namespace)
 
 	sel, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{


### PR DESCRIPTION
The `Status.NodeGroup` API is supported starting 4.18. Code that uses this function and anticipated to run on < 4.18 will fail because there will be no node groups reported in the status. Use `Status.Daemonset` instead for backward compatibility.