### PR TITLE
api: e2e: serial: initialize slice with correct length in CloneList

### DIFF
--- a/api/v1/helper/nodegroup/nodegroup.go
+++ b/api/v1/helper/nodegroup/nodegroup.go
@@ -161,7 +161,7 @@ func flattenTrees(trees []Tree) []*mcov1.MachineConfigPool {
 }
 
 func CloneList(nodeGroups []nropv1.NodeGroup) []nropv1.NodeGroup {
-	ret := make([]nropv1.NodeGroup, 0, len(nodeGroups))
+	ret := make([]nropv1.NodeGroup, len(nodeGroups))
 	for idx := range nodeGroups {
 		ng := &nodeGroups[idx] // shortcut
 		ng.DeepCopyInto(&ret[idx])


### PR DESCRIPTION
The CloneList function previously created a slice with length 0 and only set capacity, which led to a runtime panic when accessing ret[idx].