### PR TITLE
CNF-17778: CNF-17779: schedulercontroller: High availability by default

### DIFF
--- a/api/v1/numaresourcesscheduler_defaults.go
+++ b/api/v1/numaresourcesscheduler_defaults.go
@@ -28,7 +28,6 @@ const (
 	defaultSchedulerInformer    = SchedulerInformerDedicated
 	defaultCacheResyncDetection = CacheResyncDetectionRelaxed
 	defaultScoringStrategy      = LeastAllocated
-	defaultReplicas             = int32(1)
 )
 
 func SetDefaults_NUMAResourcesSchedulerSpec(spec *NUMAResourcesSchedulerSpec) {
@@ -54,8 +53,6 @@ func SetDefaults_NUMAResourcesSchedulerSpec(spec *NUMAResourcesSchedulerSpec) {
 			Type: defaultScoringStrategy,
 		}
 	}
-	if spec.Replicas == nil {
-		replicas := defaultReplicas
-		spec.Replicas = &replicas
-	}
+	// do not set replicas default value
+	// it will be computed later
 }

--- a/api/v1/numaresourcesscheduler_defaults_test.go
+++ b/api/v1/numaresourcesscheduler_defaults_test.go
@@ -62,7 +62,6 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -83,7 +82,6 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -107,7 +105,6 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -132,7 +129,6 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -157,7 +153,6 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -180,7 +175,6 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 				SchedulerInformer:    &schedInformer,
 				CacheResyncDetection: &cacheResyncDetection,
 				ScoringStrategy:      &scoringStrategyCustom,
-				Replicas:             ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -274,7 +268,6 @@ func TestSetDefaults_NUMAResourcesSchedulerSpec(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{

--- a/api/v1/numaresourcesscheduler_normalize_test.go
+++ b/api/v1/numaresourcesscheduler_normalize_test.go
@@ -62,7 +62,6 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -83,7 +82,6 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -107,7 +105,6 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -132,7 +129,6 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -157,7 +153,6 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -180,7 +175,6 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 				SchedulerInformer:    &schedInformer,
 				CacheResyncDetection: &cacheResyncDetection,
 				ScoringStrategy:      &scoringStrategyCustom,
-				Replicas:             ptr.To[int32](defaultReplicas),
 			},
 		},
 		{
@@ -274,7 +268,6 @@ func TestNUMAResourcesSchedulerSpecNormalize(t *testing.T) {
 				ScoringStrategy: &ScoringStrategyParams{
 					Type: scoringStrategyType,
 				},
-				Replicas: ptr.To[int32](defaultReplicas),
 			},
 		},
 		{

--- a/internal/controller/numaresourcesscheduler_controller.go
+++ b/internal/controller/numaresourcesscheduler_controller.go
@@ -62,7 +62,6 @@ type NUMAResourcesSchedulerReconciler struct {
 	Scheme             *runtime.Scheme
 	SchedulerManifests schedmanifests.Manifests
 	Namespace          string
-	AutodetectReplicas int
 }
 
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=*

--- a/test/e2e/sched/install/install_test.go
+++ b/test/e2e/sched/install/install_test.go
@@ -19,7 +19,6 @@ package install
 import (
 	"context"
 	"fmt"
-	"github.com/openshift-kni/numaresources-operator/test/e2e/label"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -37,6 +36,7 @@ import (
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
 	"github.com/openshift-kni/numaresources-operator/pkg/status"
+	"github.com/openshift-kni/numaresources-operator/test/e2e/label"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/internal/clients"
 	"github.com/openshift-kni/numaresources-operator/test/internal/crds"
 	"github.com/openshift-kni/numaresources-operator/test/internal/objects"
@@ -112,6 +112,9 @@ var _ = Describe("[Scheduler] install", func() {
 			By("checking the NumaResourcesScheduler CRD is deployed")
 			_, err = crds.GetByName(e2eclient.Client, crds.CrdNROSName)
 			Expect(err).NotTo(HaveOccurred())
+
+			By("checking deployment has number of replicas equal to number of control plane nodes")
+			Expect(*deployment.Spec.Replicas).To(Equal(int32(len(nodeList))), "wrong number of replicas configured for the deployment; want=%d got=%d", int32(len(nodeList)), *deployment.Spec.Replicas)
 		})
 	})
 })


### PR DESCRIPTION
Changing the topology-aware scheduler behavior to have HA by default.

Starting from OCP 4.20 the scheduler HA is enabled by default (previously it was not)
and replicas number is equal to the number of control-plane nodes.

In case the user wants to disable HA (retaining the old behavior)
he needs to explicitly set `spec.Replicas` to 1.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>