### PR TITLE
tools: pass on konflux bot commit

### DIFF
--- a/tools/verify-commit/verify-commit.go
+++ b/tools/verify-commit/verify-commit.go
@@ -34,12 +34,20 @@ type GitCommit struct {
 	DCOCoauthorTag   string `json:"dcoCoauthorTag"`
 }
 
-const dependabot = "dependabot[bot]"
+const (
+	dependabot = "dependabot[bot]"
+	konflux    = "red-hat-konflux"
+)
 
 func validate(commit GitCommit) error {
 	var errs error
+
 	if "<"+commit.Author+">" == commit.AuthorEmailLocal {
 		errs = errors.Join(errs, fmt.Errorf("missing author name - equals to email local part"))
+	}
+	if strings.Contains(commit.Author, konflux) {
+		fmt.Printf("git commit authored by konflux bot\n")
+		return nil
 	}
 	if commit.DCOSignTag == "" {
 		errs = errors.Join(errs, fmt.Errorf("DCO signoff trailer missing"))


### PR DESCRIPTION
Konflux bot started filing chore PRs and they are failing on commits verification. Failures:
```
eb72d24a Red Hat Konflux update numaresources-must-gather-4-20 Signed-off-by: red-hat-konflux <konflux@no-reply.konflux-ci.dev>
---
CHECK: eb72d24a
start verifying commits from stdin
commit: {"commit":"eb72d24afef55d47c314ff7d4e48e11b6895411c","author":"red-hat-konflux","authorEmail":"\u003ckonflux@no-reply.konflux-ci.dev\u003e","authorEmailLocal":"\u003ckonflux\u003e","dcoSignTag":"","dcoCoauthorTag":""}
read: 1 commits
done verifying commits from stdin
error: invalid commit: DCO signoff trailer missing

or

start verifying commits from stdin
error: invalid commit: DCO signoff malformed: "Signed-off-by: red-hat-konflux <126015336+red-hat-konflux[bot]@users.noreply.github.com>" does not contain expected "Signed-off-by: red-hat-konflux[bot] <126015336+red-hat-konflux[bot]@users.noreply.github.com>"
```

There are two forms of commits signatures:
1.`Signed-off-by: red-hat-konflux <126015336+red-hat-konflux[bot]@users.noreply.github.com>` which is interpretted as:
```
commit: {"commit":"9f0f34f3f264f9a5fb0936a3199e77917bb18c0d","author":"red-hat-konflux[bot]","authorEmail":"\u003c126015336+red-hat-konflux[bot]@users.noreply.github.com\u003e","authorEmailLocal":"\u003c126015336+red-hat-konflux[bot]\u003e","dcoSignTag":"Signed-off-by: red-hat-konflux \u003c126015336+red-hat-konflux[bot]@users.noreply.github.com\u003e","dcoCoauthorTag":""}
```
2.`Signed-off-by: red-hat-konflux <konflux@no-reply.konflux-ci.dev>` which is interpretted as:
```
{"commit":"eb72d24afef55d47c314ff7d4e48e11b6895411c","author":"red-hat-konflux","authorEmail":"\u003ckonflux@no-reply.konflux-ci.dev\u003e","authorEmailLocal":"\u003ckonflux\u003e","dcoSignTag":"","dcoCoauthorTag":""}
```

The dco sign could be empty for the second form and in the first form the expected dcosign is not equal to the expected so no point in continue to verify the dco sign thus finish the verification early whenever a konflux bot commit is validated.