### PR TITLE
Konflux: update renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,12 @@
     "gomod": {
         "enabled": false
     },
+    "packageRules": [
+        {
+            "matchUpdateTypes": ["minor"],
+            "enabled": false
+        }
+    ],    
     "prConcurrentLimit": 0,
     "pruneBranchAfterAutomerge": true,
     "tekton": {
@@ -19,6 +25,17 @@
         "includePaths": [
             ".tekton/**"
         ],
+        "packageRules": [
+            {
+                "addLabels": [
+                    "approved",
+                    "lgtm"
+                ],
+                "matchUpdateTypes": [
+                    "digest"
+                ]
+            }
+        ],        
         "platformAutomerge": true
     }
 }


### PR DESCRIPTION
- Set packageRules to ignore all chore(deps) updates for minor versions. We currenly want control over the minor versions of base images and go versions and we also do not want to use the latest minor version of a package in all branches
- Set auto lgtm and approve for tekton file digest updates