### PR TITLE
[release-4.18]: Konflux: Catalog configuration for 4.18

### DIFF
--- a/.konflux/Dockerfile.catalog
+++ b/.konflux/Dockerfile.catalog
@@ -1,0 +1,45 @@
+# The opm image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+ARG OPM_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18
+ARG BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.23
+
+# build the catalog
+FROM ${BUILDER_IMAGE} AS builder
+
+# create dir structure to generate the catalog
+RUN mkdir -p /app/hack /app/.konflux/catalog
+COPY Makefile /app
+COPY hack/ /app/hack/
+COPY .konflux/catalog/ /app/.konflux/catalog/
+
+# generate the catalog
+
+# debug
+RUN echo "root dir" && ls -lra $HOME
+
+WORKDIR /app
+RUN --mount=type=secret,id=telco-5g-redhat-pull-secret/.dockerconfigjson \
+    mkdir -p $HOME/.docker/ && \
+    cp /run/secrets/telco-5g-redhat-pull-secret/.dockerconfigjson $HOME/.docker/config.json
+
+# debug
+RUN echo "run secrets" && ls -lra /run/secrets/ && echo "docker dir" && ls -lra $HOME/.docker/ && cat $HOME/.docker/config.json
+
+ENV REGISTRY_AUTH_FILE=$HOME/.docker/config.json
+# The fbc build is not hermetic, so make will download yq and opm
+RUN make konflux-generate-catalog-production && \
+    rm $HOME/.docker/config.json
+
+# run the catalog
+FROM ${OPM_IMAGE}
+
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+# ensure this correponds to olm.package name
+ENV PACKAGE_NAME=numaresources-operator
+
+COPY --from=builder /app/.konflux/catalog/$PACKAGE_NAME/ /configs/$PACKAGE_NAME
+# RUN ["/bin/opm", "validate", "/configs/numaresources-operator"]
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+LABEL operators.operatorframework.io.index.configs.v1=/configs

--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,0 +1,3 @@
+---
+# When we are ready to ship the first Konflux release, replace this with the nudge to the quay build
+quay: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:8cdcec0348831715981ea6a458b58821540176c73021dc51e67f3581045490d0

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -1,0 +1,35 @@
+---
+schema: olm.template.basic
+entries:
+  # Default data
+  - defaultChannel: "4.18"
+    icon:
+      base64data: iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABHNCSVQICAgIfAhkiAAAAYNJREFUWIXt1T9rlEEQx/HPnecJGoKJhY+NEgW5VrCxSZpr0oWUKcRgYSoLGwv1RfgWfAnWFlZWKQIRJE00V6XwTxQsdSwygWV5DEeaS/EMLDPP/Gaf/e7swz49hBlaf5aLdwAdQAfQAZwfgLa7OP4TT6tPMw/6TQaPK+EAcxhlXNs3NDngaaUvpx8XuRv4g+clAOzjBRZaFprGPuN1ldtoqXuEXWzWAEdYwvczAiylH6W/iCctdZt4hit4UAJcwDAT984IsYVPGa+26CsY4D3e4MOJ0BA7x99GjIkgesQXYo4YZawaX4nrRJNzFoi9nBvE/fTjrI8ciDvEEXGZGJSU79I/xN+Mf2Gx2s0lzOMnrmbuB+4Wu98u6ufxGxPsZG6A9boDiJtJOskOILYL+n7Gb/O5KbQ14iPxqtj1mNgqaqg6UgMgXqZ4AnArn/fzOIK41gIwzKO5XQEEsVqtMSQOj49MBHpVm+tcfYHUWu+UuO39tT4zOx//gg6gA+gAOoBZ2j82IbSJZWt9tAAAAABJRU5ErkJggg==
+      mediatype: image/png
+    name: numaresources-operator
+    schema: olm.package
+  # Channel entries should contain all the releases
+  - entries:
+    - name: numaresources-operator.v4.18.0
+      skipRange: '>=4.17.0 <4.18.0'
+    - name: numaresources-operator.v4.18.1
+      replaces: numaresources-operator.v4.18.0
+      skipRange: '>=4.17.0 <4.18.1'
+    # Until we release the first build on Konflux, we just want the existing released images
+    # - name: numaresources-operator.v4.18.2
+    #   replaces: numaresources-operator.v4.18.1
+    #   skipRange: '>=4.17.0 <4.18.12'
+    name: "4.18"
+    package: numaresources-operator
+    schema: olm.channel
+    # v4.18.0 bundle
+  - image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:8b14759b8e5148fadf9511d3cf52923301567824ac7f5eacc3984e050ad33754
+    schema: olm.bundle
+    # v4.18.1 bundle
+  - image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:a372f2b3b61c0012618837e349d389f9f300ccd2ae0fa005e9cd7d379b8569a1
+    schema: olm.bundle
+# The url for this last entry (which is for the next release) is updated by hack/konflux-update-catalog-template.sh automatically
+# It takes the input data from bundle.builds.in.yaml
+# When we are ready for the next release then uncomment this section so the final bundle url is updated correctly
+# - image: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-18:f76866529ad85af58d44dc7bda62a784ef0a185e
+#   schema: olm.bundle

--- a/.konflux/catalog/numaresources-operator/catalog.yaml
+++ b/.konflux/catalog/numaresources-operator/catalog.yaml
@@ -1,0 +1,795 @@
+---
+defaultChannel: "4.18"
+icon:
+  base64data: iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABHNCSVQICAgIfAhkiAAAAYNJREFUWIXt1T9rlEEQx/HPnecJGoKJhY+NEgW5VrCxSZpr0oWUKcRgYSoLGwv1RfgWfAnWFlZWKQIRJE00V6XwTxQsdSwygWV5DEeaS/EMLDPP/Gaf/e7swz49hBlaf5aLdwAdQAfQAZwfgLa7OP4TT6tPMw/6TQaPK+EAcxhlXNs3NDngaaUvpx8XuRv4g+clAOzjBRZaFprGPuN1ldtoqXuEXWzWAEdYwvczAiylH6W/iCctdZt4hit4UAJcwDAT984IsYVPGa+26CsY4D3e4MOJ0BA7x99GjIkgesQXYo4YZawaX4nrRJNzFoi9nBvE/fTjrI8ciDvEEXGZGJSU79I/xN+Mf2Gx2s0lzOMnrmbuB+4Wu98u6ufxGxPsZG6A9boDiJtJOskOILYL+n7Gb/O5KbQ14iPxqtj1mNgqaqg6UgMgXqZ4AnArn/fzOIK41gIwzKO5XQEEsVqtMSQOj49MBHpVm+tcfYHUWu+UuO39tT4zOx//gg6gA+gAOoBZ2j82IbSJZWt9tAAAAABJRU5ErkJggg==
+  mediatype: image/png
+name: numaresources-operator
+schema: olm.package
+---
+entries:
+- name: numaresources-operator.v4.18.0
+  skipRange: '>=4.17.0 <4.18.0'
+- name: numaresources-operator.v4.18.1
+  replaces: numaresources-operator.v4.18.0
+  skipRange: '>=4.17.0 <4.18.1'
+name: "4.18"
+package: numaresources-operator
+schema: olm.channel
+---
+image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:8b14759b8e5148fadf9511d3cf52923301567824ac7f5eacc3984e050ad33754
+name: numaresources-operator.v4.18.0
+package: numaresources-operator
+properties:
+- type: olm.gvk
+  value:
+    group: nodetopology.openshift.io
+    kind: NUMAResourcesOperator
+    version: v1
+- type: olm.gvk
+  value:
+    group: nodetopology.openshift.io
+    kind: NUMAResourcesOperator
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: nodetopology.openshift.io
+    kind: NUMAResourcesScheduler
+    version: v1
+- type: olm.gvk
+  value:
+    group: nodetopology.openshift.io
+    kind: NUMAResourcesScheduler
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: numaresources-operator
+    version: 4.18.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "nodetopology.openshift.io/v1alpha1",
+            "kind": "NUMAResourcesOperator",
+            "metadata": {
+              "name": "numaresourcesoperator"
+            },
+            "spec": {
+              "nodeGroups": [
+                {
+                  "machineConfigPoolSelector": {
+                    "matchLabels": {
+                      "pools.operator.machineconfiguration.openshift.io/worker": ""
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "apiVersion": "nodetopology.openshift.io/v1alpha1",
+            "kind": "NUMAResourcesScheduler",
+            "metadata": {
+              "name": "numaresourcesscheduler"
+            },
+            "spec": {
+              "imageSpec": "URL_OF_SCHEDULER_IMAGE_FROM_REDHAT_REGISTRY",
+              "logLevel": "Normal",
+              "schedulerName": "topo-aware-scheduler"
+            }
+          }
+        ]
+      capabilities: Basic Install
+      createdAt: "2025-01-09T10:45:35Z"
+      features.operators.openshift.io/cnf: "true"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=4.17.0 <4.18.0'
+      operatorframework.io/cluster-monitoring: "true"
+      operators.openshift.io/valid-subscription: "[\n\t\"OpenShift Kubernetes Engine\",\n\t\"OpenShift
+        Container Platform\",\n\t\"OpenShift Platform Plus\"\n]"
+      operators.operatorframework.io/builder: operator-sdk-v1.36.1
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: NUMAResourcesOperator is the Schema for the numaresourcesoperators
+          API
+        displayName: NUMA Resources Operator
+        kind: NUMAResourcesOperator
+        name: numaresourcesoperators.nodetopology.openshift.io
+        resources:
+        - kind: DaemonSet
+          name: ""
+          version: v1
+        specDescriptors:
+        - description: Optional Resource Topology Exporter image URL
+          displayName: Optional RTE image URL
+          path: imageSpec
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: |-
+            Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+            Defaults to "Normal".
+          displayName: RTE log verbosity
+          path: logLevel
+        - description: Group of Nodes to enable RTE on
+          displayName: Group of nodes to enable RTE on
+          path: nodeGroups
+        - description: InfoRefreshMode sets the mechanism which will be used to refresh
+            the topology info.
+          displayName: Topology info mechanism setting
+          path: nodeGroups[0].config.infoRefreshMode
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: InfoRefreshPause defines if updates to NRTs are paused for
+            the machines belonging to this group
+          displayName: Enable or disable the RTE pause setting
+          path: nodeGroups[0].config.infoRefreshPause
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: InfoRefreshPeriod sets the topology info refresh period. Use
+            explicit 0 to disable.
+          displayName: Topology info refresh period setting
+          path: nodeGroups[0].config.infoRefreshPeriod
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: PodsFingerprinting defines if pod fingerprint should be reported
+            for the machines belonging to this group
+          displayName: Enable or disable the pods fingerprinting setting
+          path: nodeGroups[0].config.podsFingerprinting
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: |-
+            Tolerations overrides tolerations to be set into RTE daemonsets for this NodeGroup. If not empty, the tolerations will be the one set here.
+            Leave empty to make the system use the default tolerations.
+          displayName: Extra tolerations for the topology updater daemonset
+          path: nodeGroups[0].config.tolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: Optional Namespace/Name glob patterns of pod to ignore at node
+            level
+          displayName: Optional ignore pod namespace/name glob patterns
+          path: podExcludes
+        statusDescriptors:
+        - description: Conditions show the current state of the NUMAResourcesOperator
+            Operator
+          displayName: Condition reported
+          path: conditions
+        - description: DaemonSets of the configured RTEs, one per node group
+          displayName: RTE DaemonSets
+          path: daemonsets
+        - description: MachineConfigPools resolved from configured node groups
+          displayName: RTE MCPs from node groups
+          path: machineconfigpools
+        - description: Conditions represents the latest available observations of
+            MachineConfigPool current state.
+          displayName: Optional conditions reported for this NodeGroup
+          path: machineconfigpools[0].conditions
+        - description: NodeGroupConfig represents the latest available configuration
+            applied to this MachineConfigPool
+          displayName: Optional configuration enforced on this NodeGroup
+          path: machineconfigpools[0].config
+        - description: NodeGroups report the observed status of the configured NodeGroups,
+            matching by their name
+          displayName: Node groups observed status
+          path: nodeGroups
+        - description: NodeGroupConfig represents the latest available configuration
+            applied to this NodeGroup
+          displayName: Optional configuration enforced on this NodeGroup
+          path: nodeGroups[0].config
+        - description: DaemonSet of the configured RTEs, for this node group
+          displayName: RTE DaemonSets
+          path: nodeGroups[0].daemonsets
+        - description: PoolName represents the pool name to which the nodes belong
+            that the config of this node group is be applied to
+          displayName: Pool name of nodes in this node group
+          path: nodeGroups[0].selector
+        - description: RelatedObjects list of objects of interest for this operator
+          displayName: Related Objects
+          path: relatedObjects
+        version: v1
+      - description: NUMAResourcesOperator is the Schema for the numaresourcesoperators
+          API
+        displayName: NUMA Resources Operator
+        kind: NUMAResourcesOperator
+        name: numaresourcesoperators.nodetopology.openshift.io
+        resources:
+        - kind: DaemonSet
+          name: ""
+          version: v1
+        specDescriptors:
+        - description: Optional Resource Topology Exporter image URL
+          displayName: Optional RTE image URL
+          path: imageSpec
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: |-
+            Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+            Defaults to "Normal".
+          displayName: RTE log verbosity
+          path: logLevel
+        - description: Group of Nodes to enable RTE on
+          displayName: Group of nodes to enable RTE on
+          path: nodeGroups
+        - description: InfoRefreshMode sets the mechanism which will be used to refresh
+            the topology info.
+          displayName: Topology info mechanism setting
+          path: nodeGroups[0].config.infoRefreshMode
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: InfoRefreshPeriod sets the topology info refresh period. Use
+            explicit 0 to disable.
+          displayName: Topology info refresh period setting
+          path: nodeGroups[0].config.infoRefreshPeriod
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: PodsFingerprinting defines if pod fingerprint should be reported
+            for the machines belonging to this group
+          displayName: Enable or disable the pods fingerprinting setting
+          path: nodeGroups[0].config.podsFingerprinting
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: Optional Namespace/Name glob patterns of pod to ignore at node
+            level
+          displayName: Optional ignore pod namespace/name glob patterns
+          path: podExcludes
+        statusDescriptors:
+        - description: Conditions show the current state of the NUMAResourcesOperator
+            Operator
+          displayName: Condition reported
+          path: conditions
+        - description: DaemonSets of the configured RTEs, one per node group
+          displayName: RTE DaemonSets
+          path: daemonsets
+        - description: MachineConfigPools resolved from configured node groups
+          displayName: RTE MCPs from node groups
+          path: machineconfigpools
+        - description: Conditions represents the latest available observations of
+            MachineConfigPool current state.
+          displayName: Optional conditions reported for this NodeGroup
+          path: machineconfigpools[0].conditions
+        - description: NodeGroupConfig represents the latest available configuration
+            applied to this MachineConfigPool
+          displayName: Optional configuration enforced on this NodeGroup
+          path: machineconfigpools[0].config
+        version: v1alpha1
+      - description: NUMAResourcesScheduler is the Schema for the numaresourcesschedulers
+          API
+        displayName: NUMA Aware Scheduler
+        kind: NUMAResourcesScheduler
+        name: numaresourcesschedulers.nodetopology.openshift.io
+        resources:
+        - kind: Deployment
+          name: secondary-scheduler-deployment
+          version: v1
+        specDescriptors:
+        - description: Set the cache resync debug options. Defaults to disable.
+          displayName: Scheduler cache resync debug setting
+          path: cacheResyncDebug
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: Set the cache resync detection mode. Default is to trigger
+            resyncs only when detected guaranteed QoS pods which require NUMA-specific
+            resources.
+          displayName: Scheduler cache resync detection setting
+          path: cacheResyncDetection
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: Set the cache resync period. Use explicit 0 to disable.
+          displayName: Scheduler cache resync period setting
+          path: cacheResyncPeriod
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: Scheduler container image URL
+          displayName: Scheduler container image URL
+          path: imageSpec
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: |-
+            Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+            Defaults to "Normal".
+          displayName: Scheduler log verbosity
+          path: logLevel
+        - description: Replicas control how many scheduler pods must be configured
+            for High Availability (HA)
+          displayName: Scheduler replicas
+          path: replicas
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:int
+        - description: Set the informer type to be used by the scheduler to connect
+            to the apiserver. Defaults to dedicated.
+          displayName: Scheduler cache apiserver informer setting
+          path: schedulerInformer
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: Scheduler name to be used in pod templates
+          displayName: Scheduler name
+          path: schedulerName
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: ScoringStrategy a scoring model that determine how the plugin
+            will score the nodes. Defaults to LeastAllocated.
+          displayName: Scheduler scoring strategy setting
+          path: scoringStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+        - description: CacheResyncPeriod shows the current cache resync period
+          displayName: Scheduler cache resync period
+          path: cacheResyncPeriod
+        - description: Deployment of the secondary scheduler, namespaced name
+          displayName: Scheduler deployment
+          path: deployment
+        - description: RelatedObjects list of objects of interest for this operator
+          displayName: Related Objects
+          path: relatedObjects
+        - description: Scheduler name to be used in pod templates
+          displayName: Scheduler name
+          path: schedulerName
+        version: v1
+      - description: NUMAResourcesScheduler is the Schema for the numaresourcesschedulers
+          API
+        displayName: NUMA Aware Scheduler
+        kind: NUMAResourcesScheduler
+        name: numaresourcesschedulers.nodetopology.openshift.io
+        resources:
+        - kind: Deployment
+          name: secondary-scheduler-deployment
+          version: v1
+        specDescriptors:
+        - description: Set the cache resync period. Use explicit 0 to disable.
+          displayName: Scheduler cache resync period setting
+          path: cacheResyncPeriod
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: Scheduler container image URL
+          displayName: Scheduler container image URL
+          path: imageSpec
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: |-
+            Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+            Defaults to "Normal".
+          displayName: Scheduler log verbosity
+          path: logLevel
+        - description: Scheduler name to be used in pod templates
+          displayName: Scheduler name
+          path: schedulerName
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+        - description: Deployment of the secondary scheduler, namespaced name
+          displayName: Scheduler deployment
+          path: deployment
+        - description: Scheduler name to be used in pod templates
+          displayName: Scheduler name
+          path: schedulerName
+        version: v1alpha1
+    description: NUMA resources exporter operator
+    displayName: numaresources-operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+    keywords:
+    - RTE
+    - NUMA
+    links:
+    - name: Numaresources Operator
+      url: https://github.com/openshift-kni/numaresources-operator
+    maintainers:
+    - email: fromani@redhat.com
+      name: fromani
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:8b14759b8e5148fadf9511d3cf52923301567824ac7f5eacc3984e050ad33754
+  name: ""
+- image: registry.redhat.io/openshift4/numaresources-rhel9-operator@sha256:cca62cc8f4c1b04df48940632b199e15c03bf8e5437999e5101a446417c0c101
+  name: manager
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:a372f2b3b61c0012618837e349d389f9f300ccd2ae0fa005e9cd7d379b8569a1
+name: numaresources-operator.v4.18.1
+package: numaresources-operator
+properties:
+- type: olm.gvk
+  value:
+    group: nodetopology.openshift.io
+    kind: NUMAResourcesOperator
+    version: v1
+- type: olm.gvk
+  value:
+    group: nodetopology.openshift.io
+    kind: NUMAResourcesOperator
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: nodetopology.openshift.io
+    kind: NUMAResourcesScheduler
+    version: v1
+- type: olm.gvk
+  value:
+    group: nodetopology.openshift.io
+    kind: NUMAResourcesScheduler
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: numaresources-operator
+    version: 4.18.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "nodetopology.openshift.io/v1alpha1",
+            "kind": "NUMAResourcesOperator",
+            "metadata": {
+              "name": "numaresourcesoperator"
+            },
+            "spec": {
+              "nodeGroups": [
+                {
+                  "machineConfigPoolSelector": {
+                    "matchLabels": {
+                      "pools.operator.machineconfiguration.openshift.io/worker": ""
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "apiVersion": "nodetopology.openshift.io/v1alpha1",
+            "kind": "NUMAResourcesScheduler",
+            "metadata": {
+              "name": "numaresourcesscheduler"
+            },
+            "spec": {
+              "imageSpec": "URL_OF_SCHEDULER_IMAGE_FROM_REDHAT_REGISTRY",
+              "logLevel": "Normal",
+              "schedulerName": "topo-aware-scheduler"
+            }
+          }
+        ]
+      capabilities: Basic Install
+      createdAt: "2025-03-25T14:27:42Z"
+      features.operators.openshift.io/cnf: "true"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=4.17.0 <4.18.1'
+      operatorframework.io/cluster-monitoring: "true"
+      operators.openshift.io/valid-subscription: "[\n\t\"OpenShift Kubernetes Engine\",\n\t\"OpenShift
+        Container Platform\",\n\t\"OpenShift Platform Plus\"\n]"
+      operators.operatorframework.io/builder: operator-sdk-v1.36.1
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: NUMAResourcesOperator is the Schema for the numaresourcesoperators
+          API
+        displayName: NUMA Resources Operator
+        kind: NUMAResourcesOperator
+        name: numaresourcesoperators.nodetopology.openshift.io
+        resources:
+        - kind: DaemonSet
+          name: ""
+          version: v1
+        specDescriptors:
+        - description: Optional Resource Topology Exporter image URL
+          displayName: Optional RTE image URL
+          path: imageSpec
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: |-
+            Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+            Defaults to "Normal".
+          displayName: RTE log verbosity
+          path: logLevel
+        - description: Group of Nodes to enable RTE on
+          displayName: Group of nodes to enable RTE on
+          path: nodeGroups
+        - description: InfoRefreshMode sets the mechanism which will be used to refresh
+            the topology info.
+          displayName: Topology info mechanism setting
+          path: nodeGroups[0].config.infoRefreshMode
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: InfoRefreshPause defines if updates to NRTs are paused for
+            the machines belonging to this group
+          displayName: Enable or disable the RTE pause setting
+          path: nodeGroups[0].config.infoRefreshPause
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: InfoRefreshPeriod sets the topology info refresh period. Use
+            explicit 0 to disable.
+          displayName: Topology info refresh period setting
+          path: nodeGroups[0].config.infoRefreshPeriod
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: PodsFingerprinting defines if pod fingerprint should be reported
+            for the machines belonging to this group
+          displayName: Enable or disable the pods fingerprinting setting
+          path: nodeGroups[0].config.podsFingerprinting
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: |-
+            Tolerations overrides tolerations to be set into RTE daemonsets for this NodeGroup. If not empty, the tolerations will be the one set here.
+            Leave empty to make the system use the default tolerations.
+          displayName: Extra tolerations for the topology updater daemonset
+          path: nodeGroups[0].config.tolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: Optional Namespace/Name glob patterns of pod to ignore at node
+            level
+          displayName: Optional ignore pod namespace/name glob patterns
+          path: podExcludes
+        statusDescriptors:
+        - description: Conditions show the current state of the NUMAResourcesOperator
+            Operator
+          displayName: Condition reported
+          path: conditions
+        - description: DaemonSets of the configured RTEs, one per node group
+          displayName: RTE DaemonSets
+          path: daemonsets
+        - description: MachineConfigPools resolved from configured node groups
+          displayName: RTE MCPs from node groups
+          path: machineconfigpools
+        - description: Conditions represents the latest available observations of
+            MachineConfigPool current state.
+          displayName: Optional conditions reported for this NodeGroup
+          path: machineconfigpools[0].conditions
+        - description: NodeGroupConfig represents the latest available configuration
+            applied to this MachineConfigPool
+          displayName: Optional configuration enforced on this NodeGroup
+          path: machineconfigpools[0].config
+        - description: NodeGroups report the observed status of the configured NodeGroups,
+            matching by their name
+          displayName: Node groups observed status
+          path: nodeGroups
+        - description: NodeGroupConfig represents the latest available configuration
+            applied to this NodeGroup
+          displayName: Optional configuration enforced on this NodeGroup
+          path: nodeGroups[0].config
+        - description: DaemonSet of the configured RTEs, for this node group
+          displayName: RTE DaemonSets
+          path: nodeGroups[0].daemonsets
+        - description: PoolName represents the pool name to which the nodes belong
+            that the config of this node group is be applied to
+          displayName: Pool name of nodes in this node group
+          path: nodeGroups[0].selector
+        - description: RelatedObjects list of objects of interest for this operator
+          displayName: Related Objects
+          path: relatedObjects
+        version: v1
+      - description: NUMAResourcesOperator is the Schema for the numaresourcesoperators
+          API
+        displayName: NUMA Resources Operator
+        kind: NUMAResourcesOperator
+        name: numaresourcesoperators.nodetopology.openshift.io
+        resources:
+        - kind: DaemonSet
+          name: ""
+          version: v1
+        specDescriptors:
+        - description: Optional Resource Topology Exporter image URL
+          displayName: Optional RTE image URL
+          path: imageSpec
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: |-
+            Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+            Defaults to "Normal".
+          displayName: RTE log verbosity
+          path: logLevel
+        - description: Group of Nodes to enable RTE on
+          displayName: Group of nodes to enable RTE on
+          path: nodeGroups
+        - description: InfoRefreshMode sets the mechanism which will be used to refresh
+            the topology info.
+          displayName: Topology info mechanism setting
+          path: nodeGroups[0].config.infoRefreshMode
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: InfoRefreshPeriod sets the topology info refresh period. Use
+            explicit 0 to disable.
+          displayName: Topology info refresh period setting
+          path: nodeGroups[0].config.infoRefreshPeriod
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: PodsFingerprinting defines if pod fingerprint should be reported
+            for the machines belonging to this group
+          displayName: Enable or disable the pods fingerprinting setting
+          path: nodeGroups[0].config.podsFingerprinting
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: Optional Namespace/Name glob patterns of pod to ignore at node
+            level
+          displayName: Optional ignore pod namespace/name glob patterns
+          path: podExcludes
+        statusDescriptors:
+        - description: Conditions show the current state of the NUMAResourcesOperator
+            Operator
+          displayName: Condition reported
+          path: conditions
+        - description: DaemonSets of the configured RTEs, one per node group
+          displayName: RTE DaemonSets
+          path: daemonsets
+        - description: MachineConfigPools resolved from configured node groups
+          displayName: RTE MCPs from node groups
+          path: machineconfigpools
+        - description: Conditions represents the latest available observations of
+            MachineConfigPool current state.
+          displayName: Optional conditions reported for this NodeGroup
+          path: machineconfigpools[0].conditions
+        - description: NodeGroupConfig represents the latest available configuration
+            applied to this MachineConfigPool
+          displayName: Optional configuration enforced on this NodeGroup
+          path: machineconfigpools[0].config
+        version: v1alpha1
+      - description: NUMAResourcesScheduler is the Schema for the numaresourcesschedulers
+          API
+        displayName: NUMA Aware Scheduler
+        kind: NUMAResourcesScheduler
+        name: numaresourcesschedulers.nodetopology.openshift.io
+        resources:
+        - kind: Deployment
+          name: secondary-scheduler-deployment
+          version: v1
+        specDescriptors:
+        - description: Set the cache resync debug options. Defaults to disable.
+          displayName: Scheduler cache resync debug setting
+          path: cacheResyncDebug
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: Set the cache resync detection mode. Default is to trigger
+            resyncs only when detected guaranteed QoS pods which require NUMA-specific
+            resources.
+          displayName: Scheduler cache resync detection setting
+          path: cacheResyncDetection
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: Set the cache resync period. Use explicit 0 to disable.
+          displayName: Scheduler cache resync period setting
+          path: cacheResyncPeriod
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: Scheduler container image URL
+          displayName: Scheduler container image URL
+          path: imageSpec
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: |-
+            Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+            Defaults to "Normal".
+          displayName: Scheduler log verbosity
+          path: logLevel
+        - description: Replicas control how many scheduler pods must be configured
+            for High Availability (HA)
+          displayName: Scheduler replicas
+          path: replicas
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:int
+        - description: Set the informer type to be used by the scheduler to connect
+            to the apiserver. Defaults to dedicated.
+          displayName: Scheduler cache apiserver informer setting
+          path: schedulerInformer
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: Scheduler name to be used in pod templates
+          displayName: Scheduler name
+          path: schedulerName
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: ScoringStrategy a scoring model that determine how the plugin
+            will score the nodes. Defaults to LeastAllocated.
+          displayName: Scheduler scoring strategy setting
+          path: scoringStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+        - description: CacheResyncPeriod shows the current cache resync period
+          displayName: Scheduler cache resync period
+          path: cacheResyncPeriod
+        - description: Deployment of the secondary scheduler, namespaced name
+          displayName: Scheduler deployment
+          path: deployment
+        - description: RelatedObjects list of objects of interest for this operator
+          displayName: Related Objects
+          path: relatedObjects
+        - description: Scheduler name to be used in pod templates
+          displayName: Scheduler name
+          path: schedulerName
+        version: v1
+      - description: NUMAResourcesScheduler is the Schema for the numaresourcesschedulers
+          API
+        displayName: NUMA Aware Scheduler
+        kind: NUMAResourcesScheduler
+        name: numaresourcesschedulers.nodetopology.openshift.io
+        resources:
+        - kind: Deployment
+          name: secondary-scheduler-deployment
+          version: v1
+        specDescriptors:
+        - description: Set the cache resync period. Use explicit 0 to disable.
+          displayName: Scheduler cache resync period setting
+          path: cacheResyncPeriod
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: Scheduler container image URL
+          displayName: Scheduler container image URL
+          path: imageSpec
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: |-
+            Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+            Defaults to "Normal".
+          displayName: Scheduler log verbosity
+          path: logLevel
+        - description: Scheduler name to be used in pod templates
+          displayName: Scheduler name
+          path: schedulerName
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+        - description: Deployment of the secondary scheduler, namespaced name
+          displayName: Scheduler deployment
+          path: deployment
+        - description: Scheduler name to be used in pod templates
+          displayName: Scheduler name
+          path: schedulerName
+        version: v1alpha1
+    description: NUMA resources exporter operator
+    displayName: numaresources-operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+    keywords:
+    - RTE
+    - NUMA
+    links:
+    - name: Numaresources Operator
+      url: https://github.com/openshift-kni/numaresources-operator
+    maintainers:
+    - email: fromani@redhat.com
+      name: fromani
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:a372f2b3b61c0012618837e349d389f9f300ccd2ae0fa005e9cd7d379b8569a1
+  name: ""
+- image: registry.redhat.io/openshift4/numaresources-rhel9-operator@sha256:da231dc87dad63f4fe28e3b438a1ca9a96f04839389f7c3c19e8368bf4604283
+  name: manager
+schema: olm.bundle

--- a/.tekton/fbc-pipeline.yaml
+++ b/.tekton/fbc-pipeline.yaml
@@ -1,0 +1,373 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: fbc-pipeline
+spec:
+  description: |
+    This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/end-to-end/building-olm/#building-the-file-based-catalog).
+    _Uses `buildah` to create a container image. Its build-time tests are limited to verifying the included catalog and do not scan the image.
+    This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-fbc-builder?tab=tags)_
+  finally:
+  - name: show-sbom
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    taskRef:
+      params:
+      - name: name
+        value: show-sbom
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:002f7c8c1d2f9e09904035da414aba1188ae091df0ea9532cd997be05e73d594
+      - name: kind
+        value: task
+      resolver: bundles
+  params:
+  - description: Source Repository URL
+    name: git-url
+    type: string
+  - default: ""
+    description: Revision of the Source Repository
+    name: revision
+    type: string
+  - description: Fully Qualified Output Image
+    name: output-image
+    type: string
+  - default: .
+    description: Path to the source code of an application's component from where
+      to build image.
+    name: path-context
+    type: string
+  - default: Dockerfile
+    description: Path to the Dockerfile inside the context specified by parameter
+      path-context
+    name: dockerfile
+    type: string
+  - default: "false"
+    description: Force rebuild image
+    name: rebuild
+    type: string
+  - default: "false"
+    description: Skip checks against built image
+    name: skip-checks
+    type: string
+  - default: "true"
+    description: Execute the build with network isolation
+    name: hermetic
+    type: string
+  - default: ""
+    description: Build dependencies to be prefetched by Cachi2
+    name: prefetch-input
+    type: string
+  - default: ""
+    description: Image tag expiration time, time values could be something like
+      1h, 2d, 3w for hours, days, and weeks, respectively.
+    name: image-expires-after
+  - default: "false"
+    description: Build a source image.
+    name: build-source-image
+    type: string
+  - default: "true"
+    description: Add built image into an OCI image index
+    name: build-image-index
+    type: string
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings) for buildah
+    name: build-args
+    type: array
+  - default: ""
+    description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    name: build-args-file
+    type: string
+  - default:
+    - linux/x86_64
+    description: List of platforms to build the container images on. The available
+      set of values is determined by the configuration of the multi-platform-controller.
+    name: build-platforms
+    type: array
+  - default: []
+    description: Additional tags to apply to the built container image
+    name: additional-tags
+    type: array
+  results:
+  - description: ""
+    name: IMAGE_URL
+    value: $(tasks.build-image-index.results.IMAGE_URL)
+  - description: ""
+    name: IMAGE_DIGEST
+    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+  - description: ""
+    name: CHAINS-GIT_URL
+    value: $(tasks.clone-repository.results.url)
+  - description: ""
+    name: CHAINS-GIT_COMMIT
+    value: $(tasks.clone-repository.results.commit)
+  tasks:
+  - name: init
+    params:
+    - name: image-url
+      value: $(params.output-image)
+    - name: rebuild
+      value: $(params.rebuild)
+    - name: skip-checks
+      value: $(params.skip-checks)
+    taskRef:
+      params:
+      - name: name
+        value: init
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:66e90d31e1386bf516fb548cd3e3f0082b5d0234b8b90dbf9e0d4684b70dbe1a
+      - name: kind
+        value: task
+      resolver: bundles
+  - name: clone-repository
+    params:
+    - name: url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.revision)
+    - name: ociStorage
+      value: $(params.output-image).git
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
+    runAfter:
+    - init
+    taskRef:
+      params:
+      - name: name
+        value: git-clone-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:0fea1e4bd2fdde46c5b7786629f423a51e357f681c32ceddd744a6e3d48b8327
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: basic-auth
+      workspace: git-auth
+  - name: prefetch-dependencies
+    params:
+    - name: input
+      value: $(params.prefetch-input)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+    - name: ociStorage
+      value: $(params.output-image).prefetch
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
+    runAfter:
+    - clone-repository
+    taskRef:
+      params:
+      - name: name
+        value: prefetch-dependencies-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:adbd819c6b727ac0c5519475d174dcad64cfa8df6ee50acd58f7fb562c59d4f7
+      - name: kind
+        value: task
+      resolver: bundles
+    workspaces:
+    - name: git-basic-auth
+      workspace: git-auth
+    - name: netrc
+      workspace: netrc
+  - matrix:
+      params:
+      - name: PLATFORM
+        value:
+        - $(params.build-platforms)
+    name: build-images
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: HERMETIC
+      value: $(params.hermetic)
+    - name: PREFETCH_INPUT
+      value: $(params.prefetch-input)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
+      value:
+      - $(params.build-args[*])
+    - name: BUILD_ARGS_FILE
+      value: $(params.build-args-file)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    - name: IMAGE_APPEND_PLATFORM
+      value: "true"
+    - name: ADDITIONAL_SECRET
+      value: telco-5g-redhat-pull-secret
+    runAfter:
+    - clone-repository
+    taskRef:
+      params:
+      - name: name
+        value: buildah-remote-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:cfeeef2f4ab25b121afdf44eecc394ed67f3534a1bd14bef9e7beef2ee654b8e
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+  - name: build-image-index
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: ALWAYS_BUILD_INDEX
+      value: $(params.build-image-index)
+    - name: IMAGES
+      value:
+      - $(tasks.build-images.results.IMAGE_REF[*])
+    runAfter:
+    - build-images
+    taskRef:
+      params:
+      - name: name
+        value: build-image-index
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:9c95b1fe17db091ae364344ba2006af46648e08486eef1f6fe1b9e3f10866875
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+  - name: deprecated-base-image-check
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: deprecated-image-check
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:ecd33669676b3a193ff4c2c6223cb912cc1b0cf5cc36e080eaec7718500272cf
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: apply-tags
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)      
+    - name: ADDITIONAL_TAGS
+      value: $(params.additional-tags[*])
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: apply-tags
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.2@sha256:0c411c27483849a936c0c420a57e477113e9fafc63077647200d6614d9ebb872
+      - name: kind
+        value: task
+      resolver: bundles
+  - name: validate-fbc
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: validate-fbc
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1@sha256:30a5df9773eb9cab3efd808206370761302d4dc59dc5aa14e56b571c7daf9ee9
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: fbc-target-index-pruning-check
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: TARGET_INDEX
+      value: registry.redhat.io/redhat/redhat-operator-index
+    - name: RENDERED_CATALOG_DIGEST
+      value: $(tasks.validate-fbc.results.RENDERED_CATALOG_DIGEST)
+    runAfter:
+    - validate-fbc
+    taskRef:
+      params:
+      - name: name
+        value: fbc-target-index-pruning-check
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:016d0fa117dd2aa36420ebe74f938dda6cacb28d193d71775f6141dbab976cc6
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: fbc-fips-check-oci-ta
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: fbc-fips-check-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:479d93d8ff93e8e40025608fda6fc5049a556c88272e8391ddab39d95d04e307
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  workspaces:
+  - name: git-auth
+    optional: true
+  - name: netrc
+    optional: true

--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -1,0 +1,13 @@
+apiVersion: operator.openshift.io/v1alpha1
+kind: ImageDigestMirrorSet
+metadata:
+  name: numaresources-operator-digest-mirror-set
+spec:
+  imageDigestMirrors:
+  - mirrors:
+    - quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-4-18
+    source: registry.redhat.io/openshift4/numaresources-rhel9-operator
+  - mirrors:
+    - quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-18
+    source: registry.redhat.io/openshift4/numaresources-operator-bundle
+

--- a/.tekton/numaresources-operator-fbc-4-18-pull-request.yaml
+++ b/.tekton/numaresources-operator-fbc-4-18-pull-request.yaml
@@ -1,0 +1,56 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift-kni/numaresources-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" &&
+      target_branch == "release-4.18" &&
+      (
+        '.tekton/fbc-pipeline.yaml'.pathChanged() ||
+        '.tekton/images-mirror-set.yaml'.pathChanged() ||
+        '.tekton/numaresources-operator-fbc-4-18-pull-request.yaml'.pathChanged() ||
+        '.konflux/catalog/***.conf'.pathChanged() ||
+        '.konflux/Dockerfile.catalog'.pathChanged()
+      )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: numaresources-operator-fbc-4-18
+    appstudio.openshift.io/component: numaresources-operator-fbc-4-18
+    pipelines.appstudio.openshift.io/type: build
+  name: numaresources-operator-fbc-4-18-on-pull-request
+  namespace: telco-5g-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-fbc-4-18:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: .konflux/Dockerfile.catalog
+  - name: additional-tags
+    value: []
+  # We have configured an fbc exception for hermetic builds on the release repo.
+  - name: hermetic
+    value: "false"
+  pipelineRef:
+    name: fbc-pipeline    
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-numaresources-operator-fbc-4-18
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/numaresources-operator-fbc-4-18-push.yaml
+++ b/.tekton/numaresources-operator-fbc-4-18-push.yaml
@@ -1,0 +1,53 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift-kni/numaresources-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" &&
+      target_branch == "release-4.18" &&
+      (
+        '.tekton/fbc-pipeline.yaml'.pathChanged() ||
+        '.tekton/images-mirror-set.yaml'.pathChanged() ||
+        '.tekton/numaresources-operator-fbc-4-18-push.yaml'.pathChanged() ||
+        '.konflux/catalog/***.conf'.pathChanged() ||
+        '.konflux/Dockerfile.catalog'.pathChanged()
+      )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: numaresources-operator-fbc-4-18
+    appstudio.openshift.io/component: numaresources-operator-fbc-4-18
+    pipelines.appstudio.openshift.io/type: build
+  name: numaresources-operator-fbc-4-18-on-push
+  namespace: telco-5g-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-fbc-4-18:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: .konflux/Dockerfile.catalog
+  - name: additional-tags
+    value: ["latest"]
+  # We have configured an fbc exception for hermetic builds on the release repo.
+  - name: hermetic
+    value: "false"
+  pipelineRef:
+    name: fbc-pipeline    
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-numaresources-operator-fbc-4-18
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/hack/konflux-update-catalog-template.sh
+++ b/hack/konflux-update-catalog-template.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# set -x
+
+SCRIPT_NAME=$(basename "$(readlink -f "${BASH_SOURCE[0]}")")
+
+check_preconditions() {
+    echo "Checking pre-conditions..."
+
+    # yq must be installed
+    command -v yq >/dev/null 2>&1 || { echo "Error: yq seems not to be installed." >&2; exit 1; }
+
+    echo "Checking pre-conditions completed!"
+    return 0
+}
+
+parse_args() {
+    echo "Parsing args..."
+
+    # command line options
+    local options=
+    local long_options="set-catalog-template-file:,set-bundle-builds-file:,help"
+    local parsed
+    parsed=$(getopt --options="$options" --longoptions="$long_options" --name "$SCRIPT_NAME" -- "$@")
+    eval set -- "$parsed"
+
+    declare -g ARG_CATALOG_TEMPLATE_FILE=""
+    declare -g ARG_BUNDLE_BUILDS_FILE=""
+
+    while true; do
+        case $1 in
+            --help)
+                usage
+                exit
+                ;;
+            --set-catalog-template-file)
+                if [ -z "$2" ]; then
+                    echo "Error: --catalog-template-file requires a file " >&2;
+                    exit 1;
+                fi
+
+                ARG_CATALOG_TEMPLATE_FILE=$2
+                if [[ ! -f "$ARG_CATALOG_TEMPLATE_FILE" ]]; then
+                    echo "Error: file '$ARG_CATALOG_TEMPLATE_FILE' does not exist." >&2
+                    exit 1
+                fi
+
+                shift 2
+                ;;
+            --set-bundle-builds-file)
+                if [ -z "$2" ]; then
+                    echo "Error: --set-bundle-builds-file requires a file " >&2;
+                    exit 1;
+                fi
+
+                ARG_BUNDLE_BUILDS_FILE=$2
+                if [[ ! -f "$ARG_BUNDLE_BUILDS_FILE" ]]; then
+                    echo "Error: file '$ARG_BUNDLE_BUILDS_FILE' does not exist." >&2
+                    exit 1
+                fi
+
+                shift 2
+                ;;
+            --)
+                shift
+                break
+                ;;
+            *)
+                echo "Error: unexpected option: $1" >&2
+                usage
+                exit 1
+                ;;
+        esac
+    done
+
+    # Ensure both files are provided
+    if [ -z "$ARG_CATALOG_TEMPLATE_FILE" ]; then
+        echo "Error: --set-catalog-template-file is required" >&2
+        exit 1
+    fi
+
+    if [ -z "$ARG_BUNDLE_BUILDS_FILE" ]; then
+        echo "Error: --set-bundle-builds-file is required" >&2
+        exit 1
+    fi
+
+    echo "Parsing args completed!"
+    return 0
+}
+
+validate_catalog_template_file() {
+    echo "Validating catalog template file..."
+
+    # validate .entries exists
+    if ! yq e '.entries | type == "!!seq"' "$ARG_CATALOG_TEMPLATE_FILE" >/dev/null; then
+        echo "Error: .entries in $ARG_CATALOG_TEMPLATE_FILE is not a valid array." >&2
+        exit 1
+    fi
+
+    # validate the last entry has an image field
+    image_field=$(yq e ".entries[-1].image" "$ARG_CATALOG_TEMPLATE_FILE")
+    if [ -z "$image_field" ] || [ "$image_field" = "null" ]; then
+        echo "Error: Last element in .entries array of $ARG_CATALOG_TEMPLATE_FILE is missing the image field or it is null." >&2
+    fi
+
+    echo "Validating catalog template file completed!"
+    return 0
+}
+
+update_catalog_template_file() {
+    echo "Updating catalog template file..."
+
+    # Extract bundle
+    local bundle_quay
+    bundle_quay="$(yq eval '.quay' "$ARG_BUNDLE_BUILDS_FILE")"
+    if [ -z "$bundle_quay" ] || [ "$bundle_quay" = "null" ]; then
+        echo "Error: No .quay key found in $ARG_BUNDLE_BUILDS_FILE or value is null." >&2
+        exit 1
+    fi
+
+    # Override the last entry with the quay build
+    yq e -i ".entries[-1].image = \"$bundle_quay\"" $ARG_CATALOG_TEMPLATE_FILE
+    echo "Updating catalog template file: $ARG_CATALOG_TEMPLATE_FILE with bundle: $bundle_quay"
+
+    echo "Updating catalog template file completed!"
+    return 0
+}
+
+main() {
+    check_preconditions
+    parse_args "$@"
+    validate_catalog_template_file
+    update_catalog_template_file
+}
+
+usage() {
+   cat << EOF
+NAME
+   $SCRIPT_NAME - update a catalog template based on the bundle builds to be included
+SYNOPSIS
+   $SCRIPT_NAME --set-catalog-template-file FILE --set-bundle-builds-file FILE
+EXAMPLES
+   - Update the catalog template '.konflux/catalog/catalog-template.in.yaml' based on the bundles builds on 'bundle.builds.in.yaml':
+     $ $SCRIPT_NAME --set-catalog-template-file .konflux/catalog/catalog-template.in.yaml --set-bundle-builds-file .konflux/catalog/bundle.builds.in.yaml
+DESCRIPTION
+ARGS
+   --set-catalog-template-file FILE
+      Set the catalog template file.
+   --set-bundle-builds-file FILE
+      Set the bundle builds file.
+   --help
+      Display this help and exit.
+EOF
+}
+
+main "$@"

--- a/hack/konflux-update-task-refs.sh
+++ b/hack/konflux-update-task-refs.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -eoux pipefail
+
+command -v yq >/dev/null 2>&1 || { echo >&2 "'yq' is required but it's not installed.  Aborting."; exit 1; }
+command -v skopeo >/dev/null 2>&1 || { echo >&2 "'skopeo' is required but it's not installed.  Aborting."; exit 1; }
+
+PIPELINE_FILE=""
+
+function update_manifest_if_outdated {
+    image=$(echo $1 | cut -d '@' -f 1)
+    manifest=$(echo $1 | cut -d '@' -f 2)
+
+    new_manifest=$(skopeo inspect --format='{{ .Digest }}' "docker://${image}")
+    if [[ $? -ne 0 ]]; then
+        echo "error encountered running skopeo inspect against ${image}.  Aborting."; exit 1
+    fi
+
+    if [[ "$new_manifest" == "$manifest" ]]; then
+        return # no new manifest
+    fi
+
+    if update_manifest $image $manifest $new_manifest; then
+        echo "Updated manifest for ${image}:"
+        echo "${manifest} => ${new_manifest}"
+
+    else
+        echo "unable to patch ${image}.  Aborting."; exit 1
+    fi
+}
+
+function update_manifest {
+    image=$1
+    old_manifest=$2
+    new_manifest=$3
+
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' -e "s%${image}@${old_manifest}%${image}@${new_manifest}%g" $PIPELINE_FILE
+    else
+        sed -i -e "s%${image}@${old_manifest}%${image}@${new_manifest}%g" $PIPELINE_FILE
+    fi
+    return $?
+}
+
+for PIPELINE_FILE in "$@"; do
+    echo "Checking ${PIPELINE_FILE} for task manifest updates..."
+
+    active_manifests=()
+    # Fetch the manifests that are currently used in our pipelines
+    IFS=$'\n' read -r -d '' -a active_manifests < <( yq '.spec.tasks[].taskRef.params | filter(.name == "bundle") | .[].value' $PIPELINE_FILE && printf '\0' )
+
+    for manifest in "${active_manifests[@]}"; do
+        update_manifest_if_outdated $manifest
+    done
+done

--- a/hack/konflux-validate-related-images-production.sh
+++ b/hack/konflux-validate-related-images-production.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# set -x
+
+SCRIPT_NAME=$(basename "$(readlink -f "${BASH_SOURCE[0]}")")
+
+check_preconditions() {
+    echo "Checking pre-conditions..."
+
+    # yq must be installed
+    command -v yq >/dev/null 2>&1 || { echo "Error: yq seems not to be installed." >&2; exit 1; }
+
+    echo "Checking pre-conditions completed!"
+    return 0
+}
+
+parse_args() {
+    echo "Parsing args..."
+
+    # command line options
+    local options=
+    local long_options="set-catalog-file:,help"
+    local parsed
+    parsed=$(getopt --options="$options" --longoptions="$long_options" --name "$SCRIPT_NAME" -- "$@")
+    eval set -- "$parsed"
+
+    declare -g ARG_CATALOG_FILE=""
+
+    while true; do
+        case $1 in
+            --help)
+                usage
+                exit
+                ;;
+            --set-catalog-file)
+                if [ -z "$2" ]; then
+                    echo "Error: --catalog-file requires a file " >&2;
+                    exit 1;
+                fi
+
+                ARG_CATALOG_FILE=$2
+                if [[ ! -f "$ARG_CATALOG_FILE" ]]; then
+                    echo "Error: file '$ARG_CATALOG_FILE' does not exist." >&2
+                    exit 1
+                fi
+
+                shift 2
+                ;;
+            --)
+                shift
+                break
+                ;;
+            *)
+                echo "Error: unexpected option: $1" >&2
+                usage
+                exit 1
+                ;;
+        esac
+    done
+
+    if [ -z "$ARG_CATALOG_FILE" ]; then
+        echo "Error: --set-catalog--file is required" >&2
+        exit 1
+    fi
+
+    echo "Parsing args completed!"
+    return 0
+}
+
+validate_related_images() {
+    echo "Validating related images..."
+
+    # validate .entries exists
+    if ! yq e '.relatedImages | type == "!!seq"' "$ARG_CATALOG_FILE" >/dev/null; then
+        echo "Error: .entries in $ARG_CATALOG_FILE is not a valid array." >&2
+        exit 1
+    fi
+
+    local images_parsed
+    mapfile -t images_parsed < <(yq eval -N '.relatedImages | .[] | .image' "$ARG_CATALOG_FILE")
+    entries=${#images_parsed[@]}
+
+    declare -i i=0
+    for ((; i<entries; i++)); do
+        local image="${images_parsed[i]}"
+        # Only allow production (registry.redhat.io) images
+        if [[ "$image" =~ ^registry\.redhat\.io/ ]]; then
+            echo "Valid production image found: $image"
+        else
+            echo "Error: $image is not a valid image reference for production. Check bundle overlay." >&2
+            exit 1
+        fi
+    done
+
+    echo "Validating related images completed!"
+    return 0
+}
+
+
+main() {
+    check_preconditions
+    parse_args "$@"
+    validate_related_images
+}
+
+usage() {
+   cat << EOF
+NAME
+   $SCRIPT_NAME - check the relatedImages section on a catalog yaml file is suitable for production
+SYNOPSIS
+   $SCRIPT_NAME --set-catalog-file FILE
+EXAMPLES
+   - Check the catalog template 'catalog.yaml'
+     $ $SCRIPT_NAME --set-catalog-file catalog.yaml
+DESCRIPTION
+ARGS
+   --set-catalog-file FILE
+      Set the catalog file.
+   --help
+      Display this help and exit.
+EOF
+}
+
+main "$@"


### PR DESCRIPTION
- Introduce a fbc workflow (manual)
- Introduce a fbc workflow (automatic)
- Setup tekton fbc configuration
- Introduce a 'run-script' workflow
  - It runs 'konflux-build-catalog.sh' to render a catalog-template.in.yaml file That way we can check if access to 'registry.redhat.io' is authorized.
- Add mirroring file