### PR TITLE
rbac: controller: sched: add permission to watch nodes

### DIFF
--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -374,6 +374,7 @@ spec:
           - nodes
           verbs:
           - list
+          - watch
         - apiGroups:
           - ""
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -24,6 +24,7 @@ rules:
   - nodes
   verbs:
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/controller/numaresourcesscheduler_controller.go
+++ b/internal/controller/numaresourcesscheduler_controller.go
@@ -71,6 +71,7 @@ type NUMAResourcesSchedulerReconciler struct {
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=*
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=*
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=*
+//+kubebuilder:rbac:groups="",resources=nodes,verbs=list;watch
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesschedulers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesschedulers/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesschedulers/finalizers,verbs=update


### PR DESCRIPTION
recent changes made the scheduler controller watch nodes to recompute the replica count.
Fix RBAC permissions.