### PR TITLE
operator: fix and clean commandline

### DIFF
--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -518,7 +518,6 @@ spec:
               containers:
               - args:
                 - -v=4
-                - --leader-elect
                 command:
                 - /bin/numaresources-operator
                 env:

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -519,7 +519,6 @@ spec:
               - args:
                 - -v=4
                 - --leader-elect
-                - --enable-scheduler
                 command:
                 - /bin/numaresources-operator
                 env:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -74,11 +74,12 @@ const (
 )
 
 const (
-	defaultWebhookPort    = 9443
-	defaultMetricsAddr    = ":8080"
-	defaultMetricsSupport = true
-	defaultProbeAddr      = ":8081"
-	defaultNamespace      = "numaresources-operator"
+	defaultWebhookPort     = 9443
+	defaultMetricsAddr     = ":8080"
+	defaultMetricsSupport  = true
+	defaultProbeAddr       = ":8081"
+	defaultNamespace       = "numaresources-operator"
+	defaultEnableScheduler = true
 )
 
 var (
@@ -132,6 +133,7 @@ func (pa *Params) SetDefaults() {
 	pa.probeAddr = defaultProbeAddr
 	pa.render.Namespace = defaultNamespace
 	pa.enableMetrics = defaultMetricsSupport
+	pa.enableScheduler = defaultEnableScheduler
 }
 
 func (pa *Params) FromFlags() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -74,12 +74,13 @@ const (
 )
 
 const (
-	defaultWebhookPort     = 9443
-	defaultMetricsAddr     = ":8080"
-	defaultMetricsSupport  = true
-	defaultProbeAddr       = ":8081"
-	defaultNamespace       = "numaresources-operator"
-	defaultEnableScheduler = true
+	defaultWebhookPort          = 9443
+	defaultMetricsAddr          = ":8080"
+	defaultMetricsSupport       = true
+	defaultProbeAddr            = ":8081"
+	defaultNamespace            = "numaresources-operator"
+	defaultEnableScheduler      = true
+	defaultEnableLeaderElection = true
 )
 
 var (
@@ -134,6 +135,7 @@ func (pa *Params) SetDefaults() {
 	pa.render.Namespace = defaultNamespace
 	pa.enableMetrics = defaultMetricsSupport
 	pa.enableScheduler = defaultEnableScheduler
+	pa.enableLeaderElection = defaultEnableLeaderElection
 }
 
 func (pa *Params) FromFlags() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -125,14 +125,12 @@ type Params struct {
 	enableMCPCondsForward bool
 	image                 ImageParams
 	inspectFeatures       bool
-	enableReplicasDetect  bool
 }
 
 func (pa *Params) SetDefaults() {
 	pa.metricsAddr = defaultMetricsAddr
 	pa.probeAddr = defaultProbeAddr
 	pa.render.Namespace = defaultNamespace
-	pa.enableReplicasDetect = true
 	pa.enableMetrics = defaultMetricsSupport
 }
 
@@ -158,7 +156,6 @@ func (pa *Params) FromFlags() {
 	flag.BoolVar(&pa.enableMCPCondsForward, "enable-mcp-conds-fwd", pa.enableMCPCondsForward, "enable MCP Status Condition forwarding")
 	flag.StringVar(&pa.image.Exporter, "image-exporter", pa.image.Exporter, "use this image as default for the RTE")
 	flag.StringVar(&pa.image.Scheduler, "image-scheduler", pa.image.Scheduler, "use this image as default for the scheduler")
-	flag.BoolVar(&pa.enableReplicasDetect, "detect-replicas", pa.enableReplicasDetect, "autodetect optimal replica count.(DEPRECATED) autodetect enabled by default and should be configured from the NUMAResourcesScheduler CR")
 
 	flag.Parse()
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
+	"strings"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -138,6 +140,16 @@ func (pa *Params) SetDefaults() {
 	pa.enableLeaderElection = defaultEnableLeaderElection
 }
 
+func (pa *Params) Summarize() string {
+	var sb strings.Builder
+	sb.WriteString("leaderElection=" + strconv.FormatBool(pa.enableLeaderElection))
+	sb.WriteString(" scheduler=" + strconv.FormatBool(pa.enableScheduler))
+	sb.WriteString(" webhooks=" + strconv.FormatBool(pa.enableWebhooks))
+	sb.WriteString(" webhooksHTTP2=" + strconv.FormatBool(pa.enableHTTP2))
+	sb.WriteString(" metrics=" + strconv.FormatBool(pa.enableMetrics))
+	return sb.String()
+}
+
 func (pa *Params) FromFlags() {
 	flag.StringVar(&pa.metricsAddr, "metrics-bind-address", pa.metricsAddr, "The address the metric endpoint binds to.")
 	flag.StringVar(&pa.probeAddr, "health-probe-bind-address", pa.probeAddr, "The address the probe endpoint binds to.")
@@ -195,7 +207,9 @@ func main() {
 	config := textlogger.NewConfig(textlogger.Verbosity(int(klogV)))
 	ctrl.SetLogger(textlogger.NewLogger(config))
 
-	klog.InfoS("starting", "program", version.OperatorProgramName(), "version", bi.Version, "branch", bi.Branch, "gitcommit", bi.Commit, "golang", runtime.Version(), "vl", klogV, "auxv", config.Verbosity().String())
+	klog.InfoS("starting", "program", version.OperatorProgramName(), "version", bi.Version, "branch", bi.Branch, "gitcommit", bi.Commit, "golang", runtime.Version())
+	klog.InfoS("starting", "program", version.OperatorProgramName(), "logVerbosity", klogV, "auxVerbosity", config.Verbosity().String())
+	klog.InfoS("starting", "program", version.OperatorProgramName(), "params", params.Summarize())
 
 	ctx := context.Background()
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -54,7 +54,6 @@ spec:
         args:
         - -v=4
         - --leader-elect
-        - --enable-scheduler
         ports:
         - containerPort: 8080
           protocol: TCP

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -53,7 +53,6 @@ spec:
         - /bin/numaresources-operator
         args:
         - -v=4
-        - --leader-elect
         ports:
         - containerPort: 8080
           protocol: TCP


### PR DESCRIPTION
streamline command line parameters handling.
- remove deprecated option, as the command line parameters are not part of stable API promise. So we can just remove deprecated options
- switch the default for options we always use.