### PR TITLE
cmd: reuse context

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -273,7 +273,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	imgs, pullPolicy := images.Discover(context.Background(), params.image.Exporter)
+	imgs, pullPolicy := images.Discover(ctx, params.image.Exporter)
 
 	rteManifestsRendered, err := renderRTEManifests(rteManifests, namespace, imgs)
 	if err != nil {


### PR DESCRIPTION
we can use a single context, no need to have different ones.