### PR TITLE
[release 4.19] konflux: z stream update 4.19.1

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,3 +1,2 @@
 ---
-# When we are ready to ship the first Konflux release, replace this with the nudge to the quay build
-quay: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:a1d46f3a1e45c3c414f2d9a0fd2992513fee8d795bb3efd173472c004a406747
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-19:a21ebbae228193c19c2d731fef11733cec08feb6

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -12,16 +12,16 @@ entries:
   - entries:
       - name: numaresources-operator.v4.19.0
         skipRange: '>=4.18.0 <4.19.0'
-        # After 4.19.0 is released, add 4.19.1 back using the quay nudged bundle      
-        # - name: numaresources-operator.v4.19.1
-        #   replaces: numaresources-operator.v4.19.0
-        #   skipRange: '>=4.18.0 <4.19.1'
+      - name: numaresources-operator.v4.19.1
+        replaces: numaresources-operator.v4.19.0
+        skipRange: '>=4.18.0 <4.19.1'
     name: "4.19"
     package: numaresources-operator
     schema: olm.channel
   # v4.19.0 bundle
   - image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:a1d46f3a1e45c3c414f2d9a0fd2992513fee8d795bb3efd173472c004a406747
     schema: olm.bundle
-# The url for this last entry is updated by hack/konflux-update-catalog-template.sh automatically
-#  - image: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-19@sha256:a1c0c79c2ebb9e39ebb0fe298302c1cfbe2d952323b086f3b67a6bb84c13bfb8
-#    schema: olm.bundle
+  # v4.19.1 bundle  
+  # The url for this last entry is updated by hack/konflux-update-catalog-template.sh automatically
+  - image: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-19:a21ebbae228193c19c2d731fef11733cec08feb6
+    schema: olm.bundle


### PR DESCRIPTION
Configure catalog to include next z stream build (4.19.1) as a Konflux quay image