### PR TITLE
[release 4.18] konflux: set 4.18 bundle to image digest

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,3 +1,3 @@
 ---
 # When we are ready to ship the first Konflux release, replace this with the nudge to the quay build
-quay: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:8cdcec0348831715981ea6a458b58821540176c73021dc51e67f3581045490d0
+quay: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:a372f2b3b61c0012618837e349d389f9f300ccd2ae0fa005e9cd7d379b8569a1

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -10,11 +10,11 @@ entries:
     schema: olm.package
   # Channel entries should contain all the releases
   - entries:
-    - name: numaresources-operator.v4.18.0
-      skipRange: '>=4.17.0 <4.18.0'
-    - name: numaresources-operator.v4.18.1
-      replaces: numaresources-operator.v4.18.0
-      skipRange: '>=4.17.0 <4.18.1'
+      - name: numaresources-operator.v4.18.0
+        skipRange: '>=4.17.0 <4.18.0'
+      - name: numaresources-operator.v4.18.1
+        replaces: numaresources-operator.v4.18.0
+        skipRange: '>=4.17.0 <4.18.1'
     # Until we release the first build on Konflux, we just want the existing released images
     # - name: numaresources-operator.v4.18.2
     #   replaces: numaresources-operator.v4.18.1


### PR DESCRIPTION
replace url to image digest instead of manifest list digest