### PR TITLE
deploy-mco-crds: update CRD url

### DIFF
--- a/hack/deploy-mco-crds.sh
+++ b/hack/deploy-mco-crds.sh
@@ -3,7 +3,7 @@
 source hack/common.sh
 
 # Specify the URL link to the machine config pool CRD
-CRD_MACHINE_CONFIG_POOL_URL="https://raw.githubusercontent.com/openshift/api/refs/heads/master/payload-manifests/crds/0000_80_machine-config_01_machineconfigpools-Default.crd.yaml"
+CRD_MACHINE_CONFIG_POOL_URL="https://raw.githubusercontent.com/openshift/api/refs/heads/master/payload-manifests/crds/0000_80_machine-config_01_machineconfigpools.crd.yaml"
 # Specify the URL link to the kubeletconfig CRD
 CRD_KUBELET_CONFIG_URL="https://raw.githubusercontent.com/openshift/api/refs/heads/master/payload-manifests/crds/0000_80_machine-config_01_kubeletconfigs.crd.yaml"
 


### PR DESCRIPTION
Catch up with
https://github.com/openshift/api/commit/7171625473e0dacae5506ba4ccf30d3e99a2fdb2 and consume latest MC CRD.