### PR TITLE
test: nrosched: clarify docstring for CheckNROSchedulerAvailable()

### DIFF
--- a/test/e2e/serial/tests/scheduler_removal.go
+++ b/test/e2e/serial/tests/scheduler_removal.go
@@ -59,7 +59,6 @@ var _ = Describe("[serial][disruptive][scheduler][schedrst] numaresources schedu
 		Expect(err).ToNot(HaveOccurred(), "unable to setup test fixture")
 
 		nroSchedObj = nrosched.CheckNROSchedulerAvailable(context.TODO(), fxt.Client, serialconfig.Config.NROSchedObj.Name)
-		Expect(nroSchedObj).ToNot(BeNil())
 		dpNName = nroSchedObj.Status.Deployment
 	})
 
@@ -72,7 +71,6 @@ var _ = Describe("[serial][disruptive][scheduler][schedrst] numaresources schedu
 		AfterEach(func() {
 			restoreScheduler(fxt, serialconfig.Config.NROSchedObj)
 			nroSchedObj = nrosched.CheckNROSchedulerAvailable(context.TODO(), fxt.Client, serialconfig.Config.NROSchedObj.Name)
-			Expect(nroSchedObj).ToNot(BeNil())
 		})
 
 		It("[case:1][test_id:47593] should keep existing workloads running", Label(label.Tier1), func() {
@@ -161,7 +159,6 @@ var _ = Describe("[serial][disruptive][scheduler][schedrst] numaresources schedu
 
 			restoreScheduler(fxt, nroSchedObj)
 			nroSchedObj = nrosched.CheckNROSchedulerAvailable(ctx, fxt.Client, nroSchedObj.Name)
-			Expect(nroSchedObj).ToNot(BeNil())
 
 			By(fmt.Sprintf("waiting for the test deployment %q to become complete and ready", updatedDp.Name))
 			_, err = wait.With(fxt.Client).Interval(2*time.Second).Interval(30*time.Second).ForDeploymentComplete(ctx, updatedDp)

--- a/test/internal/nrosched/nrosched.go
+++ b/test/internal/nrosched/nrosched.go
@@ -155,13 +155,16 @@ func CheckPODWasScheduledWith(k8sCli *kubernetes.Clientset, podNamespace, podNam
 	return checkPODEvents(k8sCli, podNamespace, podName, isScheduledWith)
 }
 
+// CheckNROSchedulerAvailable finds the NUMA-aware scheduler by name, verifies its
+// status confirms a deployment and returns a pointer to it. The calling test will
+// fail if any verification is unsuccessful.
 func CheckNROSchedulerAvailable(ctx context.Context, cli client.Client, schedObjName string) *nropv1.NUMAResourcesScheduler {
 	GinkgoHelper()
 
 	nroSchedObj := &nropv1.NUMAResourcesScheduler{}
 	Eventually(func() error {
 		By(fmt.Sprintf("checking %q for the condition Available=true", schedObjName))
-		err := cli.Get(context.TODO(), objects.NROSchedObjectKey(), nroSchedObj)
+		err := cli.Get(ctx, objects.NROSchedObjectKey(), nroSchedObj)
 		if err != nil {
 			return fmt.Errorf("failed to get the scheduler resource: %v", err)
 		}


### PR DESCRIPTION
The function either succeeds and returns a pointer to the found
NUMA-aware scheduler, or the calling test fails. The function returned
value was asserted in some places as an attempt to ensure the functionality passed,
while that is inaccurate considering that the function already verifies its
self by being marked as ginkgo helper.
Clarify the intent of the function and remove redundant assertions.