### PR TITLE
hack: add a script to reformat the imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,18 @@ test-upgrade-e2e: build-e2e-all
 test-must-gather-e2e: build-must-gather-e2e
 	hack/run-test-must-gather-e2e.sh
 
+# intentional left out:
+#   api/, because autogeneration
+#   cmd/, because kubebuilder scaffolding
+.PHONY:
+sort-imports:
+	@hack/sort-imports.py -v ./test/
+	@hack/sort-imports.py -v ./internal/
+	@hack/sort-imports.py -v ./pkg/
+	@hack/sort-imports.py -v ./rte/
+	@hack/sort-imports.py -v ./tools/
+	@hack/sort-imports.py -v ./nrovalidate/
+
 .PHONY: lint
 lint: update-buildinfo golangci-lint ## Run golangci-lint linter
 	$(GOLANGCI_LINT) --verbose run --print-resources-usage --exclude-dirs test/internal/k8simported

--- a/hack/sort-imports.py
+++ b/hack/sort-imports.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import subprocess
+import sys
+import yaml
+
+
+def make_gci_commandline(tree, ciconfig=".golangci.yml"):
+    with open(ciconfig) as src:
+        cfg = yaml.safe_load(src)
+    try:
+        sections = cfg['linters-settings']['gci']['sections']
+    except KeyError:
+        sys.stderr.write("cannot find gci configuration on %s\n" % ciconfig)
+        sys.exit(2)
+    cmdline = [
+        "gci", "write", "--custom-order",
+    ]
+    for sect in sections:
+        cmdline.extend(("-s", sect))
+    cmdline.append(tree)
+    return cmdline
+
+
+def _main(args):
+    cmdline = make_gci_commandline(args.tree)
+    if args.verbose and not args.dry_run:
+        sys.stderr.write("running: [%s]\n" % " ".join(cmdline))
+    if args.dry_run:
+        print(" ".join(cmdline))
+        return
+    subprocess.run(cmdline)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog='sort-imports.py',
+        description='sort golang imports according to project standards delegating to gci')
+    parser.add_argument('tree')
+    parser.add_argument('-v', '--verbose', action='store_true')
+    parser.add_argument('-D', '--dry-run', action='store_true')
+    args = parser.parse_args()
+    _main(args)


### PR DESCRIPTION
add a helper script which reads the sort ordering expectation from our .golangci.yml (source of truth) and automatically constructs the recommended command line to run to conform.

Depends on python3 and gci: https://github.com/daixiang0/gci