### PR TITLE
[release-4.17] cleanup: konflux: mustgather: remove redundant lines and restore `tar`

### DIFF
--- a/.konflux/must-gather/redhat.repo
+++ b/.konflux/must-gather/redhat.repo
@@ -1,28 +1,3 @@
-#
-# Certificate-Based Repositories
-# Managed by (rhsm) subscription-manager
-#
-# *** This file is auto-generated.  Changes made here will be over-written. ***
-# *** Use "subscription-manager repo-override --help" if you wish to make changes. ***
-#
-# If this file is empty and this system is subscribed consider
-# a "yum repolist" to refresh available repos
-#
-
-[codeready-builder-for-rhel-9-$basearch-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/9.4/$basearch/codeready-builder/os
-enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7511773722896751421-key.pem
-sslclientcert = /etc/pki/entitlement/7511773722896751421.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 1
-
 [rhel-9-for-$basearch-baseos-eus-rpms]
 name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (RPMs)
 baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/$basearch/baseos/os

--- a/.konflux/must-gather/rpms.lock.yaml
+++ b/.konflux/must-gather/rpms.lock.yaml
@@ -18,5 +18,12 @@ arches:
     name: rsync
     evr: 3.2.3-19.el9_4.1
     sourcerpm: rsync-3.2.3-19.el9_4.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/Packages/t/tar-1.34-6.el9_4.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 910343
+    checksum: sha256:76f2f5fd1f37153d51a697659db31bd2a672a1a4536b42ce020cf9602ea3cde7
+    name: tar
+    evr: 2:1.34-6.el9_4.1
+    sourcerpm: tar-1.34-6.el9_4.1.src.rpm
   source: []
   module_metadata: []


### PR DESCRIPTION
A follow-up cleanup of https://github.com/openshift-kni/numaresources-operator/pull/1546, please see commits for details.