### PR TITLE
konflux: Auto-approve and merge Konflux Docker digest updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,18 @@
         {
             "matchUpdateTypes": ["minor"],
             "enabled": false
+        },
+        {
+            "addLabels": ["approved", "lgtm"],
+            "autoApprove": true,
+            "automerge": true,
+            "enabled": true,
+            "ignoreTests": false,
+            "matchDatasources": ["docker"],
+            "matchManagers": ["dockerfile"],
+            "matchPaths": [".konflux/**"],
+            "matchUpdateTypes": ["digest"],
+            "platformAutomerge": true
         }
     ],    
     "prConcurrentLimit": 0,


### PR DESCRIPTION
Add Renovate package rule to auto label (lgtm and approve), auto-approve and auto-merge Docker digest updates under .konflux/ with platform automerge enabled

xref: https://konflux-ci.dev/docs/mintmaker/user/