### PR TITLE
hack: remove `ginkgo.fail-fast` for non-install suites

### DIFF
--- a/hack/run-test-e2e.sh
+++ b/hack/run-test-e2e.sh
@@ -36,7 +36,7 @@ export E2E_TOPOLOGY_MANAGER_SCOPE="${E2E_TOPOLOGY_MANAGER_SCOPE}"
 # --flake-attempts: rerun the test if it fails
 # -requireSuite: fail if tests are not executed because of missing suite
 echo "TM config policy=[${E2E_TOPOLOGY_MANAGER_POLICY}] scope=[${E2E_TOPOLOGY_MANAGER_SCOPE}]"
-${BIN_DIR}/e2e-nrop-rte.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.flake-attempts=2 --ginkgo.junit-report=${REPORT_DIR}/e2e.xml --ginkgo.skip='\[Disruptive\]|\[StateDirectories\]|\[NodeRefresh\]|\[local\]' --ginkgo.focus='\[release\]'
+${BIN_DIR}/e2e-nrop-rte.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.flake-attempts=2 --ginkgo.junit-report=${REPORT_DIR}/e2e.xml --ginkgo.skip='\[Disruptive\]|\[StateDirectories\]|\[NodeRefresh\]|\[local\]' --ginkgo.focus='\[release\]'
 
 if [ "$ENABLE_SCHED_TESTS" = true ]; then
   # Run install test suite
@@ -50,7 +50,7 @@ if [ "$ENABLE_SCHED_TESTS" = true ]; then
   # --fail-fast: ginkgo will stop the suite right after the first spec failure
   # --flake-attempts: rerun the test if it fails
   # -requireSuite: fail if tests are not executed because of missing suite
-  ${BIN_DIR}/e2e-nrop-sched.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.flake-attempts=2 --ginkgo.junit-report=${REPORT_DIR}/e2e-sched.xml
+  ${BIN_DIR}/e2e-nrop-sched.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.flake-attempts=2 --ginkgo.junit-report=${REPORT_DIR}/e2e-sched.xml
 
   if [ "$ENABLE_CLEANUP" = true ]; then
     echo "Running NROScheduler uninstall test suite";

--- a/hack/run-test-must-gather-e2e.sh
+++ b/hack/run-test-must-gather-e2e.sh
@@ -14,4 +14,4 @@ setupreport
 
 # Run must-gather test suite
 echo "Running NRO must-gather test suite"
-${BIN_DIR}/e2e-nrop-must-gather.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.junit-report=${REPORT_DIR}/must-gather.xml --ginkgo.focus='\[must-gather\]'
+${BIN_DIR}/e2e-nrop-must-gather.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=${REPORT_DIR}/must-gather.xml --ginkgo.focus='\[must-gather\]'


### PR DESCRIPTION
For suites that in which the tests are successive, failing fast e.i exit the suite of the first failure saves execution time knowing that the initial steps failed so there would be no point to proceed in checking the next expected results because they are likely to fail as well.

However, running non-install (and non-uninstall) suites would benefit from keeping the suite run alive even on one test failure because normally tests in such suites are independent, and a continuous run would provide more verbose picture about the overall state, and would also give hints and  narrow down the possible reasons, providing more efficient debugging experience.