### PR TITLE
test: introduce E2E_NODE_ROLE

### DIFF
--- a/hack/run-test-compact-e2e.sh
+++ b/hack/run-test-compact-e2e.sh
@@ -6,6 +6,8 @@ source hack/common.sh
 
 ENABLE_CLEANUP="${ENABLE_CLEANUP:-false}"
 
+export E2E_NODE_ROLE="master"
+
 NO_COLOR=""
 if ! which tput &> /dev/null 2>&1 || [[ $(tput -T$TERM colors) -lt 8 ]]; then
   echo "Terminal does not seem to support colored output, disabling it"

--- a/test/internal/objects/objects.go
+++ b/test/internal/objects/objects.go
@@ -19,6 +19,7 @@ package objects
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -37,12 +38,21 @@ import (
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
 )
 
+const (
+	e2eNodeRole        = "E2E_NODE_ROLE"
+	machineConfigLabel = "pools.operator.machineconfiguration.openshift.io"
+	workerLabel        = "worker"
+)
+
 func EmptyMatchLabels() map[string]string {
 	return map[string]string{}
 }
 
 func OpenshiftMatchLabels() map[string]string {
-	return map[string]string{"pools.operator.machineconfiguration.openshift.io/worker": ""}
+	if nodeRole, ok := os.LookupEnv(e2eNodeRole); ok {
+		return map[string]string{machineConfigLabel + "/" + nodeRole: ""}
+	}
+	return map[string]string{machineConfigLabel + "/" + workerLabel: ""}
 }
 
 func TestNROScheduler() *nropv1.NUMAResourcesScheduler {


### PR DESCRIPTION
test: introduce E2E_NODE_ROLE

For compact cluster configuration, we need to differentiate between
the MCP pools on which to do the installation. For compact cluster we
would be interested to use the `master` pool because worker pool is
empty (machine count is 0).