### PR TITLE
CNF-17780:numaresourcesscheduler: support HA for HyperShift platform

### DIFF
--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -62,7 +62,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-07-15T16:26:43Z"
+    createdAt: "2025-07-23T11:36:11Z"
     olm.skipRange: '>=4.19.0 <4.20.0'
     operatorframework.io/cluster-monitoring: "true"
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
@@ -615,11 +615,7 @@ spec:
           resources:
           - networkpolicies
           verbs:
-          - create
-          - delete
-          - get
-          - list
-          - update
+          - '*'
         serviceAccountName: numaresources-controller-manager
     strategy: deployment
   installModes:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -156,8 +156,4 @@ rules:
   resources:
   - networkpolicies
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
+  - '*'

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -97,7 +97,7 @@ type NUMAResourcesOperatorReconciler struct {
 
 // Namespace Scoped
 //+kubebuilder:rbac:groups="",resources=services,verbs=*,namespace="numaresources"
-//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;create;update;delete,namespace="numaresources"
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=*,namespace="numaresources"
 
 // Cluster Scoped
 //+kubebuilder:rbac:groups=topology.node.k8s.io,resources=noderesourcetopologies,verbs=get;list;create;update

--- a/internal/controller/numaresourcesscheduler_controller.go
+++ b/internal/controller/numaresourcesscheduler_controller.go
@@ -82,6 +82,10 @@ type NUMAResourcesSchedulerReconciler struct {
 	PlatformInfo       PlatformInfo
 }
 
+// Namespace Scoped
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=*,namespace="numaresources"
+
+// Cluster Scoped
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=*
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=*
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=*

--- a/pkg/objectstate/rte/rte.go
+++ b/pkg/objectstate/rte/rte.go
@@ -211,14 +211,21 @@ func (em *ExistingManifests) State(mf Manifests) []objectstate.ObjectState {
 			Error:    em.errs.Core.APIServerNetworkPolicy,
 			Desired:  mf.Core.APIServerNetworkPolicy.DeepCopy(),
 			Compare:  compare.Object,
-			Merge:    merge.ObjectForUpdate,
+			Merge:    merge.MetadataForUpdate,
 		},
 		{
 			Existing: em.existing.Core.MetricsServerNetworkPolicy,
 			Error:    em.errs.Core.MetricsServerNetworkPolicy,
 			Desired:  mf.Core.MetricsServerNetworkPolicy.DeepCopy(),
 			Compare:  compare.Object,
-			Merge:    merge.ObjectForUpdate,
+			Merge:    merge.MetadataForUpdate,
+		},
+		{
+			Existing: em.existing.Core.DefaultNetworkPolicy,
+			Error:    em.errs.Core.DefaultNetworkPolicy,
+			Desired:  mf.Core.DefaultNetworkPolicy.DeepCopy(),
+			Compare:  compare.Object,
+			Merge:    merge.MetadataForUpdate,
 		},
 	}
 


### PR DESCRIPTION
Add support for scheduler high availability when running on HyperShift platform. On HyperShift, scheduler replicas are deployed on worker nodes, as opposed to standard OpenShift where replicas run on control-plane nodes.

Implement intelligent replica management with the following logic:
- Use worker nodes for replica count calculation on HyperShift
- Use control-plane nodes for replica count calculation on OpenShift
- Prefer odd-sized replica counts (1 or 3) to avoid split-brain scenarios
- Cap maximum replicas at 3 to prevent resource overconsumption
- Return error when no target nodes are found for the platform

The automatic replica detection can be overridden by explicitly setting the replicas field in the NUMAResourcesScheduler custom resource.

Includes comprehensive unit tests covering all platform and node count scenarios.