### PR TITLE
NO-JIRA:e2e:networkpolicy: do not mask context

### DIFF
--- a/test/e2e/serial/tests/network_policy.go
+++ b/test/e2e/serial/tests/network_policy.go
@@ -58,7 +58,7 @@ var _ = Describe("network policies are applied", Ordered, Label("feature:network
 	var operatorPod, schedulerPod, rteWorkerPod, prometheusPod *corev1.Pod
 
 	BeforeAll(func() {
-		ctx := context.Background()
+		ctx = context.Background()
 		nropObj = objects.TestNRO()
 		Expect(e2eclient.Client.Get(ctx, client.ObjectKeyFromObject(nropObj), nropObj)).To(Succeed())
 


### PR DESCRIPTION
We should initialize the outer context in the `BeforeAll()` but it was masked instead, which means a `nil` context was passed to all the functions.