### PR TITLE
[release-4.19] controller: sched: conditionally enable Shared informer by default

### DIFF
--- a/api/v1/numaresourcesscheduler_types.go
+++ b/api/v1/numaresourcesscheduler_types.go
@@ -38,7 +38,7 @@ const (
 type SchedulerInformerMode string
 
 const (
-	// SchedulerInformerDedicated makes the NodeResourceTopologyMatch plugin use the default framework informer.
+	// SchedulerInformerShared makes the NodeResourceTopologyMatch plugin use the default framework informer.
 	SchedulerInformerShared SchedulerInformerMode = "Shared"
 
 	// SchedulerInformerDedicated sets an additional separate informer just for the NodeResourceTopologyMatch plugin. Default.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -329,7 +329,14 @@ func main() {
 			Scheme:             mgr.GetScheme(),
 			SchedulerManifests: schedMf,
 			Namespace:          namespace,
+<<<<<<< HEAD
 			AutodetectReplicas: info.NodeCount,
+=======
+			PlatformInfo: controller.PlatformInfo{
+				Platform: clusterPlatform,
+				Version:  clusterPlatformVersion,
+			},
+>>>>>>> 6a568405 (controller: sched: conditionally enable Shared informer by default)
 		}).SetupWithManager(mgr); err != nil {
 			klog.ErrorS(err, "unable to create controller", "controller", "NUMAResourcesScheduler")
 			os.Exit(1)

--- a/internal/controller/numaresourcesscheduler_controller.go
+++ b/internal/controller/numaresourcesscheduler_controller.go
@@ -217,11 +217,10 @@ func (r *NUMAResourcesSchedulerReconciler) syncNUMASchedulerResources(ctx contex
 		return nropv1.NUMAResourcesSchedulerStatus{}, err
 	}
 
-	schedStatus := nropv1.NUMAResourcesSchedulerStatus{
-		SchedulerName: schedSpec.SchedulerName,
-		CacheResyncPeriod: &metav1.Duration{
-			Duration: cacheResyncPeriod,
-		},
+	schedStatus := *instance.Status.DeepCopy()
+	schedStatus.SchedulerName = schedSpec.SchedulerName
+	schedStatus.CacheResyncPeriod = &metav1.Duration{
+		Duration: cacheResyncPeriod,
 	}
 
 	r.SchedulerManifests.Deployment.Spec.Replicas = r.computeSchedulerReplicas(schedSpec)

--- a/internal/controller/numaresourcesscheduler_controller_test.go
+++ b/internal/controller/numaresourcesscheduler_controller_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	configv1 "github.com/openshift/api/config/v1"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -33,21 +32,25 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	configv1 "github.com/openshift/api/config/v1"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	depmanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
 	depobjupdate "github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate"
+
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
+	testobjs "github.com/openshift-kni/numaresources-operator/internal/objects"
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	nrosched "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler"
 	schedmanifests "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/manifests/sched"
 	"github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/objectstate/sched"
 	schedupdate "github.com/openshift-kni/numaresources-operator/pkg/objectupdate/sched"
 	"github.com/openshift-kni/numaresources-operator/pkg/status"
-
-	testobjs "github.com/openshift-kni/numaresources-operator/internal/objects"
 )
 
 const testSchedulerName = "testSchedulerName"
@@ -605,6 +608,157 @@ var _ = ginkgo.Describe("Test NUMAResourcesScheduler Reconcile", func() {
 			ginkgo.Entry("replicas=1", int32(1), false),
 			ginkgo.Entry("replicas=3", int32(3), true),
 		)
+	})
+
+	ginkgo.Context("with kubelet PodResourcesAPI listing active pods by default", func() {
+		var nrs *nropv1.NUMAResourcesScheduler
+		var reconciler *NUMAResourcesSchedulerReconciler
+
+		ginkgo.When("kubelet fix is enabled", func() {
+			fixedVersion, _ := platform.ParseVersion(activePodsResourcesSupportSince)
+
+			ginkgo.DescribeTable("should configure by default the informerMode to the expected when field is not set", func(reconcilerPlatInfo PlatformInfo, expectedInformer string) {
+				var err error
+				nrs = testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 11*time.Second)
+				reconciler, err = NewFakeNUMAResourcesSchedulerReconciler(nrs)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				reconciler.PlatformInfo = reconcilerPlatInfo
+
+				key := client.ObjectKeyFromObject(nrs)
+				_, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				expectCacheParams(reconciler.Client, depmanifests.CacheResyncAutodetect, depmanifests.CacheResyncOnlyExclusiveResources, expectedInformer)
+			},
+				ginkgo.Entry("with fixed Openshift the default informer is Shared", PlatformInfo{
+					Platform: platform.OpenShift,
+					Version:  fixedVersion,
+				}, depmanifests.CacheInformerShared),
+				ginkgo.Entry("with fixed Hypershift the default informer is Shared", PlatformInfo{
+					Platform: platform.HyperShift,
+					Version:  fixedVersion,
+				}, depmanifests.CacheInformerShared),
+				ginkgo.Entry("with unknown platform the default informer is Dedicated (unchanged)", PlatformInfo{}, depmanifests.CacheInformerDedicated))
+
+			ginkgo.DescribeTable("should preserve informerMode value if set", func(reconcilerPlatInfo PlatformInfo) {
+				var err error
+				nrs = testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 11*time.Second)
+				infMode := nropv1.SchedulerInformerDedicated
+				nrs.Spec.SchedulerInformer = &infMode
+				reconciler, err = NewFakeNUMAResourcesSchedulerReconciler(nrs)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				reconciler.PlatformInfo = reconcilerPlatInfo
+
+				key := client.ObjectKeyFromObject(nrs)
+				_, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				expectCacheParams(reconciler.Client, depmanifests.CacheResyncAutodetect, depmanifests.CacheResyncOnlyExclusiveResources, string(infMode))
+			},
+				ginkgo.Entry("with Openshift", PlatformInfo{
+					Platform: platform.OpenShift,
+					Version:  fixedVersion,
+				}),
+				ginkgo.Entry("with Hypershift", PlatformInfo{
+					Platform: platform.HyperShift,
+					Version:  fixedVersion,
+				}),
+				ginkgo.Entry("with unknown platform", PlatformInfo{}))
+
+			ginkgo.DescribeTable("should allow to update the informerMode to be Dedicated after an overridden default", func(reconcilerPlatInfo PlatformInfo) {
+				var err error
+				nrs = testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 11*time.Second)
+				reconciler, err = NewFakeNUMAResourcesSchedulerReconciler(nrs)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				reconciler.PlatformInfo = reconcilerPlatInfo
+
+				key := client.ObjectKeyFromObject(nrs)
+				_, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				// intentionally skip checking default value
+
+				// should query the object after reconcile because the defaults are overridden
+				gomega.Expect(reconciler.Client.Get(context.TODO(), key, nrs)).ToNot(gomega.HaveOccurred())
+
+				nrsUpdated := nrs.DeepCopy()
+				informerMode := nropv1.SchedulerInformerDedicated
+				nrsUpdated.Spec.SchedulerInformer = &informerMode
+				gomega.Eventually(func() bool {
+					if err := reconciler.Client.Update(context.TODO(), nrsUpdated); err != nil {
+						klog.Warningf("failed to update the scheduler object; err: %v", err)
+						return false
+					}
+					return true
+				}, 30*time.Second, 5*time.Second).Should(gomega.BeTrue())
+
+				_, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				expectCacheParams(reconciler.Client, depmanifests.CacheResyncAutodetect, depmanifests.CacheResyncOnlyExclusiveResources, string(informerMode))
+			},
+				ginkgo.Entry("with Openshift", PlatformInfo{
+					Platform: platform.OpenShift,
+					Version:  fixedVersion,
+				}),
+				ginkgo.Entry("with Hypershift", PlatformInfo{
+					Platform: platform.HyperShift,
+					Version:  fixedVersion,
+				}))
+		})
+	})
+})
+
+var _ = ginkgo.Describe("Test scheduler spec PreNormalize", func() {
+	ginkgo.When("Spec.SchedulerInformer is not set by the user", func() {
+		ginkgo.It("should override default informer to Shared if kubelet is fixed - first supported zstream version", func() {
+			v, _ := platform.ParseVersion(activePodsResourcesSupportSince)
+			spec := nropv1.NUMAResourcesSchedulerSpec{}
+			platformNormalize(&spec, PlatformInfo{Platform: platform.OpenShift, Version: v})
+			gomega.Expect(*spec.SchedulerInformer).To(gomega.Equal(nropv1.SchedulerInformerShared))
+		})
+
+		ginkgo.It("should override default informer to Shared if kubelet is fixed - version is greater than first supported (zstream)", func() {
+			v, _ := platform.ParseVersion("4.20.1000")
+			spec := nropv1.NUMAResourcesSchedulerSpec{}
+			platformNormalize(&spec, PlatformInfo{Platform: platform.OpenShift, Version: v})
+			gomega.Expect(*spec.SchedulerInformer).To(gomega.Equal(nropv1.SchedulerInformerShared))
+		})
+
+		ginkgo.It("should override default informer to Shared if kubelet is fixed - version is greater than first supported (ystream)", func() {
+			v, _ := platform.ParseVersion("4.21.0")
+			spec := nropv1.NUMAResourcesSchedulerSpec{}
+			platformNormalize(&spec, PlatformInfo{Platform: platform.OpenShift, Version: v})
+			gomega.Expect(*spec.SchedulerInformer).To(gomega.Equal(nropv1.SchedulerInformerShared))
+		})
+
+		ginkgo.It("should not override default informer if kubelet is not fixed - version is less than first supported (zstream)", func() {
+			// this is only for testing purposes as there is plan to backport the fix to older minor versions
+			// will need to remove this test if the fix is supported starting the first zstream of the release
+			v, _ := platform.ParseVersion("4.19.0")
+			spec := nropv1.NUMAResourcesSchedulerSpec{}
+			platformNormalize(&spec, PlatformInfo{Platform: platform.OpenShift, Version: v})
+			gomega.Expect(spec.SchedulerInformer).To(gomega.BeNil())
+		})
+
+		ginkgo.It("should not override default informer if kubelet is not fixed - version is less than first supported (ystream)", func() {
+			v, _ := platform.ParseVersion("4.13.0")
+			spec := nropv1.NUMAResourcesSchedulerSpec{}
+			platformNormalize(&spec, PlatformInfo{Platform: platform.OpenShift, Version: v})
+			gomega.Expect(spec.SchedulerInformer).To(gomega.BeNil())
+		})
+	})
+	ginkgo.When("Spec.SchedulerInformer is set by the user", func() {
+		ginkgo.It("should preserve informer value set by the user even if kubelet is fixed", func() {
+			v, _ := platform.ParseVersion(activePodsResourcesSupportSince)
+			spec := nropv1.NUMAResourcesSchedulerSpec{
+				SchedulerInformer: ptr.To(nropv1.SchedulerInformerDedicated),
+			}
+			platformNormalize(&spec, PlatformInfo{Platform: platform.OpenShift, Version: v})
+			gomega.Expect(*spec.SchedulerInformer).To(gomega.Equal(nropv1.SchedulerInformerDedicated))
+		})
 	})
 })
 


### PR DESCRIPTION
conditionally enable Shared informer by default based on a fixed OCP version and report the informer status as a condition in NRS CR. Please check the commits for details.