### PR TITLE
controller: add `PodAntiAffinity` to RTE DS

### DIFF
--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -524,8 +524,13 @@ func (r *NUMAResourcesOperatorReconciler) syncNUMAResourcesOperatorResources(ctx
 		}
 	}
 
-	// using a slice of poolDaemonSet instead of a map because Go maps assignment order is not consistent and non-deterministic
 	dsPoolPairs := []poolDaemonSet{}
+	err = rteupdate.DaemonSetAffinitySettings(r.RTEManifests.Core.DaemonSet, r.RTEManifests.Core.DaemonSet.Spec.Template.Labels)
+	if err != nil {
+		klog.ErrorS(err, "failed to update RTE affinity settings")
+	}
+
+	// using a slice of poolDaemonSet instead of a map because Go maps assignment order is not consistent and non-deterministic
 	err = rteupdate.DaemonSetUserImageSettings(r.RTEManifests.Core.DaemonSet, instance.Spec.ExporterImage, r.Images.Preferred(), r.ImagePullPolicy)
 	if err != nil {
 		return dsPoolPairs, err

--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -23,6 +23,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
 	securityv1 "github.com/openshift/api/security/v1"
@@ -95,6 +96,26 @@ func DaemonSetPauseContainerSettings(ds *appsv1.DaemonSet) error {
 	}
 	cnt.Args = []string{
 		"while true; do sleep 30s; done",
+	}
+	return nil
+}
+
+func DaemonSetAffinitySettings(ds *appsv1.DaemonSet, labels map[string]string) error {
+	if len(labels) == 0 {
+		return fmt.Errorf("no labels provided for PodAffinity")
+	}
+
+	ds.Spec.Template.Spec.Affinity = &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: labels,
+					},
+					TopologyKey: "kubernetes.io/hostname",
+				},
+			},
+		},
 	}
 	return nil
 }


### PR DESCRIPTION
controller: add PodAntiAffinity to RTE DS

We want to avoid having more than 1 RTE pod deployed on node when there
are overlapping nodeGroups specified in the NRO CR.

We cannot prevent the misconfiguration of the cluster node labels with
respect to MCO (e.i a node may match to more than one MCP's node
selector field) but we can mitigate having duplicated RTEs on the same
node.As a result, the order of RTE pods being created following
configuration modifications, like nodes labels, MCP node selectors or any
other adjustments that may relate to the specified nodeGroup(s), will
keep the pod pending starting the second one.

Important note: this change doesn't prevent running the RTE pod on nodes that do not
belong to the specified MCP but still match their nodeSelectors. The
only way to manage that is by not having overlapping node labels in the
first place. The operator depends on the MCO to group nodes of the
cluster into one configuration, but it should not duplicate how MCO
computes which node belongs to which MCP.