### PR TITLE
[release-4.19][manual] review scheduler resources requests

### DIFF
--- a/internal/api/annotations/annotations.go
+++ b/internal/api/annotations/annotations.go
@@ -29,6 +29,11 @@ const (
 
 	NRTAPIDefinitionAnnotation = "config.numa-operator.openshift.io/nrt-api-definition"
 	NRTAPIFromCluster          = "cluster" // trust whatever it is already in the cluster, if at all
+
+	// introduced in: 4.20
+	// remove in: 4.22 (tentative)
+	SchedulerQOSRequestAnnotation = "config.numa-operator.openshift.io/scheduler-qos-request"
+	SchedulerQOSRequestBurstable  = "burstable"
 )
 
 func IsCustomPolicyEnabled(annot map[string]string) bool {
@@ -54,6 +59,13 @@ func IsPauseReconciliationEnabled(annot map[string]string) bool {
 
 func IsNRTAPIDefinitionCluster(annot map[string]string) bool {
 	if v, ok := annot[NRTAPIDefinitionAnnotation]; ok && v == NRTAPIFromCluster {
+		return true
+	}
+	return false
+}
+
+func IsSchedulerQOSRequestBurstable(annot map[string]string) bool {
+	if v, ok := annot[SchedulerQOSRequestAnnotation]; ok && v == SchedulerQOSRequestBurstable {
 		return true
 	}
 	return false

--- a/internal/api/annotations/annotations_test.go
+++ b/internal/api/annotations/annotations_test.go
@@ -157,3 +157,38 @@ func TestIsNRTAPIDefinitionCluster(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSchedulerQOSRequestBurstable(t *testing.T) {
+	testcases := []struct {
+		description string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			description: "empty map",
+			annotations: map[string]string{},
+			expected:    false,
+		},
+		{
+			description: "annotation set to anything but not \"burstable\" means the requested QoS is guaranteed",
+			annotations: map[string]string{
+				SchedulerQOSRequestAnnotation: "guaranteed",
+			},
+			expected: false,
+		},
+		{
+			description: "request burstable QoS",
+			annotations: map[string]string{
+				SchedulerQOSRequestAnnotation: SchedulerQOSRequestBurstable,
+			},
+			expected: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			if got := IsSchedulerQOSRequestBurstable(tc.annotations); got != tc.expected {
+				t.Errorf("expected %v got %v", tc.expected, got)
+			}
+		})
+	}
+}

--- a/internal/controller/numaresourcesscheduler_controller.go
+++ b/internal/controller/numaresourcesscheduler_controller.go
@@ -214,6 +214,11 @@ func (r *NUMAResourcesSchedulerReconciler) syncNUMASchedulerResources(ctx contex
 
 	// node-critical so the pod won't be preempted by pods having the most critical priority class
 	r.SchedulerManifests.Deployment.Spec.Template.Spec.PriorityClassName = nrosched.SchedulerPriorityClassName
+	if err := schedupdate.SchedulerResourcesRequest(r.SchedulerManifests.Deployment, instance); err != nil {
+		// NOT CRITICAL! should never happen. Trust the existing manifests and move on
+		// TODO: this becomes critical once we remove the defaults from the manifests
+		klog.ErrorS(err, "failed to enforce the scheduler resources, continuing with manifests defaults")
+	}
 
 	schedupdate.DeploymentImageSettings(r.SchedulerManifests.Deployment, schedSpec.SchedulerImage)
 	cmHash := hash.ConfigMapData(r.SchedulerManifests.ConfigMap)

--- a/pkg/numaresourcesscheduler/manifests/yaml/deployment.yaml
+++ b/pkg/numaresourcesscheduler/manifests/yaml/deployment.yaml
@@ -43,8 +43,8 @@ spec:
           image: ${IMAGE}
           resources:
             requests:
-              cpu: "600m"
-              memory: "1200Mi"
+              cpu: "150m"
+              memory: "500Mi"
           command:
             - /bin/kube-scheduler
           args:

--- a/pkg/numaresourcesscheduler/manifests/yaml/deployment.yaml
+++ b/pkg/numaresourcesscheduler/manifests/yaml/deployment.yaml
@@ -42,9 +42,6 @@ spec:
               drop: ["ALL"]
           image: ${IMAGE}
           resources:
-            limits:
-              cpu: "600m"
-              memory: "1200Mi"
             requests:
               cpu: "600m"
               memory: "1200Mi"

--- a/pkg/objectupdate/sched/sched.go
+++ b/pkg/objectupdate/sched/sched.go
@@ -21,6 +21,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
 
 	k8swgmanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
@@ -28,6 +29,8 @@ import (
 	k8swgschedupdate "github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate/sched"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
+	"github.com/openshift-kni/numaresources-operator/internal/api/annotations"
+	intreslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	schedstate "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/objectstate/sched"
 )
@@ -138,4 +141,52 @@ func SchedulerConfig(cm *corev1.ConfigMap, name string, params *k8swgmanifests.C
 
 	cm.Data[schedstate.SchedulerConfigFileName] = string(newData)
 	return nil
+}
+
+func SchedulerResourcesRequest(dp *appsv1.Deployment, instance *nropv1.NUMAResourcesScheduler) error {
+	cnt := k8swgobjupdate.FindContainerByName(dp.Spec.Template.Spec.Containers, MainContainerName)
+	if cnt == nil {
+		return fmt.Errorf("cannot find container %q", MainContainerName)
+	}
+	defer func(c *corev1.Container) {
+		klog.V(2).InfoS("scheduler resources", "requests", intreslist.ToString(c.Resources.Requests), "limits", intreslist.ToString(c.Resources.Limits))
+	}(cnt)
+	// legacy values
+	cpuVal := "600m"
+	memVal := "1200Mi"
+	enforceLimits := true
+	if annotations.IsSchedulerQOSRequestBurstable(instance.Annotations) {
+		cpuVal = "150m"
+		memVal = "500Mi"
+		enforceLimits = false
+	}
+	rr, err := makeResourceRequirements(cpuVal, memVal, enforceLimits)
+	if err != nil {
+		return err
+	}
+	cnt.Resources = rr
+	return nil
+}
+
+func makeResourceRequirements(cpuVal, memVal string, enforceLimits bool) (corev1.ResourceRequirements, error) {
+	rr := corev1.ResourceRequirements{}
+	cpuQty, err := resource.ParseQuantity(cpuVal)
+	if err != nil {
+		return rr, err
+	}
+	memQty, err := resource.ParseQuantity(memVal)
+	if err != nil {
+		return rr, err
+	}
+	res := corev1.ResourceList{
+		corev1.ResourceCPU:    cpuQty,
+		corev1.ResourceMemory: memQty,
+	}
+	if !enforceLimits {
+		rr.Requests = res
+		return rr, nil
+	}
+	rr.Limits = res
+	rr.Requests = res.DeepCopy() // non necessary, added as nicety
+	return rr, nil
 }


### PR DESCRIPTION
update the secondary scheduler resource requests according to scalability requirements.
In a nutshell, this means removing the resource caps, which was set initially and never challenged till now.

manual backport of #1689 
