### PR TITLE
[release-4.18][manual] review scheduler resources requests

### DIFF
--- a/controllers/numaresourcesscheduler_controller.go
+++ b/controllers/numaresourcesscheduler_controller.go
@@ -214,6 +214,11 @@ func (r *NUMAResourcesSchedulerReconciler) syncNUMASchedulerResources(ctx contex
 
 	// node-critical so the pod won't be preempted by pods having the most critical priority class
 	r.SchedulerManifests.Deployment.Spec.Template.Spec.PriorityClassName = nrosched.SchedulerPriorityClassName
+	if err := schedupdate.SchedulerResourcesRequest(r.SchedulerManifests.Deployment, instance); err != nil {
+		// NOT CRITICAL! should never happen. Trust the existing manifests and move on
+		// TODO: this becomes critical once we remove the defaults from the manifests
+		klog.ErrorS(err, "failed to enforce the scheduler resources, continuing with manifests defaults")
+	}
 
 	schedupdate.DeploymentImageSettings(r.SchedulerManifests.Deployment, schedSpec.SchedulerImage)
 	cmHash := hash.ConfigMapData(r.SchedulerManifests.ConfigMap)

--- a/controllers/numaresourcesscheduler_controller_test.go
+++ b/controllers/numaresourcesscheduler_controller_test.go
@@ -18,6 +18,8 @@ package controllers
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -25,10 +27,13 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/onsi/gomega/gcustom"
+	"github.com/onsi/gomega/types"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -40,14 +45,14 @@ import (
 	depmanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
 	depobjupdate "github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate"
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
+	"github.com/openshift-kni/numaresources-operator/internal/api/annotations"
+	testobjs "github.com/openshift-kni/numaresources-operator/internal/objects"
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	nrosched "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler"
 	schedmanifests "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/manifests/sched"
 	"github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/objectstate/sched"
 	schedupdate "github.com/openshift-kni/numaresources-operator/pkg/objectupdate/sched"
 	"github.com/openshift-kni/numaresources-operator/pkg/status"
-
-	testobjs "github.com/openshift-kni/numaresources-operator/internal/objects"
 )
 
 const testSchedulerName = "testSchedulerName"
@@ -606,7 +611,104 @@ var _ = ginkgo.Describe("Test NUMAResourcesScheduler Reconcile", func() {
 			ginkgo.Entry("replicas=3", int32(3), true),
 		)
 	})
+
+	ginkgo.When("setting the scheduler pod resource requests", func() {
+		var nrs *nropv1.NUMAResourcesScheduler
+		var reconciler *NUMAResourcesSchedulerReconciler
+		numOfMasters := 3
+
+		ginkgo.BeforeEach(func() {
+			var err error
+			nrs = testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 11*time.Second)
+			initObjects := []runtime.Object{nrs}
+			initObjects = append(initObjects, fakeNodes(numOfMasters, 3)...)
+			reconciler, err = NewFakeNUMAResourcesSchedulerReconciler(initObjects...)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should keep setting the legacy guaranteed values by default", func(ctx context.Context) {
+			key := client.ObjectKeyFromObject(nrs)
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			expectedRR := corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    mustParseResource("600m"),
+					corev1.ResourceMemory: mustParseResource("1200Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    mustParseResource("600m"),
+					corev1.ResourceMemory: mustParseResource("1200Mi"),
+				},
+			}
+
+			dp := &appsv1.Deployment{}
+			gomega.Expect(reconciler.Client.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "secondary-scheduler"}, dp)).To(gomega.Succeed())
+			gomega.Expect(dp).To(HaveTheSameResourceRequirements(expectedRR))
+		})
+
+		ginkgo.It("should keep setting the legacy guaranteed values explicitly", func(ctx context.Context) {
+			nrs := nrs.DeepCopy()
+			nrs.Annotations = map[string]string{
+				annotations.SchedulerQOSRequestAnnotation: "guaranteed",
+			}
+			gomega.Eventually(reconciler.Client.Update).WithArguments(ctx, nrs).WithPolling(30 * time.Second).WithTimeout(5 * time.Minute).Should(gomega.Succeed())
+
+			key := client.ObjectKeyFromObject(nrs)
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			expectedRR := corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    mustParseResource("600m"),
+					corev1.ResourceMemory: mustParseResource("1200Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    mustParseResource("600m"),
+					corev1.ResourceMemory: mustParseResource("1200Mi"),
+				},
+			}
+
+			dp := &appsv1.Deployment{}
+			gomega.Expect(reconciler.Client.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "secondary-scheduler"}, dp)).To(gomega.Succeed())
+			gomega.Expect(dp).To(HaveTheSameResourceRequirements(expectedRR))
+		})
+
+		ginkgo.It("should setting the burstable values only if requested", func(ctx context.Context) {
+			nrs := nrs.DeepCopy()
+			nrs.Annotations = map[string]string{
+				annotations.SchedulerQOSRequestAnnotation: annotations.SchedulerQOSRequestBurstable,
+			}
+			gomega.Eventually(reconciler.Client.Update).WithArguments(ctx, nrs).WithPolling(30 * time.Second).WithTimeout(5 * time.Minute).Should(gomega.Succeed())
+
+			key := client.ObjectKeyFromObject(nrs)
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			expectedRR := corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    mustParseResource("150m"),
+					corev1.ResourceMemory: mustParseResource("500Mi"),
+				},
+			}
+
+			dp := &appsv1.Deployment{}
+			gomega.Expect(reconciler.Client.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "secondary-scheduler"}, dp)).To(gomega.Succeed())
+			gomega.Expect(dp).To(HaveTheSameResourceRequirements(expectedRR))
+		})
+	})
 })
+
+func HaveTheSameResourceRequirements(expectedRR corev1.ResourceRequirements) types.GomegaMatcher {
+	return gcustom.MakeMatcher(func(actual *appsv1.Deployment) (bool, error) {
+		cntName := schedupdate.MainContainerName // shortcut
+		cnt := depobjupdate.FindContainerByName(actual.Spec.Template.Spec.Containers, cntName)
+		if cnt == nil {
+			return false, fmt.Errorf("cannot find container %q", cntName)
+		}
+		return reflect.DeepEqual(cnt.Resources, expectedRR), nil
+	}).WithTemplate("Deployment {{.Actual.Namespace}}/{{.Actual.Name}} resources request mismatch")
+}
 
 func pop(m map[string]string, k string) string {
 	v := m[k]
@@ -694,4 +796,38 @@ func expectLeaderElectParams(cli client.Client, enabled bool, resourceNamespace,
 	gomega.Expect(cfg.LeaderElection.LeaderElect).To(gomega.Equal(enabled))
 	gomega.Expect(cfg.LeaderElection.ResourceNamespace).To(gomega.Equal(resourceNamespace))
 	gomega.Expect(cfg.LeaderElection.ResourceName).To(gomega.Equal(resourceName))
+}
+
+func fakeNodes(numOfMasters, numOfWorkers int) []runtime.Object {
+	var nodes []runtime.Object
+	for i := range numOfMasters {
+		nodes = append(nodes, &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("master-node-%d", i+1),
+				Labels: map[string]string{
+					"node-role.kubernetes.io/control-plane": "",
+				},
+			},
+		})
+	}
+	for i := range numOfWorkers {
+		nodes = append(nodes, &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("worker-node-%d", i+1),
+				Labels: map[string]string{
+					"node-role.kubernetes.io/worker": "",
+				},
+			},
+		})
+	}
+	return nodes
+}
+
+func mustParseResource(v string) resource.Quantity {
+	ginkgo.GinkgoHelper()
+	qty, err := resource.ParseQuantity(v)
+	if err != nil {
+		ginkgo.Fail(fmt.Sprintf("cannot parse %q: %v", v, err))
+	}
+	return qty
 }

--- a/internal/api/annotations/annotations.go
+++ b/internal/api/annotations/annotations.go
@@ -29,6 +29,11 @@ const (
 
 	NRTAPIDefinitionAnnotation = "config.numa-operator.openshift.io/nrt-api-definition"
 	NRTAPIFromCluster          = "cluster" // trust whatever it is already in the cluster, if at all
+
+	// introduced in: 4.20
+	// remove in: 4.22 (tentative)
+	SchedulerQOSRequestAnnotation = "config.numa-operator.openshift.io/scheduler-qos-request"
+	SchedulerQOSRequestBurstable  = "burstable"
 )
 
 func IsCustomPolicyEnabled(annot map[string]string) bool {
@@ -54,6 +59,13 @@ func IsPauseReconciliationEnabled(annot map[string]string) bool {
 
 func IsNRTAPIDefinitionCluster(annot map[string]string) bool {
 	if v, ok := annot[NRTAPIDefinitionAnnotation]; ok && v == NRTAPIFromCluster {
+		return true
+	}
+	return false
+}
+
+func IsSchedulerQOSRequestBurstable(annot map[string]string) bool {
+	if v, ok := annot[SchedulerQOSRequestAnnotation]; ok && v == SchedulerQOSRequestBurstable {
 		return true
 	}
 	return false

--- a/internal/api/annotations/annotations_test.go
+++ b/internal/api/annotations/annotations_test.go
@@ -157,3 +157,38 @@ func TestIsNRTAPIDefinitionCluster(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSchedulerQOSRequestBurstable(t *testing.T) {
+	testcases := []struct {
+		description string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			description: "empty map",
+			annotations: map[string]string{},
+			expected:    false,
+		},
+		{
+			description: "annotation set to anything but not \"burstable\" means the requested QoS is guaranteed",
+			annotations: map[string]string{
+				SchedulerQOSRequestAnnotation: "guaranteed",
+			},
+			expected: false,
+		},
+		{
+			description: "request burstable QoS",
+			annotations: map[string]string{
+				SchedulerQOSRequestAnnotation: SchedulerQOSRequestBurstable,
+			},
+			expected: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			if got := IsSchedulerQOSRequestBurstable(tc.annotations); got != tc.expected {
+				t.Errorf("expected %v got %v", tc.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/numaresourcesscheduler/manifests/yaml/deployment.yaml
+++ b/pkg/numaresourcesscheduler/manifests/yaml/deployment.yaml
@@ -43,8 +43,8 @@ spec:
           image: ${IMAGE}
           resources:
             requests:
-              cpu: "600m"
-              memory: "1200Mi"
+              cpu: "150m"
+              memory: "500Mi"
           command:
             - /bin/kube-scheduler
           args:

--- a/pkg/numaresourcesscheduler/manifests/yaml/deployment.yaml
+++ b/pkg/numaresourcesscheduler/manifests/yaml/deployment.yaml
@@ -42,9 +42,6 @@ spec:
               drop: ["ALL"]
           image: ${IMAGE}
           resources:
-            limits:
-              cpu: "600m"
-              memory: "1200Mi"
             requests:
               cpu: "600m"
               memory: "1200Mi"

--- a/pkg/objectupdate/sched/sched.go
+++ b/pkg/objectupdate/sched/sched.go
@@ -21,6 +21,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
 
 	k8swgmanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
@@ -28,6 +29,8 @@ import (
 	k8swgschedupdate "github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate/sched"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
+	"github.com/openshift-kni/numaresources-operator/internal/api/annotations"
+	intreslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	schedstate "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/objectstate/sched"
 )
@@ -138,4 +141,52 @@ func SchedulerConfig(cm *corev1.ConfigMap, name string, params *k8swgmanifests.C
 
 	cm.Data[schedstate.SchedulerConfigFileName] = string(newData)
 	return nil
+}
+
+func SchedulerResourcesRequest(dp *appsv1.Deployment, instance *nropv1.NUMAResourcesScheduler) error {
+	cnt := k8swgobjupdate.FindContainerByName(dp.Spec.Template.Spec.Containers, MainContainerName)
+	if cnt == nil {
+		return fmt.Errorf("cannot find container %q", MainContainerName)
+	}
+	defer func(c *corev1.Container) {
+		klog.V(2).InfoS("scheduler resources", "requests", intreslist.ToString(c.Resources.Requests), "limits", intreslist.ToString(c.Resources.Limits))
+	}(cnt)
+	// legacy values
+	cpuVal := "600m"
+	memVal := "1200Mi"
+	enforceLimits := true
+	if annotations.IsSchedulerQOSRequestBurstable(instance.Annotations) {
+		cpuVal = "150m"
+		memVal = "500Mi"
+		enforceLimits = false
+	}
+	rr, err := makeResourceRequirements(cpuVal, memVal, enforceLimits)
+	if err != nil {
+		return err
+	}
+	cnt.Resources = rr
+	return nil
+}
+
+func makeResourceRequirements(cpuVal, memVal string, enforceLimits bool) (corev1.ResourceRequirements, error) {
+	rr := corev1.ResourceRequirements{}
+	cpuQty, err := resource.ParseQuantity(cpuVal)
+	if err != nil {
+		return rr, err
+	}
+	memQty, err := resource.ParseQuantity(memVal)
+	if err != nil {
+		return rr, err
+	}
+	res := corev1.ResourceList{
+		corev1.ResourceCPU:    cpuQty,
+		corev1.ResourceMemory: memQty,
+	}
+	if !enforceLimits {
+		rr.Requests = res
+		return rr, nil
+	}
+	rr.Limits = res
+	rr.Requests = res.DeepCopy() // non necessary, added as nicety
+	return rr, nil
 }

--- a/pkg/objectupdate/sched/sched_test.go
+++ b/pkg/objectupdate/sched/sched_test.go
@@ -25,11 +25,13 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	k8swgmanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
+	"github.com/openshift-kni/numaresources-operator/internal/api/annotations"
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	schedstate "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/objectstate/sched"
 )
@@ -413,6 +415,114 @@ func TestDeploymentEnvVarSettings(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSchedulerResourcesRequest(t *testing.T) {
+	type testCase struct {
+		name       string
+		inst       nropv1.NUMAResourcesScheduler
+		initialDp  *appsv1.Deployment
+		expectedRR corev1.ResourceRequirements
+	}
+
+	testCases := []testCase{
+		{
+			name:      "defaults with nil annotations",
+			inst:      nropv1.NUMAResourcesScheduler{},
+			initialDp: dpMinimal,
+			expectedRR: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    mustParseResource(t, "600m"),
+					corev1.ResourceMemory: mustParseResource(t, "1200Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    mustParseResource(t, "600m"),
+					corev1.ResourceMemory: mustParseResource(t, "1200Mi"),
+				},
+			},
+		},
+		{
+			name: "defaults with empty annotations",
+			inst: nropv1.NUMAResourcesScheduler{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			initialDp: dpMinimal,
+			expectedRR: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    mustParseResource(t, "600m"),
+					corev1.ResourceMemory: mustParseResource(t, "1200Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    mustParseResource(t, "600m"),
+					corev1.ResourceMemory: mustParseResource(t, "1200Mi"),
+				},
+			},
+		},
+		{
+			name: "defaults with explicit guarantees",
+			inst: nropv1.NUMAResourcesScheduler{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annotations.SchedulerQOSRequestAnnotation: "guaranteed",
+					},
+				},
+			},
+			initialDp: dpMinimal,
+			expectedRR: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    mustParseResource(t, "600m"),
+					corev1.ResourceMemory: mustParseResource(t, "1200Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    mustParseResource(t, "600m"),
+					corev1.ResourceMemory: mustParseResource(t, "1200Mi"),
+				},
+			},
+		},
+		{
+			name: "request burstable QoS explicitly",
+			inst: nropv1.NUMAResourcesScheduler{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annotations.SchedulerQOSRequestAnnotation: "burstable",
+					},
+				},
+			},
+			initialDp: dpMinimal,
+			expectedRR: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    mustParseResource(t, "150m"),
+					corev1.ResourceMemory: mustParseResource(t, "500Mi"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dp := tc.initialDp.DeepCopy()
+			err := SchedulerResourcesRequest(dp, &tc.inst)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			rr := dp.Spec.Template.Spec.Containers[0].Resources // shortcut
+			// TODO: don't assume the container ordering
+			if !reflect.DeepEqual(rr, tc.expectedRR) {
+				t.Errorf("got=%s expected %s", toJSON(rr), toJSON(tc.expectedRR))
+			}
+		})
+	}
+}
+
+func mustParseResource(t *testing.T, v string) resource.Quantity {
+	t.Helper()
+	qty, err := resource.ParseQuantity(v)
+	if err != nil {
+		t.Fatalf("cannot parse %q: %v", v, err)
+	}
+	return qty
 }
 
 func toJSON(obj interface{}) string {


### PR DESCRIPTION
update the secondary scheduler resource requests according to scalability requirements.
In a nutshell, this means removing the resource caps, which was set initially and never challenged till now.

manual backport of https://github.com/openshift-kni/numaresources-operator/pull/1695