### PR TITLE
controller: sched: adapt that kubelet PodResourcesAPI fix has landed

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -60,6 +60,7 @@ import (
 	"github.com/openshift-kni/numaresources-operator/internal/api/features"
 	"github.com/openshift-kni/numaresources-operator/internal/controller"
 	intkloglevel "github.com/openshift-kni/numaresources-operator/internal/kloglevel"
+	"github.com/openshift-kni/numaresources-operator/internal/platform/activepodresources"
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	"github.com/openshift-kni/numaresources-operator/pkg/images"
 	rtemetricsmanifests "github.com/openshift-kni/numaresources-operator/pkg/metrics/manifests/monitor"
@@ -339,8 +340,9 @@ func main() {
 			SchedulerManifests: schedMf,
 			Namespace:          namespace,
 			PlatformInfo: controller.PlatformInfo{
-				Platform: clusterPlatform,
-				Version:  clusterPlatformVersion,
+				Platform:                     clusterPlatform,
+				Version:                      clusterPlatformVersion,
+				KubeletSupportsActivePodList: activepodresources.IsVersionFixed(clusterPlatform, clusterPlatformVersion),
 			},
 		}).SetupWithManager(mgr); err != nil {
 			klog.ErrorS(err, "unable to create controller", "controller", "NUMAResourcesScheduler")

--- a/internal/platform/activepodresources/supportversion.go
+++ b/internal/platform/activepodresources/supportversion.go
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package activepodresources
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/klog/v2"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+)
+
+// This file processes the known OCP platform versions, so far nightly, konflux-nightly, CI, dev-preview, and RC
+
+const (
+	// first OCP build to have the fix is always the nightly build. Yet that doesn't necessarily mean that builds of other lanes
+	// (e.i CI, dev-preview) that produce the build after the specific nightly build date will certainly
+	// have the fix, thus we need to track them separately
+	StableSupportSince           = "4.20.0"
+	NightlySupportSince          = "4.20.0-0.nightly-2025-08-04-154809"
+	KonfluxNightlySupportSince   = "4.20.0-0.konflux-nightly-0000-00-00-000000"
+	CISupportSince               = "4.20.0-0.ci-0000-00-00-000000"
+	DevPreviewSupportSince       = "4.20.0-ec.0"
+	ReleaseCandidateSupportSince = "4.20.0-rc.0"
+)
+
+// isStable checks if the version matches the stable build form and returns least supported stable version
+func isStable(v string) (bool, string) {
+	// example: 4.20.1
+	if !strings.Contains(v, "-") {
+		return true, StableSupportSince
+	}
+	return false, ""
+}
+
+// isReleaseCandidate checks if the version matches the RC build form and returns least supported RC version
+func isReleaseCandidate(v string) (bool, string) {
+	// example: 4.20.0-rc.1
+	if strings.Contains(v, "-rc.") {
+		return true, ReleaseCandidateSupportSince
+	}
+	return false, ""
+}
+
+// isNightly checks if the version matches the nightly build form and returns least supported nightly version
+func isNightly(v string) (bool, string) {
+	// example: 4.20.0-0.nightly-2025-08-04-154809
+	if strings.Contains(v, ".nightly-") {
+		return true, NightlySupportSince
+	}
+	return false, ""
+}
+
+// isKonfluxNightly checks if the version matches the konflux-nightly build form and returns least supported konflux-nightly version
+func isKonfluxNightly(v string) (bool, string) {
+	// example: 4.19.0-0.konflux-nightly-2025-08-05-060813
+	if strings.Contains(v, ".konflux-nightly-") {
+		return true, KonfluxNightlySupportSince
+	}
+	return false, ""
+}
+
+// isCI checks if the version matches the CI build form and returns the least supported CI version
+func isCI(v string) (bool, string) {
+	// example: 4.19.0-0.ci-2025-08-05-050737
+	if strings.Contains(v, ".ci-") {
+		return true, CISupportSince
+	}
+	return false, ""
+}
+
+// isDevPreview checks if the version matches the dev-preview build form and returns the least supported dev-preview version
+func isDevPreview(v string) (bool, string) {
+	// example: 4.20.0-ec.5
+	if strings.Contains(v, "-ec.") {
+		return true, DevPreviewSupportSince
+	}
+	return false, ""
+}
+
+func GetLeastSupportedByBuildType(version platform.Version) (string, error) {
+	v := version.String()
+	if ok, leastSupported := isStable(v); ok {
+		return leastSupported, nil
+	}
+	if ok, leastSupported := isNightly(v); ok {
+		return leastSupported, nil
+	}
+
+	if ok, leastSupported := isKonfluxNightly(v); ok {
+		return leastSupported, nil
+	}
+
+	if ok, leastSupported := isCI(v); ok {
+		return leastSupported, nil
+	}
+
+	if ok, leastSupported := isDevPreview(v); ok {
+		return leastSupported, nil
+	}
+
+	if ok, leastSupported := isReleaseCandidate(v); ok {
+		return leastSupported, nil
+	}
+
+	return "", fmt.Errorf("version form %s is unrecognized", v)
+}
+
+func IsVersionFixed(platf platform.Platform, version platform.Version) bool {
+	if platf != platform.OpenShift && platf != platform.HyperShift {
+		return false
+	}
+
+	leastSupported, err := GetLeastSupportedByBuildType(version)
+	if err != nil {
+		klog.Infof("failed to get least supported version, err %v", err)
+		return false
+	}
+
+	parsedVersion, _ := platform.ParseVersion(leastSupported)
+	ok, err := version.AtLeast(parsedVersion)
+	if err != nil {
+		klog.Infof("failed to compare version %v with %v, err %v", parsedVersion, version, err)
+		return false
+	}
+
+	return ok
+}

--- a/internal/platform/activepodresources/supportversion_test.go
+++ b/internal/platform/activepodresources/supportversion_test.go
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package activepodresources
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+)
+
+func TestGetLeastSupportedByBuildType(t *testing.T) {
+	nightly, _ := platform.ParseVersion("4.20.0-0.nightly-2025-08-04-12")
+	konflux, _ := platform.ParseVersion("4.20.0-0.konflux-nightly-2025-08-04-12")
+	ci, _ := platform.ParseVersion("4.20.0-0.ci-2025-08-04-12")
+	ec, _ := platform.ParseVersion("4.20.0-ec.2")
+	rc, _ := platform.ParseVersion("4.20.0-rc.2")
+	stable, _ := platform.ParseVersion("4.20.0")
+	unrecognized, _ := platform.ParseVersion("4.20.0-unknown")
+
+	tests := []struct {
+		name                 string
+		version              platform.Version
+		leastSupportExpected string
+		err                  error
+	}{
+		{
+			name:                 "nightly",
+			version:              nightly,
+			leastSupportExpected: NightlySupportSince,
+		},
+		{
+			name:                 "stable",
+			version:              stable,
+			leastSupportExpected: StableSupportSince,
+		},
+		{
+			name:                 "ci",
+			version:              ci,
+			leastSupportExpected: CISupportSince,
+		},
+		{
+			name:                 "rc",
+			version:              rc,
+			leastSupportExpected: ReleaseCandidateSupportSince,
+		},
+		{
+			name:                 "ec",
+			version:              ec,
+			leastSupportExpected: DevPreviewSupportSince,
+		},
+		{
+			name:                 "konflux",
+			version:              konflux,
+			leastSupportExpected: KonfluxNightlySupportSince,
+		},
+		{
+			name:                 "unrecognized",
+			version:              unrecognized,
+			leastSupportExpected: "",
+			err:                  fmt.Errorf("version form %s is unrecognized", unrecognized),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetLeastSupportedByBuildType(tt.version)
+			if tt.err != nil {
+				if err == nil {
+					t.Fatalf("expected error but got nil")
+				}
+				if err.Error() != tt.err.Error() {
+					t.Fatalf("mismatching error string: error = %v, expected = %v", err, tt.err)
+				}
+				return
+			}
+
+			if tt.err == nil && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != tt.leastSupportExpected {
+				t.Errorf("GetLeastSupportedByBuildType() got = %v, want %v", got, tt.leastSupportExpected)
+			}
+		})
+	}
+}
+
+func TestIsVersionFixed(t *testing.T) {
+	nightlyGreater, _ := platform.ParseVersion("4.20.0-0.nightly-2025-08-04-154810")
+	k5xNightlyGreater, _ := platform.ParseVersion("4.20.0-0.konflux-nightly-2025-10-00-000000")
+	ciGreater, _ := platform.ParseVersion("4.20.0-0.ci-2025-10-00-000000")
+	stableGreater, _ := platform.ParseVersion("4.20.1")
+	ecGreater, _ := platform.ParseVersion("4.20.0-ec.2")
+	rcGreater, _ := platform.ParseVersion("4.20.0-rc.2")
+
+	unsupportedNightly, _ := platform.ParseVersion("4.20.0-0.nightly-2024-08-04-150000")
+	unsupportedStable, _ := platform.ParseVersion("4.19.0")
+
+	tests := []struct {
+		name    string
+		platf   platform.Platform
+		version platform.Version
+		want    bool
+	}{
+		{
+			name: "empty",
+			want: false,
+		},
+		{
+			name:    "nightly - least supported",
+			platf:   platform.OpenShift,
+			version: NightlySupportSince,
+			want:    true,
+		},
+		{
+			name:    "nightly - greater than least supported",
+			platf:   platform.OpenShift,
+			version: nightlyGreater,
+			want:    true,
+		},
+		{
+			name:    "nightly - unsupported",
+			platf:   platform.OpenShift,
+			version: unsupportedNightly,
+			want:    false,
+		},
+		{
+			name:    "konflux nightly - least supported",
+			platf:   platform.OpenShift,
+			version: KonfluxNightlySupportSince,
+			want:    true,
+		},
+		{
+			name:    "konflux nightly - greater than least supported",
+			platf:   platform.HyperShift,
+			version: k5xNightlyGreater,
+			want:    true,
+		},
+		{
+			name:    "stable - least supported",
+			platf:   platform.OpenShift,
+			version: StableSupportSince,
+			want:    true,
+		},
+		{
+			name:    "stable - greater than least supported",
+			platf:   platform.OpenShift,
+			version: stableGreater,
+			want:    true,
+		},
+		{
+			name:    "stable - unsupported",
+			platf:   platform.OpenShift,
+			version: unsupportedStable,
+			want:    false,
+		},
+		{
+			name:    "CI - least supported",
+			platf:   platform.OpenShift,
+			version: CISupportSince,
+			want:    true,
+		},
+		{
+			name:    "CI - greater than least supported",
+			platf:   platform.OpenShift,
+			version: ciGreater,
+			want:    true,
+		},
+		{
+			name:    "dev-preview - least supported",
+			platf:   platform.OpenShift,
+			version: DevPreviewSupportSince,
+			want:    true,
+		},
+		{
+			name:    "dev-preview - greater than least supported",
+			platf:   platform.OpenShift,
+			version: ecGreater,
+			want:    true,
+		},
+		{
+			name:    "release candidate - least supported",
+			platf:   platform.OpenShift,
+			version: ReleaseCandidateSupportSince,
+			want:    true,
+		},
+		{
+			name:    "release candidate - greater than least supported",
+			platf:   platform.OpenShift,
+			version: rcGreater,
+			want:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsVersionFixed(tt.platf, tt.version); got != tt.want {
+				t.Errorf("IsVersionFixed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The fix has landed in OCP nightly 4.20, make sure this is reflected to consume the new default of schedulerInformer in case it is not set.