### PR TITLE
AA: go: bump to 1.24

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "docker.io/golang:1.23",
+  "image": "docker.io/golang:1.24",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  GOLANG_VERSION: 1.23.3
+  GOLANG_VERSION: 1.24.7
 
 defaults:
   run:

--- a/.github/workflows/e2e-local.yaml
+++ b/.github/workflows/e2e-local.yaml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.3
+        go-version: 1.24.7
 
     - name: Verify modules
       run: go mod verify

--- a/.github/workflows/e2e-tools.yaml
+++ b/.github/workflows/e2e-tools.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.3
+        go-version: 1.24.7
 
     - name: Verify modules
       run: go mod verify

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.3
+        go-version: 1.24.7
 
     - name: Verify modules
       run: go mod verify

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up golang
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.3
+          go-version: 1.24.7
 
       - name: Show current working directory
         run: pwd

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-go@v5
         id: go
         with:
-          go-version: 1.23.3
+          go-version: 1.24.7
 
       - name: Set release version env var
         run: |

--- a/.github/workflows/support-tools.yaml
+++ b/.github/workflows/support-tools.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-go@v5
         id: go
         with:
-          go-version: 1.23.3
+          go-version: 1.24.7
 
   build:
     needs: [setup]

--- a/.konflux/Dockerfile.catalog
+++ b/.konflux/Dockerfile.catalog
@@ -1,6 +1,6 @@
 # The opm image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
 ARG OPM_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.20
-ARG BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.23
+ARG BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.24
 
 # build the catalog
 FROM ${BUILDER_IMAGE} AS builder

--- a/.konflux/operator/konflux.Dockerfile
+++ b/.konflux/operator/konflux.Dockerfile
@@ -1,4 +1,5 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.23@sha256:96cfceb50f5323efa1aa8569d4420cdbf1bb391225d5171ef72a0d0ecf028467 as builder
+# follow https://brewweb.engineering.redhat.com/brew/packageinfo?packageID=70135
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.24@sha256:b91431604c435f3cabec20ddb653c0537c8ba8097ada57960d54a1266f95a7c3 as builder
 
 WORKDIR /go/src/github.com/openshift-kni/numaresources-operator
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.23 AS builder
+FROM docker.io/golang:1.24 AS builder
 
 WORKDIR /go/src/github.com/openshift-kni/numaresources-operator
 COPY . .

--- a/Dockerfile.pause
+++ b/Dockerfile.pause
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.23 AS builder
+FROM docker.io/golang:1.24 AS builder
 
 WORKDIR /go/src/github.com/openshift-kni/numaresources-operator
 COPY . .

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.23 AS builder
+FROM docker.io/golang:1.24 AS builder
 
 WORKDIR /go/src/github.com/openshift-kni/numaresources-operator
 COPY . .

--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi
 
 ENV HOME=/home/ci
 ENV GOROOT=/usr/local/go
-ENV GOVERSION=1.23.3
+ENV GOVERSION=1.24.7
 ENV GOPATH=/go
 ENV GOBIN=${GOPATH}/bin
 ENV PATH=${PATH}:${GOROOT}/bin:${GOBIN}

--- a/test/deviceplugin/cmd/numacell/Dockerfile
+++ b/test/deviceplugin/cmd/numacell/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.23 AS builder
+FROM docker.io/golang:1.24 AS builder
 
 WORKDIR /go/src/github.com/openshift-kni/numaresources-operator
 COPY . .


### PR DESCRIPTION
Follow Openshift and bump to go v1.24.

Note: the below AI-Attribution tag was genereted using the https://aiattribution.github.io/create-attribution to interpret it please paste its value in
https://aiattribution.github.io/interpret-attribution.

Assisted-by: Cursor v1.2.2
AI-Attribution: AIA PAI Ce Hin R Cursor v1.2.2 model:gpt-5 v1.0