### PR TITLE
WIP: rbac: controllers: narrow down permissions

### DIFF
--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -62,7 +62,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-07-23T11:36:11Z"
+    createdAt: "2025-08-08T10:00:31Z"
     olm.skipRange: '>=4.19.0 <4.20.0'
     operatorframework.io/cluster-monitoring: "true"
     operators.operatorframework.io/builder: operator-sdk-v1.40.0

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -62,7 +62,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-08-08T10:00:51Z"
+    createdAt: "2025-08-13T11:15:13Z"
     olm.skipRange: '>=4.19.0 <4.20.0'
     operatorframework.io/cluster-monitoring: "true"
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
@@ -357,13 +357,6 @@ spec:
         - apiGroups:
           - ""
           resources:
-          - configmaps
-          - serviceaccounts
-          verbs:
-          - '*'
-        - apiGroups:
-          - ""
-          resources:
           - events
           verbs:
           - create
@@ -376,24 +369,9 @@ spec:
           - list
           - watch
         - apiGroups:
-          - ""
-          resources:
-          - pods
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
           - apiextensions.k8s.io
           resources:
           - customresourcedefinitions
-          verbs:
-          - '*'
-        - apiGroups:
-          - apps
-          resources:
-          - daemonsets
-          - deployments
           verbs:
           - '*'
         - apiGroups:
@@ -460,8 +438,6 @@ spec:
           resources:
           - clusterrolebindings
           - clusterroles
-          - rolebindings
-          - roles
           verbs:
           - '*'
         - apiGroups:
@@ -598,13 +574,37 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - configmaps
+          - serviceaccounts
           - services
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - deployments
           verbs:
           - '*'
         - apiGroups:
           - networking.k8s.io
           resources:
           - networkpolicies
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
           verbs:
           - '*'
         serviceAccountName: numaresources-controller-manager

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -62,7 +62,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-08-08T10:00:31Z"
+    createdAt: "2025-08-08T10:00:51Z"
     olm.skipRange: '>=4.19.0 <4.20.0'
     operatorframework.io/cluster-monitoring: "true"
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
@@ -434,8 +434,11 @@ spec:
           - nodetopology.openshift.io
           resources:
           - numaresourcesoperators
+          - numaresourcesschedulers
           verbs:
-          - '*'
+          - get
+          - list
+          - watch
         - apiGroups:
           - nodetopology.openshift.io
           resources:
@@ -452,18 +455,6 @@ spec:
           - get
           - patch
           - update
-        - apiGroups:
-          - nodetopology.openshift.io
-          resources:
-          - numaresourcesschedulers
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,14 +36,12 @@ import (
 	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
 	securityv1 "github.com/openshift/api/security/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/textlogger"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -261,13 +259,10 @@ func main() {
 
 	klog.InfoS("metrics server", "enabled", params.enableMetrics, "addr", params.metricsAddr)
 
+	lm := controller.NewLocalManager(namespace)
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Cache: cache.Options{
-			DefaultNamespaces: map[string]cache.Config{
-				namespace:            {},
-				metav1.NamespaceNone: {},
-			},
-		},
+		Cache:  lm.CacheOptions(),
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress:   params.metricsAddr,

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -84,8 +84,11 @@ rules:
   - nodetopology.openshift.io
   resources:
   - numaresourcesoperators
+  - numaresourcesschedulers
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
 - apiGroups:
   - nodetopology.openshift.io
   resources:
@@ -102,18 +105,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - nodetopology.openshift.io
-  resources:
-  - numaresourcesschedulers
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,13 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  - serviceaccounts
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
   - events
   verbs:
   - create
@@ -26,24 +19,9 @@ rules:
   - list
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  - deployments
   verbs:
   - '*'
 - apiGroups:
@@ -110,8 +88,6 @@ rules:
   resources:
   - clusterrolebindings
   - clusterroles
-  - rolebindings
-  - roles
   verbs:
   - '*'
 - apiGroups:
@@ -139,12 +115,36 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  - serviceaccounts
   - services
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
   verbs:
   - '*'
 - apiGroups:
   - networking.k8s.io
   resources:
   - networkpolicies
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
   verbs:
   - '*'

--- a/internal/controller/cache/ctrlcache.go
+++ b/internal/controller/cache/ctrlcache.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+	"sync"
+
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ObjectDeduper struct {
+	lock sync.Mutex
+	objs map[string]client.Object
+}
+
+func NewObjectDeduper(objs ...client.Object) *ObjectDeduper {
+	od := ObjectDeduper{
+		objs: make(map[string]client.Object),
+	}
+	for _, obj := range objs {
+		gvk := keyFor(obj)
+		od.objs[gvk] = obj
+	}
+	return &od
+}
+
+func (od *ObjectDeduper) UniquePtr(obj client.Object) client.Object {
+	od.lock.Lock()
+	defer od.lock.Unlock()
+	gvk := keyFor(obj)
+	if objKey, ok := od.objs[gvk]; ok {
+		klog.V(4).InfoS("reusing object pointer", "gvk", gvk)
+		return objKey
+	}
+	klog.V(4).InfoS("creating object pointer", "gvk", gvk)
+	od.objs[gvk] = obj
+	return obj
+}
+
+type ByObjectBuilder struct {
+	od   *ObjectDeduper
+	data map[client.Object]cache.ByObject
+}
+
+func MakeByObject(od *ObjectDeduper) *ByObjectBuilder {
+	return &ByObjectBuilder{
+		od:   od,
+		data: make(map[client.Object]cache.ByObject),
+	}
+}
+
+func (bob *ByObjectBuilder) For(obj client.Object, namespaces ...string) *ByObjectBuilder {
+	nsConf := map[string]cache.Config{}
+	for _, ns := range namespaces {
+		nsConf[ns] = cache.Config{}
+	}
+	bob.data[bob.od.UniquePtr(obj)] = cache.ByObject{
+		Namespaces: nsConf,
+	}
+	return bob
+}
+
+func (bob *ByObjectBuilder) Done() map[client.Object]cache.ByObject {
+	for obj, conf := range bob.data {
+		klog.V(2).InfoS("ByObject cache", "gvk", keyFor(obj), "namespaces", strings.Join(slices.Sorted(maps.Keys(conf.Namespaces)), ","))
+	}
+	return bob.data
+}
+
+func keyFor(obj client.Object) string {
+	objType := reflect.TypeOf(obj).Elem()
+	return objType.PkgPath() + "." + objType.Name()
+}

--- a/internal/controller/cachecontrol.go
+++ b/internal/controller/cachecontrol.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+
+	nropcache "github.com/openshift-kni/numaresources-operator/internal/controller/cache"
+)
+
+type LocalManager struct {
+	ns string
+	od *nropcache.ObjectDeduper
+}
+
+func NewLocalManager(namespace string) *LocalManager {
+	return &LocalManager{
+		ns: namespace,
+		od: nropcache.NewObjectDeduper(),
+	}
+}
+
+func (lm *LocalManager) CacheOptions() cache.Options {
+	namespace := lm.ns // shortcut
+	byObjCache := nropcache.MakeByObject(lm.od).
+		For(&corev1.Service{}, namespace).
+		For(&corev1.ServiceAccount{}, namespace).
+		For(&corev1.ConfigMap{}, namespace).
+		For(&corev1.Pod{}, namespace).
+		For(&rbacv1.Role{}, namespace).
+		For(&rbacv1.RoleBinding{}, namespace).
+		For(&appsv1.Deployment{}, namespace).
+		For(&appsv1.DaemonSet{}, namespace).
+		For(&networkingv1.NetworkPolicy{}, namespace).
+		Done()
+
+	return cache.Options{
+		ByObject: byObjCache,
+		DefaultNamespaces: map[string]cache.Config{
+			metav1.NamespaceAll: {},
+		},
+	}
+}

--- a/internal/controller/kubeletconfig_controller.go
+++ b/internal/controller/kubeletconfig_controller.go
@@ -87,6 +87,9 @@ type kubeletConfigHandler struct {
 	setCtrlRef func(owner, controlled metav1.Object, scheme *runtime.Scheme, opts ...controllerutil.OwnerReferenceOption) error
 }
 
+// Namespace Scoped
+
+// Cluster Scoped
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=*
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=kubeletconfigs,verbs=get;list;watch

--- a/internal/controller/kubeletconfig_controller.go
+++ b/internal/controller/kubeletconfig_controller.go
@@ -88,9 +88,9 @@ type kubeletConfigHandler struct {
 }
 
 // Namespace Scoped
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=*,namespace="numaresources"
 
 // Cluster Scoped
-//+kubebuilder:rbac:groups="",resources=configmaps,verbs=*
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=kubeletconfigs,verbs=get;list;watch
 //+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=kubeletconfigs/finalizers,verbs=update

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -24,6 +24,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -636,10 +637,12 @@ func (r *NUMAResourcesOperatorReconciler) SetupWithManager(mgr ctrl.Manager) err
 		handler.EnqueueRequestsFromMapFunc(r.configMapToNUMAResourceOperator),
 		builder.WithPredicates(configMapPredicates)).
 		Owns(&apiextensionv1.CustomResourceDefinition{}).
+		Owns(&corev1.Service{}, builder.WithPredicates(p)).
 		Owns(&corev1.ServiceAccount{}, builder.WithPredicates(p)).
 		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(p)).
 		Owns(&rbacv1.Role{}, builder.WithPredicates(p)).
 		Owns(&appsv1.DaemonSet{}, builder.WithPredicates(p)).
+		Owns(&networkingv1.NetworkPolicy{}, builder.WithPredicates(p)).
 		Complete(r)
 }
 

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -94,14 +94,11 @@ type NUMAResourcesOperatorReconciler struct {
 	ForwardMCPConds bool
 }
 
-// TODO: narrow down
-
 // Namespace Scoped
 //+kubebuilder:rbac:groups="",resources=services,verbs=*,namespace="numaresources"
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=*,namespace="numaresources"
 
 // Cluster Scoped
-//+kubebuilder:rbac:groups=topology.node.k8s.io,resources=noderesourcetopologies,verbs=get;list;create;update
 //+kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=list
 //+kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators,verbs=get
 //+kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -114,7 +114,7 @@ type NUMAResourcesOperatorReconciler struct {
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=*
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=list
-//+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesoperators,verbs=*
+//+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesoperators,verbs=get;list;watch
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesoperators/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesoperators/finalizers,verbs=update
 

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -95,25 +95,28 @@ type NUMAResourcesOperatorReconciler struct {
 }
 
 // Namespace Scoped
+//+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch,namespace="numaresources"
 //+kubebuilder:rbac:groups="",resources=services,verbs=*,namespace="numaresources"
+//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=*,namespace="numaresources"
+//+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=*,namespace="numaresources"
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=*,namespace="numaresources"
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=*,namespace="numaresources"
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=*,namespace="numaresources"
 
 // Cluster Scoped
 //+kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=list
 //+kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators,verbs=get
 //+kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get
-//+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigs,verbs=*
 //+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigpools,verbs=get;list;watch
+
+//+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigs,verbs=*
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=*
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=*
-//+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=*
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=*
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=*
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=*
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=*
-//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=*
-//+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=list
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesoperators,verbs=get;list;watch
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesoperators/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesoperators/finalizers,verbs=update

--- a/internal/controller/numaresourcesscheduler_controller.go
+++ b/internal/controller/numaresourcesscheduler_controller.go
@@ -93,7 +93,7 @@ type NUMAResourcesSchedulerReconciler struct {
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=*
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=*
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=list;watch
-//+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesschedulers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesschedulers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesschedulers/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesschedulers/finalizers,verbs=update
 

--- a/internal/controller/numaresourcesscheduler_controller.go
+++ b/internal/controller/numaresourcesscheduler_controller.go
@@ -23,6 +23,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -172,6 +173,7 @@ func (r *NUMAResourcesSchedulerReconciler) SetupWithManager(mgr ctrl.Manager) er
 		Owns(&corev1.ServiceAccount{}, builder.WithPredicates(p)).
 		Owns(&corev1.ConfigMap{}, builder.WithPredicates(p)).
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(p)).
+		Owns(&networkingv1.NetworkPolicy{}, builder.WithPredicates(p)).
 		Watches(&corev1.Node{}, handler.EnqueueRequestsFromMapFunc(r.nodeToNUMAResourcesScheduler),
 			builder.WithPredicates(nodesPredicate)).
 		Complete(r)

--- a/internal/controller/numaresourcesscheduler_controller.go
+++ b/internal/controller/numaresourcesscheduler_controller.go
@@ -84,15 +84,16 @@ type NUMAResourcesSchedulerReconciler struct {
 }
 
 // Namespace Scoped
+//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=*,namespace="numaresources"
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=*,namespace="numaresources"
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=*,namespace="numaresources"
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=*,namespace="numaresources"
 
 // Cluster Scoped
+//+kubebuilder:rbac:groups="",resources=nodes,verbs=list;watch
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=*
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=*
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=*
-//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=*
-//+kubebuilder:rbac:groups="",resources=configmaps,verbs=*
-//+kubebuilder:rbac:groups="",resources=nodes,verbs=list;watch
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesschedulers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesschedulers/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=nodetopology.openshift.io,resources=numaresourcesschedulers/finalizers,verbs=update

--- a/rte/main.go
+++ b/rte/main.go
@@ -47,6 +47,11 @@ const (
 	defaultTopologyManagerScope = "container"
 )
 
+// Namespace Scoped
+
+// Cluster Scoped
+//+kubebuilder:rbac:groups=topology.node.k8s.io,resources=noderesourcetopologies,verbs=get;list;create;update
+
 func main() {
 	bi := version.GetBuildInfo()
 	klog.Infof("starting %s %s %s\n", version.ExporterProgramName(), bi.String(), runtime.Version())


### PR DESCRIPTION
narrow down RBAC permissions in two ways:
1. (minor) reduce verb requirements; this is still ongoing and the changes in this area are just initial. We should avoid asterisk permission and always spell them out even if it's the full list.
2. (major) reduce scoping. Move from cluster-role to roles as much as possible. This requires also cache tunings to actually query the target namespace.

The PR is reviewable but should be merged post the 4.20 cutoff, and we need to careful test it works with different namespaces - I'm testing using the default `numaresources` namespace. The expectation is it does, but we need to verify both the component contracts and the actual behavior.

