### PR TITLE
e2e: Serial: Add test case ids to the leftover tests

### DIFF
--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -308,7 +308,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.SchedulerTestName)
 		})
 
-		It("should report the NodeGroupConfig in the status", Label("tier2", "openshift"), func() {
+		It("[test_id:84307] should report the NodeGroupConfig in the status", Label("tier2", "openshift"), func() {
 			nroKey := objects.NROObjectKey()
 			nroOperObj := nropv1.NUMAResourcesOperator{}
 
@@ -384,7 +384,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			Expect(err).ToNot(HaveOccurred(), "failed to check the NodeGroupConfig status for %q", nroKey.String())
 		})
 
-		It("should report relatedObjects in the status", Label("related_objects"), func(ctx context.Context) {
+		It("[test_id:84309] should report relatedObjects in the status", Label("related_objects"), func(ctx context.Context) {
 			By("getting NROP object")
 			nroKey := objects.NROObjectKey()
 			nroOperObj := nropv1.NUMAResourcesOperator{}
@@ -430,7 +430,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			Expect(nrsGot).To(Equal(nrsExpected), "mismatching related objects for NUMAResourcesScheduler")
 		})
 
-		It("ignores non-matching kubeletconfigs", Label(label.Slow, label.Tier1, label.OpenShift), func(ctx context.Context) {
+		It("[test_id:84310] ignores non-matching kubeletconfigs", Label(label.Slow, label.Tier1, label.OpenShift), func(ctx context.Context) {
 			By("getting the NROP object")
 			nroOperObj := &nropv1.NUMAResourcesOperator{}
 			nroKey := objects.NROObjectKey()
@@ -958,7 +958,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 				Expect(fxt.Client.Get(ctx, nroKey, initialOperObj)).To(Succeed(), "cannot get %q in the cluster", nroKey.String())
 			})
 
-			It("should not allow configuring PoolName and MCP selector on same node group", Label(label.Tier2), func(ctx context.Context) {
+			It("[test_id:84311] should not allow configuring PoolName and MCP selector on same node group", Label(label.Tier2), func(ctx context.Context) {
 				labelSel := &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"test2": "test2",
@@ -1004,7 +1004,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 				}).WithTimeout(5*time.Minute).WithPolling(5*time.Second).Should(Succeed(), "Timed out waiting for degraded condition")
 			})
 
-			It("should report the NodeGroupConfig in the NodeGroupStatus with NodePool set and allow updates", Label(label.Tier1, label.OpenShift), func(ctx context.Context) {
+			It("[test_id:84312] should report the NodeGroupConfig in the NodeGroupStatus with NodePool set and allow updates", Label(label.Tier1, label.OpenShift), func(ctx context.Context) {
 				mcp := objects.TestMCP()
 				By(fmt.Sprintf("create new MCP %q", mcp.Name))
 				// we rely on the fact that RTE DS will be created for a valid MCP even with machine count 0, that will
@@ -1270,7 +1270,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 				Expect(fxt.Client.Get(ctx, nroKey, nroObj)).To(Succeed(), "cannot get %q in the cluster", nroKey.String())
 			})
 
-			It("should reflect correct TM configuration in the NRT object attributes", Label(label.Tier0), func(ctx context.Context) {
+			It("[test_id:84315] should reflect correct TM configuration in the NRT object attributes", Label(label.Tier0), func(ctx context.Context) {
 				rteConfigMap := &corev1.ConfigMap{}
 				Eventually(func() bool {
 					updatedConfigMaps := &corev1.ConfigMapList{}
@@ -1320,7 +1320,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 				}
 			})
 
-			It("should change NRT attributes correctly when RTE is pointing to a different nodeGroup", Label(label.OpenShift, label.Slow, label.Tier2, label.Reboot), func(ctx context.Context) {
+			It("[test_id:84316] should change NRT attributes correctly when RTE is pointing to a different nodeGroup", Label(label.OpenShift, label.Slow, label.Tier2, label.Reboot), func(ctx context.Context) {
 				fxt.IsRebootTest = true
 				waitForMCPUpdateFunc := func(mcp *machineconfigv1.MachineConfigPool) {
 					_ = wait.With(fxt.Client).

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -110,7 +110,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 		})
 
 		When("invalid tolerations are submitted ", Label(label.Tier2), func() {
-			It("should handle invalid field: operator", func(ctx context.Context) {
+			It("[test_id:84302] should handle invalid field: operator", func(ctx context.Context) {
 				By("adding extra invalid tolerations with wrong operator field")
 				_ = setRTETolerations(ctx, fxt.Client, nroKey, []corev1.Toleration{
 					{
@@ -169,7 +169,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 			})
 		})
 
-		It("should enable to change tolerations in the RTE daemonsets", Label(label.Tier3), func(ctx context.Context) {
+		It("[test_id:84303] should enable to change tolerations in the RTE daemonsets", Label(label.Tier3), func(ctx context.Context) {
 			By("getting RTE manifests object")
 			// TODO: this is similar but not quite what the main operator does
 			rteManifests, err := rtemanifests.GetManifests(configuration.Plat, configuration.PlatVersion, "", true, true)
@@ -290,7 +290,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 				Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
 			})
 
-			It("should evict running RTE pod if taint-toleration matching criteria is shaken - NROP CR toleration update", Label(label.Tier3, label.Slow), func(ctx context.Context) {
+			It("[test_id:84304] should evict running RTE pod if taint-toleration matching criteria is shaken - NROP CR toleration update", Label(label.Tier3, label.Slow), func(ctx context.Context) {
 				By("add toleration with value to the NROP CR")
 				tolerateVal := corev1.Toleration{
 					Key:      testKey,
@@ -345,7 +345,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 				Expect(err).ToNot(HaveOccurred(), "pod %s/%s still exists", podOnNode.Namespace, podOnNode.Name)
 			})
 
-			It("should evict running RTE pod if taint-tolartion matching criteria is shaken - node taints update", Label(label.Tier3, label.Slow), func(ctx context.Context) {
+			It("[test_id:84305] should evict running RTE pod if taint-tolartion matching criteria is shaken - node taints update", Label(label.Tier3, label.Slow), func(ctx context.Context) {
 				By("taint one node with taint value and NoExecute effect")
 				var err error
 				workers, err = nodes.GetWorkers(fxt.DEnv())
@@ -711,7 +711,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 				})
 			})
 
-			It("should evict RTE pod on tainted node with NoExecute effect and restore it when taint is removed", Label(label.Tier3), func(ctx context.Context) {
+			It("[test_id:84306] should evict RTE pod on tainted node with NoExecute effect and restore it when taint is removed", Label(label.Tier3), func(ctx context.Context) {
 				By("taint one worker node with NoExecute effect")
 				var err error
 				workers, err = nodes.GetWorkers(fxt.DEnv())


### PR DESCRIPTION
This PR assigns unique IDs to previously un-tagged tests in the serial suite.