### PR TITLE
OCPBUGS-60848: controller: sched: detect and use cluster properties

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -60,6 +60,7 @@ import (
 	"github.com/openshift-kni/numaresources-operator/internal/api/features"
 	"github.com/openshift-kni/numaresources-operator/internal/controller"
 	intkloglevel "github.com/openshift-kni/numaresources-operator/internal/kloglevel"
+	"github.com/openshift-kni/numaresources-operator/internal/platforminfo"
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	"github.com/openshift-kni/numaresources-operator/pkg/images"
 	rtemetricsmanifests "github.com/openshift-kni/numaresources-operator/pkg/metrics/manifests/monitor"
@@ -338,10 +339,7 @@ func main() {
 			Scheme:             mgr.GetScheme(),
 			SchedulerManifests: schedMf,
 			Namespace:          namespace,
-			PlatformInfo: controller.PlatformInfo{
-				Platform: clusterPlatform,
-				Version:  clusterPlatformVersion,
-			},
+			PlatformInfo:       platforminfo.New(clusterPlatform, clusterPlatformVersion),
 		}).SetupWithManager(mgr); err != nil {
 			klog.ErrorS(err, "unable to create controller", "controller", "NUMAResourcesScheduler")
 			os.Exit(1)

--- a/internal/controller/numaresourcesscheduler_controller.go
+++ b/internal/controller/numaresourcesscheduler_controller.go
@@ -47,6 +47,7 @@ import (
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
 	"github.com/openshift-kni/numaresources-operator/internal/api/annotations"
+	"github.com/openshift-kni/numaresources-operator/internal/platforminfo"
 	"github.com/openshift-kni/numaresources-operator/internal/relatedobjects"
 	"github.com/openshift-kni/numaresources-operator/pkg/apply"
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
@@ -60,18 +61,9 @@ import (
 )
 
 const (
-	// ActivePodsResourcesSupportSince defines the OCP version which started to support the fixed kubelet
-	// in which the PodResourcesAPI lists the active pods by default
-	activePodsResourcesSupportSince = "4.20.999"
-
 	// MaxSchedulerReplicas is the maximum number of scheduler replicas that can be deployed
 	MaxSchedulerReplicas = 3
 )
-
-type PlatformInfo struct {
-	Platform platform.Platform
-	Version  platform.Version
-}
 
 // NUMAResourcesSchedulerReconciler reconciles a NUMAResourcesScheduler object
 type NUMAResourcesSchedulerReconciler struct {
@@ -79,7 +71,7 @@ type NUMAResourcesSchedulerReconciler struct {
 	Scheme             *runtime.Scheme
 	SchedulerManifests schedmanifests.Manifests
 	Namespace          string
-	PlatformInfo       PlatformInfo
+	PlatformInfo       platforminfo.PlatformInfo
 }
 
 // Namespace Scoped
@@ -359,26 +351,21 @@ func (r *NUMAResourcesSchedulerReconciler) syncNUMASchedulerResources(ctx contex
 	return schedStatus, nil
 }
 
-func platformNormalize(spec *nropv1.NUMAResourcesSchedulerSpec, platInfo PlatformInfo) {
+func platformNormalize(spec *nropv1.NUMAResourcesSchedulerSpec, platInfo platforminfo.PlatformInfo) {
 	if platInfo.Platform != platform.OpenShift && platInfo.Platform != platform.HyperShift {
 		return
 	}
-
-	parsedVersion, _ := platform.ParseVersion(activePodsResourcesSupportSince)
-	ok, err := platInfo.Version.AtLeast(parsedVersion)
-	if err != nil {
-		klog.Infof("failed to compare version %v with %v, err %v", parsedVersion, platInfo.Version, err)
+	if spec.SchedulerInformer != nil {
+		// assume user-provided value. Nothing to do.
+		klog.V(4).InfoS("SchedulerInformer explicit value", "Platform", platInfo.Platform, "PlatformVersion", platInfo.Version.String(), "SchedulerInformer", *spec.SchedulerInformer)
 		return
 	}
-
-	if !ok {
+	if !platInfo.Properties.PodResourcesListFilterActivePods {
+		// keep shared default for backward compatibility. TODO: review/switch default in 4.21
 		return
 	}
-
-	if spec.SchedulerInformer == nil {
-		spec.SchedulerInformer = ptr.To(nropv1.SchedulerInformerShared)
-		klog.V(4).InfoS("SchedulerInformer default is overridden", "Platform", platInfo.Platform, "PlatformVersion", platInfo.Version.String(), "SchedulerInformer", &spec.SchedulerInformer)
-	}
+	spec.SchedulerInformer = ptr.To(nropv1.SchedulerInformerShared)
+	klog.V(4).InfoS("SchedulerInformer default is overridden", "Platform", platInfo.Platform, "PlatformVersion", platInfo.Version.String(), "SchedulerInformer", *spec.SchedulerInformer)
 }
 
 func buildDedicatedInformerCondition(instance nropv1.NUMAResourcesScheduler, normalized nropv1.NUMAResourcesSchedulerSpec) metav1.Condition {

--- a/internal/platforminfo/platforminfo.go
+++ b/internal/platforminfo/platforminfo.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package platforminfo
+
+import (
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+)
+
+// PlatformProperties represents the platform capabilities we have to infer and which are not explicitly
+// advertised from the platform using standard APIs.
+type PlatformProperties struct {
+	PodResourcesListFilterActivePods bool
+}
+
+type PlatformInfo struct {
+	Platform   platform.Platform
+	Version    platform.Version
+	Properties PlatformProperties
+}
+
+func New(plat platform.Platform, ver platform.Version) PlatformInfo {
+	info := PlatformInfo{
+		Platform: plat,
+		Version:  ver,
+	}
+	discoverProperties(&info)
+	return info
+}
+
+func discoverProperties(info *PlatformInfo) {
+	info.Properties.PodResourcesListFilterActivePods = isVersionEnoughForPodresourcesListFilterActivePods(info.Platform, info.Version)
+}

--- a/internal/platforminfo/platforminfo_test.go
+++ b/internal/platforminfo/platforminfo_test.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package platforminfo
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+)
+
+func TestNewWithDiscover(t *testing.T) {
+	testcases := []struct {
+		description string
+		plat        platform.Platform
+		ver         platform.Version
+		expected    PlatformProperties
+	}{
+		{
+			description: "empty",
+		},
+		{
+			description: "last major unfixed",
+			plat:        platform.OpenShift,
+			ver:         mustParseVersion("4.19.0"),
+			expected: PlatformProperties{
+				PodResourcesListFilterActivePods: false,
+			},
+		},
+		{
+			description: "first major fixed",
+			plat:        platform.OpenShift,
+			ver:         mustParseVersion("4.20.0"), // at time of writing
+			expected: PlatformProperties{
+				PodResourcesListFilterActivePods: true,
+			},
+		},
+		{
+			description: "next Z-stream fixed, must never regress", // at time of writing
+			plat:        platform.OpenShift,
+			ver:         mustParseVersion("4.20.1"),
+			expected: PlatformProperties{
+				PodResourcesListFilterActivePods: true,
+			},
+		},
+		{
+			description: "next major fixed, must never regress", // at time of writing
+			plat:        platform.OpenShift,
+			ver:         mustParseVersion("4.21.0"),
+			expected: PlatformProperties{
+				PodResourcesListFilterActivePods: true,
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			got := New(tc.plat, tc.ver)
+			if !reflect.DeepEqual(got.Properties, tc.expected) {
+				t.Errorf("expected %#v got %#v", tc.expected, got.Properties)
+			}
+		})
+	}
+}
+
+func mustParseVersion(ver string) platform.Version {
+	v, err := platform.ParseVersion(ver)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}

--- a/internal/platforminfo/supportversion.go
+++ b/internal/platforminfo/supportversion.go
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package platforminfo
+
+import (
+	"strings"
+
+	"k8s.io/klog/v2"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+)
+
+// This file processes the known OCP platform versions, so far nightly, konflux-nightly, CI, dev-preview, and RC
+
+// supported version for the podresources List API fix.
+// see: https://issues.redhat.com/browse/OCPBUGS-56785
+// see: https://github.com/kubernetes/kubernetes/pull/132028
+const (
+	// first OCP build to have the fix is always the nightly build. Yet that doesn't necessarily mean that builds of other lanes
+	// (e.i CI, dev-preview) that produce the build after the specific nightly build date will certainly
+	// have the fix, thus we need to track them separately
+	StableSupportSince           = "4.20.0"
+	NightlySupportSince          = "4.20.0-0.nightly-2025-08-04-154809"
+	KonfluxNightlySupportSince   = "4.20.0-0.konflux-nightly-0000-00-00-000000"
+	CISupportSince               = "4.20.0-0.ci-0000-00-00-000000"
+	DevPreviewSupportSince       = "4.20.0-ec.0"
+	ReleaseCandidateSupportSince = "4.20.0-rc.0"
+)
+
+func decodeMinimumVersion(version platform.Version) string {
+	v := version.String()
+	// Nightly; example: 4.20.0-0.nightly-2025-08-04-154809
+	if strings.Contains(v, ".nightly-") {
+		return NightlySupportSince
+	}
+	// K5x nightly; example: 4.19.0-0.konflux-nightly-2025-08-05-060813
+	if strings.Contains(v, ".konflux-nightly-") {
+		return KonfluxNightlySupportSince
+	}
+	// CI; example: 4.19.0-0.ci-2025-08-05-050737
+	if strings.Contains(v, ".ci-") {
+		return CISupportSince
+	}
+	// DevPreview; example: 4.20.0-ec.5
+	if strings.Contains(v, "-ec.") {
+		return DevPreviewSupportSince
+	}
+	// Release Candidate: example: 4.20.0-rc.1
+	if strings.Contains(v, "-rc.") {
+		return ReleaseCandidateSupportSince
+	}
+	// Stable: example: 4.20.1
+	if !strings.Contains(v, "-") {
+		return StableSupportSince
+	}
+	return ""
+}
+
+func isVersionEnoughForPodresourcesListFilterActivePods(platf platform.Platform, version platform.Version) bool {
+	if platf != platform.OpenShift && platf != platform.HyperShift {
+		return false
+	}
+
+	minVer := decodeMinimumVersion(version)
+	if minVer == "" {
+		// should never happen, so we are loud about it
+		klog.Infof("unrecognized version %q", version)
+		return false
+	}
+
+	parsedVersion, err := platform.ParseVersion(minVer)
+	if err != nil {
+		// should never happen, so we are loud about it
+		klog.Infof("failed to parse version %q: %v", minVer, err)
+		return false
+	}
+
+	ok, err := version.AtLeast(parsedVersion)
+	if err != nil {
+		klog.Infof("failed to compare version %v with %v, err %v", parsedVersion, version, err)
+		return false
+	}
+
+	return ok
+}

--- a/internal/platforminfo/supportversion_test.go
+++ b/internal/platforminfo/supportversion_test.go
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package platforminfo
+
+import (
+	"testing"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+)
+
+func TestDecodeMinimumVersion(t *testing.T) {
+	nightly, _ := platform.ParseVersion("4.20.0-0.nightly-2025-08-04-12")
+	konflux, _ := platform.ParseVersion("4.20.0-0.konflux-nightly-2025-08-04-12")
+	ci, _ := platform.ParseVersion("4.20.0-0.ci-2025-08-04-12")
+	ec, _ := platform.ParseVersion("4.20.0-ec.2")
+	rc, _ := platform.ParseVersion("4.20.0-rc.2")
+	stable, _ := platform.ParseVersion("4.20.0")
+	unrecognized, _ := platform.ParseVersion("4.20.0-unknown")
+
+	tests := []struct {
+		name                 string
+		version              platform.Version
+		leastSupportExpected string
+		shouldBeUnrecognized bool
+	}{
+		{
+			name:                 "nightly",
+			version:              nightly,
+			leastSupportExpected: NightlySupportSince,
+		},
+		{
+			name:                 "stable",
+			version:              stable,
+			leastSupportExpected: StableSupportSince,
+		},
+		{
+			name:                 "ci",
+			version:              ci,
+			leastSupportExpected: CISupportSince,
+		},
+		{
+			name:                 "rc",
+			version:              rc,
+			leastSupportExpected: ReleaseCandidateSupportSince,
+		},
+		{
+			name:                 "ec",
+			version:              ec,
+			leastSupportExpected: DevPreviewSupportSince,
+		},
+		{
+			name:                 "konflux",
+			version:              konflux,
+			leastSupportExpected: KonfluxNightlySupportSince,
+		},
+		{
+			name:                 "unrecognized",
+			version:              unrecognized,
+			leastSupportExpected: "",
+			shouldBeUnrecognized: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := decodeMinimumVersion(tt.version)
+			if tt.shouldBeUnrecognized {
+				if got != "" {
+					t.Fatalf("expected unrecognized, but got %q", tt.version)
+				}
+				return
+			}
+
+			if !tt.shouldBeUnrecognized && got == "" {
+				t.Fatalf("unexpected unrecognized version: got %v from %v", got, tt.version)
+			}
+
+			if got != tt.leastSupportExpected {
+				t.Errorf("DecodeMinimumVersion() got = %v, want %v", got, tt.leastSupportExpected)
+			}
+		})
+	}
+}
+
+func TestIsVersionEnoughForPodresourcesListFilterActivePods(t *testing.T) {
+	nightlyGreater, _ := platform.ParseVersion("4.20.0-0.nightly-2025-08-04-154810")
+	k5xNightlyGreater, _ := platform.ParseVersion("4.20.0-0.konflux-nightly-2025-10-00-000000")
+	ciGreater, _ := platform.ParseVersion("4.20.0-0.ci-2025-10-00-000000")
+	stableGreater, _ := platform.ParseVersion("4.20.1")
+	ecGreater, _ := platform.ParseVersion("4.20.0-ec.2")
+	rcGreater, _ := platform.ParseVersion("4.20.0-rc.2")
+
+	unsupportedNightly, _ := platform.ParseVersion("4.20.0-0.nightly-2024-08-04-150000")
+	unsupportedStable, _ := platform.ParseVersion("4.19.0")
+
+	tests := []struct {
+		name    string
+		platf   platform.Platform
+		version platform.Version
+		want    bool
+	}{
+		{
+			name: "empty",
+			want: false,
+		},
+		{
+			name:    "nightly - least supported",
+			platf:   platform.OpenShift,
+			version: NightlySupportSince,
+			want:    true,
+		},
+		{
+			name:    "nightly - greater than least supported",
+			platf:   platform.OpenShift,
+			version: nightlyGreater,
+			want:    true,
+		},
+		{
+			name:    "nightly - unsupported",
+			platf:   platform.OpenShift,
+			version: unsupportedNightly,
+			want:    false,
+		},
+		{
+			name:    "konflux nightly - least supported",
+			platf:   platform.OpenShift,
+			version: KonfluxNightlySupportSince,
+			want:    true,
+		},
+		{
+			name:    "konflux nightly - greater than least supported",
+			platf:   platform.HyperShift,
+			version: k5xNightlyGreater,
+			want:    true,
+		},
+		{
+			name:    "stable - least supported",
+			platf:   platform.OpenShift,
+			version: StableSupportSince,
+			want:    true,
+		},
+		{
+			name:    "stable - greater than least supported",
+			platf:   platform.OpenShift,
+			version: stableGreater,
+			want:    true,
+		},
+		{
+			name:    "stable - unsupported",
+			platf:   platform.OpenShift,
+			version: unsupportedStable,
+			want:    false,
+		},
+		{
+			name:    "CI - least supported",
+			platf:   platform.OpenShift,
+			version: CISupportSince,
+			want:    true,
+		},
+		{
+			name:    "CI - greater than least supported",
+			platf:   platform.OpenShift,
+			version: ciGreater,
+			want:    true,
+		},
+		{
+			name:    "dev-preview - least supported",
+			platf:   platform.OpenShift,
+			version: DevPreviewSupportSince,
+			want:    true,
+		},
+		{
+			name:    "dev-preview - greater than least supported",
+			platf:   platform.OpenShift,
+			version: ecGreater,
+			want:    true,
+		},
+		{
+			name:    "release candidate - least supported",
+			platf:   platform.OpenShift,
+			version: ReleaseCandidateSupportSince,
+			want:    true,
+		},
+		{
+			name:    "release candidate - greater than least supported",
+			platf:   platform.OpenShift,
+			version: rcGreater,
+			want:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isVersionEnoughForPodresourcesListFilterActivePods(tt.platf, tt.version); got != tt.want {
+				t.Errorf("isVersionEnoughForPodresourcesListFilterActivePods() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The fix has landed in OCP nightly 4.20, make sure this is reflected to consume the new default of schedulerInformer in case it is not set by the user.

Previously the version parsing relied on the assumption that the platform version is of type stable (e.i 4.20.1, 4.20.2 ..) but this is in correct because the cluster may be deployed with different types of builds and each requires its own processing logic, which must know the first supported build for each type. Ensure that the different types are recognized and processed as required.

Design notes:
moved platforminfo in a separate package, still internal. Previously, it was a private controller helper. Moved into a new packge mostly because didn't want to pollute controllers with version check.

Added a Properties sub-struct vs add straight into the PlatformInfo the value. This is debatable. We don't plan to add more properties, so why to bother? Thing is, I can't remember a time on which I added a specific flag or field top-level and never regret later on. At very least we have namespaced properties which is nicer. I acknowledge the tension between not overcomplicate things, not do things "just in case" (there is no future expansion on the radar) but still if we don't namespace things early on, it's harder to retrofit. So went with this approach this time, but again, is debatable.

The same line of thought lead to implement the version check in a specific, non-generic way tailor made for this case, exactly because we don't see more usecases coming so generalizing felt overkill.

The summarization is thus that the **internal** API was made extensible (even if we don't see extensions happening) because APIs are harder to change, so "just in case" has more merit here. The implementation, on the other hand, is simpler to change and addresses only the problem at hand.

PlatformInfo is heavily overused. Should probably be ClusterInfo.

Replaces: https://github.com/openshift-kni/numaresources-operator/pull/1748