### PR TITLE
platforminfo: update first builds that has the kubelet fix

### DIFF
--- a/internal/platforminfo/supportversion.go
+++ b/internal/platforminfo/supportversion.go
@@ -35,9 +35,8 @@ const (
 	// have the fix, thus we need to track them separately
 	StableSupportSince           = "4.20.0"
 	NightlySupportSince          = "4.20.0-0.nightly-2025-08-04-154809"
-	KonfluxNightlySupportSince   = "4.20.0-0.konflux-nightly-0000-00-00-000000"
-	CISupportSince               = "4.20.0-0.ci-0000-00-00-000000"
-	DevPreviewSupportSince       = "4.20.0-ec.0"
+	CISupportSince               = "4.20.0-0.ci-2025-08-01-195417"
+	DevPreviewSupportSince       = "4.20.0-ec.6"
 	ReleaseCandidateSupportSince = "4.20.0-rc.0"
 )
 
@@ -46,10 +45,6 @@ func decodeMinimumVersion(version platform.Version) string {
 	// Nightly; example: 4.20.0-0.nightly-2025-08-04-154809
 	if strings.Contains(v, ".nightly-") {
 		return NightlySupportSince
-	}
-	// K5x nightly; example: 4.19.0-0.konflux-nightly-2025-08-05-060813
-	if strings.Contains(v, ".konflux-nightly-") {
-		return KonfluxNightlySupportSince
 	}
 	// CI; example: 4.19.0-0.ci-2025-08-05-050737
 	if strings.Contains(v, ".ci-") {

--- a/internal/platforminfo/supportversion_test.go
+++ b/internal/platforminfo/supportversion_test.go
@@ -24,7 +24,6 @@ import (
 
 func TestDecodeMinimumVersion(t *testing.T) {
 	nightly, _ := platform.ParseVersion("4.20.0-0.nightly-2025-08-04-12")
-	konflux, _ := platform.ParseVersion("4.20.0-0.konflux-nightly-2025-08-04-12")
 	ci, _ := platform.ParseVersion("4.20.0-0.ci-2025-08-04-12")
 	ec, _ := platform.ParseVersion("4.20.0-ec.2")
 	rc, _ := platform.ParseVersion("4.20.0-rc.2")
@@ -63,11 +62,6 @@ func TestDecodeMinimumVersion(t *testing.T) {
 			leastSupportExpected: DevPreviewSupportSince,
 		},
 		{
-			name:                 "konflux",
-			version:              konflux,
-			leastSupportExpected: KonfluxNightlySupportSince,
-		},
-		{
 			name:                 "unrecognized",
 			version:              unrecognized,
 			leastSupportExpected: "",
@@ -98,10 +92,9 @@ func TestDecodeMinimumVersion(t *testing.T) {
 
 func TestIsVersionEnoughForPodresourcesListFilterActivePods(t *testing.T) {
 	nightlyGreater, _ := platform.ParseVersion("4.20.0-0.nightly-2025-08-04-154810")
-	k5xNightlyGreater, _ := platform.ParseVersion("4.20.0-0.konflux-nightly-2025-10-00-000000")
 	ciGreater, _ := platform.ParseVersion("4.20.0-0.ci-2025-10-00-000000")
 	stableGreater, _ := platform.ParseVersion("4.20.1")
-	ecGreater, _ := platform.ParseVersion("4.20.0-ec.2")
+	ecGreater, _ := platform.ParseVersion("4.20.0-ec.8")
 	rcGreater, _ := platform.ParseVersion("4.20.0-rc.2")
 
 	unsupportedNightly, _ := platform.ParseVersion("4.20.0-0.nightly-2024-08-04-150000")
@@ -134,18 +127,6 @@ func TestIsVersionEnoughForPodresourcesListFilterActivePods(t *testing.T) {
 			platf:   platform.OpenShift,
 			version: unsupportedNightly,
 			want:    false,
-		},
-		{
-			name:    "konflux nightly - least supported",
-			platf:   platform.OpenShift,
-			version: KonfluxNightlySupportSince,
-			want:    true,
-		},
-		{
-			name:    "konflux nightly - greater than least supported",
-			platf:   platform.HyperShift,
-			version: k5xNightlyGreater,
-			want:    true,
 		},
 		{
 			name:    "stable - least supported",


### PR DESCRIPTION
Update the different types of build releases that had the kubelet PodResourceAPI fix first.

CI and Nightly confirmed using sippy: https://sippy.dptools.openshift.org/sippy-ng/pull_requests/Presubmits
Konflux nightly builds are meant for internal testing only and should be
ignored.