### PR TITLE
e2e: ensure sched pod count is correct for different ocp versions

### DIFF
--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -849,7 +849,8 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 
 			schedPods, err := podlist.With(fxt.Client).ByDeployment(ctx, *schedDeployment)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(schedPods).To(HaveLen(1))
+			schedPodsReplicas := *schedDeployment.Spec.Replicas
+			Expect(schedPods).To(HaveLen(int(schedPodsReplicas)))
 
 			schedulerName = nroSchedObj.Status.SchedulerName
 			Expect(schedulerName).ToNot(BeEmpty(), "cannot autodetect the TAS scheduler name from the cluster")


### PR DESCRIPTION
As of version 4.20, the scheduler deployment will consist of 3 pods instead of 1. Added logic to correctly identify the running version so test 75354 won't break from 4.20 onwards.