### PR TITLE
sched: report computed replicas in status

### DIFF
--- a/api/v1/numaresourcesscheduler_types.go
+++ b/api/v1/numaresourcesscheduler_types.go
@@ -132,9 +132,15 @@ type NUMAResourcesSchedulerStatus struct {
 	// +optional
 	//+operator-sdk:csv:customresourcedefinitions:type=status,displayName="Scheduler cache resync period"
 	CacheResyncPeriod *metav1.Duration `json:"cacheResyncPeriod,omitempty"`
+	// Computed scheduler replicas
+	// +optional
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Scheduler replicas",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:int"}
+	Replicas *int32 `json:"replicas,omitempty"`
 	// Conditions show the current state of the NUMAResourcesOperator Operator
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 	// RelatedObjects list of objects of interest for this operator
+	// +optional
 	//+operator-sdk:csv:customresourcedefinitions:type=status,displayName="Related Objects"
 	RelatedObjects []configv1.ObjectReference `json:"relatedObjects,omitempty"`
 }

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -300,6 +300,11 @@ func (in *NUMAResourcesSchedulerStatus) DeepCopyInto(out *NUMAResourcesScheduler
 		*out = new(metav1.Duration)
 		**out = **in
 	}
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]metav1.Condition, len(*in))

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesschedulers.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesschedulers.yaml
@@ -214,6 +214,10 @@ spec:
                   - resource
                   type: object
                 type: array
+              replicas:
+                description: Computed scheduler replicas
+                format: int32
+                type: integer
               schedulerName:
                 description: Scheduler name to be used in pod templates
                 type: string

--- a/internal/controller/numaresourcesscheduler_controller.go
+++ b/internal/controller/numaresourcesscheduler_controller.go
@@ -302,6 +302,7 @@ func (r *NUMAResourcesSchedulerReconciler) syncNUMASchedulerResources(ctx contex
 	schedStatus.CacheResyncPeriod = &metav1.Duration{
 		Duration: cacheResyncPeriod,
 	}
+	schedStatus.Replicas = replicas
 
 	informerCondition := buildDedicatedInformerCondition(*instance, schedSpec)
 	schedStatus.Conditions = status.GetUpdatedSchedulerConditions(schedStatus.Conditions, informerCondition)


### PR DESCRIPTION
the scheduler can compute automatically the scheduler replicas (HA by default). It is better and friendlier (for humans and programs) to have direct visibility of the computed values in the NUMAResourcesScheduler status.

In general, all the autodetermined values should have explicit feedback in the status, because this represent the desired state.