### PR TITLE
sched: status: reset the status conditions to defaults

### DIFF
--- a/internal/controller/numaresourcesscheduler_controller.go
+++ b/internal/controller/numaresourcesscheduler_controller.go
@@ -304,7 +304,8 @@ func (r *NUMAResourcesSchedulerReconciler) syncNUMASchedulerResources(ctx contex
 	}
 
 	informerCondition := buildDedicatedInformerCondition(*instance, schedSpec)
-	schedStatus.Conditions = status.GetUpdatedSchedulerConditions(schedStatus.Conditions, informerCondition)
+	// intentionally override with nil conditions to trigger a reset of the old status conditions
+	schedStatus.Conditions = status.GetUpdatedSchedulerConditions(nil, informerCondition)
 
 	r.SchedulerManifests.Deployment.Spec.Replicas = schedSpec.Replicas
 	klog.V(4).InfoS("using scheduler replicas", "replicas", *r.SchedulerManifests.Deployment.Spec.Replicas)

--- a/test/e2e/sched/install/install_test.go
+++ b/test/e2e/sched/install/install_test.go
@@ -45,7 +45,7 @@ import (
 
 var _ = Describe("[Scheduler] install", func() {
 	Context("with a running cluster with all the components", func() {
-		It("[test_id:48598] should perform the scheduler deployment and verify the condition is reported as available", Label(label.Tier2), func() {
+		It("[test_id:48598] should perform the scheduler deployment and verify it is reported as available with healthy conditions", Label(label.Tier2), func() {
 			var err error
 			nroSchedObj := objects.TestNROScheduler()
 
@@ -65,15 +65,8 @@ var _ = Describe("[Scheduler] install", func() {
 					return false
 				}
 
-				cond := status.FindCondition(updatedNROObj.Status.Conditions, status.ConditionAvailable)
-				if cond == nil {
-					klog.InfoS("missing conditions", "nroObj", updatedNROObj)
-					return false
-				}
-
-				klog.InfoS("scheduler status", "availableCondition", cond, "conditions", updatedNROObj.Status.Conditions)
-
-				return cond.Status == metav1.ConditionTrue
+				klog.InfoS("scheduler status", "conditions", updatedNROObj.Status.Conditions)
+				return isReportedAvailable(updatedNROObj.Status.Conditions)
 			}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).Should(BeTrue(), "NRO Scheduler condition did not become available")
 
 			err = e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroSchedObj), nroSchedObj)
@@ -118,3 +111,49 @@ var _ = Describe("[Scheduler] install", func() {
 		})
 	})
 })
+
+func isReportedAvailable(conditions []metav1.Condition) bool {
+	// conditions that should be True
+	availableCond := status.FindCondition(conditions, status.ConditionAvailable)
+	if availableCond == nil {
+		klog.InfoS("missing available condition status")
+		return false
+	}
+	if availableCond.Status != metav1.ConditionTrue {
+		klog.Info("scheduler not reported as available")
+		return false
+	}
+
+	upgradeCond := status.FindCondition(conditions, status.ConditionUpgradeable)
+	if upgradeCond == nil {
+		klog.InfoS("missing upgradeable condition status")
+		return false
+	}
+	if upgradeCond.Status != metav1.ConditionTrue {
+		klog.Info("scheduler not reported as upgradeable")
+		return false
+	}
+
+	// conditions that should be False
+	degradedCond := status.FindCondition(conditions, status.ConditionDegraded)
+	if degradedCond == nil {
+		klog.Info("missing degraded condition status")
+		return false
+	}
+	if degradedCond.Status == metav1.ConditionTrue {
+		klog.Info("scheduler reported as degraded")
+		return false
+	}
+
+	progressCond := status.FindCondition(conditions, status.ConditionProgressing)
+	if progressCond == nil {
+		klog.Info("missing progressing condition status")
+		return false
+	}
+	if progressCond.Status == metav1.ConditionTrue {
+		klog.Info("scheduler reported as progressing")
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
The problem with the current implementation is that if the status condition A is updated to `True` (like Progressing or Degraded condition) it will never be updated again if the reconcilation interation is not updating that exact condition. This creates accumulated status conditions as follows:

```
    conditions:
    - lastTransitionTime: "2025-09-09T10:24:02Z"
      message: ""
      reason: AsExpected
      status: "True"
      type: Available
    - lastTransitionTime: "2025-09-09T10:24:02Z"
      message: ""
      reason: Upgradeable
      status: "True"
      type: Upgradeable
    - lastTransitionTime: "2025-09-09T10:23:47Z"
      message: ""
      reason: AsExpected
      status: "True"
      type: Progressing
    - lastTransitionTime: "2025-09-09T10:23:47Z"
      message: 'could not apply (apps/v1, Kind=Deployment) openshift-numaresources/secondary-scheduler:
        could not update object (apps/v1, Kind=Deployment) openshift-numaresources/secondary-scheduler:
        Operation cannot be fulfilled on deployments.apps "secondary-scheduler": the
        object has been modified; please apply your changes to the latest version
        and try again'
      reason: InternalError
      status: "True"
      type: Degraded
    - lastTransitionTime: "2025-09-09T10:24:02Z"
      message: ""
      observedGeneration: 1
      reason: DedicatedInformerActive
      status: "False"
      type: DedicatedInformerActive
```

From which the user cannot know what condition is the true one. To fix this, in the phase where the scheduler status is being updated, make the status starts with default conditions instead of the old ones to ensure a reset of the old conditions and a fresh start.

This is a reporting issue and doesn't affect the scheduler functionality.