### PR TITLE
status: cleanup and redesign

### DIFF
--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -195,7 +195,7 @@ func updateStatusConditionsIfNeeded(instance *nropv1.NUMAResourcesOperator, cond
 		return
 	}
 	klog.InfoS("updateStatus", "condition", cond.Type, "reason", cond.Reason, "message", cond.Message)
-	conditions, ok := status.UpdateConditions(instance.Status.Conditions, cond.Type, cond.Reason, cond.Message)
+	conditions, ok := status.ComputeConditions(instance.Status.Conditions, cond.Type, cond.Reason, cond.Message)
 	if ok {
 		instance.Status.Conditions = conditions
 	}

--- a/internal/controller/numaresourcesscheduler_controller_test.go
+++ b/internal/controller/numaresourcesscheduler_controller_test.go
@@ -90,6 +90,7 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 
 		Expect(reconciler.Client.Get(context.TODO(), key, nrs)).ToNot(HaveOccurred())
 		degradedCondition := getConditionByType(nrs.Status.Conditions, status.ConditionDegraded)
+		Expect(degradedCondition).ToNot(BeNil())
 		Expect(degradedCondition.Status).To(Equal(metav1.ConditionTrue))
 		Expect(degradedCondition.Reason).To(Equal(reason))
 	}


### PR DESCRIPTION
cleanup, reoganize and document the `status` package, which accrued some cruft over the years.

While the API had small changes, there is no intended impact on behavior. Once the (pretty trivial) port is done, client
code should behave like before.