### PR TITLE
e2e: serial: sched stall test fixes

### DIFF
--- a/internal/wait/pod.go
+++ b/internal/wait/pod.go
@@ -118,7 +118,12 @@ func (wt Waiter) ForPodsAllDeleted(ctx context.Context, pods []*corev1.Pod) erro
 		return nil
 	}
 
+	ts := time.Now()
 	klog.Infof("Waiting for %d pod(s) to be deleted.", len(pods))
+	defer func() {
+		elapsed := time.Since(ts)
+		klog.Infof("Waited for %d pods(s) deleted for %v", len(pods), elapsed)
+	}()
 
 	var eg errgroup.Group
 	for _, pod := range pods {

--- a/test/e2e/serial/tests/scheduler_cache_stall.go
+++ b/test/e2e/serial/tests/scheduler_cache_stall.go
@@ -140,10 +140,6 @@ var _ = Describe("[serial][scheduler][cache] scheduler cache stall", Label("sche
 				noisePods = []*corev1.Pod{}
 			})
 
-			AfterEach(func(ctx context.Context) {
-				Expect(wait.With(fxt.Client).Interval(3*time.Second).Timeout(30*time.Second).ForPodsAllDeleted(ctx, noisePods)).To(Succeed())
-			})
-
 			DescribeTable("should be able to schedule pods with no stalls", Label("nodeAll"),
 				// like non-regression tests, but with jobs present
 				func(ctx context.Context, makeNoisePod makePodFunc) {

--- a/test/internal/fixture/fixture.go
+++ b/test/internal/fixture/fixture.go
@@ -147,7 +147,11 @@ func Setup(baseName string, nrtList nrtv1alpha2.NodeResourceTopologyList) (*Fixt
 }
 
 func Teardown(ft *Fixture) error {
+	ts := time.Now()
 	ginkgo.By(fmt.Sprintf("tearing down the test namespace %q", ft.Namespace.Name))
+	defer func() {
+		klog.Infof("tore down the test namespace %q in %v", ft.Namespace.Name, time.Since(ts))
+	}()
 	err := teardownNamespace(ft.Client, ft.Namespace)
 	if err != nil {
 		klog.Errorf("cannot teardown namespace %q: %s", ft.Namespace.Name, err)


### PR DESCRIPTION
Fixes which escaped 8f1ca11d8b38bdb056927c8cd7614d19060c8e13

PR: https://github.com/openshift-kni/numaresources-operator/pull/1378