### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for numaresources-must-gather-4-14

### DIFF
--- a/.konflux/must-gather/must-gather.konflux.Dockerfile
+++ b/.konflux/must-gather/must-gather.konflux.Dockerfile
@@ -36,4 +36,5 @@ LABEL com.redhat.component="numaresources-must-gather-container" \
     distribution-scope="public" \
     release="${OPENSHIFT_VERSION}" \
     url="https://github.com/openshift-kni/numaresources-operator" \
-    vendor="Red Hat, Inc."
+    vendor="Red Hat, Inc." \
+    cpe="cpe:/a:redhat:openshift:4.14::el9"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
