### PR TITLE
[release-4.17] Konflux: pin operator image to manifest list

### DIFF
--- a/.konflux/bundle/overlay/pin_images.in.yaml
+++ b/.konflux/bundle/overlay/pin_images.in.yaml
@@ -1,4 +1,4 @@
 # Do not modify the manager 'key' value: 'manager'
 - key: manager
   source: quay.io/openshift-kni/numaresources-operator:4.17.999-snapshot
-  target: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-4-17@sha256:426b016e42d91563e24967d5ce8aafdacc39029722dabb238241898fb2227532
+  target: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-4-17@sha256:50202cb16b0c25c05bb91660460091b7eeb2177e42073809a59364454cf77a25


### PR DESCRIPTION
Replace image pinning to manifest list digest instead of single image digest