### PR TITLE
Konflux: update to 4.21 and pin image digests

### DIFF
--- a/.konflux/bundle/overlay/pin_images.in.yaml
+++ b/.konflux/bundle/overlay/pin_images.in.yaml
@@ -1,5 +1,5 @@
 # Do not modify the manager 'key' value: 'manager'
 - key: manager
-  source: quay.io/openshift-kni/numaresources-operator:4.20.999-snapshot
-  target: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-4-20@sha256:64c7a5f07868dc40e8f20da588a3305bc8fa70b42ce580e157561ad6395aa2f1
+  source: quay.io/openshift-kni/numaresources-operator:4.21.999-snapshot
+  target: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-4-21@sha256:b818729290ccd617290eecf01373609caa2f5ce1abbd1174245bf2d39cf0315c
 

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -19,6 +19,6 @@ entries:
     name: "4.21"
     package: numaresources-operator
     schema: olm.channel
-  - image: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-21 # TODO add 4.21 SHA
+  - image: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-21@sha256:43cf0f525626c0cebd78ab2489488fdaeb1c04531e29888baaa6834556fe6234
     # The url for this last entry is updated by hack/konflux-update-catalog-template.sh automatically
     schema: olm.bundle


### PR DESCRIPTION
Pin specific image digests for numaresources-operator and bundle images in the 4.21 release configuration.