### PR TITLE
CNF-19769: Revert "bundle: disable networkpolicies again"

### DIFF
--- a/bundle/manifests/numaresources-allow-webhook-traffic_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/numaresources-allow-webhook-traffic_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: numaresources-allow-webhook-traffic
+spec:
+  ingress:
+  - ports:
+    - port: 9443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: numaresources-operator
+  policyTypes:
+  - Ingress

--- a/bundle/manifests/numaresources-ingress-to-operator-metrics_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/numaresources-ingress-to-operator-metrics_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: numaresources-ingress-to-operator-metrics
+spec:
+  ingress:
+  - ports:
+    - port: 8080
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: numaresources-operator
+  policyTypes:
+  - Ingress

--- a/bundle/manifests/numaresources-manager-role_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/numaresources-manager-role_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: numaresources-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - '*'

--- a/bundle/manifests/numaresources-operator-default-deny-all_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/numaresources-operator-default-deny-all_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: numaresources-operator-default-deny-all
+spec:
+  podSelector:
+    matchLabels:
+      app: numaresources-operator
+  policyTypes:
+  - Ingress
+  - Egress

--- a/bundle/manifests/numaresources-operator-egress-to-api-server_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/numaresources-operator-egress-to-api-server_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: numaresources-operator-egress-to-api-server
+spec:
+  egress:
+  - ports:
+    - port: 6443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: numaresources-operator
+  policyTypes:
+  - Egress

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -16,7 +16,7 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
-#- ../networkpolicy
+- ../networkpolicy
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook

--- a/test/e2e/serial/tests/network_policy.go
+++ b/test/e2e/serial/tests/network_policy.go
@@ -159,7 +159,6 @@ var _ = Describe("network policies are applied", Ordered, Label("feature:network
 			ToPort:      "8081",
 			ShouldAllow: false,
 			Description: "scheduler should NOT access operator",
-			SkipBroken:  true,
 		}),
 
 		// Testing network traffic restrictions between pods cross namespaces (numaresouces and openshift-monitoring)
@@ -169,7 +168,6 @@ var _ = Describe("network policies are applied", Ordered, Label("feature:network
 			ToPort:      "8081",
 			ShouldAllow: false,
 			Description: "numaresources operator should NOT access prometheus operator pod",
-			SkipBroken:  true,
 		}),
 
 		Entry("prometheus operator -> numaresouces operator", trafficCase{
@@ -178,7 +176,6 @@ var _ = Describe("network policies are applied", Ordered, Label("feature:network
 			ToPort:      "8081", // readinessProbe!
 			ShouldAllow: false,
 			Description: "prometheus operator pod should NOT access numaresources operator pod's readiness probe endpoint)",
-			SkipBroken:  true,
 		}),
 	)
 })


### PR DESCRIPTION
We were asked to enable the networkpolicies again for NROP bundle.

This reverts commit dc66e1070a3a2b6b1ff3ad5af96b7d84185bc45a.