### PR TITLE
e2e: serial: fix `tmpol` test panics

### DIFF
--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -368,7 +368,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}
 
 			By("Waiting for padding pods to be ready")
-			failedPodIds := e2efixture.WaitForPaddingPodsRunning(fxt, paddingPods)
+			failedPodIds := e2efixture.WaitForPaddingPodsRunning(context.Background(), fxt, paddingPods)
 			Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
 			By("waiting for the NRT data to settle")

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -160,7 +160,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			}
 
 			By("Waiting for padding pods to be ready")
-			failedPodIds := e2efixture.WaitForPaddingPodsRunning(fxt, paddingPods)
+			failedPodIds := e2efixture.WaitForPaddingPodsRunning(context.Background(), fxt, paddingPods)
 			Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
 			By("waiting for the NRT data to settle")
@@ -196,7 +196,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			}
 
 			By("Waiting for padding pods to be ready")
-			failedPodIds = e2efixture.WaitForPaddingPodsRunning(fxt, targetPaddingPods)
+			failedPodIds = e2efixture.WaitForPaddingPodsRunning(context.Background(), fxt, targetPaddingPods)
 			Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
 			By("waiting for the NRT data to settle")
@@ -226,7 +226,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			allPaddingPods = append(allPaddingPods, targetPaddingPods...)
 
 			By("Waiting for padding pods to be ready")
-			failedPodIds = e2efixture.WaitForPaddingPodsRunning(fxt, allPaddingPods)
+			failedPodIds = e2efixture.WaitForPaddingPodsRunning(context.Background(), fxt, allPaddingPods)
 			Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
 			By("waiting for the NRT data to settle")
@@ -394,7 +394,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			}
 
 			By("Waiting for padding pods to be ready")
-			failedPodIds := e2efixture.WaitForPaddingPodsRunning(fxt, paddingPods)
+			failedPodIds := e2efixture.WaitForPaddingPodsRunning(context.Background(), fxt, paddingPods)
 			Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
 			By("waiting for the NRT data to settle")

--- a/test/e2e/serial/tests/resource_hostlevel.go
+++ b/test/e2e/serial/tests/resource_hostlevel.go
@@ -314,7 +314,7 @@ var _ = Describe("[serial][hostlevel] numaresources host-level resources", Seria
 				}
 
 				By("wait for padding pods to be running")
-				failedPodIds := e2efixture.WaitForPaddingPodsRunning(fxt, paddingPods)
+				failedPodIds := e2efixture.WaitForPaddingPodsRunning(ctx, fxt, paddingPods)
 				Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
 				// no need to wait for NRT to settle because padding pods are BE

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -213,7 +213,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				}
 
 				By("Waiting for padding pods to be ready")
-				failedPodIds := e2efixture.WaitForPaddingPodsRunning(fxt, paddingPods)
+				failedPodIds := e2efixture.WaitForPaddingPodsRunning(context.Background(), fxt, paddingPods)
 				Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
 				By(fmt.Sprintf("checking the resource allocation on %q as the test starts", targetNodeName))
@@ -370,7 +370,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				}
 
 				By("Waiting for padding pods on non-target node to be ready")
-				failedPodIds := e2efixture.WaitForPaddingPodsRunning(fxt, paddingPods)
+				failedPodIds := e2efixture.WaitForPaddingPodsRunning(context.Background(), fxt, paddingPods)
 				Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
 				By("padding a NUMA node on the target node")
@@ -398,7 +398,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				}
 
 				By("Waiting for padding pod on target node to be ready")
-				failedPodIds = e2efixture.WaitForPaddingPodsRunning(fxt, paddingPodsTargetNode)
+				failedPodIds = e2efixture.WaitForPaddingPodsRunning(context.Background(), fxt, paddingPodsTargetNode)
 				Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
 				By("checking the resource allocation as the test starts")

--- a/test/e2e/serial/tests/workload_placement_nodelabel.go
+++ b/test/e2e/serial/tests/workload_placement_nodelabel.go
@@ -172,7 +172,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				}
 			}
 			By("Waiting for padding pods to be ready")
-			failedPodIds := e2efixture.WaitForPaddingPodsRunning(fxt, paddingPods)
+			failedPodIds := e2efixture.WaitForPaddingPodsRunning(context.Background(), fxt, paddingPods)
 			Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
 			var err error

--- a/test/e2e/serial/tests/workload_placement_resources.go
+++ b/test/e2e/serial/tests/workload_placement_resources.go
@@ -216,7 +216,7 @@ func setupNodes(fxt *e2efixture.Fixture, ctx context.Context, nrtCandidates []nr
 	paddingPods = append(paddingPods, createPaddingPod(fxt, ctx, "padding-tgt-1", targetNodeName, targetNrtInfo.Zones[1], requiredResources))
 
 	By("Waiting for padding pods to be ready")
-	failedPodIds := e2efixture.WaitForPaddingPodsRunning(fxt, paddingPods)
+	failedPodIds := e2efixture.WaitForPaddingPodsRunning(ctx, fxt, paddingPods)
 	Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
 	By("waiting for the NRT data to settle")

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -162,7 +162,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}
 
 			By("Waiting for padding pods to be ready")
-			failedPodIds := e2efixture.WaitForPaddingPodsRunning(fxt, paddingPods)
+			failedPodIds := e2efixture.WaitForPaddingPodsRunning(context.Background(), fxt, paddingPods)
 			Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 		}
 
@@ -440,7 +440,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			paddingPods := setupPadding(fxt, nrtList, padInfo)
 
 			By("Waiting for padding pods to be ready")
-			failedPodIds := e2efixture.WaitForPaddingPodsRunning(fxt, paddingPods)
+			failedPodIds := e2efixture.WaitForPaddingPodsRunning(context.Background(), fxt, paddingPods)
 			Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
 			By("waiting for the NRT data to settle")
@@ -1375,7 +1375,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			paddingPods := setupPadding(fxt, nrtList, padInfo)
 
 			By("Waiting for padding pods to be ready")
-			failedPodIds := e2efixture.WaitForPaddingPodsRunning(fxt, paddingPods)
+			failedPodIds := e2efixture.WaitForPaddingPodsRunning(context.Background(), fxt, paddingPods)
 			Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
 			By("waiting for the NRT data to settle")

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -168,7 +168,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			}
 
 			By("Waiting for padding pods to be ready")
-			failedPodIds := e2efixture.WaitForPaddingPodsRunning(fxt, paddingPods)
+			failedPodIds := e2efixture.WaitForPaddingPodsRunning(context.Background(), fxt, paddingPods)
 			Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
 			By("waiting for the NRT data to settle")
@@ -379,7 +379,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			}
 
 			By("Waiting for padding pods to be ready")
-			failedPodIds := e2efixture.WaitForPaddingPodsRunning(fxt, paddingPods)
+			failedPodIds := e2efixture.WaitForPaddingPodsRunning(context.Background(), fxt, paddingPods)
 			Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
 			By("waiting for the NRT data to settle")
@@ -560,7 +560,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			}
 
 			By("Waiting for padding pods to be ready")
-			failedPodIds := e2efixture.WaitForPaddingPodsRunning(fxt, paddingPods)
+			failedPodIds := e2efixture.WaitForPaddingPodsRunning(context.Background(), fxt, paddingPods)
 			Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
 			By("waiting for the NRT data to settle")
@@ -884,7 +884,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			}
 
 			By("Waiting for padding pods to be ready")
-			failedPodIds := e2efixture.WaitForPaddingPodsRunning(fxt, paddingPods)
+			failedPodIds := e2efixture.WaitForPaddingPodsRunning(context.Background(), fxt, paddingPods)
 			Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
 			e2efixture.MustSettleNRT(fxt)

--- a/test/internal/fixture/wait.go
+++ b/test/internal/fixture/wait.go
@@ -30,9 +30,9 @@ import (
 )
 
 // WaitPodsRunning waits for all padding pods to be up and running ( or fail)
-func WaitForPaddingPodsRunning(fxt *Fixture, paddingPods []*corev1.Pod) []string {
+func WaitForPaddingPodsRunning(ctx context.Context, fxt *Fixture, paddingPods []*corev1.Pod) []string {
 	var failedPodIds []string
-	failedPods, _ := wait.With(fxt.Client).ForPodsAllRunning(context.TODO(), paddingPods)
+	failedPods, _ := wait.With(fxt.Client).ForPodsAllRunning(ctx, paddingPods)
 	for _, failedPod := range failedPods {
 		_ = objects.LogEventsForPod(fxt.K8sClient, failedPod.Namespace, failedPod.Name)
 		//note that this test does not use podOverhead thus pod req and lim would be the pod's resources as set upon creating


### PR DESCRIPTION
recent updates (2c3e1408) made the initialization happen incorrectly. Fix again by further simplifying the code.