### PR TITLE
e2e: move vars to avoid nil pointer dereference at runtime

### DIFF
--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -72,16 +72,16 @@ type tmScopeFuncs struct {
 
 type tmScopeFuncsHandler map[string]tmScopeFuncs
 
+var (
+	singleNUMAContainerScopeFuncs = newContainerScopeSingleNUMANodeFuncs()
+	singleNUMAPodScopeFuncs       = newPodScopeSingleNUMANodeFuncs()
+)
+
 var _ = Describe("[serial][disruptive][scheduler] numaresources workload placement considering TM policy", Serial, Label("disruptive", "scheduler"), Label("feature:wlplacement", "feature:tmpol"), func() {
 	var fxt *e2efixture.Fixture
 	var nrtList nrtv1alpha2.NodeResourceTopologyList
-	var singleNUMAContainerScopeFuncs tmScopeFuncs
-	var singleNUMAPodScopeFuncs tmScopeFuncs
 
 	BeforeEach(func() {
-		singleNUMAContainerScopeFuncs = newContainerScopeSingleNUMANodeFuncs()
-		singleNUMAPodScopeFuncs = newPodScopeSingleNUMANodeFuncs()
-
 		Expect(serialconfig.Config).ToNot(BeNil())
 		Expect(serialconfig.Config.Ready()).To(BeTrue(), "NUMA fixture initialization failed")
 


### PR DESCRIPTION
This issue was a bit tricky to notice. The initialization of both ```singleNUMAContainerScopeFuncs``` and ```singleNUMAPodScopeFuncs``` inside the top-level BeforeEach block caused the tests using them in the ```DescribeTable``` to fail with a nil pointer error.

The problem occurred because Ginkgo captures ```Entry``` parameters when the Go package loads, whereas the BeforeEach block executes at runtime. As a result, when the table Entries tried to use ```singleNUMAContainerScopeFuncs```, it was already nil because the ```BeforeEach``` had not run yet to initialize it.

To fix it, we can simply move the initialization to the package level. This ensures the variables are initialized before Ginkgo parses the test structure.