### PR TITLE
renovate: label specific PRs with `auto-merge`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,8 @@
         {
             "addLabels": [
                 "approved",
-                "lgtm"
+                "lgtm",
+                "auto-merge"
             ],
             "autoApprove": true,
             "automerge": true,
@@ -54,7 +55,8 @@
             {
                 "addLabels": [
                     "approved",
-                    "lgtm"
+                    "lgtm",
+                    "auto-merge"
                 ],
                 "matchUpdateTypes": [
                     "digest"


### PR DESCRIPTION
There are few problems with the current auto-merge mechanism of mintmaker PRs which leads them to not be auto-merged but rather lingering on the open PRs list until human resolve them and sometimes it requires that the person who handles these PRs to have adminstrative permissions to unblock the PR from being merged. Problems are:
1. when the PR is updated again while it's open, it looses the lgtm label which makes it unmergeable without human intervention.
2. prow CI outages
3. unrelated failures on prow CI beside that there is no need at all to run prow CI at these PRs so immediete merge is what we want, so let's not wait for that to finish even if it finishes with success.