### PR TITLE
CNF-20021: status: nrooper: set ObservedGeneration in status conds

### DIFF
--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -195,7 +195,12 @@ func updateStatusConditionsIfNeeded(instance *nropv1.NUMAResourcesOperator, cond
 		return
 	}
 	klog.InfoS("updateStatus", "condition", cond.Type, "reason", cond.Reason, "message", cond.Message)
-	conditions, ok := status.ComputeConditions(instance.Status.Conditions, cond.Type, cond.Reason, cond.Message)
+	conditions, ok := status.ComputeConditions(instance.Status.Conditions, metav1.Condition{
+		Type:               cond.Type,
+		Reason:             cond.Reason,
+		Message:            cond.Message,
+		ObservedGeneration: instance.Generation,
+	}, time.Now())
 	if ok {
 		instance.Status.Conditions = conditions
 	}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -88,8 +88,8 @@ func EqualConditions(current, updated []metav1.Condition) bool {
 // ComputeConditions compute new conditions based on arguments, and then compare with given current conditions.
 // Returns the conditions to use, either current or newly computed, and a boolean flag which is `true` if conditions need
 // update - so if they are updated since the current conditions.
-func ComputeConditions(currentConditions []metav1.Condition, condition string, reason string, message string) ([]metav1.Condition, bool) {
-	conditions := NewConditions(condition, reason, message)
+func ComputeConditions(currentConditions []metav1.Condition, cond metav1.Condition, now time.Time) ([]metav1.Condition, bool) {
+	conditions := NewConditions(cond, now)
 	if EqualConditions(currentConditions, conditions) {
 		return currentConditions, false
 	}
@@ -135,21 +135,24 @@ func FindCondition(conditions []metav1.Condition, condition string) *metav1.Cond
 
 // NewConditions creates a new set of pristine conditions. The given `condition` is set, and its `reason` and `message` are
 // optionally set. Note that Available always imply Upgradeable, and that we ignore `reason` and `message` for it.
-func NewConditions(condition string, reason string, message string) []metav1.Condition {
-	now := time.Now()
+func NewConditions(cond metav1.Condition, now time.Time) []metav1.Condition {
 	conditions := newBaseConditions(now)
-	switch condition {
+	switch cond.Type {
 	case ConditionAvailable:
 		conditions[0].Status = metav1.ConditionTrue
+		conditions[0].ObservedGeneration = cond.ObservedGeneration
 		conditions[1].Status = metav1.ConditionTrue
+		conditions[1].ObservedGeneration = cond.ObservedGeneration
 	case ConditionProgressing:
 		conditions[2].Status = metav1.ConditionTrue
-		conditions[2].Reason = reason
-		conditions[2].Message = message
+		conditions[2].Reason = cond.Reason
+		conditions[2].Message = cond.Message
+		conditions[2].ObservedGeneration = cond.ObservedGeneration
 	case ConditionDegraded:
 		conditions[3].Status = metav1.ConditionTrue
-		conditions[3].Reason = reason
-		conditions[3].Message = message
+		conditions[3].Reason = cond.Reason
+		conditions[3].Message = cond.Message
+		conditions[3].ObservedGeneration = cond.ObservedGeneration
 	}
 	return conditions
 }

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -86,7 +86,12 @@ func TestComputeConditions(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(nro).Build()
 
 	var ok bool
-	nro.Status.Conditions, ok = ComputeConditions(nro.Status.Conditions, ConditionProgressing, "testReason", "test message")
+	nro.Status.Conditions, ok = ComputeConditions(nro.Status.Conditions, metav1.Condition{
+		Type:               ConditionProgressing,
+		Reason:             "testReason",
+		Message:            "test message",
+		ObservedGeneration: 8181,
+	}, time.Time{})
 	if !ok {
 		t.Errorf("Update did not change status, but it should")
 	}
@@ -109,7 +114,12 @@ func TestComputeConditions(t *testing.T) {
 	}
 
 	// same status twice in a row. We should not overwrite identical status to save transactions.
-	_, ok = ComputeConditions(nro.Status.Conditions, ConditionProgressing, "testReason", "test message")
+	_, ok = ComputeConditions(nro.Status.Conditions, metav1.Condition{
+		Type:               ConditionProgressing,
+		Reason:             "testReason",
+		Message:            "test message",
+		ObservedGeneration: 8181, // assume we reprocess the original spec
+	}, time.Time{})
 	if ok {
 		t.Errorf("Update did change status, but it should not")
 	}
@@ -132,22 +142,38 @@ func TestNUMAResourceOperatorNeedsUpdate(t *testing.T) {
 		{
 			name: "status, conditions, updated only time",
 			oldStatus: &nropv1.NUMAResourcesOperatorStatus{
-				Conditions: NewConditions(ConditionAvailable, "test all good", "testing info"),
+				Conditions: NewConditions(metav1.Condition{
+					Type:    ConditionAvailable,
+					Reason:  "testAllGood",
+					Message: "testing info",
+				}, time.Now()),
 			},
 			updaterFunc: func(st *nropv1.NUMAResourcesOperatorStatus) {
 				time.Sleep(42 * time.Millisecond) // make sure the timestamp changed
-				st.Conditions = NewConditions(ConditionAvailable, "test all good", "testing info")
+				st.Conditions = NewConditions(metav1.Condition{
+					Type:    ConditionAvailable,
+					Reason:  "testAllGood",
+					Message: "testing info",
+				}, time.Now())
 			},
 			expectedUpdated: false,
 		},
 		{
 			name: "status, conditions, updated only time, other fields changed",
 			oldStatus: &nropv1.NUMAResourcesOperatorStatus{
-				Conditions: NewConditions(ConditionAvailable, "test all good", "testing info"),
+				Conditions: NewConditions(metav1.Condition{
+					Type:    ConditionAvailable,
+					Reason:  "testAllGood",
+					Message: "testing info",
+				}, time.Now()),
 			},
 			updaterFunc: func(st *nropv1.NUMAResourcesOperatorStatus) {
 				time.Sleep(42 * time.Millisecond) // make sure the timestamp changed
-				st.Conditions = NewConditions(ConditionAvailable, "test all good", "testing info")
+				st.Conditions = NewConditions(metav1.Condition{
+					Type:    ConditionAvailable,
+					Reason:  "testAllGood",
+					Message: "testing info",
+				}, time.Now())
 				st.DaemonSets = []nropv1.NamespacedName{
 					{
 						Namespace: "foo",
@@ -160,7 +186,11 @@ func TestNUMAResourceOperatorNeedsUpdate(t *testing.T) {
 		{
 			name: "status, conditions, updated only time, other fields mutated",
 			oldStatus: &nropv1.NUMAResourcesOperatorStatus{
-				Conditions: NewConditions(ConditionAvailable, "test all good", "testing info"),
+				Conditions: NewConditions(metav1.Condition{
+					Type:    ConditionAvailable,
+					Reason:  "testAllGood",
+					Message: "testing info",
+				}, time.Now()),
 				DaemonSets: []nropv1.NamespacedName{
 					{
 						Namespace: "foo",
@@ -170,7 +200,11 @@ func TestNUMAResourceOperatorNeedsUpdate(t *testing.T) {
 			},
 			updaterFunc: func(st *nropv1.NUMAResourcesOperatorStatus) {
 				time.Sleep(42 * time.Millisecond) // make sure the timestamp changed
-				st.Conditions = NewConditions(ConditionAvailable, "test all good", "testing info")
+				st.Conditions = NewConditions(metav1.Condition{
+					Type:    ConditionAvailable,
+					Reason:  "testAllGood",
+					Message: "testing info",
+				}, time.Now())
 				st.DaemonSets = []nropv1.NamespacedName{
 					{
 						Namespace: "foo",
@@ -212,22 +246,38 @@ func TestNUMAResourcesSchedulerNeedsUpdate(t *testing.T) {
 		{
 			name: "status, conditions, updated only time",
 			oldStatus: nropv1.NUMAResourcesSchedulerStatus{
-				Conditions: NewConditions(ConditionAvailable, "test all good", "testing info"),
+				Conditions: NewConditions(metav1.Condition{
+					Type:    ConditionAvailable,
+					Reason:  "testAllGood",
+					Message: "testing info",
+				}, time.Now()),
 			},
 			updaterFunc: func(st *nropv1.NUMAResourcesSchedulerStatus) {
 				time.Sleep(42 * time.Millisecond) // make sure the timestamp changed
-				st.Conditions = NewConditions(ConditionAvailable, "test all good", "testing info")
+				st.Conditions = NewConditions(metav1.Condition{
+					Type:    ConditionAvailable,
+					Reason:  "testAllGood",
+					Message: "testing info",
+				}, time.Now())
 			},
 			expectedUpdated: false,
 		},
 		{
 			name: "status, conditions, updated only time, other fields changed",
 			oldStatus: nropv1.NUMAResourcesSchedulerStatus{
-				Conditions: NewConditions(ConditionAvailable, "test all good", "testing info"),
+				Conditions: NewConditions(metav1.Condition{
+					Type:    ConditionAvailable,
+					Reason:  "testAllGood",
+					Message: "testing info",
+				}, time.Now()),
 			},
 			updaterFunc: func(st *nropv1.NUMAResourcesSchedulerStatus) {
 				time.Sleep(42 * time.Millisecond) // make sure the timestamp changed
-				st.Conditions = NewConditions(ConditionAvailable, "test all good", "testing info")
+				st.Conditions = NewConditions(metav1.Condition{
+					Type:    ConditionAvailable,
+					Reason:  "testAllGood",
+					Message: "testing info",
+				}, time.Now())
 				st.CacheResyncPeriod = ptr.To(metav1.Duration{Duration: 42 * time.Second})
 			},
 			expectedUpdated: true,

--- a/test/internal/objects/daemonset.go
+++ b/test/internal/objects/daemonset.go
@@ -24,6 +24,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
 )
 
 func NewTestDaemonset(podLabels map[string]string, nodeSelector map[string]string, namespace, name, image string, command, args []string) *appsv1.DaemonSet {
@@ -68,6 +70,18 @@ func NewTestDaemonsetWithPodSpec(podLabels map[string]string, nodeSelector map[s
 		ds.Spec.Template.Spec.NodeSelector = nodeSelector
 	}
 	return ds
+}
+
+func GetDaemonSetsByNamespacedName(cli client.Client, ctx context.Context, nnames ...nropv1.NamespacedName) ([]*appsv1.DaemonSet, error) {
+	var dss []*appsv1.DaemonSet
+	for _, nname := range nnames {
+		var ds appsv1.DaemonSet
+		if err := cli.Get(ctx, client.ObjectKey{Namespace: nname.Namespace, Name: nname.Name}, &ds); err != nil {
+			return nil, err
+		}
+		dss = append(dss, &ds)
+	}
+	return dss, nil
 }
 
 func GetDaemonSetsOwnedBy(cli client.Client, objMeta metav1.ObjectMeta) ([]*appsv1.DaemonSet, error) {


### PR DESCRIPTION
The NUMAResourcesScheduler object status condition never reports ObservedGeneration in any status conditions, unlike the scheduler object.

Likewise the scheduler change, let's expose it in all the relevant conditions, doing some minimal internal refactoring along the way.

Note that we can't test this change using controller tests due both the unique requirements of the operator and the way we (mis)use the controller tests; we should add checks in (existing?) e2e tests, but we postpone this to a later change.