### PR TITLE
conditional use of ObservedGeneration

### DIFF
--- a/internal/api/features/_topics.json
+++ b/internal/api/features/_topics.json
@@ -23,6 +23,7 @@
     "nrtcrdanns",
     "netpols",
     "mgselinuxcollect",
-    "tlscompliance"
+    "tlscompliance",
+    "operobsgen"
   ]
 }

--- a/internal/api/features/types.go
+++ b/internal/api/features/types.go
@@ -23,7 +23,13 @@ import (
 )
 
 const (
-	Version = "v5.0.0"
+	// Version is the version of the API, and covers data layout.
+	// The version should be bumped when the API definition changes,
+	// and is not strictly tied to the operator version.
+	// The payload (e.g. active topics) may and will changes even
+	// within the same operator version; e.g. is totally legit
+	// to add more topics during a Z stream.
+	Version = "v1.0.0"
 )
 
 type Metadata struct {

--- a/test/e2e/serial/config/fixture.go
+++ b/test/e2e/serial/config/fixture.go
@@ -64,7 +64,7 @@ var Config *E2EConfig
 
 func SetupFixture() error {
 	var err error
-	Config, err = NewFixtureWithOptions("e2e-test-infra", e2efixture.OptionRandomizeName|e2efixture.OptionAvoidCooldown|e2efixture.OptionStaticClusterData)
+	Config, err = NewFixtureWithOptions(context.Background(), "e2e-test-infra", e2efixture.OptionRandomizeName|e2efixture.OptionAvoidCooldown|e2efixture.OptionStaticClusterData)
 	return err
 }
 
@@ -72,29 +72,29 @@ func TeardownFixture() error {
 	return e2efixture.Teardown(Config.Fixture)
 }
 
-func NewFixtureWithOptions(nsName string, options e2efixture.Options) (*E2EConfig, error) {
+func NewFixtureWithOptions(ctx context.Context, nsName string, options e2efixture.Options) (*E2EConfig, error) {
 	var err error
 	cfg := E2EConfig{
 		NROOperObj:  &nropv1.NUMAResourcesOperator{},
 		NROSchedObj: &nropv1.NUMAResourcesScheduler{},
 	}
 
-	cfg.Fixture, err = e2efixture.SetupWithOptions(nsName, nrtv1alpha2.NodeResourceTopologyList{}, options)
+	cfg.Fixture, err = e2efixture.SetupWithOptions(ctx, nsName, nrtv1alpha2.NodeResourceTopologyList{}, options)
 	if err != nil {
 		return nil, err
 	}
 
-	err = cfg.Fixture.Client.List(context.TODO(), &cfg.infraNRTList)
+	err = cfg.Fixture.Client.List(ctx, &cfg.infraNRTList)
 	if err != nil {
 		return nil, err
 	}
 
-	err = cfg.Fixture.Client.Get(context.TODO(), objects.NROObjectKey(), cfg.NROOperObj)
+	err = cfg.Fixture.Client.Get(ctx, objects.NROObjectKey(), cfg.NROOperObj)
 	if err != nil {
 		return nil, err
 	}
 
-	err = cfg.Fixture.Client.Get(context.TODO(), objects.NROSchedObjectKey(), cfg.NROSchedObj)
+	err = cfg.Fixture.Client.Get(ctx, objects.NROSchedObjectKey(), cfg.NROSchedObj)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/serial/config/fixture.go
+++ b/test/e2e/serial/config/fixture.go
@@ -24,6 +24,7 @@ import (
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
+	"github.com/openshift-kni/numaresources-operator/internal/api/features"
 	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	e2efixture "github.com/openshift-kni/numaresources-operator/test/internal/fixture"
 	"github.com/openshift-kni/numaresources-operator/test/internal/objects"
@@ -35,6 +36,7 @@ type E2EConfig struct {
 	NROOperObj    *nropv1.NUMAResourcesOperator
 	NROSchedObj   *nropv1.NUMAResourcesScheduler
 	SchedulerName string
+	ClusterTopics features.TopicInfo
 	infraNRTList  nrtv1alpha2.NodeResourceTopologyList
 }
 
@@ -101,6 +103,11 @@ func NewFixtureWithOptions(ctx context.Context, nsName string, options e2efixtur
 
 	cfg.SchedulerName = cfg.NROSchedObj.Status.SchedulerName
 	klog.InfoS("detected scheduler name", "schedulerName", cfg.SchedulerName)
+
+	cfg.ClusterTopics, err = FetchClusterTopics(ctx, cfg.Fixture, cfg.NROOperObj)
+	if err != nil {
+		return nil, err
+	}
 
 	return &cfg, nil
 }

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1843,6 +1844,10 @@ func isNROOperSyncedAt(nropStatus *nropv1.NUMAResourcesOperatorStatus, condition
 	}
 	if cond.Status != metav1.ConditionTrue {
 		return errors.New("condition not true")
+	}
+	// TODO: until all the version reports ObservedGeneration
+	if serialconfig.Config != nil && !slices.Contains(serialconfig.Config.ClusterTopics.Active, "operobsgen") {
+		return nil
 	}
 	if cond.ObservedGeneration != gen {
 		return fmt.Errorf("condition at %d expected %d", cond.ObservedGeneration, gen)

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -235,25 +235,29 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 				g.Expect(isNROOperSyncedAt(&updatedOperObj.Status, status.ConditionAvailable, updatedOperObj.Generation)).To(Succeed())
 			}).WithTimeout(10*time.Minute).WithPolling(30*time.Second).Should(Succeed(), "failed to update RTE daemonset node selector")
 
-			dss, err := objects.GetDaemonSetsByNamespacedName(fxt.Client, ctx, updatedOperObj.Status.DaemonSets...)
-			Expect(err).ToNot(HaveOccurred())
+			// Eventually is not strictly needed but till all the supported version report ObservedGeneration in status
+			// (aka oldest supported version is 4.20) we can't really depend on `isNROOperUpToDate`
+			Eventually(func(g Gomega) {
+				dss, err := objects.GetDaemonSetsByNamespacedName(fxt.Client, ctx, updatedOperObj.Status.DaemonSets...)
+				g.Expect(err).ToNot(HaveOccurred())
 
-			Expect(dss).To(HaveLen(len(nroOperObj.Spec.NodeGroups)), "daemonsets found owned by NRO object doesn't align with specified NodeGroups")
-			for _, ds := range dss {
-				e2efixture.By("check RTE daemonset %q", ds.Name)
-				if ds.Name == objectnames.GetComponentName(updatedOperObj.Name, roleMCPTest) {
-					By("check the correct match labels for the new RTE daemonset")
-					Expect(ds.Spec.Template.Spec.NodeSelector).To(Equal(testMCP.Spec.NodeSelector.MatchLabels))
+				g.Expect(dss).To(HaveLen(len(nroOperObj.Spec.NodeGroups)), "daemonsets found owned by NRO object doesn't align with specified NodeGroups")
+				for _, ds := range dss {
+					e2efixture.By("check RTE daemonset %q", ds.Name)
+					if ds.Name == objectnames.GetComponentName(updatedOperObj.Name, roleMCPTest) {
+						By("check the correct match labels for the new RTE daemonset")
+						g.Expect(ds.Spec.Template.Spec.NodeSelector).To(Equal(testMCP.Spec.NodeSelector.MatchLabels))
+					}
+					By("check the correct image")
+					cnt := ds.Spec.Template.Spec.Containers[0] // shortcut
+					g.Expect(cnt.Image).To(Equal(serialconfig.GetRteCiImage()))
+
+					By("checking the correct LogLevel")
+					found, match := matchLogLevelToKlog(&cnt, newLogLevel)
+					g.Expect(found).To(BeTrue(), "-v flag doesn't exist in container %q args under DaemonSet: %q", cnt.Name, ds.Name)
+					g.Expect(match).To(BeTrue(), "LogLevel %s doesn't match the existing -v flag in container: %q managed by DaemonSet: %q", updatedOperObj.Spec.LogLevel, cnt.Name, ds.Name)
 				}
-				By("check the correct image")
-				cnt := ds.Spec.Template.Spec.Containers[0] // shortcut
-				Expect(cnt.Image).To(Equal(serialconfig.GetRteCiImage()))
-
-				By("checking the correct LogLevel")
-				found, match := matchLogLevelToKlog(&cnt, newLogLevel)
-				Expect(found).To(BeTrue(), "-v flag doesn't exist in container %q args under DaemonSet: %q", cnt.Name, ds.Name)
-				Expect(match).To(BeTrue(), "LogLevel %s doesn't match the existing -v flag in container: %q managed by DaemonSet: %q", updatedOperObj.Spec.LogLevel, cnt.Name, ds.Name)
-			}
+			}).WithTimeout(10*time.Minute).WithPolling(30*time.Second).Should(Succeed(), "failed to update RTE daemonset node selector")
 		})
 
 		It("should converge with mixed SELinux policy across node groups", Label(label.Tier2, label.OpenShift), func(ctx context.Context) {

--- a/test/internal/fixture/fixture.go
+++ b/test/internal/fixture/fixture.go
@@ -99,8 +99,7 @@ func init() {
 	cooldownThreshold = getCooldownThresholdFromEnvVar()
 }
 
-func SetupWithOptions(name string, nrtList nrtv1alpha2.NodeResourceTopologyList, options Options) (*Fixture, error) {
-	ctx := context.Background()
+func SetupWithOptions(ctx context.Context, name string, nrtList nrtv1alpha2.NodeResourceTopologyList, options Options) (*Fixture, error) {
 	if !e2eclient.ClientsEnabled {
 		return nil, fmt.Errorf("clients not enabled")
 	}
@@ -191,7 +190,7 @@ func SetupWithOptions(name string, nrtList nrtv1alpha2.NodeResourceTopologyList,
 }
 
 func Setup(baseName string, nrtList nrtv1alpha2.NodeResourceTopologyList) (*Fixture, error) {
-	return SetupWithOptions(baseName, nrtList, OptionRandomizeName)
+	return SetupWithOptions(context.Background(), baseName, nrtList, OptionRandomizeName)
 }
 
 func Teardown(ft *Fixture) error {


### PR DESCRIPTION
in PR https://github.com/openshift-kni/numaresources-operator/pull/2431 we added reporting of `ObservedGeneration` in the `NUMAResourcesOperator.Status`. This is a good change and closes a known gap, but we can't just use the value unconditionally in e2e tests, because a long tail of old versions (pre https://github.com/openshift-kni/numaresources-operator/pull/2722) won't expose this value, which will create a storm of false negatives tests.

Ignoring the value till all the version supports it seems excessive; reverting the tests is wrong, reverting the change seems worse. The best way forward seems to be a more granular check, introduced in this PR.

This creates a challenge for future tests. The best option is probably to use ObservedGeneration only in the new tests and stop refactoring of existing codebase. Either way, we will need to be more careful in the future.