### PR TITLE
GH actions: run CI on all supported main branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,8 +4,14 @@ on:
   pull_request:
     branches:
       - main
-      - "release-4.18"
+      - "release-4.21"
       - "release-4.20"
+      - "release-4.19"
+      - "release-4.18"
+      - "release-4.17"
+      - "release-4.16"
+      - "release-4.14"
+      - "release-4.12"
   push:
     branches: 
       - main

--- a/.github/workflows/e2e-local.yaml
+++ b/.github/workflows/e2e-local.yaml
@@ -4,8 +4,14 @@ on:
   pull_request:
     branches:
       - main
-      - "release-4.18"
+      - "release-4.21"
       - "release-4.20"
+      - "release-4.19"
+      - "release-4.18"
+      - "release-4.17"
+      - "release-4.16"
+      - "release-4.14"
+      - "release-4.12"
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+"

--- a/.github/workflows/e2e-tools.yaml
+++ b/.github/workflows/e2e-tools.yaml
@@ -4,8 +4,14 @@ on:
   pull_request:
     branches:
       - main
-      - "release-4.18"
+      - "release-4.21"
       - "release-4.20"
+      - "release-4.19"
+      - "release-4.18"
+      - "release-4.17"
+      - "release-4.16"
+      - "release-4.14"
+      - "release-4.12"
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,8 +4,14 @@ on:
   pull_request:
     branches:
       - main
-      - "release-4.18"
+      - "release-4.21"
       - "release-4.20"
+      - "release-4.19"
+      - "release-4.18"
+      - "release-4.17"
+      - "release-4.16"
+      - "release-4.14"
+      - "release-4.12"
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+"

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -4,8 +4,14 @@ on:
   pull_request:
     branches:
       - main
-      - "release-4.18"
+      - "release-4.21"
       - "release-4.20"
+      - "release-4.19"
+      - "release-4.18"
+      - "release-4.17"
+      - "release-4.16"
+      - "release-4.14"
+      - "release-4.12"
   push:
     branches:
       - main


### PR DESCRIPTION
Keep the CI running on all official supported branches to avoid merging content with less checks.
Given that the repo is public and the runners used in the workflows (`ubuntu-latest`) are standard github-hosted runners, we can freely use them in the actions of this repo. ref:
https://docs.github.com/en/billing/concepts/product-billing/github-actions#free-use-of-github-actions