### PR TITLE
e2e: serial: stabilize RTE DS pod count after NoExecute taint

### DIFF
--- a/internal/wait/daemonset.go
+++ b/internal/wait/daemonset.go
@@ -41,12 +41,14 @@ func (wt Waiter) ForDaemonSetReadyByKey(ctx context.Context, key ObjectKey) (*ap
 		}
 
 		if !AreDaemonSetPodsReady(&updatedDs.Status) {
-			klog.Warningf("daemonset %s desired %d scheduled %d ready %d up-to-date %d",
+			klog.Warningf("daemonset %s not ready: desired=%d current=%d ready=%d updated=%d available=%d unavailable=%d",
 				key.String(),
 				updatedDs.Status.DesiredNumberScheduled,
 				updatedDs.Status.CurrentNumberScheduled,
 				updatedDs.Status.NumberReady,
-				updatedDs.Status.UpdatedNumberScheduled)
+				updatedDs.Status.UpdatedNumberScheduled,
+				updatedDs.Status.NumberAvailable,
+				updatedDs.Status.NumberUnavailable)
 			return false, nil
 		}
 
@@ -62,7 +64,9 @@ func (wt Waiter) ForDaemonSetReady(ctx context.Context, ds *appsv1.DaemonSet) (*
 
 func AreDaemonSetPodsReady(newStatus *appsv1.DaemonSetStatus) bool {
 	return newStatus.DesiredNumberScheduled > 0 &&
-		newStatus.DesiredNumberScheduled == newStatus.NumberReady && newStatus.UpdatedNumberScheduled == newStatus.NumberReady
+		newStatus.CurrentNumberScheduled == newStatus.DesiredNumberScheduled &&
+		newStatus.NumberAvailable == newStatus.DesiredNumberScheduled &&
+		newStatus.NumberUnavailable == 0
 }
 
 func (wt Waiter) ForDaemonsetPodsCreation(ctx context.Context, key ObjectKey, expectedPods int) (*appsv1.DaemonSet, error) {

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -475,19 +475,24 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 
 				By("applying the taint 2 - NoExecute")
 				applyTaintToNode(ctx, fxt.Client, targetNode, &tntNoExec[0])
-				By("waiting for DaemonSet to be ready")
-				updatedDs, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
-				Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
 
 				// NoExecute promises the pod will be evicted "immediately" but the system will still need nonzero time to notice
-				// and the pod will take nonzero time to terminate, so we need a Eventually block.
+				// and the pod will take nonzero time to terminate, so we need a Eventually block. Count only non-terminating pods:
+				// the list can still include the evicted pod until deletion finishes.
 				e2efixture.By("ensuring the RTE DS is running with less pods because taints (expected pods=%v)", len(workers)-1)
 				Eventually(func(g Gomega) {
-					Expect(fxt.Client.Get(ctx, dsKey.AsKey(), updatedDs)).To(Succeed())
-					pods, err = podlist.With(fxt.Client).ByDaemonset(ctx, *updatedDs)
-					Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset pods %s: %v", dsKey.String(), err)
+					g.Expect(fxt.Client.Get(ctx, dsKey.AsKey(), updatedDs)).To(Succeed())
+					allPods, err := podlist.With(fxt.Client).ByDaemonset(ctx, *updatedDs)
+					g.Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset pods %s: %v", dsKey.String(), err)
+					var runningPods []corev1.Pod
+					for _, pod := range allPods {
+						if pod.DeletionTimestamp == nil {
+							runningPods = append(runningPods, pod)
+						}
+					}
+					klog.InfoS("pod count after eviction", "all", len(allPods), "running", len(runningPods), "expected", len(workers)-1)
 					g.Expect(int(updatedDs.Status.NumberReady)).To(Equal(len(workers)-1), "updated DS ready=%v original worker nodes=%v", updatedDs.Status.NumberReady, len(workers)-1)
-					g.Expect(int(updatedDs.Status.NumberReady)).To(Equal(len(pods)), "updated DS ready=%v expected pods", updatedDs.Status.NumberReady, len(pods))
+					g.Expect(runningPods).To(HaveLen(len(workers)-1), "running DS pods=%d expected=%d (total including terminating=%d)", len(runningPods), len(workers)-1, len(allPods))
 				}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 			})
 


### PR DESCRIPTION
The test was flaky because after a NoExecute taint, the DaemonSet status updates later, and we were sometimes checking a stale DaemonSet object. Re-fetching the DaemonSet inside Eventually makes every poll use the current status, so the check is stable.