### PR TITLE
build: mg: use `latest`base and fetch the digest in tekton

### DIFF
--- a/.konflux/must-gather/must-gather.konflux.Dockerfile
+++ b/.konflux/must-gather/must-gather.konflux.Dockerfile
@@ -1,3 +1,6 @@
+# this is used to prefetch the base image in the build pipeline
+ARG BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
+
 # follow https://brewweb.engineering.redhat.com/brew/packageinfo?packageID=70135
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.24@sha256:a3a516cd657576fc8462f88c695b2fa87ada72b00416a24c9253f5b3dc6125a4 as tool-builder
 
@@ -16,7 +19,7 @@ RUN mv /usr/bin/gather /usr/bin/gather_original
 RUN mkdir -p /usr/libexec/must-gather/numaresources-operator && \
     cp /must-gather/collection-scripts/* /usr/libexec/must-gather/numaresources-operator/
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:c7d44146f826037f6873d99da479299b889473492d3c1ab8af86f08af04ec8a0
+FROM ${BASE_IMAGE}
 
 ARG OPENSHIFT_VERSION
 

--- a/.tekton/build-pipeline-must-gather.yaml
+++ b/.tekton/build-pipeline-must-gather.yaml
@@ -204,6 +204,7 @@ spec:
     - name: BUILD_ARGS
       value:
       - $(params.build-args[*])
+      - "BASE_IMAGE=$(tasks.get-base-sha.results.base)@$(tasks.get-base-sha.results.sha)"
     - name: BUILD_ARGS_FILE
       value: $(params.build-args-file)
     - name: PRIVILEGED_NESTED
@@ -220,8 +221,15 @@ spec:
       value: $(tasks.init.results.http-proxy)
     - name: NO_PROXY
       value: $(tasks.init.results.no-proxy)
+    # this param must be defined in the task, see
+    # https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-remote-oci-ta/0.8/buildah-remote-oci-ta.yaml 
+    # be mindful to the versions changes.
+    - name: LABELS
+      value:
+      - "base.image.digest=$(tasks.get-base-sha.results.sha)"
     runAfter:
     - prefetch-dependencies
+    - get-base-sha
     taskRef:
       params:
       - name: name
@@ -593,6 +601,51 @@ spec:
       operator: in
       values:
       - "false"
+  - name: get-base-sha
+    retries: 3
+    params:
+      - name: dockerfile-path
+        value: $(params.dockerfile)
+      # New parameter to use the Trusted Artifact from the git-clone Task.
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+    runAfter:
+    - clone-repository
+    taskSpec:
+      results:
+        - name: sha
+        - name: base
+      params:
+        # https://konflux-ci.dev/docs/building/using-trusted-artifacts/#migrate-to-trusted-artifacts
+        - description: The Trusted Artifact URI pointing to the artifact with the application source code.
+          name: SOURCE_ARTIFACT
+          type: string
+      stepTemplate:
+        volumeMounts:
+          - mountPath: /var/workdir
+            name: workdir
+      steps:
+        # New step to fetch the Trusted Artifact and make it available to the next steps.
+        - name: use-trusted-artifact
+          image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:8391272c4e5011120e9e7fee2c1f339e9405366110bf239dadcbc21e953ce099
+          args:
+            - use
+            - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+        - name: extract-digest
+          image: quay.io/containers/skopeo:latest
+          workingDir: /var/workdir/source
+          script: |
+            #!/usr/bin/env bash
+            set -e
+            set -o pipefail
+
+            url=$(grep '^ARG BASE_IMAGE=' /var/workdir/source/$(params.dockerfile-path) | cut -d= -f2- | sed 's/[[:space:]]*#.*//'| tr -d '\n')
+            echo -n "$url" > $(results.base.path)
+            skopeo inspect --format='{{.Digest}}' docker://$url | tr -d '\n' > $(results.sha.path)
+      volumes:
+        # New volume to store a copy of the source code accessible only to this Task.
+        - name: workdir
+          emptyDir: {}
   workspaces:
   - name: git-auth
     optional: true


### PR DESCRIPTION
So far we've been using an exact digest of the base image for better traceability whenever needed. Due to the nature of how mintmaker works and some limitations we started getting PRs that would update the digests and separate PRs that would refresh the RPMs. Idealy these should be patched together but due to a current limitation (https://issues.redhat.com/browse/CWFHEALTH-4153) we need to manually update the RPMs on monorepos.

To still allow tracability (reflect the base image digest) both with cleaner automatic RPM updates, this commit:
* uses the `latest` tag in the dockerfile for the base image
* handles the tracability in the pipeline level via tekton tasks

The second part is handled by creating a new task , following instructions in
https://tekton.dev/docs/pipelines/pipelines/#adding-tasks-to-the-pipeline, to extract the sha of the latest base image, and fetch the result in `build-images`. In turn `build-images` task is featured with `LABELS` parameter (see https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-remote-oci-ta/0.8/buildah-remote-oci-ta.yaml#L120) which is appended to the produced image.

The task is less likely to fail, still, we allow 3 retries, and avoid fallbacks because if it fails for a valid reason we want to know and fix it preferring traceability over the image build.