### PR TITLE
OCPBUGS-79418: ctrl: sched: add PodAntiAffinity to deployment

### DIFF
--- a/internal/affinity/affinity.go
+++ b/internal/affinity/affinity.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package affinity
+
+import (
+	"errors"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var ErrNoPodTemplateLabels = errors.New("no labels provided for PodAffinity")
+
+func GetPodAntiAffinity(labels map[string]string) (*corev1.PodAntiAffinity, error) {
+	if len(labels) == 0 {
+		return nil, ErrNoPodTemplateLabels
+	}
+
+	return &corev1.PodAntiAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+			{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				TopologyKey: "kubernetes.io/hostname",
+			},
+		},
+	}, nil
+}

--- a/internal/affinity/affinity_test.go
+++ b/internal/affinity/affinity_test.go
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package affinity
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetPodAntiAffinity(t *testing.T) {
+	tests := []struct {
+		name    string
+		labels  map[string]string
+		want    *corev1.PodAntiAffinity
+		wantErr error
+	}{
+		{
+			name:    "nil labels",
+			labels:  nil,
+			wantErr: ErrNoPodTemplateLabels,
+		},
+		{
+			name:    "empty labels",
+			labels:  map[string]string{},
+			wantErr: ErrNoPodTemplateLabels,
+		},
+		{
+			name: "multiple labels",
+			labels: map[string]string{
+				"app":                          "secondary-scheduler",
+				"pod-template-hash":            "abc123",
+				"openshift.io/deployment.name": "secondary-scheduler",
+			},
+			want: &corev1.PodAntiAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"app":                          "secondary-scheduler",
+								"pod-template-hash":            "abc123",
+								"openshift.io/deployment.name": "secondary-scheduler",
+							},
+						},
+						TopologyKey: "kubernetes.io/hostname",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetPodAntiAffinity(tt.labels)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("error: want %v, got %v", tt.wantErr, err)
+				}
+				if got != nil {
+					t.Fatalf("expected nil PodAntiAffinity on error, got %#v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got == nil {
+				t.Fatal("GetPodAntiAffinity returned nil PodAntiAffinity")
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatalf("GetPodAntiAffinity mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -528,7 +528,7 @@ func (r *NUMAResourcesOperatorReconciler) syncNUMAResourcesOperatorResources(ctx
 	}
 
 	rteupdate.DaemonSetRolloutSettings(r.RTEManifests.Core.DaemonSet)
-	err = rteupdate.DaemonSetAffinitySettings(r.RTEManifests.Core.DaemonSet, r.RTEManifests.Core.DaemonSet.Spec.Template.Labels)
+	err = rteupdate.DaemonSetAffinitySettings(r.RTEManifests.Core.DaemonSet)
 	if err != nil {
 		klog.ErrorS(err, "failed to update RTE affinity settings")
 	}

--- a/internal/controller/numaresourcesoperator_controller_test.go
+++ b/internal/controller/numaresourcesoperator_controller_test.go
@@ -2377,7 +2377,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 			Expect(reconciler.Client.Get(context.TODO(), dsKey, &ds)).To(Succeed())
 			Expect(ds.Spec.Template.Labels).ToNot(BeEmpty())
 
-			expected := corev1.PodAntiAffinity{
+			expectedPodAntiAff := corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 					{
 						LabelSelector: &metav1.LabelSelector{
@@ -2387,10 +2387,9 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 					},
 				},
 			}
-
-			Expect(ds.Spec.Template.Spec.Affinity).ToNot(BeNil())
-			Expect(ds.Spec.Template.Spec.Affinity.PodAntiAffinity).ToNot(BeNil())
-			Expect(*ds.Spec.Template.Spec.Affinity.PodAntiAffinity).To(Equal(expected))
+			affinity := ds.Spec.Template.Spec.Affinity
+			Expect(affinity).ToNot(BeNil())
+			Expect(affinity.PodAntiAffinity).To(Equal(&expectedPodAntiAff))
 		})
 
 		It("should have a update strategy with MaxUnavailable set", func() {

--- a/internal/controller/numaresourcesscheduler_controller.go
+++ b/internal/controller/numaresourcesscheduler_controller.go
@@ -360,6 +360,10 @@ func (r *NUMAResourcesSchedulerReconciler) syncNUMASchedulerResources(ctx contex
 		return nropv1.NUMAResourcesSchedulerStatus{}, err
 	}
 
+	if err := schedupdate.DeploymentAffinity(r.SchedulerManifests.Deployment, instance.Spec); err != nil {
+		return nropv1.NUMAResourcesSchedulerStatus{}, err
+	}
+
 	k8swgrbacupdate.RoleForLeaderElection(r.SchedulerManifests.Role, r.Namespace, nrosched.LeaderElectionResourceName)
 	k8swgrbacupdate.RoleBinding(r.SchedulerManifests.RoleBinding, r.SchedulerManifests.ServiceAccount.Name, r.Namespace)
 

--- a/internal/controller/numaresourcesscheduler_controller_test.go
+++ b/internal/controller/numaresourcesscheduler_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -1029,6 +1030,105 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 			Expect(reconciler.Client.Get(context.TODO(), client.ObjectKey{Namespace: testNamespace, Name: "secondary-scheduler"}, dp)).To(Succeed())
 			Expect(dp.Spec.Template.Spec.Containers[0].Args).To(ContainElement("--tls-min-version=" + updatedSettings.MinVersion))
 			Expect(dp.Spec.Template.Spec.Containers[0].Args).To(ContainElement("--tls-cipher-suites=" + updatedSettings.CipherSuites))
+		})
+	})
+
+	Context("when setting the scheduler PodAntiAffinity", func() {
+		type testCase struct {
+			replicasCount         *int32
+			expectPodAntiAffinity bool
+		}
+		schedDeployLabels := map[string]string{
+			"app": "secondary-scheduler",
+		}
+		expectedPodAntiAff := &corev1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: schedDeployLabels,
+					},
+					TopologyKey: "kubernetes.io/hostname",
+				},
+			},
+		}
+		expectedStrategy := appsv1.DeploymentStrategy{
+			Type: appsv1.RollingUpdateDeploymentStrategyType,
+			RollingUpdate: &appsv1.RollingUpdateDeployment{
+				MaxUnavailable: ptr.To(intstr.FromInt(1)),
+				MaxSurge:       ptr.To(intstr.FromInt(0)),
+			},
+		}
+		DescribeTable("should set PodAntiAffinity for scheduler Deployment according to replicas count", func(ctx context.Context, tc testCase) {
+			nrs := testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 11*time.Second)
+			nrs.Spec.Replicas = tc.replicasCount
+			initObjects := []runtime.Object{nrs}
+			initObjects = append(initObjects, fakeNodes(3, 0)...)
+			reconciler, err := NewFakeNUMAResourcesSchedulerReconciler(initObjects...)
+			Expect(err).ToNot(HaveOccurred())
+			// Baseline node affinity comes from the scheduler deployment manifest; reconcile must preserve it.
+			expectedNodeAff := reconciler.SchedulerManifests.Deployment.Spec.Template.Spec.Affinity.NodeAffinity.DeepCopy()
+
+			key := client.ObjectKeyFromObject(nrs)
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).ToNot(HaveOccurred())
+
+			dp := &appsv1.Deployment{}
+			Expect(reconciler.Client.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "secondary-scheduler"}, dp)).To(Succeed())
+			affinity := dp.Spec.Template.Spec.Affinity
+			Expect(affinity).ToNot(BeNil())
+			Expect(affinity.NodeAffinity).To(Equal(expectedNodeAff))
+
+			if !tc.expectPodAntiAffinity {
+				Expect(affinity.PodAntiAffinity).To(BeNil())
+				return
+			}
+
+			podAntiAffinity := affinity.PodAntiAffinity
+			Expect(podAntiAffinity).ToNot(BeNil())
+			Expect(podAntiAffinity).To(Equal(expectedPodAntiAff))
+			Expect(dp.Spec.Strategy).To(Equal(expectedStrategy))
+		},
+			Entry("when replicas are not set, expected podAntiAffinity", testCase{expectPodAntiAffinity: true}),
+			Entry("when replicas are set and zero, expected podAntiAffinity", testCase{replicasCount: ptr.To(int32(0)), expectPodAntiAffinity: true}),
+			Entry("when replicas are set and non-zero, no podAntiAffinity is set", testCase{replicasCount: ptr.To(int32(1)), expectPodAntiAffinity: false}),
+		)
+
+		It("should reset podAntiAffinity and strategy with explicit non-zero replicas count", func(ctx context.Context) {
+			nrs := testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 11*time.Second)
+			nrs.Spec.Replicas = nil
+			initObjects := []runtime.Object{nrs}
+			initObjects = append(initObjects, fakeNodes(3, 0)...)
+			reconciler, err := NewFakeNUMAResourcesSchedulerReconciler(initObjects...)
+			Expect(err).ToNot(HaveOccurred())
+
+			key := client.ObjectKeyFromObject(nrs)
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).ToNot(HaveOccurred())
+
+			dp := &appsv1.Deployment{}
+			Expect(reconciler.Client.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "secondary-scheduler"}, dp)).To(Succeed())
+
+			podAntiAffinity := dp.Spec.Template.Spec.Affinity.PodAntiAffinity
+			Expect(podAntiAffinity).To(Equal(expectedPodAntiAff))
+			Expect(dp.Spec.Strategy).To(Equal(expectedStrategy))
+
+			// reconcile with non-zero replicas count
+			Eventually(func() bool {
+				Expect(reconciler.Client.Get(context.TODO(), key, nrs)).ToNot(HaveOccurred())
+				nrs.Spec.Replicas = ptr.To(int32(2))
+				if err := reconciler.Client.Update(context.TODO(), nrs); err != nil {
+					klog.Warningf("failed to update the scheduler object; err: %v", err)
+					return false
+				}
+				return true
+			}, 30*time.Second, 5*time.Second).Should(BeTrue())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).ToNot(HaveOccurred())
+
+			dp = &appsv1.Deployment{}
+			Expect(reconciler.Client.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "secondary-scheduler"}, dp)).To(Succeed())
+			Expect(dp.Spec.Template.Spec.Affinity.PodAntiAffinity).To(BeNil())
+			Expect(dp.Spec.Strategy).To(Equal(appsv1.DeploymentStrategy{}))
 		})
 	})
 })

--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -22,7 +22,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog/v2"
 
@@ -35,6 +34,7 @@ import (
 	"github.com/k8stopologyawareschedwg/podfingerprint"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
+	intaff "github.com/openshift-kni/numaresources-operator/internal/affinity"
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectupdate/envvar"
 	objtls "github.com/openshift-kni/numaresources-operator/pkg/objectupdate/tls"
@@ -102,23 +102,24 @@ func DaemonSetPauseContainerSettings(ds *appsv1.DaemonSet) error {
 	return nil
 }
 
-func DaemonSetAffinitySettings(ds *appsv1.DaemonSet, labels map[string]string) error {
+func DaemonSetAffinitySettings(ds *appsv1.DaemonSet) error {
+	labels := ds.Spec.Template.Labels
 	if len(labels) == 0 {
-		return fmt.Errorf("no labels provided for PodAffinity")
+		return intaff.ErrNoPodTemplateLabels
 	}
 
-	ds.Spec.Template.Spec.Affinity = &corev1.Affinity{
-		PodAntiAffinity: &corev1.PodAntiAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-				{
-					LabelSelector: &metav1.LabelSelector{
-						MatchLabels: labels,
-					},
-					TopologyKey: "kubernetes.io/hostname",
-				},
-			},
-		},
+	affinityCopy := ds.Spec.Template.Spec.Affinity.DeepCopy()
+	if affinityCopy == nil {
+		ds.Spec.Template.Spec.Affinity = &corev1.Affinity{}
 	}
+
+	podAntiAffinity, err := intaff.GetPodAntiAffinity(labels)
+	if err != nil {
+		return err
+	}
+
+	ds.Spec.Template.Spec.Affinity.PodAntiAffinity = podAntiAffinity
+	klog.V(3).InfoS("Exporter DaemonSet affinity", "podAntiAffinity", ds.Spec.Template.Spec.Affinity.PodAntiAffinity.String())
 	return nil
 }
 

--- a/pkg/objectupdate/rte/rte_test.go
+++ b/pkg/objectupdate/rte/rte_test.go
@@ -25,11 +25,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
+	intaff "github.com/openshift-kni/numaresources-operator/internal/affinity"
 	objtls "github.com/openshift-kni/numaresources-operator/pkg/objectupdate/tls"
 )
 
@@ -344,91 +347,63 @@ func getSetFromStringList(args []string) map[string]struct{} {
 	return argsSet
 }
 
+func TestDaemonSetAffinitySettingsNoLabels(t *testing.T) {
+	ds := testDs.DeepCopy()
+	ds.Spec.Template.Labels = nil
+	err := DaemonSetAffinitySettings(ds)
+	if err == nil {
+		t.Fatalf("expected error but received nil")
+	}
+	if err != intaff.ErrNoPodTemplateLabels {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestDaemonSetAffinitySettings(t *testing.T) {
-	tests := []struct {
-		name        string
-		ds          *appsv1.DaemonSet
-		labels      map[string]string
-		expectedErr error
-	}{
-		{
-			name: "no labels",
-			ds: &appsv1.DaemonSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "ds1",
-				},
-			},
-			expectedErr: fmt.Errorf("no labels provided for PodAffinity"),
-		},
-		{
-			name: "override affinity",
-			ds: &appsv1.DaemonSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "ds1",
-				},
-				Spec: appsv1.DaemonSetSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Affinity: &corev1.Affinity{
-								PodAntiAffinity: &corev1.PodAntiAffinity{
-									RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-										{
-											LabelSelector: &metav1.LabelSelector{
-												MatchLabels: map[string]string{
-													"test1": "test1",
-												},
-											},
-										},
-									},
-								},
-							},
+	ds := testDs.DeepCopy()
+	labels := map[string]string{
+		"app": "secondary-scheduler",
+	}
+	nodeAffinity := corev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+			NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "node-role.kubernetes.io/worker",
+							Operator: corev1.NodeSelectorOpExists,
+							Values:   []string{""},
 						},
 					},
 				},
-			},
-			labels: map[string]string{
-				"test2": "test2",
 			},
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dsCopy := tt.ds.DeepCopy()
+	ds.Spec.Template.Labels = labels
+	ds.Spec.Template.Spec.Affinity = &corev1.Affinity{
+		NodeAffinity: &nodeAffinity,
+	}
+	err := DaemonSetAffinitySettings(ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
-			expectedAffinity := &corev1.Affinity{
-				PodAntiAffinity: &corev1.PodAntiAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-						{
-							LabelSelector: &metav1.LabelSelector{
-								MatchLabels: tt.labels,
-							},
-							TopologyKey: "kubernetes.io/hostname",
-						},
-					},
+	expectedPodAntiAff := corev1.PodAntiAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+			{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: ds.Spec.Template.Labels,
 				},
-			}
+				TopologyKey: "kubernetes.io/hostname",
+			},
+		},
+	}
+	if diff := cmp.Diff(&expectedPodAntiAff, ds.Spec.Template.Spec.Affinity.PodAntiAffinity); diff != "" {
+		t.Fatalf("pod anti-affinity mismatch (-expected +got):\n%s", diff)
+	}
 
-			err := DaemonSetAffinitySettings(tt.ds, tt.labels)
-
-			if err == nil && tt.expectedErr != nil {
-				t.Fatalf("expected error %v but received nil", tt.expectedErr)
-			}
-
-			if err != nil && tt.expectedErr == nil {
-				t.Fatalf("unexpected error %v", tt.expectedErr)
-			}
-
-			if tt.expectedErr != nil {
-				expectedAffinity = dsCopy.Spec.Template.Spec.Affinity
-				if err.Error() != tt.expectedErr.Error() {
-					t.Fatalf("mismatching errors: expected %v got %v", tt.expectedErr, err)
-				}
-			}
-
-			if !reflect.DeepEqual(expectedAffinity, tt.ds.Spec.Template.Spec.Affinity) {
-				t.Errorf("expected affinity %+v, got %+v", expectedAffinity, tt.ds.Spec.Template.Spec.Affinity)
-			}
-		})
+	if diff := cmp.Diff(&nodeAffinity, ds.Spec.Template.Spec.Affinity.NodeAffinity); diff != "" {
+		t.Fatalf("node affinity mismatch (-expected +got):\n%s", diff)
 	}
 }
 

--- a/pkg/objectupdate/sched/sched.go
+++ b/pkg/objectupdate/sched/sched.go
@@ -22,7 +22,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/flagcodec"
 	k8swgmanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
@@ -30,6 +32,7 @@ import (
 	k8swgschedupdate "github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate/sched"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
+	intaff "github.com/openshift-kni/numaresources-operator/internal/affinity"
 	"github.com/openshift-kni/numaresources-operator/internal/api/annotations"
 	intreslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
@@ -99,6 +102,61 @@ func DeploymentTLSSettings(dp *appsv1.Deployment, tlsSettings objtls.Settings) e
 	cnt.Args = flags.Argv()
 
 	klog.V(3).InfoS("Scheduler TLS settings", "minVersion", tlsSettings.MinVersion, "cipherSuites", tlsSettings.CipherSuites)
+	return nil
+}
+
+// DeploymentAffinity configures required pod anti-affinity on the scheduler
+// deployment only when the CR leaves replica count to autodetection (Replicas unset or 0).
+// An explicit non-zero Replicas value means the user chose a replica count and keeps
+// full control (no required pod anti-affinity).
+func DeploymentAffinity(dp *appsv1.Deployment, spec nropv1.NUMAResourcesSchedulerSpec) error {
+	affinityCopy := dp.Spec.Template.Spec.Affinity.DeepCopy()
+	if spec.Replicas != nil && *spec.Replicas != 0 {
+		if affinityCopy != nil && affinityCopy.PodAntiAffinity != nil {
+			// At the time of writing this, the original pod anti-affinity as well
+			// as deployment strategy rollout are not set in the manifest, and
+			// since we control what goes there we can simply revert the change
+			// by resetting it here.
+			dp.Spec.Template.Spec.Affinity.PodAntiAffinity = nil
+			dp.Spec.Strategy = appsv1.DeploymentStrategy{}
+		}
+		return nil
+	}
+
+	labels := dp.Spec.Template.Labels
+	if len(labels) == 0 {
+		return intaff.ErrNoPodTemplateLabels
+	}
+
+	if affinityCopy == nil {
+		dp.Spec.Template.Spec.Affinity = &corev1.Affinity{}
+	}
+
+	podAntiAffinity, err := intaff.GetPodAntiAffinity(labels)
+	if err != nil {
+		return err
+	}
+
+	dp.Spec.Template.Spec.Affinity.PodAntiAffinity = podAntiAffinity
+	klog.V(3).InfoS("Scheduler Deploymentaffinity", "podAntiAffinity", dp.Spec.Template.Spec.Affinity.PodAntiAffinity)
+	// When PodAntiAffinity is set, we need to set the Rollout Strategy to first delete
+	// existing pod (at least one) then recreate new ones.That is specifically important on
+	// control-plane-cluster where the pods already running with high availability; When
+	// podAntiAffinity is set together with high availability and the preferred NodeAffinity
+	// to control-planes,it triggers the deployment rollout but rollout stalls, because the
+	// default behavior of the deployment, as set in the manifest, sets maxSurge to >0 (25%),
+	// which means it first creates the new pod then terminates the old one gradually.
+	// To fix this, we configure the Rollout Strategy to first delete one existing pod to make
+	// room for the new pod on the target node.
+	// NOTE: this needs to be reconsidered if ever the rollout strategy changes in the manifest.
+	dp.Spec.Strategy = appsv1.DeploymentStrategy{
+		Type: appsv1.RollingUpdateDeploymentStrategyType,
+		RollingUpdate: &appsv1.RollingUpdateDeployment{
+			MaxUnavailable: ptr.To(intstr.FromInt(1)),
+			MaxSurge:       ptr.To(intstr.FromInt(0)),
+		},
+	}
+	klog.V(3).InfoS("Scheduler Deployment Rollout Strategy", "rolloutStrategy", dp.Spec.Strategy.String())
 	return nil
 }
 

--- a/pkg/objectupdate/sched/sched_test.go
+++ b/pkg/objectupdate/sched/sched_test.go
@@ -24,14 +24,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 
 	k8swgmanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
+	intaff "github.com/openshift-kni/numaresources-operator/internal/affinity"
 	"github.com/openshift-kni/numaresources-operator/internal/api/annotations"
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	schedstate "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/objectstate/sched"
@@ -629,6 +634,152 @@ func TestDeploymentTLSSettingsRepeated(t *testing.T) {
 	if !reflect.DeepEqual(firstArgs, secondArgs) {
 		t.Errorf("duplicates found in TLS args\nfirst:  %v\nsecond: %v", firstArgs, secondArgs)
 	}
+}
+
+func TestDeploymentAffinityNoLabels(t *testing.T) {
+	dp := dpMinimal.DeepCopy()
+	err := DeploymentAffinity(dp, nropv1.NUMAResourcesSchedulerSpec{})
+	if err == nil {
+		t.Fatalf("expected error but received nil")
+	}
+	if err != intaff.ErrNoPodTemplateLabels {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeploymentAffinityExplicitReplicas(t *testing.T) {
+	dp := dpMinimal.DeepCopy()
+	dp.Spec.Template.ObjectMeta.Labels = map[string]string{"app": "scheduler"}
+	initialNodeAffinity := &corev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+			NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "node-role.kubernetes.io/worker",
+							Operator: corev1.NodeSelectorOpExists,
+							Values:   []string{""},
+						},
+					},
+				},
+			},
+		},
+	}
+	dp.Spec.Template.Spec.Affinity = &corev1.Affinity{
+		NodeAffinity: initialNodeAffinity,
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "scheduler"},
+					},
+				},
+			},
+		},
+	}
+	err := DeploymentAffinity(dp, nropv1.NUMAResourcesSchedulerSpec{Replicas: ptr.To(int32(1))})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diff := cmp.Diff(initialNodeAffinity, dp.Spec.Template.Spec.Affinity.NodeAffinity); diff != "" {
+		t.Errorf("should preserve existing NodeAffinity: affinity mismatch (-expected +got):\n%s", diff)
+	}
+	if dp.Spec.Template.Spec.Affinity.PodAntiAffinity != nil {
+		t.Fatalf("expected podAntiAffinity to be reset but got %v", dp.Spec.Template.Spec.Affinity.PodAntiAffinity)
+	}
+}
+
+func TestDeploymentAffinity(t *testing.T) {
+	labels := map[string]string{"app": "scheduler"}
+	expectedStrategy := appsv1.DeploymentStrategy{
+		Type: appsv1.RollingUpdateDeploymentStrategyType,
+		RollingUpdate: &appsv1.RollingUpdateDeployment{
+			MaxUnavailable: ptr.To(intstr.FromInt(1)),
+			MaxSurge:       ptr.To(intstr.FromInt(0)),
+		},
+	}
+	expectedPodAntiAffinity := &corev1.PodAntiAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+			{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				TopologyKey: "kubernetes.io/hostname",
+			},
+		},
+	}
+	t.Run("override PodAntiAffinity on autodetection of replicas", func(t *testing.T) {
+		dp := dpMinimal.DeepCopy()
+		dp.Spec.Template.ObjectMeta.Labels = labels
+
+		err := DeploymentAffinity(dp, nropv1.NUMAResourcesSchedulerSpec{Replicas: ptr.To(int32(0))})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if diff := cmp.Diff(expectedPodAntiAffinity, dp.Spec.Template.Spec.Affinity.PodAntiAffinity); diff != "" {
+			t.Errorf("affinity mismatch (-expected +got):\n%s", diff)
+		}
+
+		if diff := cmp.Diff(expectedStrategy, dp.Spec.Strategy); diff != "" {
+			t.Errorf("strategy mismatch (-expected +got):\n%s", diff)
+		}
+
+		// check reset works
+		err = DeploymentAffinity(dp, nropv1.NUMAResourcesSchedulerSpec{Replicas: ptr.To(int32(2))})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if dp.Spec.Template.Spec.Affinity != nil && dp.Spec.Template.Spec.Affinity.PodAntiAffinity != nil {
+			t.Fatalf("Override failed: expected no podAntiAffinity but got %v", dp.Spec.Template.Spec.Affinity.PodAntiAffinity)
+		}
+		if dp.Spec.Strategy != (appsv1.DeploymentStrategy{}) {
+			t.Fatalf("expected strategy to be reset but got %v", dp.Spec.Strategy)
+		}
+	})
+
+	t.Run("override PodAntiAffinity with replicas is in autodetection mode", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			replicas *int32
+		}{
+			{
+				name:     "zero replicas count",
+				replicas: ptr.To(int32(0)),
+			},
+			{
+				name:     "nil replicas count",
+				replicas: nil,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				dp := dpMinimal.DeepCopy()
+				dp.Spec.Template.ObjectMeta.Labels = map[string]string{"app": "scheduler"}
+				err := DeploymentAffinity(dp, nropv1.NUMAResourcesSchedulerSpec{Replicas: tc.replicas})
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if dp.Spec.Template.Spec.Affinity == nil {
+					t.Fatalf("expected affinity but received nil")
+				}
+				if dp.Spec.Template.Spec.Affinity.PodAntiAffinity == nil {
+					t.Fatalf("expected podAntiAffinity but received nil")
+				}
+
+				expectedPodAntiAffinity, err := intaff.GetPodAntiAffinity(dp.Spec.Template.Labels)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				if diff := cmp.Diff(expectedPodAntiAffinity, dp.Spec.Template.Spec.Affinity.PodAntiAffinity); diff != "" {
+					t.Errorf("affinity mismatch (-expected +got):\n%s", diff)
+				}
+			})
+		}
+	})
 }
 
 func mustParseResource(t *testing.T, v string) resource.Quantity {


### PR DESCRIPTION
The default functionality of the scheduler HA feature is to create scheduler pod per node (control-plane in Hypershift and worker in Openshift). This will create the pods regardless of the readiness of the nodes, and doesn't necessarily place one pod on each node and this specially rises when some of the hosting nodes are down. The scheduler pod that was meant to be scheduled on that node will be running on another node which already has the scheduler pod. The duplicate pod does not add much value while
 still consume node resources.
This commit adjusts the scheduler deployment to use PodAntiAffinity to avoid creating the same app pod on the same host; IOW each possible host will host only one scheduler pod.

AI note: unit tests were generated by Cursor on prompt and were humanly reviewed.

Assisted-by: Cursor v2.3.37
AIA Attribution: AIA Primarily human, Stylistic edits, Human-initiated, Reviewed v1.0