### PR TITLE
manifests: add annotation to link must-gather image

### DIFF
--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -79,6 +79,7 @@ metadata:
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=4.22.0 <5.0.0'
     operatorframework.io/cluster-monitoring: "true"
+    operators.openshift.io/must-gather-image: registry.redhat.io/openshift4/numaresources-must-gather-rhel9:v5.0
     operators.openshift.io/valid-subscription: |-
       [
         "OpenShift Kubernetes Engine",

--- a/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
@@ -16,6 +16,7 @@ metadata:
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=4.22.0 <5.0.0'
     operatorframework.io/cluster-monitoring: "true"
+    operators.openshift.io/must-gather-image: registry.redhat.io/openshift4/numaresources-must-gather-rhel9:v5.0
     operators.openshift.io/valid-subscription: |-
       [
         "OpenShift Kubernetes Engine",


### PR DESCRIPTION
Include the must gather (informative only ) annotation, so automation (and humans) have a way to learn about the soft dependency.