### PR TITLE
e2e: robustness fixes related to retry loops

### DIFF
--- a/test/e2e/rte/rte_test.go
+++ b/test/e2e/rte/rte_test.go
@@ -19,6 +19,7 @@ package rte
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -68,34 +69,32 @@ var _ = Describe("with a running cluster with all the components", func() {
 			err := clients.Client.Get(context.TODO(), client.ObjectKey{Name: objectnames.DefaultNUMAResourcesOperatorCrName}, nropObj)
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(func() bool {
+			Eventually(func() error {
 				rteDss, err := getOwnedDss(clients.K8sClient, nropObj.ObjectMeta)
 				if err != nil {
-					klog.ErrorS(err, "failed to get the owned DaemonSets")
-					return false
+					return fmt.Errorf("failed to get the owned DaemonSets: %w", err)
 				}
 				if len(rteDss) == 0 {
-					klog.InfoS("expect the numaresourcesoperator to own at least one DaemonSet")
-					return false
+					return fmt.Errorf("expect the numaresourcesoperator to own at least one DaemonSet")
 				}
 
 				for _, ds := range rteDss {
 					rteCnt := k8swgobjupdate.FindContainerByName(ds.Spec.Template.Spec.Containers, rteupdate.MainContainerName)
-					Expect(rteCnt).ToNot(BeNil())
+					if rteCnt == nil {
+						return fmt.Errorf("no container %q found in DaemonSet %q", rteupdate.MainContainerName, ds.Name)
+					}
 
 					found, match := matchLogLevelToKlog(rteCnt, nropObj.Spec.LogLevel)
 					if !found {
-						klog.InfoS("-v flag doesn't exist in container args managed by DaemonSet", "containerName", rteCnt.Name, "daemonsetName", ds.Name)
-						return false
+						return fmt.Errorf("-v flag doesn't exist in container %q args managed by DaemonSet %q", rteCnt.Name, ds.Name)
 					}
 					if !match {
-						klog.InfoS("LogLevel doesn't match the existing -v flag in container under DaemonSet", "logLevel", nropObj.Spec.LogLevel, "containerName", rteCnt.Name, "daemonsetName", ds.Name)
-						return false
+						return fmt.Errorf("LogLevel doesn't match the existing -v flag in container %q under DaemonSet %q", rteCnt.Name, ds.Name)
 					}
 				}
-				return true
+				return nil
 
-			}).WithTimeout(timeout).WithPolling(interval).Should(BeTrue())
+			}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
 		})
 
 		It("can modify the LogLevel in NRO CR and klog under RTE container should change respectively", func() {
@@ -107,35 +106,33 @@ var _ = Describe("with a running cluster with all the components", func() {
 			err = clients.Client.Update(context.TODO(), nropObj)
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(func() bool {
+			Eventually(func() error {
 				rteDss, err := getOwnedDss(clients.K8sClient, nropObj.ObjectMeta)
 				if err != nil {
-					klog.ErrorS(err, "failed to get the owned DaemonSets")
-					return false
+					return fmt.Errorf("failed to get the owned DaemonSets: %w", err)
 				}
 				if len(rteDss) == 0 {
-					klog.InfoS("expect the numaresourcesoperator to own at least one DaemonSet")
-					return false
+					return errors.New("expect the numaresourcesoperator to own at least one DaemonSet")
 				}
 
 				for _, ds := range rteDss {
 					rteCnt := k8swgobjupdate.FindContainerByName(ds.Spec.Template.Spec.Containers, rteupdate.MainContainerName)
-					Expect(rteCnt).ToNot(BeNil())
+					if rteCnt == nil {
+						return fmt.Errorf("no container %q found", rteupdate.MainContainerName)
+					}
 
 					found, match := matchLogLevelToKlog(rteCnt, nropObj.Spec.LogLevel)
 					if !found {
-						klog.InfoS("-v flag doesn't exist in container args under DaemonSet", "containerName", rteCnt.Name, "daemonsetName", ds.Name)
-						return false
+						return fmt.Errorf("-v flag doesn't exist in container %q args  DaemonSet %q", rteCnt.Name, ds.Name)
 					}
 
 					if !match {
-						klog.InfoS("LogLevel doesn't match the existing -v flag in container managed by DaemonSet", "logLevel", nropObj.Spec.LogLevel, "containerName", rteCnt.Name, "daemonsetName", ds.Name)
-						return false
+						return fmt.Errorf("LogLevel doesn't match the existing -v=%v flag in container %q managed by DaemonSet %q", nropObj.Spec.LogLevel, rteCnt.Name, ds.Name)
 					}
 				}
-				return true
+				return nil
 
-			}).WithTimeout(timeout).WithPolling(interval).Should(BeTrue())
+			}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
 		})
 	})
 

--- a/test/e2e/rte/rte_test.go
+++ b/test/e2e/rte/rte_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
 	"time"
@@ -99,12 +100,18 @@ var _ = Describe("with a running cluster with all the components", func() {
 
 		It("can modify the LogLevel in NRO CR and klog under RTE container should change respectively", func() {
 			nropObj := &nropv1.NUMAResourcesOperator{}
-			err := clients.Client.Get(context.TODO(), client.ObjectKey{Name: objectnames.DefaultNUMAResourcesOperatorCrName}, nropObj)
-			Expect(err).ToNot(HaveOccurred())
-
-			nropObj.Spec.LogLevel = operatorv1.Trace
-			err = clients.Client.Update(context.TODO(), nropObj)
-			Expect(err).ToNot(HaveOccurred())
+			Eventually(func() error {
+				err := clients.Client.Get(context.TODO(), client.ObjectKey{Name: objectnames.DefaultNUMAResourcesOperatorCrName}, nropObj)
+				if err != nil {
+					return err
+				}
+				nropObj.Spec.LogLevel = operatorv1.Trace
+				err = clients.Client.Update(context.TODO(), nropObj)
+				if err != nil {
+					return err
+				}
+				return nil
+			}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).Should(Succeed(), "failed to update LogLevel in NRO CR")
 
 			Eventually(func() error {
 				rteDss, err := getOwnedDss(clients.K8sClient, nropObj.ObjectMeta)
@@ -222,28 +229,33 @@ var _ = Describe("with a running cluster with all the components", func() {
 
 			generatedName := objectnames.GetComponentName(nropObj.Name, mcp.Name)
 			klog.InfoS("generated config map", "name", generatedName)
-			cm, err := clients.K8sClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), generatedName, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
 
-			desiredMapState := make(map[string]string)
-			for k, v := range cm.Data {
-				desiredMapState[k] = v
-			}
+			var desiredMapState map[string]string
+			Eventually(func() error {
+				cm, err := clients.K8sClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), generatedName, metav1.GetOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to get ConfigMap %q: %w", generatedName, err)
+				}
+				desiredMapState = maps.Clone(cm.Data)
+				cm.Data = nil
+				_, err = clients.K8sClient.CoreV1().ConfigMaps(namespace).Update(context.TODO(), cm, metav1.UpdateOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to update ConfigMap %q: %w", generatedName, err)
+				}
+				return nil
+			}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).Should(Succeed(), "failed to clear ConfigMap data")
 
-			cm.Data = nil
-			cm, err = clients.K8sClient.CoreV1().ConfigMaps(namespace).Update(context.TODO(), cm, metav1.UpdateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			Eventually(func() bool {
-				cm, err = clients.K8sClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), generatedName, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+			Eventually(func() error {
+				cm, err := clients.K8sClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), generatedName, metav1.GetOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to get ConfigMap %q: %w", generatedName, err)
+				}
 
 				if !reflect.DeepEqual(cm.Data, desiredMapState) {
-					klog.InfoS("ConfigMap data is not in it's desired state, waiting for controller to update it", "configMapName", cm.Name)
-					return false
+					return fmt.Errorf("ConfigMap %q data is not in its desired state, waiting for controller to update it", cm.Name)
 				}
-				return true
-			}).WithTimeout(time.Minute * 5).WithPolling(time.Second * 30).Should(BeTrue())
+				return nil
+			}).WithTimeout(time.Minute * 5).WithPolling(time.Second * 30).Should(Succeed())
 		})
 	})
 

--- a/test/e2e/sched/sched_test.go
+++ b/test/e2e/sched/sched_test.go
@@ -98,12 +98,15 @@ var _ = Describe("[Scheduler] imageReplacement", func() {
 
 			Eventually(func() error {
 				// find deployment by the ownerReference
-				deploy, err := podlist.With(e2eclient.Client).DeploymentByOwnerReference(context.TODO(), uid)
+				dp, err := podlist.With(e2eclient.Client).DeploymentByOwnerReference(context.TODO(), uid)
 				if err != nil {
 					return fmt.Errorf("deployment pod listing failed: %w", err)
 				}
-				if deploy.Spec.Template.Spec.Containers[0].Image != e2eimages.SchedTestImageCI {
-					return fmt.Errorf("image mismatch: got %q, want %q", deploy.Spec.Template.Spec.Containers[0].Image, e2eimages.SchedTestImageCI)
+				if len(dp.Spec.Template.Spec.Containers) < 1 {
+					return fmt.Errorf("missing containers in deployment")
+				}
+				if dp.Spec.Template.Spec.Containers[0].Image != e2eimages.SchedTestImageCI {
+					return fmt.Errorf("image mismatch: got %q, want %q", dp.Spec.Template.Spec.Containers[0].Image, e2eimages.SchedTestImageCI)
 				}
 				return nil
 			}).WithTimeout(time.Minute).WithPolling(time.Second * 10).Should(Succeed())

--- a/test/e2e/sched/sched_test.go
+++ b/test/e2e/sched/sched_test.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -56,21 +56,15 @@ var _ = Describe("[Scheduler] imageReplacement", func() {
 		Expect(e2eclient.Client.Get(context.TODO(), nroSchedKey, nroSchedObj)).ToNot(HaveOccurred(), "cannot get %q in the cluster", nroSchedKey.String())
 
 		DeferCleanup(func() {
-			Eventually(func() bool {
+			Eventually(func() error {
 				err := e2eclient.Client.Get(context.TODO(), nroSchedKey, nroSchedObj)
 				if err != nil {
-					klog.ErrorS(err, "failed to get NUMAResourcesScheduler", "name", nroSchedObj.Name)
-					return false
+					return err
 				}
 
 				nroSchedObj.Spec = objects.TestNROScheduler().Spec
-				err = e2eclient.Client.Update(context.TODO(), nroSchedObj)
-				if err != nil {
-					klog.ErrorS(err, "failed to update NUMAResourcesScheduler", "name", nroSchedObj.Name)
-					return false
-				}
-				return true
-			}).Should(BeTrue(), "failed to revert changes to %q during cleanup", nroSchedKey)
+				return e2eclient.Client.Update(context.TODO(), nroSchedObj)
+			}).Should(Succeed(), "failed to revert changes to %q during cleanup", nroSchedKey)
 
 			dp, err := podlist.With(e2eclient.Client).DeploymentByOwnerReference(context.TODO(), nroSchedObj.UID)
 			Expect(err).ToNot(HaveOccurred(), "unable to get deployment by owner reference")
@@ -86,47 +80,42 @@ var _ = Describe("[Scheduler] imageReplacement", func() {
 
 			var uid types.UID
 			By(fmt.Sprintf("switching the NROS image to %s", e2eimages.SchedTestImageCI))
-			Eventually(func() bool {
+			Eventually(func() error {
 				if err := e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroSchedObj), nroSchedObj); err != nil {
-					klog.ErrorS(err, "failed to get NUMAResourcesScheduler", "name", nroSchedObj.Name)
-					return false
+					return err
 				}
 				nroSchedObj.Spec.SchedulerImage = e2eimages.SchedTestImageCI
 				if err := e2eclient.Client.Update(context.TODO(), nroSchedObj); err != nil {
-					klog.ErrorS(err, "failed to update NUMAResourcesScheduler", "name", nroSchedObj.Name)
-					return false
+					return err
 				}
 				uid = nroSchedObj.GetUID()
-				return true
-			}).WithTimeout(time.Minute).WithPolling(time.Second * 10).Should(BeTrue())
+				return nil
+			}).WithTimeout(time.Minute).WithPolling(time.Second * 10).Should(Succeed())
 
 			err = e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroSchedObj), nroSchedObj)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(nroSchedObj.GetUID()).To(BeEquivalentTo(uid))
 
-			Eventually(func() bool {
+			Eventually(func() error {
 				// find deployment by the ownerReference
 				deploy, err := podlist.With(e2eclient.Client).DeploymentByOwnerReference(context.TODO(), uid)
 				if err != nil {
-					klog.ErrorS(err, "deployment pod listing failed")
-					return false
+					return fmt.Errorf("deployment pod listing failed: %w", err)
 				}
-				return deploy.Spec.Template.Spec.Containers[0].Image == e2eimages.SchedTestImageCI
-			}).WithTimeout(time.Minute).WithPolling(time.Second * 10).Should(BeTrue())
+				if deploy.Spec.Template.Spec.Containers[0].Image != e2eimages.SchedTestImageCI {
+					return fmt.Errorf("image mismatch: got %q, want %q", deploy.Spec.Template.Spec.Containers[0].Image, e2eimages.SchedTestImageCI)
+				}
+				return nil
+			}).WithTimeout(time.Minute).WithPolling(time.Second * 10).Should(Succeed())
 
 			By("reverting NROS changes")
-			Eventually(func() bool {
+			Eventually(func() error {
 				if err := e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroSchedObj), nroSchedObj); err != nil {
-					klog.ErrorS(err, "failed to get NUMAResourcesScheduler", "name", nroSchedObj.Name)
-					return false
+					return err
 				}
 				nroSchedObj.Spec = objects.TestNROScheduler().Spec
-				if err = e2eclient.Client.Update(context.TODO(), nroSchedObj); err != nil {
-					klog.ErrorS(err, "failed to update NUMAResourcesScheduler", "name", nroSchedObj.Name)
-					return false
-				}
-				return true
-			}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(BeTrue())
+				return e2eclient.Client.Update(context.TODO(), nroSchedObj)
+			}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(Succeed())
 
 			// find deployment by the ownerReference
 			dp, err := podlist.With(e2eclient.Client).DeploymentByOwnerReference(context.TODO(), nroSchedObj.GetUID())
@@ -146,11 +135,10 @@ var _ = Describe("[Scheduler] imageReplacement", func() {
 			var nroCM *corev1.ConfigMap
 			var initialCM *corev1.ConfigMap
 
-			Eventually(func() bool {
+			Eventually(func() error {
 				cmList := &corev1.ConfigMapList{}
 				if err := e2eclient.Client.List(context.TODO(), cmList); err != nil {
-					klog.ErrorS(err, "failed to list ConfigMaps")
-					return false
+					return fmt.Errorf("failed to list ConfigMaps: %w", err)
 				}
 
 				for i := 0; i < len(cmList.Items); i++ {
@@ -159,70 +147,55 @@ var _ = Describe("[Scheduler] imageReplacement", func() {
 					}
 				}
 				if nroCM == nil {
-					klog.InfoS("cannot match ConfigMap affecting scheduler", "schedulerName", nroSchedObj.Spec.SchedulerName, "schedulerImage", nroSchedObj.Spec.SchedulerImage)
-					return false
+					return fmt.Errorf("cannot match ConfigMap affecting scheduler %q image %q", nroSchedObj.Spec.SchedulerName, nroSchedObj.Spec.SchedulerImage)
 				}
 
 				initialCM = nroCM.DeepCopy()
 				nroCM.Data["somekey"] = "somevalue"
 
-				err = e2eclient.Client.Update(context.TODO(), nroCM)
-				if err != nil {
-					klog.ErrorS(err, "failed to update ConfigMap", "namespace", nroCM.Namespace, "name", nroCM.Name)
-					return false
-				}
-				return true
-			}).WithTimeout(60 * time.Second).WithPolling(10 * time.Second).Should(BeTrue())
+				return e2eclient.Client.Update(context.TODO(), nroCM)
+			}).WithTimeout(60 * time.Second).WithPolling(10 * time.Second).Should(Succeed())
 
 			key := client.ObjectKeyFromObject(nroCM)
-			Eventually(func() bool {
+			Eventually(func() error {
 				err = e2eclient.Client.Get(context.TODO(), key, nroCM)
 				if err != nil {
-					klog.ErrorS(err, "failed to obtain ConfigMap")
-					return false
+					return fmt.Errorf("failed to get ConfigMap: %w", err)
 				}
 
 				if diff := cmp.Diff(nroCM.Data, initialCM.Data); diff != "" {
-					// TODO: multi-line value in structured log
-					klog.InfoS("updated ConfigMap data is not equal to the expected", "diff", diff)
-					return false
+					return fmt.Errorf("updated ConfigMap data is not equal to the expected: %s", diff)
 				}
-				return true
-			}).WithTimeout(time.Minute * 2).WithPolling(time.Second * 30).Should(BeTrue())
+				return nil
+			}).WithTimeout(time.Minute * 2).WithPolling(time.Second * 30).Should(Succeed())
 
-			dp, err := podlist.With(e2eclient.Client).DeploymentByOwnerReference(context.TODO(), nroSchedObj.GetUID())
-			Expect(err).ToNot(HaveOccurred())
-
-			initialDP := dp.DeepCopy()
-
-			dp.Spec.Template.Spec.Hostname = "newhostname"
-			c := objects.NewTestPodPause("", "newcontainer").Spec.Containers[0]
-			dp.Spec.Template.Spec.Containers = append(dp.Spec.Template.Spec.Containers, c)
-
-			Eventually(func() bool {
-				if err = e2eclient.Client.Update(context.TODO(), dp); err != nil {
-					klog.ErrorS(err, "failed to update Deployment", "namespace", dp.Namespace, "name", dp.Name)
-					return false
-				}
-				return true
-			}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(BeTrue())
-			Expect(err).ToNot(HaveOccurred())
-
-			key = client.ObjectKeyFromObject(dp)
-			Eventually(func() bool {
-				err = e2eclient.Client.Get(context.TODO(), key, dp)
+			var initialDP *appsv1.Deployment
+			var dpKey client.ObjectKey
+			Eventually(func() error {
+				dp, err := podlist.With(e2eclient.Client).DeploymentByOwnerReference(context.TODO(), nroSchedObj.GetUID())
 				if err != nil {
-					klog.ErrorS(err, "failed to obtain ConfigMap")
-					return false
+					return fmt.Errorf("failed to get Deployment: %w", err)
+				}
+				initialDP = dp.DeepCopy()
+				dpKey = client.ObjectKeyFromObject(dp)
+				dp.Spec.Template.Spec.Hostname = "newhostname"
+				c := objects.NewTestPodPause("", "newcontainer").Spec.Containers[0]
+				dp.Spec.Template.Spec.Containers = append(dp.Spec.Template.Spec.Containers, c)
+				return e2eclient.Client.Update(context.TODO(), dp)
+			}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(Succeed())
+
+			dp := &appsv1.Deployment{}
+			Eventually(func() error {
+				err = e2eclient.Client.Get(context.TODO(), dpKey, dp)
+				if err != nil {
+					return fmt.Errorf("failed to get Deployment: %w", err)
 				}
 
 				if diff := cmp.Diff(dp.Spec.Template.Spec, initialDP.Spec.Template.Spec); diff != "" {
-					// TODO: multi-line value in structured log
-					klog.InfoS("updated Deployment is not equal to the expected", "diff", diff)
-					return false
+					return fmt.Errorf("updated Deployment is not equal to the expected: %s", diff)
 				}
-				return true
-			}).WithTimeout(time.Minute * 2).WithPolling(time.Second * 30).Should(BeTrue())
+				return nil
+			}).WithTimeout(time.Minute * 2).WithPolling(time.Second * 30).Should(Succeed())
 		})
 		It("should reflect changes in cacheResyncPeriod when configured", func() {
 			deployment, err := podlist.With(e2eclient.Client).DeploymentByOwnerReference(context.TODO(), nroSchedObj.UID)
@@ -241,21 +214,14 @@ var _ = Describe("[Scheduler] imageReplacement", func() {
 			}
 
 			nroSchedKey := objects.NROSchedObjectKey()
-			Eventually(func() bool {
+			Eventually(func() error {
 				err := e2eclient.Client.Get(context.TODO(), nroSchedKey, nroSchedObj)
 				if err != nil {
-					klog.ErrorS(err, "failed to get", "key", nroSchedKey)
-					return false
+					return err
 				}
 				nroSchedObj.Spec.CacheResyncPeriod = &metav1.Duration{Duration: t}
-
-				err = e2eclient.Client.Update(context.TODO(), nroSchedObj)
-				if err != nil {
-					klog.ErrorS(err, "failed to update", "key", nroSchedKey)
-					return false
-				}
-				return true
-			}).Should(BeTrue(), "failed to update %s's CacheResyncPeriod value", nroSchedKey)
+				return e2eclient.Client.Update(context.TODO(), nroSchedObj)
+			}).Should(Succeed(), "failed to update %s's CacheResyncPeriod value", nroSchedKey)
 
 			By("checking cacheResyncPeriod under the CR's Status")
 			Eventually(func(g Gomega) bool {


### PR DESCRIPTION
make sure the update block get+modify+update are all wrapped inot a retry (Eventually) block, to avoid
false negatives caused by kube's optimistic concurrency.

In addition, instead of handling errors, logging them and return bool in the Eventually's closures, let the error be
returned and bubble up in the Eventually block, letting it handle by ginkgo.

