### PR TITLE
e2e: serial: ginkgo.By(fmt.Sprintf(...)) -> e2efixture.By(...)

### DIFF
--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -176,7 +176,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 
 			Expect(fxt.Client.Create(ctx, testMCP)).To(Succeed())
 			defer func(dctx context.Context) {
-				By(fmt.Sprintf("CLEANUP: deleting mcp: %q", testMCP.Name))
+				e2efixture.By("CLEANUP: deleting mcp: %q", testMCP.Name)
 				Expect(fxt.Client.Delete(dctx, testMCP)).To(Succeed())
 
 				err := wait.With(fxt.Client).
@@ -666,7 +666,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			}
 			Expect(err).ToNot(HaveOccurred())
 
-			By(fmt.Sprintf("checking the pod was scheduled with the topology aware scheduler %q", schedulerName))
+			e2efixture.By("checking the pod was scheduled with the topology aware scheduler %q", schedulerName)
 			schedOK, err := nrosched.CheckPODWasScheduledWith(ctx, fxt.K8sClient, testPod.Namespace, testPod.Name, schedulerName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", testPod.Namespace, testPod.Name, schedulerName)
@@ -679,7 +679,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			By("Waiting for the NRT data to stabilize")
 			e2efixture.MustSettleNRT(fxt)
 
-			By(fmt.Sprintf("checking NRT for target node %q updated correctly", testPod.Spec.NodeName))
+			e2efixture.By("checking NRT for target node %q updated correctly", testPod.Spec.NodeName)
 			// TODO: this is only partially correct. We should check with NUMA zone granularity (not with NODE granularity)
 			expectNRTConsumedResources(fxt, *nrtPreCreate, rl, testPod)
 		})
@@ -698,7 +698,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 				cpuResourcePercentage = 1.5 // 1.5 meaning 150 percent
 			)
 			var nrtCandidates []nrtv1alpha2.NodeResourceTopology
-			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", NUMAZonesRequired))
+			e2efixture.By("filtering available nodes with at least %d NUMA zones", NUMAZonesRequired)
 			nrtCandidates = e2enrt.FilterZoneCountEqual(nrtList.Items, NUMAZonesRequired)
 			if len(nrtCandidates) < hostsRequired {
 				e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates))
@@ -863,7 +863,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			schedulerName = nroSchedObj.Status.SchedulerName
 			Expect(schedulerName).ToNot(BeEmpty(), "cannot autodetect the TAS scheduler name from the cluster")
 
-			By(fmt.Sprintf("deleting the NRO Scheduler object to trigger the pod to restart: %s", nroSchedObj.Name))
+			e2efixture.By("deleting the NRO Scheduler object to trigger the pod to restart: %s", nroSchedObj.Name)
 			Expect(fxt.Client.Delete(ctx, &schedPods[0])).ToNot(HaveOccurred())
 
 			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(time.Minute).ForDeploymentComplete(ctx, schedDeployment)
@@ -917,7 +917,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			updatedDeployment := appsv1.Deployment{}
 			for step := 0; step < maxStep; step++ {
 				time.Sleep(10 * time.Second)
-				By(fmt.Sprintf("ensuring the deployment %q keep being pending %d/%d", deployment.Name, step+1, maxStep))
+				e2efixture.By("ensuring the deployment %q keep being pending %d/%d", deployment.Name, step+1, maxStep)
 				err = fxt.Client.Get(ctx, client.ObjectKeyFromObject(deployment), &updatedDeployment)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(wait.IsDeploymentComplete(deployment, &updatedDeployment.Status)).To(BeFalse(), "deployment %q become ready", deployment.Name)
@@ -1017,7 +1017,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 
 			It("[test_id:84312] should report the NodeGroupConfig in the NodeGroupStatus with NodePool set and allow updates", Label(label.Tier1, label.OpenShift), func(ctx context.Context) {
 				mcp := objects.TestMCP()
-				By(fmt.Sprintf("create new MCP %q", mcp.Name))
+				e2efixture.By("create new MCP %q", mcp.Name)
 				// we rely on the fact that RTE DS will be created for a valid MCP even with machine count 0, that will
 				// save the reboot, so create a temporary MCP just to test this
 
@@ -1037,7 +1037,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 				Expect(fxt.Client.Create(ctx, mcp)).To(Succeed())
 
 				defer func() {
-					By(fmt.Sprintf("CLEANUP: deleting mcp: %q", mcp.Name))
+					e2efixture.By("CLEANUP: deleting mcp: %q", mcp.Name)
 					Expect(fxt.Client.Delete(ctx, mcp)).To(Succeed())
 
 					err := wait.With(fxt.Client).
@@ -1077,7 +1077,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 				}).WithTimeout(10*time.Minute).WithPolling(30*time.Second).Should(Succeed(), "failed to update node groups")
 
 				defer func() {
-					By(fmt.Sprintf("revert initial NodeGroup in NUMAResourcesOperator object %q", initialOperObj.Name))
+					e2efixture.By("revert initial NodeGroup in NUMAResourcesOperator object %q", initialOperObj.Name)
 					var updatedNRO nropv1.NUMAResourcesOperator
 					Expect(fxt.Client.Get(ctx, nroKey, &updatedNRO)).To(Succeed())
 					if !reflect.DeepEqual(updatedNRO.Spec.NodeGroups, initialOperObj.Spec.NodeGroups) {
@@ -1186,7 +1186,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 				}
 
 				defer func() {
-					By(fmt.Sprintf("reverting initial NodeGroup in NUMAResourcesOperator object %q", initialOperObj.Name))
+					e2efixture.By("reverting initial NodeGroup in NUMAResourcesOperator object %q", initialOperObj.Name)
 					var updatedNRO nropv1.NUMAResourcesOperator
 
 					Eventually(func(g Gomega) {
@@ -1208,7 +1208,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 					PoolName: &poolName,
 				}
 
-				By(fmt.Sprintf("modifying the NUMAResourcesOperator by appending a node group with pool name: %q", poolName))
+				e2efixture.By("modifying the NUMAResourcesOperator by appending a node group with pool name: %q", poolName)
 				var updatedNRO nropv1.NUMAResourcesOperator
 				Eventually(func(g Gomega) {
 					g.Expect(fxt.Client.Get(ctx, nroKey, &updatedNRO)).To(Succeed())
@@ -1216,7 +1216,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 					g.Expect(fxt.Client.Update(ctx, &updatedNRO)).To(Succeed())
 				}).WithTimeout(10*time.Minute).WithPolling(30*time.Second).Should(Succeed(), "failed to update node groups")
 
-				By(fmt.Sprintf("verifying degraded condition due to pool name: %q", poolName))
+				e2efixture.By("verifying degraded condition due to pool name: %q", poolName)
 				Eventually(func(g Gomega) {
 					var updated nropv1.NUMAResourcesOperator
 					g.Expect(fxt.Client.Get(ctx, nroKey, &updated)).To(Succeed())
@@ -1240,7 +1240,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 					MachineConfigPoolSelector: labelSel,
 				}
 
-				By(fmt.Sprintf("modifying the NUMAResourcesOperator by appending a node group with MCP selector specifier only: %+v", ng))
+				e2efixture.By("modifying the NUMAResourcesOperator by appending a node group with MCP selector specifier only: %+v", ng)
 				var updatedNRO nropv1.NUMAResourcesOperator
 				Eventually(func(g Gomega) {
 					g.Expect(fxt.Client.Get(ctx, nroKey, &updatedNRO)).To(Succeed())
@@ -1249,7 +1249,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 				}).WithTimeout(10*time.Minute).WithPolling(30*time.Second).Should(Succeed(), "failed to update node groups")
 
 				defer func() {
-					By(fmt.Sprintf("revert initial NodeGroup in NUMAResourcesOperator object %q", initialOperObj.Name))
+					e2efixture.By("revert initial NodeGroup in NUMAResourcesOperator object %q", initialOperObj.Name)
 					var updatedNRO nropv1.NUMAResourcesOperator
 					Eventually(func(g Gomega) {
 						g.Expect(fxt.Client.Get(ctx, nroKey, &updatedNRO)).To(Succeed())
@@ -1351,7 +1351,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 						ForMachineConfigPoolCondition(ctx, mcp, machineconfigv1.MachineConfigPoolUpdated)
 				}
 				mcp := objects.TestMCP()
-				By(fmt.Sprintf("create new MCP %q", mcp.Name))
+				e2efixture.By("create new MCP %q", mcp.Name)
 
 				mcp.Labels = map[string]string{"machineconfiguration.openshift.io/role": roleMCPTest}
 				mcp.Spec.MachineConfigSelector = &metav1.LabelSelector{
@@ -1436,7 +1436,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 				ns := nroObj.Status.DaemonSets[0].Namespace
 				dsName := objectnames.GetComponentName(nroObj.Name, mcp.Name)
 				dsKey := wait.ObjectKey{Namespace: ns, Name: dsName}
-				By(fmt.Sprintf("waiting for DaemonSet %q to be ready", dsKey))
+				e2efixture.By("waiting for DaemonSet %q to be ready", dsKey)
 				_, err = wait.With(fxt.Client).ForDaemonSetReadyByKey(ctx, dsKey)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1719,7 +1719,7 @@ func createTAEDeployment(fxt *e2efixture.Fixture, ctx context.Context, name, sch
 		corev1.ResourceMemory: resource.MustParse("256Mi"),
 	}
 
-	By(fmt.Sprintf("creating a topology affinity error deployment %q", name))
+	e2efixture.By("creating a topology affinity error deployment %q", name)
 	err = fxt.Client.Create(ctx, deployment)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -1739,7 +1739,7 @@ func updatePerformanceProfileFieldUnstructured(dynamicClient dynamic.Interface, 
 	profile, err := dynamicClient.Resource(performanceProfileGVR).Get(ctx, name, metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred(), "Failed to fetch PerformanceProfile using the dynamic client: %v", err)
 
-	By(fmt.Sprintf("checking if the field path %v exists in PerformanceProfile %s", fieldPath, name))
+	e2efixture.By("checking if the field path %v exists in PerformanceProfile %s", fieldPath, name)
 	lenFieldPath := len(fieldPath)
 	fieldToUpdate := fieldPath[lenFieldPath-1]
 	current := profile.Object
@@ -1751,7 +1751,7 @@ func updatePerformanceProfileFieldUnstructured(dynamicClient dynamic.Interface, 
 	_, found, _ := unstructured.NestedFieldNoCopy(current, fieldToUpdate)
 	Expect(found).To(BeTrue(), fmt.Sprintf("Final field '%s' in path %v does not exist in PerformanceProfile %s. Current object: %v", fieldToUpdate, fieldPath, name, current))
 
-	By(fmt.Sprintf("updating field %v in PerformanceProfile %s", fieldPath, name))
+	e2efixture.By("updating field %v in PerformanceProfile %s", fieldPath, name)
 	Eventually(func(g Gomega) {
 		profile, err := dynamicClient.Resource(performanceProfileGVR).Get(ctx, name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred(), "Failed to fetch PerformanceProfile using the dynamic client: %v", err)

--- a/test/e2e/serial/tests/network_policy.go
+++ b/test/e2e/serial/tests/network_policy.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openshift-kni/numaresources-operator/internal/remoteexec"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/internal/clients"
 	"github.com/openshift-kni/numaresources-operator/test/internal/deploy"
+	e2efixture "github.com/openshift-kni/numaresources-operator/test/internal/fixture"
 	"github.com/openshift-kni/numaresources-operator/test/internal/objects"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -188,7 +189,7 @@ func trafficTest(cli *kubernetes.Clientset, ctx context.Context, sourcePod *core
 	endpoint := net.JoinHostPort(destinationIP, destinationPort)
 
 	key := client.ObjectKeyFromObject(sourcePod)
-	By(fmt.Sprintf("verifying HTTP egress connectivity from pod %q to endpoint %s", key.String(), endpoint))
+	e2efixture.By("verifying HTTP egress connectivity from pod %q to endpoint %s", key.String(), endpoint)
 
 	cmd := []string{"sh", "-c", fmt.Sprintf("curl --connect-timeout 5 http://%s", endpoint)}
 

--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -78,7 +78,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		Expect(err).ToNot(HaveOccurred())
 
 		// so we can't support ATM zones > 2. HW with zones > 2 is rare anyway, so not to big of a deal now.
-		By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", 2))
+		e2efixture.By("filtering available nodes with at least %d NUMA zones", 2)
 		nrtCandidates := e2enrt.FilterZoneCountEqual(nrtList.Items, 2)
 		if len(nrtCandidates) < 2 {
 			e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates))
@@ -153,7 +153,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			testPod := objects.NewTestPodPause(fxt.Namespace.Name, "testpod")
 			pSpec := &testPod.Spec
 
-			By(fmt.Sprintf("explicitly mentioning which node we want the pod to land on: %q", targetNodeName))
+			e2efixture.By("explicitly mentioning which node we want the pod to land on: %q", targetNodeName)
 			pSpec.NodeName = targetNodeName
 
 			By("setting a fake schedule name under the pod to make sure pod not scheduled by any scheduler")
@@ -168,7 +168,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			cnt.Resources.Requests = requiredRes
 			cnt.Resources.Limits = requiredRes
 
-			By(fmt.Sprintf("creating pod %s/%s", testPod.Namespace, testPod.Name))
+			e2efixture.By("creating pod %s/%s", testPod.Namespace, testPod.Name)
 			err = fxt.Client.Create(context.TODO(), testPod)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -178,14 +178,14 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}
 			Expect(err).ToNot(HaveOccurred())
 
-			By(fmt.Sprintf("checking the pod landed on the target node %q vs %q", updatedPod.Spec.NodeName, targetNodeName))
+			e2efixture.By("checking the pod landed on the target node %q vs %q", updatedPod.Spec.NodeName, targetNodeName)
 			Expect(updatedPod.Spec.NodeName).To(Equal(targetNodeName),
 				"node landed on %q instead of on %v", updatedPod.Spec.NodeName, targetNodeName)
 
 			By("Waiting for the NRT data to stabilize")
 			e2efixture.MustSettleNRT(fxt)
 
-			By(fmt.Sprintf("checking NRT for target node %q updated correctly", targetNodeName))
+			e2efixture.By("checking NRT for target node %q updated correctly", targetNodeName)
 			rl := e2ereslist.FromGuaranteedPod(*updatedPod)
 			nrtPostCreate := expectNRTConsumedResources(fxt, nrtInitial, rl, updatedPod)
 
@@ -195,7 +195,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			// the NRT updaters MAY be slow to react for a number of reasons including factors out of our control
 			// (kubelet, runtime). This is a known behavior. We can only tolerate some delay in reporting on pod removal.
-			By(fmt.Sprintf("checking the resources are restored as expected on %q", targetNodeName))
+			e2efixture.By("checking the resources are restored as expected on %q", targetNodeName)
 			nrtPostDelete, err := e2enrt.GetUpdatedForNode(fxt.Client, context.TODO(), nrtPostCreate, 1*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 			ok, err = e2enrt.CheckEqualAvailableResources(nrtInitial, nrtPostDelete)
@@ -216,7 +216,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(ok).To(BeTrue())
 			targetNodeName := workers[targetIdx].Name
 
-			By(fmt.Sprintf("explicitly specfying the node where the pod should land: %q. Scheduler Name does not matter in this case", targetNodeName))
+			e2efixture.By("explicitly specfying the node where the pod should land: %q. Scheduler Name does not matter in this case", targetNodeName)
 			nonExistingSchedulerName := "foo"
 
 			var replicas int32 = 1
@@ -249,7 +249,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				RestartPolicy: corev1.RestartPolicyAlways,
 			}
 
-			By(fmt.Sprintf("creating a deployment with a guaranteed pod with two containers requiring total %s", e2ereslist.ToString(e2ereslist.FromContainerLimits(podSpec.Containers))))
+			e2efixture.By("creating a deployment with a guaranteed pod with two containers requiring total %s", e2ereslist.ToString(e2ereslist.FromContainerLimits(podSpec.Containers)))
 			dp := objects.NewTestDeploymentWithPodSpec(replicas, podLabels, nil, fxt.Namespace.Name, "testdp", *podSpec)
 
 			err = fxt.Client.Create(context.TODO(), dp)
@@ -267,11 +267,11 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			updatedPod := pods[0]
 
-			By(fmt.Sprintf("checking the pod landed on the target node %q vs %q", updatedPod.Spec.NodeName, targetNodeName))
+			e2efixture.By("checking the pod landed on the target node %q vs %q", updatedPod.Spec.NodeName, targetNodeName)
 			Expect(updatedPod.Spec.NodeName).To(Equal(targetNodeName),
 				"node landed on %q instead of on %v", updatedPod.Spec.NodeName, targetNodeName)
 
-			By(fmt.Sprintf("checking the pod was assigned to a specific node and not scheduled by a scheduler %q", nonExistingSchedulerName))
+			e2efixture.By("checking the pod was assigned to a specific node and not scheduled by a scheduler %q", nonExistingSchedulerName)
 			schedOK, err := nrosched.CheckPODWasScheduledWith(context.TODO(), fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, nonExistingSchedulerName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(schedOK).To(BeFalse(), "pod %s/%s not assigned to a specific node without a scheduler %s", updatedPod.Namespace, updatedPod.Name, nonExistingSchedulerName)
@@ -294,7 +294,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			policyFuncs := tmSingleNUMANodeFuncsHandler[scope.Value]
 
-			By(fmt.Sprintf("checking post-create NRT for target node %q updated correctly", targetNodeName))
+			e2efixture.By("checking post-create NRT for target node %q updated correctly", targetNodeName)
 			dataBefore, err := yaml.Marshal(nrtInitial)
 			Expect(err).ToNot(HaveOccurred())
 			dataAfter, err := yaml.Marshal(nrtPostCreate)
@@ -310,7 +310,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			// the NRT updaters MAY be slow to react for a number of reasons including factors out of our control
 			// (kubelet, runtime). This is a known behavior. We can only tolerate some delay in reporting on pod removal.
 			Eventually(func() bool {
-				By(fmt.Sprintf("checking the resources are restored as expected on %q", updatedPod.Spec.NodeName))
+				e2efixture.By("checking the resources are restored as expected on %q", updatedPod.Spec.NodeName)
 
 				nrtListPostDelete, err := e2enrt.GetUpdated(fxt.Client, nrtPostCreateDeploymentList, 1*time.Minute)
 				Expect(err).ToNot(HaveOccurred())
@@ -333,7 +333,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			//select target node
 			targetNodeName, ok := e2efixture.PopNodeName(nrtNames)
 			Expect(ok).To(BeTrue(), "cannot select a node among %#v", e2efixture.ListNodeNames(nrtNames))
-			By(fmt.Sprintf("selecting node to schedule the test pod: %q", targetNodeName))
+			e2efixture.By("selecting node to schedule the test pod: %q", targetNodeName)
 
 			//pad non target nodes
 			By("padding non target nodes leaving room for the baseload only")
@@ -355,7 +355,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				Expect(err).ToNot(HaveOccurred(), "could not get padding resources for node %q", nrtInfo.Name)
 
 				for _, zone := range nrtInfo.Zones {
-					By(fmt.Sprintf("fully padding node %q zone %q ", nrtInfo.Name, zone.Name))
+					e2efixture.By("fully padding node %q zone %q ", nrtInfo.Name, zone.Name)
 					padPod := newPaddingPod(nrtInfo.Name, zone.Name, fxt.Namespace.Name, paddingRes[zone.Name])
 
 					padPod, err = pinPodTo(padPod, nrtInfo.Name, zone.Name)
@@ -397,7 +397,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			pod.Spec.SchedulerName = serialconfig.Config.SchedulerName
 			pod.Spec.Containers[0].Resources.Limits = requiredRes
 
-			By(fmt.Sprintf("Scheduling the testing pod with resources that are not allocatable on any numa zone of the target node. requested resources of the test pod: %s", e2ereslist.ToString(e2ereslist.FromContainerLimits(pod.Spec.Containers))))
+			e2efixture.By("Scheduling the testing pod with resources that are not allocatable on any numa zone of the target node. requested resources of the test pod: %s", e2ereslist.ToString(e2ereslist.FromContainerLimits(pod.Spec.Containers)))
 			err = fxt.Client.Create(context.TODO(), pod)
 			Expect(err).NotTo(HaveOccurred(), "unable to create pod %q", pod.Name)
 
@@ -458,7 +458,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			dpName := "test-dp-scaleup"
 			replicas := int32(len(nrtCandidates)) // initially. Then the final value will be 1 replica per NUMA node
-			By(fmt.Sprintf("creating a deployment %q with replicas %d candidate nodes %d", dpName, replicas, len(nrtCandidates)))
+			e2efixture.By("creating a deployment %q with replicas %d candidate nodes %d", dpName, replicas, len(nrtCandidates))
 
 			nroSchedObj := nrosched.CheckNROSchedulerAvailable(ctx, fxt.Client, objectnames.DefaultNUMAResourcesSchedulerCrName)
 
@@ -493,7 +493,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			dp, err = wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDeploymentReplicasReadiness(ctx, dp, replicas)
 			Expect(err).NotTo(HaveOccurred())
 
-			By(fmt.Sprintf("checking deployment pods have been scheduled by %q ", schedulerName))
+			e2efixture.By("checking deployment pods have been scheduled by %q ", schedulerName)
 			pods, err := podlist.With(fxt.Client).ByDeployment(ctx, *dp)
 			Expect(err).ToNot(HaveOccurred(), "unable to get pods from deployment %q:  %v", dp.Name, err)
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", dp.Namespace, dp.Name)

--- a/test/e2e/serial/tests/non_regression_fundamentals.go
+++ b/test/e2e/serial/tests/non_regression_fundamentals.go
@@ -132,7 +132,7 @@ var _ = Describe("numaresources fundamentals non-regression", Serial, Label("ser
 					_, err := pinPodToNode(testPod, targetNodeName)
 					Expect(err).ToNot(HaveOccurred())
 
-					By(fmt.Sprintf("creating pod %s/%s", testPod.Namespace, testPod.Name))
+					e2efixture.By("creating pod %s/%s", testPod.Namespace, testPod.Name)
 					err = fxt.Client.Create(context.TODO(), testPod)
 					Expect(err).ToNot(HaveOccurred())
 
@@ -229,7 +229,7 @@ var _ = Describe("numaresources fundamentals non-regression", Serial, Label("ser
 						serialconfig.MultiNUMALabel: "2",
 					}
 
-					By(fmt.Sprintf("creating pod %s/%s", testPod.Namespace, testPod.Name))
+					e2efixture.By("creating pod %s/%s", testPod.Namespace, testPod.Name)
 					err = fxt.Client.Create(context.TODO(), testPod)
 					Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -104,7 +104,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			const requiredNodeNumber int = 1
 			// TODO: we need AT LEAST 2 (so 4, 8 is fine...) but we hardcode the padding logic to keep the test simple,
 			// so we can't support ATM zones > 2. HW with zones > 2 is rare anyway, so not to big of a deal now.
-			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", requiredNumaZones))
+			e2efixture.By("filtering available nodes with at least %d NUMA zones", requiredNumaZones)
 			nrtTwoZoneCandidates = e2enrt.FilterZoneCountEqual(nrts, requiredNumaZones)
 			if len(nrtTwoZoneCandidates) < requiredNodeNumber {
 				e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d", len(nrtTwoZoneCandidates))
@@ -123,7 +123,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 				corev1.ResourceMemory: resource.MustParse("8Gi"),
 			}
 
-			By(fmt.Sprintf("creating test pod, total resources required %s", e2ereslist.ToString(requiredRes)))
+			e2efixture.By("creating test pod, total resources required %s", e2ereslist.ToString(requiredRes))
 
 			By("filtering available nodes with allocatable resources on each NUMA zone that can match request")
 			nrtCandidates := e2enrt.FilterAnyZoneMatchingResources(nrtTwoZoneCandidates, requiredRes)
@@ -137,17 +137,17 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(ok).To(BeTrue(), "cannot select a target node among %#v", e2efixture.ListNodeNames(candidateNodeNames))
 			unsuitableNodeNames := e2efixture.ListNodeNames(candidateNodeNames)
 
-			By(fmt.Sprintf("selecting target node %q and unsuitable nodes %#v (random pick)", targetNodeName, unsuitableNodeNames))
+			e2efixture.By("selecting target node %q and unsuitable nodes %#v (random pick)", targetNodeName, unsuitableNodeNames)
 			var targetPaddingPods []*corev1.Pod
 			var paddingPods []*corev1.Pod
 
-			By(fmt.Sprintf("preparing target node %q to fit the test case", targetNodeName))
+			e2efixture.By("preparing target node %q to fit the test case", targetNodeName)
 			// first, let's make sure that ONLY the required res can fit in either zone on the target node
 			nrtInfo, err := e2enrt.FindFromList(nrtList.Items, targetNodeName)
 			Expect(err).ToNot(HaveOccurred(), "missing NRT info for %q", targetNodeName)
 
 			for _, zone := range nrtInfo.Zones {
-				By(fmt.Sprintf("padding node %q zone %q", nrtInfo.Name, zone.Name))
+				e2efixture.By("padding node %q zone %q", nrtInfo.Name, zone.Name)
 				padPod, err := makePaddingPod(fxt.Namespace.Name, "target", zone, requiredRes)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -177,7 +177,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 					targetNrtBefore, err = e2enrt.FindFromList(targetNrtListBefore.Items, targetNodeName)
 					Expect(err).NotTo(HaveOccurred())
 				}
-				By(fmt.Sprintf("making node %q zone %q unsuitable with a placeholder pod", nrtInfo.Name, zone.Name))
+				e2efixture.By("making node %q zone %q unsuitable with a placeholder pod", nrtInfo.Name, zone.Name)
 				// now put a minimal pod (1 cpu 1Gi) on both zones. Now the target node as whole will still have the
 				// required resources, but no NUMA zone individually will
 				targetedPaddingPod := objects.NewTestPodPause(fxt.Namespace.Name, fmt.Sprintf("tgtpadpod-%s", zone.Name))
@@ -209,7 +209,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 
 				for _, zone := range nrtInfo.Zones {
 					name := fmt.Sprintf("unsuitable%d", idx)
-					By(fmt.Sprintf("saturating node %q -> %q zone %q", nrtInfo.Name, name, zone.Name))
+					e2efixture.By("saturating node %q -> %q zone %q", nrtInfo.Name, name, zone.Name)
 					padPod, err := makePaddingPod(fxt.Namespace.Name, name, zone, unsuitableFreeRes)
 					Expect(err).ToNot(HaveOccurred())
 
@@ -237,7 +237,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			}
 			dumpNRTForNode(fxt.Client, targetNodeName, "targeted")
 
-			By(fmt.Sprintf("running the test pod requiring: %s", e2ereslist.ToString(requiredRes)))
+			e2efixture.By("running the test pod requiring: %s", e2ereslist.ToString(requiredRes))
 			pod := objects.NewTestPodPause(fxt.Namespace.Name, "testpod")
 			pod.Spec.SchedulerName = serialconfig.Config.SchedulerName
 			pod.Spec.Containers[0].Resources.Limits = requiredRes
@@ -280,11 +280,11 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			}
 			Expect(err).ToNot(HaveOccurred())
 
-			By(fmt.Sprintf("checking the pod landed on the target node %q vs %q", updatedPod.Spec.NodeName, targetNodeName))
+			e2efixture.By("checking the pod landed on the target node %q vs %q", updatedPod.Spec.NodeName, targetNodeName)
 			Expect(updatedPod.Spec.NodeName).To(Equal(targetNodeName),
 				"node landed on %q instead of on %v", updatedPod.Spec.NodeName, targetNodeName)
 
-			By(fmt.Sprintf("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName))
+			e2efixture.By("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName)
 			schedOK, err := nrosched.CheckPODWasScheduledWith(context.TODO(), fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
@@ -316,7 +316,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 		*/
 		BeforeEach(func() {
 			const requiredNUMAZones = 2
-			By(fmt.Sprintf("filtering available nodes with %d NUMA zones", requiredNUMAZones))
+			e2efixture.By("filtering available nodes with %d NUMA zones", requiredNUMAZones)
 			nrtCandidates = e2enrt.FilterZoneCountEqual(nrts, requiredNUMAZones)
 
 			const neededNodes = 1
@@ -329,7 +329,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			var ok bool
 			targetNodeName, ok = e2efixture.PopNodeName(nrtCandidateNames)
 			Expect(ok).To(BeTrue(), "cannot select a node among %#v", e2efixture.ListNodeNames(nrtCandidateNames))
-			By(fmt.Sprintf("selecting node to schedule the test pod: %q", targetNodeName))
+			e2efixture.By("selecting node to schedule the test pod: %q", targetNodeName)
 
 			// TODO: just use nrtList?
 			err = fxt.Client.List(context.TODO(), &targetNrtListInitial)
@@ -345,20 +345,20 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			//calculate base load on the target node
 			baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), targetNodeName)
 			Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", targetNodeName)
-			By(fmt.Sprintf("considering the computed base load: %s", baseload))
+			e2efixture.By("considering the computed base load: %s", baseload)
 
 			//get maximum available node CPU and Memory
 			reqResources = corev1.ResourceList{
 				corev1.ResourceCPU:    availableResourceType(*targetNrtInitial, corev1.ResourceCPU),
 				corev1.ResourceMemory: availableResourceType(*targetNrtInitial, corev1.ResourceMemory),
 			}
-			By(fmt.Sprintf("considering maximum available resources: %s", e2ereslist.ToString(reqResources)))
+			e2efixture.By("considering maximum available resources: %s", e2ereslist.ToString(reqResources))
 
 			By("prepare the test's pod resources as maximum available resources on the target node with the baselaod deducted")
 			err = baseload.Deduct(reqResources)
 			Expect(err).ToNot(HaveOccurred(), "failed deducting resources from baseload: %v", err)
 
-			By(fmt.Sprintf("padding all other candidate nodes leaving room for the baseload only (updated maximum available resources: %s)", e2ereslist.ToString(reqResources)))
+			e2efixture.By("padding all other candidate nodes leaving room for the baseload only (updated maximum available resources: %s)", e2ereslist.ToString(reqResources))
 			var paddingPods []*corev1.Pod
 			for _, nodeName := range e2efixture.ListNodeNames(nrtCandidateNames) {
 				node := &corev1.Node{}
@@ -381,7 +381,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 				Expect(err).ToNot(HaveOccurred(), "could not get padding resources for node %q", nrtInfo.Name)
 
 				for _, zone := range nrtInfo.Zones {
-					By(fmt.Sprintf("fully padding node %q zone %q ", nrtInfo.Name, zone.Name))
+					e2efixture.By("fully padding node %q zone %q ", nrtInfo.Name, zone.Name)
 					padPod := newPaddingPod(nrtInfo.Name, zone.Name, fxt.Namespace.Name, paddingRes[zone.Name])
 
 					padPod, err = pinPodTo(padPod, nrtInfo.Name, zone.Name)
@@ -431,7 +431,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			}
 			Expect(err).ToNot(HaveOccurred())
 
-			By(fmt.Sprintf("checking the pod has been scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName))
+			e2efixture.By("checking the pod has been scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName)
 			schedOK, err := nrosched.CheckPODWasScheduledWith(context.TODO(), fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
@@ -462,7 +462,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			}
 			Expect(err).ToNot(HaveOccurred())
 
-			By(fmt.Sprintf("checking the pod has been scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName))
+			e2efixture.By("checking the pod has been scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName)
 			schedOK, err := nrosched.CheckPODWasScheduledWith(context.TODO(), fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
@@ -495,7 +495,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(1*time.Minute).ForDeploymentComplete(context.TODO(), deployment)
 			Expect(err).NotTo(HaveOccurred(), "Deployment %q not up & running after %v", deployment.Name, 1*time.Minute)
 
-			By(fmt.Sprintf("checking deployment pods have been scheduled with the topology aware scheduler %q and in the proper node %q", serialconfig.Config.SchedulerName, targetNodeName))
+			e2efixture.By("checking deployment pods have been scheduled with the topology aware scheduler %q and in the proper node %q", serialconfig.Config.SchedulerName, targetNodeName)
 			pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *deployment)
 			Expect(err).NotTo(HaveOccurred(), "Unable to get pods from Deployment %q: %v", deployment.Name, err)
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
@@ -576,7 +576,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			}
 			Expect(err).ToNot(HaveOccurred())
 
-			By(fmt.Sprintf("checking the pod has been scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName))
+			e2efixture.By("checking the pod has been scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName)
 			schedOK, err := nrosched.CheckPODWasScheduledWith(context.TODO(), fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
@@ -607,7 +607,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			}
 			Expect(err).ToNot(HaveOccurred())
 
-			By(fmt.Sprintf("checking the pod has been scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName))
+			e2efixture.By("checking the pod has been scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName)
 			schedOK, err := nrosched.CheckPODWasScheduledWith(context.TODO(), fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
@@ -670,7 +670,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			}
 			Expect(err).ToNot(HaveOccurred())
 
-			By(fmt.Sprintf("checking the pod has been scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName))
+			e2efixture.By("checking the pod has been scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName)
 			schedOK, err = nrosched.CheckPODWasScheduledWith(context.TODO(), fxt.K8sClient, updatedPod2.Namespace, updatedPod2.Name, serialconfig.Config.SchedulerName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
@@ -693,7 +693,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 
 			policyFuncs := tmSingleNUMANodeFuncsHandler[scope.Value]
 
-			By(fmt.Sprintf("checking post-update NRT for target node %q updated correctly", targetNodeName))
+			e2efixture.By("checking post-update NRT for target node %q updated correctly", targetNodeName)
 			// it's simpler (no resource subtraction/difference) to check against initial than compute
 			// the delta between postUpdate and postCreate. Both must yield the same result anyway.
 			dataBefore, err := yaml.Marshal(targetNrtInitial)
@@ -711,7 +711,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			// the NRT updaters MAY be slow to react for a number of reasons including factors out of our control
 			// (kubelet, runtime). This is a known behavior. We can only tolerate some delay in reporting on pod removal.
 			Eventually(func() bool {
-				By(fmt.Sprintf("checking the resources are restored as expected on %q", updatedPod2.Spec.NodeName))
+				e2efixture.By("checking the resources are restored as expected on %q", updatedPod2.Spec.NodeName)
 
 				nrtListPostPodDelete, err := e2enrt.GetUpdated(fxt.Client, nrtPostPodCreateList, 1*time.Minute)
 				Expect(err).ToNot(HaveOccurred())
@@ -751,7 +751,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(1*time.Minute).ForDaemonSetReady(context.TODO(), ds)
 			Expect(err).NotTo(HaveOccurred(), "Daemonset %q not up & running after %v", ds.Name, 1*time.Minute)
 
-			By(fmt.Sprintf("checking Daemonset pods have been scheduled with the topology aware scheduler %q and in the proper node %q", serialconfig.Config.SchedulerName, targetNodeName))
+			e2efixture.By("checking Daemonset pods have been scheduled with the topology aware scheduler %q and in the proper node %q", serialconfig.Config.SchedulerName, targetNodeName)
 			pods, err := podlist.With(fxt.Client).ByDaemonset(context.TODO(), *ds)
 			Expect(err).NotTo(HaveOccurred(), "Unable to get pods from Daemonset %q: %v", ds.Name, err)
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DS %s/%s", ds.Namespace, ds.Name)

--- a/test/e2e/serial/tests/resource_hostlevel.go
+++ b/test/e2e/serial/tests/resource_hostlevel.go
@@ -108,7 +108,7 @@ var _ = Describe("[serial][hostlevel] numaresources host-level resources", Seria
 				klog.InfoS("pod resources", "namespace", updatedPod.Namespace, "name", updatedPod.Name, "resources", intreslist.ToString(intreslist.FromContainerRequests(pod.Spec.Containers)))
 				Expect(updatedPod.Status.QOSClass).To(Equal(expectedQOS), "pod QOS mismatch")
 
-				By(fmt.Sprintf("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName))
+				e2efixture.By("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName)
 				schedOK, err := nrosched.CheckPODWasScheduledWith(context.TODO(), fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
@@ -342,7 +342,7 @@ var _ = Describe("[serial][hostlevel] numaresources host-level resources", Seria
 				// TODO: multi-line value in structured log
 				klog.InfoS("pod resources", "namespace", updatedPod.Namespace, "name", updatedPod.Name, "resources", intreslist.ToString(intreslist.FromContainerRequests(pod.Spec.Containers)))
 				Expect(updatedPod.Status.QOSClass).To(Equal(expectedQOS), "pod QoS mismatch")
-				By(fmt.Sprintf("checking the pod is handled by the topology aware scheduler %q but failed to be scheduled on any node", serialconfig.Config.SchedulerName))
+				e2efixture.By("checking the pod is handled by the topology aware scheduler %q but failed to be scheduled on any node", serialconfig.Config.SchedulerName)
 				isFailed, err := nrosched.CheckPodSchedulingFailedWithMsg(context.TODO(), fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName, fmt.Sprintf("%d Insufficient ephemeral-storage", len(candidateNodeNames)))
 				if err != nil {
 					_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
@@ -415,7 +415,7 @@ type desiredNodesState struct {
 }
 
 func filterNodes(fxt *e2efixture.Fixture, nodesState desiredNodesState) []nrtv1alpha2.NodeResourceTopology {
-	By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", nodesState.RequiredNUMAZones))
+	e2efixture.By("filtering available nodes with at least %d NUMA zones", nodesState.RequiredNUMAZones)
 	nrtCandidates := e2enrt.FilterZoneCountEqual(nodesState.NRTList.Items, nodesState.RequiredNUMAZones)
 
 	if len(nrtCandidates) < nodesState.RequiredNodes {

--- a/test/e2e/serial/tests/scheduler_cache.go
+++ b/test/e2e/serial/tests/scheduler_cache.go
@@ -132,7 +132,7 @@ var _ = Describe("scheduler cache", Serial, Label(label.Tier0, "scheduler", "cac
 
 				Expect(desiredPods).To(BeNumerically(">", hostsRequired)) // this is more like a C assert. Should never ever fail.
 
-				By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", NUMAZonesRequired))
+				e2efixture.By("filtering available nodes with at least %d NUMA zones", NUMAZonesRequired)
 				nrtCandidates = e2enrt.FilterZoneCountEqual(nrtList.Items, NUMAZonesRequired)
 				if len(nrtCandidates) < hostsRequired {
 					e2efixture.Skipf(fxt, "not enough nodes with %d NUMA Zones: found %d", NUMAZonesRequired, len(nrtCandidates))
@@ -228,7 +228,7 @@ var _ = Describe("scheduler cache", Serial, Label(label.Tier0, "scheduler", "cac
 					// TODO: should it be desiredPodsPerNode?
 					Expect(interference.ratio).To(BeNumerically("<=", desiredPods)) // this is more like a C assert. Should never ever fail.
 
-					By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", NUMAZonesRequired))
+					e2efixture.By("filtering available nodes with at least %d NUMA zones", NUMAZonesRequired)
 					nrtCandidates = e2enrt.FilterZoneCountEqual(nrtList.Items, NUMAZonesRequired)
 					if len(nrtCandidates) < hostsRequired {
 						e2efixture.Skipf(fxt, "not enough nodes with %d NUMA Zones: found %d", NUMAZonesRequired, len(nrtCandidates))
@@ -364,7 +364,7 @@ var _ = Describe("scheduler cache", Serial, Label(label.Tier0, "scheduler", "cac
 
 				// so we can't support ATM zones > 2. HW with zones > 2 is rare anyway, so not to big of a deal now.
 				// TODO: when we support NUMA zones > 2, switch to FilterZoneCountAtLeast
-				By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", NUMAZonesRequired))
+				e2efixture.By("filtering available nodes with at least %d NUMA zones", NUMAZonesRequired)
 				nrtCandidates = e2enrt.FilterZoneCountEqual(nrtList.Items, NUMAZonesRequired)
 				if len(nrtCandidates) < hostsRequired {
 					e2efixture.Skipf(fxt, "not enough nodes with %d NUMA Zones: found %d", NUMAZonesRequired, len(nrtCandidates))
@@ -372,7 +372,7 @@ var _ = Describe("scheduler cache", Serial, Label(label.Tier0, "scheduler", "cac
 				klog.InfoS("Found nodes", "count", len(nrtCandidates), "NUMAZoneCount", NUMAZonesRequired)
 
 				NUMAZonesWithDevice := 1
-				By(fmt.Sprintf("filtering available nodes which provide %q on exactly %d zones", deviceName, NUMAZonesWithDevice))
+				e2efixture.By("filtering available nodes which provide %q on exactly %d zones", deviceName, NUMAZonesWithDevice)
 				nrtCandidates = filterAnyZoneProvidingResourcesAtMost(nrtCandidates, deviceName, int64(desiredPods), NUMAZonesWithDevice)
 				if len(nrtCandidates) < hostsRequired {
 					e2efixture.Skipf(fxt, "not enough nodes with at most %d NUMA Zones offering %q: found %d", NUMAZonesWithDevice, deviceName, len(nrtCandidates))
@@ -485,7 +485,7 @@ var _ = Describe("scheduler cache", Serial, Label(label.Tier0, "scheduler", "cac
 
 				// so we can't support ATM zones > 2. HW with zones > 2 is rare anyway, so not to big of a deal now.
 				// TODO: when we support NUMA zones > 2, switch to FilterZoneCountAtLeast
-				By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", NUMAZonesRequired))
+				e2efixture.By("filtering available nodes with at least %d NUMA zones", NUMAZonesRequired)
 				nrtCandidates = e2enrt.FilterZoneCountEqual(nrtList.Items, NUMAZonesRequired)
 				if len(nrtCandidates) < hostsRequired {
 					e2efixture.Skipf(fxt, "not enough nodes with %d NUMA Zones: found %d", NUMAZonesRequired, len(nrtCandidates))
@@ -493,7 +493,7 @@ var _ = Describe("scheduler cache", Serial, Label(label.Tier0, "scheduler", "cac
 				klog.InfoS("Found nodes", "count", len(nrtCandidates), "NUMAZoneCount", NUMAZonesRequired)
 
 				NUMAZonesWithDevice := 1
-				By(fmt.Sprintf("filtering available nodes which provide %q on exactly %d zones", deviceName, NUMAZonesWithDevice))
+				e2efixture.By("filtering available nodes which provide %q on exactly %d zones", deviceName, NUMAZonesWithDevice)
 				nrtCandidates = filterAnyZoneProvidingResourcesAtMost(nrtCandidates, deviceName, int64(desiredPods), NUMAZonesWithDevice)
 				if len(nrtCandidates) < hostsRequired {
 					e2efixture.Skipf(fxt, "not enough nodes with at most %d NUMA Zones offering %q: found %d", NUMAZonesWithDevice, deviceName, len(nrtCandidates))

--- a/test/e2e/serial/tests/scheduler_cache_stall.go
+++ b/test/e2e/serial/tests/scheduler_cache_stall.go
@@ -130,7 +130,7 @@ var _ = Describe("[serial][scheduler][cache] scheduler cache stall", Label("sche
 				NUMAZonesRequired = 2
 				cpusPerPod = 2 // must be even. Must be >= 2
 
-				By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", NUMAZonesRequired))
+				e2efixture.By("filtering available nodes with at least %d NUMA zones", NUMAZonesRequired)
 				nrtCandidates = e2enrt.FilterZoneCountEqual(nrtList.Items, NUMAZonesRequired)
 				if len(nrtCandidates) < hostsRequired {
 					e2efixture.Skipf(fxt, "not enough nodes with %d NUMA Zones: found %d", NUMAZonesRequired, len(nrtCandidates))
@@ -414,7 +414,7 @@ var _ = Describe("[serial][scheduler][cache] scheduler cache stall", Label("sche
 				NUMAZonesRequired = 2
 				cpusPerPod = 2 // must be even. Must be >= 2
 
-				By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", NUMAZonesRequired))
+				e2efixture.By("filtering available nodes with at least %d NUMA zones", NUMAZonesRequired)
 				nrtCandidates = e2enrt.FilterZoneCountEqual(nrtList.Items, NUMAZonesRequired)
 				if len(nrtCandidates) < hostsRequired {
 					e2efixture.Skipf(fxt, "not enough nodes with %d NUMA Zones: found %d", NUMAZonesRequired, len(nrtCandidates))
@@ -644,7 +644,7 @@ var _ = Describe("[serial][scheduler][cache] scheduler cache stall", Label("sche
 							serialconfig.MultiNUMALabel: "2",
 						}
 
-						By(fmt.Sprintf("creating pod %s/%s", testPod.Namespace, testPod.Name))
+						e2efixture.By("creating pod %s/%s", testPod.Namespace, testPod.Name)
 						err = fxt.Client.Create(ctx, testPod)
 						Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/serial/tests/scheduler_removal.go
+++ b/test/e2e/serial/tests/scheduler_removal.go
@@ -18,7 +18,6 @@ package tests
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -78,7 +77,7 @@ var _ = Describe("[serial][disruptive][scheduler][schedrst] numaresources schedu
 
 			dp := createDeploymentSync(fxt, "testdp", serialconfig.Config.SchedulerName)
 
-			By(fmt.Sprintf("deleting the NRO Scheduler object: %s", serialconfig.Config.NROSchedObj.Name))
+			e2efixture.By("deleting the NRO Scheduler object: %s", serialconfig.Config.NROSchedObj.Name)
 			err = fxt.Client.Delete(context.TODO(), serialconfig.Config.NROSchedObj)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -90,7 +89,7 @@ var _ = Describe("[serial][disruptive][scheduler][schedrst] numaresources schedu
 			for step := 0; step < maxStep; step++ {
 				time.Sleep(10 * time.Second)
 
-				By(fmt.Sprintf("ensuring the deployment %q keep being ready %d/%d", dp.Name, step+1, maxStep))
+				e2efixture.By("ensuring the deployment %q keep being ready %d/%d", dp.Name, step+1, maxStep)
 
 				updatedDp := &appsv1.Deployment{}
 				err = fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(dp), updatedDp)
@@ -103,7 +102,7 @@ var _ = Describe("[serial][disruptive][scheduler][schedrst] numaresources schedu
 		It("[test_id:49093][case:2] should keep new scheduled workloads pending", Label(label.Tier1, "unsched", "feature:unsched"), func() {
 			var err error
 
-			By(fmt.Sprintf("deleting the NRO Scheduler object: %s", serialconfig.Config.NROSchedObj.Name))
+			e2efixture.By("deleting the NRO Scheduler object: %s", serialconfig.Config.NROSchedObj.Name)
 			err = fxt.Client.Delete(context.TODO(), serialconfig.Config.NROSchedObj)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -117,7 +116,7 @@ var _ = Describe("[serial][disruptive][scheduler][schedrst] numaresources schedu
 			for step := 0; step < maxStep; step++ {
 				time.Sleep(10 * time.Second)
 
-				By(fmt.Sprintf("ensuring the deployment %q keep being pending %d/%d", dp.Name, step+1, maxStep))
+				e2efixture.By("ensuring the deployment %q keep being pending %d/%d", dp.Name, step+1, maxStep)
 
 				updatedDp := &appsv1.Deployment{}
 				err = fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(dp), updatedDp)
@@ -134,7 +133,7 @@ var _ = Describe("[serial][disruptive][scheduler][schedrst] numaresources schedu
 
 			ctx := context.TODO()
 
-			By(fmt.Sprintf("deleting the NRO Scheduler object: %s", nroSchedObj.Name))
+			e2efixture.By("deleting the NRO Scheduler object: %s", nroSchedObj.Name)
 			err = fxt.Client.Delete(ctx, nroSchedObj)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -149,7 +148,7 @@ var _ = Describe("[serial][disruptive][scheduler][schedrst] numaresources schedu
 			for step := 0; step < maxStep; step++ {
 				time.Sleep(10 * time.Second)
 
-				By(fmt.Sprintf("ensuring the deployment %q keep being pending %d/%d", dp.Name, step+1, maxStep))
+				e2efixture.By("ensuring the deployment %q keep being pending %d/%d", dp.Name, step+1, maxStep)
 
 				err = fxt.Client.Get(ctx, client.ObjectKeyFromObject(dp), updatedDp)
 				Expect(err).ToNot(HaveOccurred())
@@ -160,7 +159,7 @@ var _ = Describe("[serial][disruptive][scheduler][schedrst] numaresources schedu
 			restoreScheduler(fxt, nroSchedObj)
 			nroSchedObj = nrosched.CheckNROSchedulerAvailable(ctx, fxt.Client, nroSchedObj.Name)
 
-			By(fmt.Sprintf("waiting for the test deployment %q to become complete and ready", updatedDp.Name))
+			e2efixture.By("waiting for the test deployment %q to become complete and ready", updatedDp.Name)
 			_, err = wait.With(fxt.Client).Interval(2*time.Second).Interval(30*time.Second).ForDeploymentComplete(ctx, updatedDp)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -169,7 +168,7 @@ var _ = Describe("[serial][disruptive][scheduler][schedrst] numaresources schedu
 })
 
 func restoreScheduler(fxt *e2efixture.Fixture, nroSchedObj *nropv1.NUMAResourcesScheduler) {
-	By(fmt.Sprintf("re-creating the NRO Scheduler object: %s", nroSchedObj.Name))
+	e2efixture.By("re-creating the NRO Scheduler object: %s", nroSchedObj.Name)
 	nroSched := &nropv1.NUMAResourcesScheduler{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "NUMAResourcesScheduler",
@@ -196,7 +195,7 @@ func createDeployment(fxt *e2efixture.Fixture, name, schedulerName string) *apps
 	dp := objects.NewTestDeployment(replicas, podLabels, nodeSelector, fxt.Namespace.Name, name, images.GetPauseImage(), []string{images.PauseCommand}, []string{})
 	dp.Spec.Template.Spec.SchedulerName = schedulerName
 
-	By(fmt.Sprintf("creating a test deployment %q", name))
+	e2efixture.By("creating a test deployment %q", name)
 	err = fxt.Client.Create(context.TODO(), dp)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -205,7 +204,7 @@ func createDeployment(fxt *e2efixture.Fixture, name, schedulerName string) *apps
 
 func createDeploymentSync(fxt *e2efixture.Fixture, name, schedulerName string) *appsv1.Deployment {
 	dp := createDeployment(fxt, name, schedulerName)
-	By(fmt.Sprintf("waiting for the test deployment %q to be complete and ready", name))
+	e2efixture.By("waiting for the test deployment %q to be complete and ready", name)
 	_, err := wait.With(fxt.Client).Interval(10*time.Second).Timeout(time.Minute).ForDeploymentComplete(context.TODO(), dp)
 	Expect(err).ToNot(HaveOccurred(), "Deployment %q is not up & running after %v", dp.Name, time.Minute)
 	return dp

--- a/test/e2e/serial/tests/tolerations.go
+++ b/test/e2e/serial/tests/tolerations.go
@@ -240,7 +240,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 					_ = setRTETolerations(ctx, fxt.Client, nroKey, []corev1.Toleration{})
 				}
 
-				By(fmt.Sprintf("ensuring the RTE DS was restored - expected pods=%d", len(workers)))
+				e2efixture.By("ensuring the RTE DS was restored - expected pods=%d", len(workers))
 				ds, err := wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDaemonsetPodsCreation(ctx, dsKey, len(workers))
 				Expect(err).NotTo(HaveOccurred(), "pods number is not as expected for daemonset: expected %d found %d", len(workers), ds.Status.CurrentNumberScheduled)
 				updatedDs, err := wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
@@ -258,7 +258,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 				workers, err = nodes.GetWorkers(fxt.DEnv())
 				Expect(err).ToNot(HaveOccurred())
 
-				By(fmt.Sprintf("randomly picking the target node (among %d)", len(workers)))
+				e2efixture.By("randomly picking the target node (among %d)", len(workers))
 				targetIdx, ok := e2efixture.PickNodeIndex(workers)
 				Expect(ok).To(BeTrue())
 				targetNode := &workers[targetIdx]
@@ -272,7 +272,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 				updatedNode := applyTaintToNode(ctx, fxt.Client, targetNode, tnt)
 				targetNodeNames = append(targetNodeNames, updatedNode.Name)
 
-				By(fmt.Sprintf("waiting for DaemonSet to be ready - should match worker nodes count %d", len(workers)))
+				e2efixture.By("waiting for DaemonSet to be ready - should match worker nodes count %d", len(workers))
 				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(1*time.Minute).ForDaemonsetPodsCreation(ctx, dsKey, len(workers))
 				Expect(err).ToNot(HaveOccurred(), "daemonset %s did not start updated: %v", dsKey.String(), err)
 				updatedDs, err := wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
@@ -282,7 +282,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 				By("deleting the DS to force the system recreate the pod")
 				// hack! remove the DS object to make the operator recreate the DS and thus restart all the pods
 				Expect(fxt.Client.Delete(ctx, updatedDs)).Should(Succeed())
-				By(fmt.Sprintf("checking that the DaemonSet is recreated with matching worker nodes count %d", len(workers)))
+				e2efixture.By("checking that the DaemonSet is recreated with matching worker nodes count %d", len(workers))
 				ds, err := wait.With(fxt.Client).Interval(time.Second).Timeout(2*time.Minute).ForDaemonsetPodsCreation(ctx, dsKey, len(workers))
 				Expect(err).NotTo(HaveOccurred(), "pods number is not as expected for daemonset: expected %d found %d", len(workers), ds.Status.CurrentNumberScheduled)
 				// the key will remain the same, the DS namespaced name is predictable and fixed
@@ -333,7 +333,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 				targetNodeNames = append(targetNodeNames, taintedNode.Name)
 				klog.InfoS("considering node tainted", "node", taintedNode.Name, "taint", tnt.String())
 
-				By(fmt.Sprintf("ensuring the RTE DS was created with expected pods count=%d", len(workers)))
+				e2efixture.By("ensuring the RTE DS was created with expected pods count=%d", len(workers))
 				ds, err := wait.With(fxt.Client).Interval(time.Second).Timeout(3*time.Minute).ForDaemonsetPodsCreation(ctx, dsKey, len(workers))
 				Expect(err).NotTo(HaveOccurred(), "pods number is not as expected for daemonset: expected %d found %d", len(workers), ds.Status.CurrentNumberScheduled)
 				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
@@ -346,7 +346,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 				tolerateVal.Value = "val2"
 				_ = setRTETolerations(ctx, fxt.Client, nroKey, []corev1.Toleration{tolerateVal})
 
-				By(fmt.Sprintf("ensuring the RTE DS was created with expected pods count=%d", len(workers)-1))
+				e2efixture.By("ensuring the RTE DS was created with expected pods count=%d", len(workers)-1)
 				ds, err = wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDaemonsetPodsCreation(ctx, dsKey, len(workers)-1)
 				Expect(err).NotTo(HaveOccurred(), "pods number is not as expected for daemonset: expected %d found %d", len(workers)-1, ds.Status.CurrentNumberScheduled)
 				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
@@ -389,7 +389,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 				_ = setRTETolerations(ctx, fxt.Client, nroKey, tolerateVal1)
 				extraTols = true
 
-				By(fmt.Sprintf("ensuring the RTE DS was created with expected pods count=%d", len(workers)))
+				e2efixture.By("ensuring the RTE DS was created with expected pods count=%d", len(workers))
 				ds, err := wait.With(fxt.Client).Interval(time.Second).Timeout(3*time.Minute).ForDaemonsetPodsCreation(ctx, dsKey, len(workers))
 				Expect(err).NotTo(HaveOccurred(), "pods number is not as expected for daemonset: expected %d found %d", len(workers), ds.Status.CurrentNumberScheduled)
 				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
@@ -407,7 +407,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 				applyTaintToNode(ctx, fxt.Client, taintedNode, tnt)
 				klog.InfoS("considering node tainted", "node", taintedNode.Name, "taint", tnt.String())
 
-				By(fmt.Sprintf("waiting for daemonset %v to report correct pods' number", dsKey.String()))
+				e2efixture.By("waiting for daemonset %v to report correct pods' number", dsKey.String())
 				updatedDs, err := wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDaemonsetPodsCreation(ctx, dsKey, len(workers)-1)
 				Expect(err).NotTo(HaveOccurred(), "pods number is not as expected for RTE daemonset: expected %d found %d", len(workers)-1, updatedDs.Status.CurrentNumberScheduled)
 				_, err = wait.With(e2eclient.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
@@ -429,12 +429,12 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 				if len(tnts) > 0 && len(targetNodeNames) > 0 {
 					By("untainting nodes")
 					for idx := range tnts {
-						By(fmt.Sprintf("removing taint: %v", tnts[idx]))
+						e2efixture.By("removing taint: %v", tnts[idx])
 						untaintNodes(fxt.Client, targetNodeNames, &tnts[idx])
 					}
 				}
 
-				By(fmt.Sprintf("ensuring the RTE DS was restored - expected pods=%d", len(workers)))
+				e2efixture.By("ensuring the RTE DS was restored - expected pods=%d", len(workers))
 				ds, err := wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDaemonsetPodsCreation(ctx, dsKey, len(workers))
 				Expect(err).NotTo(HaveOccurred(), "pods number is not as expected for daemonset: expected %d found %d", len(workers), ds.Status.CurrentNumberScheduled)
 				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
@@ -447,7 +447,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 				workers, err = nodes.GetWorkers(fxt.DEnv())
 				Expect(err).ToNot(HaveOccurred())
 
-				By(fmt.Sprintf("randomly picking the target node (among %d)", len(workers)))
+				e2efixture.By("randomly picking the target node (among %d)", len(workers))
 				targetIdx, ok := e2efixture.PickNodeIndex(workers)
 				Expect(ok).To(BeTrue())
 				targetNode := &workers[targetIdx]
@@ -470,7 +470,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 
 				pods, err := podlist.With(fxt.Client).ByDaemonset(ctx, *updatedDs)
 				Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset pods %s: %v", dsKey.String(), err)
-				By(fmt.Sprintf("ensuring the RTE DS is running with the same pods count (expected pods=%d)", len(workers)))
+				e2efixture.By("ensuring the RTE DS is running with the same pods count (expected pods=%d)", len(workers))
 				Expect(pods).To(HaveLen(len(workers)), "updated DS ready=%v original worker nodes=%d", len(pods), len(workers))
 
 				By("applying the taint 2 - NoExecute")
@@ -481,7 +481,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 
 				// NoExecute promises the pod will be evicted "immediately" but the system will still need nonzero time to notice
 				// and the pod will take nonzero time to terminate, so we need a Eventually block.
-				By(fmt.Sprintf("ensuring the RTE DS is running with less pods because taints (expected pods=%v)", len(workers)-1))
+				e2efixture.By("ensuring the RTE DS is running with less pods because taints (expected pods=%v)", len(workers)-1)
 				Eventually(func(g Gomega) {
 					Expect(fxt.Client.Get(ctx, dsKey.AsKey(), updatedDs)).To(Succeed())
 					pods, err = podlist.With(fxt.Client).ByDaemonset(ctx, *updatedDs)
@@ -502,7 +502,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 
 				tnt := &tnts[0]
 
-				By(fmt.Sprintf("randomly picking the target node (among %d)", len(workers)))
+				e2efixture.By("randomly picking the target node (among %d)", len(workers))
 				targetIdx, ok := e2efixture.PickNodeIndex(workers)
 				Expect(ok).To(BeTrue())
 				taintedNode := &workers[targetIdx]
@@ -598,7 +598,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 
 					tnt := &tnts[0]
 
-					By(fmt.Sprintf("randomly picking the target node (among %d)", len(workers)))
+					e2efixture.By("randomly picking the target node (among %d)", len(workers))
 					targetIdx, ok := e2efixture.PickNodeIndex(workers)
 					Expect(ok).To(BeTrue())
 					taintedNode = &workers[targetIdx]
@@ -733,7 +733,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 
 				tnt := &tnts[0]
 
-				By(fmt.Sprintf("randomly picking the target node (among %d)", len(workers)))
+				e2efixture.By("randomly picking the target node (among %d)", len(workers))
 				targetIdx, ok := e2efixture.PickNodeIndex(workers)
 				Expect(ok).To(BeTrue())
 				taintedNode := &workers[targetIdx]
@@ -742,7 +742,7 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 				targetNodeNames = append(targetNodeNames, taintedNode.Name)
 				klog.InfoS("considering node tainted", "node", taintedNode.Name, "taint", tnt.String())
 
-				By(fmt.Sprintf("waiting for daemonset %v to report correct pods' number", dsKey.String()))
+				e2efixture.By("waiting for daemonset %v to report correct pods' number", dsKey.String())
 				updatedDs, err := wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDaemonsetPodsCreation(ctx, dsKey, len(workers)-1)
 				Expect(err).NotTo(HaveOccurred(), "pods number is not as expected for RTE daemonset: expected %d found %d", len(workers)-1, updatedDs.Status.CurrentNumberScheduled)
 				_, err = wait.With(e2eclient.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
@@ -761,11 +761,11 @@ var _ = Describe("[serial][disruptive][rtetols] numaresources RTE tolerations su
 					}
 				}
 
-				By(fmt.Sprintf("un-tainting node %s", taintedNode.Name))
+				e2efixture.By("un-tainting node %s", taintedNode.Name)
 				untaintNodes(fxt.Client, []string{taintedNode.Name}, &tnts[0])
 				targetNodeNames = []string{}
 
-				By(fmt.Sprintf("watch for daemonset %v pods scale up", dsKey.String()))
+				e2efixture.By("watch for daemonset %v pods scale up", dsKey.String())
 				updatedDs, err = wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDaemonsetPodsCreation(ctx, dsKey, len(workers))
 				Expect(err).NotTo(HaveOccurred(), "pods number is not as expected for RTE daemonset: expected %d found %d", len(workers), updatedDs.Status.CurrentNumberScheduled)
 				_, err = wait.With(e2eclient.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -18,7 +18,6 @@ package tests
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -99,7 +98,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 			const requiredNodeNumber int = 1
 			// TODO: we need AT LEAST 2 (so 4, 8 is fine...) but we hardcode the padding logic to keep the test simple,
 			// so we can't support ATM zones > 2. HW with zones > 2 is rare anyway, so not to big of a deal now.
-			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", requiredNumaZones))
+			e2efixture.By("filtering available nodes with at least %d NUMA zones", requiredNumaZones)
 			nrtTwoZoneCandidates = e2enrt.FilterZoneCountEqual(nrts, requiredNumaZones)
 			if len(nrtTwoZoneCandidates) < requiredNodeNumber {
 				e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d", len(nrtTwoZoneCandidates))
@@ -216,12 +215,12 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				failedPodIds := e2efixture.WaitForPaddingPodsRunning(context.Background(), fxt, paddingPods)
 				Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
-				By(fmt.Sprintf("checking the resource allocation on %q as the test starts", targetNodeName))
+				e2efixture.By("checking the resource allocation on %q as the test starts", targetNodeName)
 				var nrtInitial nrtv1alpha2.NodeResourceTopology
 				err := fxt.Client.Get(context.TODO(), client.ObjectKey{Name: targetNodeName}, &nrtInitial)
 				Expect(err).ToNot(HaveOccurred())
 
-				By(fmt.Sprintf("Scheduling the testing deployment with RuntimeClass=%q", rtClass.Name))
+				e2efixture.By("Scheduling the testing deployment with RuntimeClass=%q", rtClass.Name)
 				var deploymentName string = "test-dp"
 				var replicas int32 = 1
 
@@ -247,7 +246,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				nrtPostCreate, err := e2enrt.GetUpdatedForNode(fxt.Client, context.TODO(), nrtInitial, 1*time.Minute)
 				Expect(err).ToNot(HaveOccurred())
 
-				By(fmt.Sprintf("checking deployment pods have been scheduled with the topology aware scheduler %q and in the proper node %q", serialconfig.Config.SchedulerName, targetNodeName))
+				e2efixture.By("checking deployment pods have been scheduled with the topology aware scheduler %q and in the proper node %q", serialconfig.Config.SchedulerName, targetNodeName)
 				pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *deployment)
 				Expect(err).NotTo(HaveOccurred(), "Unable to get pods from Deployment %q:  %v", deployment.Name, err)
 				Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
@@ -261,7 +260,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 					Expect(err).ToNot(HaveOccurred())
 					Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", pod.Namespace, pod.Name, serialconfig.Config.SchedulerName)
 
-					By(fmt.Sprintf("checking the resources are accounted as expected on %q", pod.Spec.NodeName))
+					e2efixture.By("checking the resources are accounted as expected on %q", pod.Spec.NodeName)
 					match, err := e2enrt.CheckZoneConsumedResourcesAtLeast(nrtInitial, nrtPostCreate, podResources, corev1qos.GetPodQOS(&pod))
 					Expect(err).ToNot(HaveOccurred())
 					// If the pods are running, and they are because we reached this far, then the resources must have been accounted SOMEWHERE!
@@ -304,7 +303,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				var ok bool
 				targetNodeName, ok = e2efixture.PopNodeName(candidateNodeNames)
 				Expect(ok).To(BeTrue(), "cannot select a node among %#v", e2efixture.ListNodeNames(candidateNodeNames))
-				By(fmt.Sprintf("selecting node to schedule the test pod: %q", targetNodeName))
+				e2efixture.By("selecting node to schedule the test pod: %q", targetNodeName)
 
 				err = fxt.Client.List(context.TODO(), &targetNrtListInitial)
 				Expect(err).ToNot(HaveOccurred())
@@ -405,7 +404,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				nrtListInitial, err := e2enrt.GetUpdated(fxt.Client, nrtList, 1*time.Minute)
 				Expect(err).ToNot(HaveOccurred())
 
-				By(fmt.Sprintf("Scheduling the testing deployment with RuntimeClass=%q", rtClass.Name))
+				e2efixture.By("Scheduling the testing deployment with RuntimeClass=%q", rtClass.Name)
 				var deploymentName string = "test-dp"
 				var replicas int32 = 1
 

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -199,7 +199,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				RestartPolicy: corev1.RestartPolicyAlways,
 			}
 
-			By(fmt.Sprintf("creating a deployment with a guaranteed pod with two containers requiring total %s", e2ereslist.ToString(e2ereslist.FromContainerLimits(podSpec.Containers))))
+			e2efixture.By("creating a deployment with a guaranteed pod with two containers requiring total %s", e2ereslist.ToString(e2ereslist.FromContainerLimits(podSpec.Containers)))
 			dp := objects.NewTestDeploymentWithPodSpec(replicas, podLabels, nodeSelector, fxt.Namespace.Name, "testdp47591", *podSpec)
 
 			err = fxt.Client.Create(context.TODO(), dp)
@@ -213,11 +213,11 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(pods).To(HaveLen(1))
 
 			updatedPod := pods[0]
-			By(fmt.Sprintf("checking the pod landed on the target node %q vs %q", updatedPod.Spec.NodeName, targetNodeName))
+			e2efixture.By("checking the pod landed on the target node %q vs %q", updatedPod.Spec.NodeName, targetNodeName)
 			Expect(updatedPod.Spec.NodeName).To(Equal(targetNodeName),
 				"node landed on %q instead of on %v", updatedPod.Spec.NodeName, targetNodeName)
 
-			By(fmt.Sprintf("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName))
+			e2efixture.By("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName)
 			schedOK, err := nrosched.CheckPODWasScheduledWith(context.TODO(), fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
@@ -246,7 +246,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			policyFuncs := tmSingleNUMANodeFuncsHandler[scope.Value]
 
-			By(fmt.Sprintf("checking post-create NRT for target node %q updated correctly", targetNodeName))
+			e2efixture.By("checking post-create NRT for target node %q updated correctly", targetNodeName)
 			dataBefore, err := yaml.Marshal(nrtInitial)
 			Expect(err).ToNot(HaveOccurred())
 			dataAfter, err := yaml.Marshal(nrtPostCreate)
@@ -266,7 +266,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			podSpec.Containers[0].Resources.Requests = requiredRes
 			podSpec.Containers[0].Resources.Limits = requiredRes
 
-			By(fmt.Sprintf("updating the deployment to require total %s", e2ereslist.ToString(e2ereslist.FromContainerLimits(podSpec.Containers))))
+			e2efixture.By("updating the deployment to require total %s", e2ereslist.ToString(e2ereslist.FromContainerLimits(podSpec.Containers)))
 
 			Eventually(func() error {
 				return fxt.Client.Update(context.TODO(), updatedDp)
@@ -304,11 +304,11 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			updatedPod = pods[0]
-			By(fmt.Sprintf("checking the pod landed on the target node %q vs %q", updatedPod.Spec.NodeName, targetNodeName))
+			e2efixture.By("checking the pod landed on the target node %q vs %q", updatedPod.Spec.NodeName, targetNodeName)
 			Expect(updatedPod.Spec.NodeName).To(Equal(targetNodeName),
 				"node landed on %q instead of on %v", updatedPod.Spec.NodeName, targetNodeName)
 
-			By(fmt.Sprintf("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName))
+			e2efixture.By("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName)
 			schedOK, err = nrosched.CheckPODWasScheduledWith(context.TODO(), fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
@@ -323,7 +323,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			nrtPostUpdate, err := e2enrt.FindFromList(nrtPostUpdateDeploymentList.Items, updatedPod.Spec.NodeName)
 			Expect(err).ToNot(HaveOccurred())
 
-			By(fmt.Sprintf("checking post-update NRT for target node %q updated correctly", targetNodeName))
+			e2efixture.By("checking post-update NRT for target node %q updated correctly", targetNodeName)
 			// it's simpler (no resource subtraction/difference) to check against initial than compute
 			// the delta between postUpdate and postCreate. Both must yield the same result anyway.
 			dataBefore, err = yaml.Marshal(nrtInitial)
@@ -414,13 +414,13 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			updatedPod = pods[0]
-			By(fmt.Sprintf("checking the pod landed on a node which is different than target node %q vs %q", targetNodeName, updatedPod.Spec.NodeName))
+			e2efixture.By("checking the pod landed on a node which is different than target node %q vs %q", targetNodeName, updatedPod.Spec.NodeName)
 			if updatedPod.Spec.NodeName == targetNodeName {
 				_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
 			}
 			Expect(updatedPod.Spec.NodeName).ToNot(Equal(targetNodeName), "pod should not land on node %q", targetNodeName)
 
-			By(fmt.Sprintf("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName))
+			e2efixture.By("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName)
 			schedOK, err = nrosched.CheckPODWasScheduledWith(context.TODO(), fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
@@ -438,7 +438,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			nrtLastUpdate, err := e2enrt.FindFromList(nrtLastUpdateDeploymentList.Items, updatedPod.Spec.NodeName)
 			Expect(err).ToNot(HaveOccurred())
 
-			By(fmt.Sprintf("checking rerouted NRT for target node %q updated correctly", targetNodeName))
+			e2efixture.By("checking rerouted NRT for target node %q updated correctly", targetNodeName)
 			dataBefore, err = yaml.Marshal(nrtReorganized)
 			Expect(err).ToNot(HaveOccurred())
 			dataAfter, err = yaml.Marshal(nrtLastUpdate)
@@ -454,7 +454,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			// the NRT updaters MAY be slow to react for a number of reasons including factors out of our control
 			// (kubelet, runtime). This is a known behavior. We can only tolerate some delay in reporting on pod removal.
 			Eventually(func() bool {
-				By(fmt.Sprintf("checking the resources are restored as expected on %q", updatedPod.Spec.NodeName))
+				e2efixture.By("checking the resources are restored as expected on %q", updatedPod.Spec.NodeName)
 
 				nrtListPostDelete, err := e2enrt.GetUpdated(fxt.Client, nrtLastUpdateDeploymentList, 1*time.Minute)
 				Expect(err).ToNot(HaveOccurred())
@@ -495,7 +495,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 		BeforeEach(func() {
 			// so we can't support ATM zones > 2. HW with zones > 2 is rare anyway, so not to big of a deal now.
-			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", 2))
+			e2efixture.By("filtering available nodes with at least %d NUMA zones", 2)
 			nrtCandidates := e2enrt.FilterZoneCountEqual(nrtList.Items, 2)
 			if len(nrtCandidates) < hostsRequired {
 				e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates))
@@ -582,7 +582,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				serialconfig.MultiNUMALabel: "2",
 			}
 
-			By(fmt.Sprintf("creating a deployment with a deployment pod with two replicas requiring %s", e2ereslist.ToString(reqResources)))
+			e2efixture.By("creating a deployment with a deployment pod with two replicas requiring %s", e2ereslist.ToString(reqResources))
 			dp := objects.NewTestDeployment(replicas, podLabels, nodeSelector, fxt.Namespace.Name, "testdp48746", images.GetPauseImage(), []string{images.PauseCommand}, []string{})
 			dp.Spec.Template.Spec.SchedulerName = serialconfig.Config.SchedulerName
 			dp.Spec.Template.Spec.Containers[0].Resources.Limits = reqResources
@@ -625,7 +625,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			// We need to determine total resources consumed on the node
 			checkConsumedRes := e2enrt.CheckNodeConsumedResourcesAtLeast
-			By(fmt.Sprintf("checking post-create NRT after pod: %q for target node %q updated correctly", updatedPod0.Name, targetNodeName))
+			e2efixture.By("checking post-create NRT after pod: %q for target node %q updated correctly", updatedPod0.Name, targetNodeName)
 			dataBefore, err := yaml.Marshal(nrtInitial)
 			Expect(err).ToNot(HaveOccurred())
 			dataAfter, err := yaml.Marshal(nrtPostCreate)
@@ -651,7 +651,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			updatedDp.Spec.Template.Spec.Containers[0].Resources.Requests = reqResources
 			updatedDp.Spec.Template.Spec.Containers[0].Resources.Limits = reqResources
 
-			By(fmt.Sprintf("updating the deployment to require total %s", e2ereslist.ToString(reqResources)))
+			e2efixture.By("updating the deployment to require total %s", e2ereslist.ToString(reqResources))
 
 			Eventually(func() error {
 				return fxt.Client.Update(context.TODO(), updatedDp)
@@ -691,7 +691,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			nrtPostUpdate, err := e2enrt.FindFromList(nrtPostCreateDeploymentList.Items, targetNodeName)
 			Expect(err).ToNot(HaveOccurred())
 
-			By(fmt.Sprintf("checking post-create NRT after pod: %q for target node %q updated correctly", updatedPod0.Name, targetNodeName))
+			e2efixture.By("checking post-create NRT after pod: %q for target node %q updated correctly", updatedPod0.Name, targetNodeName)
 			dataBefore, err = yaml.Marshal(nrtInitial)
 			Expect(err).ToNot(HaveOccurred())
 			dataAfterUpdate, err := yaml.Marshal(nrtPostUpdate)
@@ -714,7 +714,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			// the NRT updaters MAY be slow to react for a number of reasons including factors out of our control
 			// (kubelet, runtime). This is a known behavior. We can only tolerate some delay in reporting on pod removal.
 			Eventually(func() bool {
-				By(fmt.Sprintf("checking the resources are restored as expected on %q", targetNodeName))
+				e2efixture.By("checking the resources are restored as expected on %q", targetNodeName)
 
 				nrtListPostDelete, err := e2enrt.GetUpdated(fxt.Client, nrtPostUpdateDeploymentList, 1*time.Minute)
 				Expect(err).ToNot(HaveOccurred())
@@ -735,7 +735,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 		BeforeEach(func() {
 			// so we can't support ATM zones > 2. HW with zones > 2 is rare anyway, so not to big of a deal now.
-			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", 2))
+			e2efixture.By("filtering available nodes with at least %d NUMA zones", 2)
 			nrtCandidates := e2enrt.FilterZoneCountEqual(nrtList.Items, 2)
 			if len(nrtCandidates) < hostsRequired {
 				e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d", len(nrtCandidates))
@@ -822,7 +822,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			})
 
 			rsCreateStart := time.Now()
-			By(fmt.Sprintf("creating a replicaset %s/%s with %d replicas scheduling with scheduler: %s", fxt.Namespace.Name, rsName, replicaNumber, corev1.DefaultSchedulerName))
+			e2efixture.By("creating a replicaset %s/%s with %d replicas scheduling with scheduler: %s", fxt.Namespace.Name, rsName, replicaNumber, corev1.DefaultSchedulerName)
 			err = fxt.Client.Create(context.TODO(), rs)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -849,7 +849,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}, time.Minute, time.Second).Should(BeTrue(), "there should be %d pods under replicaset: %q", replicaNumber, namespacedRsName.String())
 			schedTimeWithDefaultScheduler := time.Since(rsCreateStart)
 
-			By(fmt.Sprintf("checking the pods were scheduled with scheduler %q", corev1.DefaultSchedulerName))
+			e2efixture.By("checking the pods were scheduled with scheduler %q", corev1.DefaultSchedulerName)
 			for _, pod := range pods {
 				schedOK, err := nrosched.CheckPODWasScheduledWith(context.TODO(), fxt.K8sClient, pod.Namespace, pod.Name, corev1.DefaultSchedulerName)
 				Expect(err).ToNot(HaveOccurred())
@@ -857,7 +857,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			}
 
-			By(fmt.Sprintf("checking the pods were scheduled on the target node %q", targetNodeName))
+			e2efixture.By("checking the pods were scheduled on the target node %q", targetNodeName)
 			for _, pod := range pods {
 				Expect(pod.Spec.NodeName).To(Equal(targetNodeName), "pod landed on %q instead of on %v", pod.Spec.NodeName, targetNodeName)
 			}
@@ -865,7 +865,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			By("Waiting for the NRT data to stabilize")
 			e2efixture.MustSettleNRT(fxt)
 
-			By(fmt.Sprintf("verifying resources allocation correctness for NRT target: %q", targetNodeName))
+			e2efixture.By("verifying resources allocation correctness for NRT target: %q", targetNodeName)
 			var nrtAfterRSCreation nrtv1alpha2.NodeResourceTopologyList
 			nrtAfterRSCreation, err = e2enrt.GetUpdated(fxt.Client, nrtInitial, timeout)
 			Expect(err).ToNot(HaveOccurred())
@@ -884,7 +884,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 			Expect(match).ToNot(BeEmpty(), "inconsistent accounting when checking NRTs consumed resources")
 
-			By(fmt.Sprintf("deleting replicaset %s/%s", fxt.Namespace.Name, rsName))
+			e2efixture.By("deleting replicaset %s/%s", fxt.Namespace.Name, rsName)
 			err = fxt.Client.Delete(context.TODO(), rs)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -898,7 +898,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			By("Waiting for the NRT data to stabilize")
 			e2efixture.MustSettleNRT(fxt)
 
-			By(fmt.Sprintf("checking the resources are restored as expected on %q", targetNodeName))
+			e2efixture.By("checking the resources are restored as expected on %q", targetNodeName)
 
 			nrtListPostDelete, err := e2enrt.GetUpdated(fxt.Client, nrtAfterRSCreation, 1*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
@@ -920,7 +920,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			nrtInitial, err = e2enrt.GetUpdated(fxt.Client, nrtv1alpha2.NodeResourceTopologyList{}, timeout)
 			Expect(err).ToNot(HaveOccurred())
 
-			By(fmt.Sprintf("creating a replicaset %s/%s with %d replicas scheduling with: %s", fxt.Namespace.Name, rsName, replicaNumber, serialconfig.Config.SchedulerName))
+			e2efixture.By("creating a replicaset %s/%s with %d replicas scheduling with: %s", fxt.Namespace.Name, rsName, replicaNumber, serialconfig.Config.SchedulerName)
 			rsCreateStart = time.Now()
 			err = fxt.Client.Create(context.TODO(), rs)
 			Expect(err).ToNot(HaveOccurred())
@@ -947,12 +947,12 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}, time.Minute, time.Second).Should(BeTrue(), "there should be %d pods under replicaset: %q", replicaNumber, namespacedRsName.String())
 			schedTimeWithTopologyScheduler := time.Since(rsCreateStart)
 
-			By(fmt.Sprintf("checking the pods were scheduled on the target node %q", targetNodeName))
+			e2efixture.By("checking the pods were scheduled on the target node %q", targetNodeName)
 			for _, pod := range pods {
 				Expect(pod.Spec.NodeName).To(Equal(targetNodeName), "pod landed on %q instead of on %v", pod.Spec.NodeName, targetNodeName)
 			}
 
-			By(fmt.Sprintf("checking the pods were scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName))
+			e2efixture.By("checking the pods were scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName)
 			for _, pod := range pods {
 				schedOK, err := nrosched.CheckPODWasScheduledWith(context.TODO(), fxt.K8sClient, pod.Namespace, pod.Name, serialconfig.Config.SchedulerName)
 				Expect(err).ToNot(HaveOccurred())
@@ -962,7 +962,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			By("Waiting for the NRT data to stabilize")
 			e2efixture.MustSettleNRT(fxt)
 
-			By(fmt.Sprintf("verifying resources allocation correctness for NRT target: %q", targetNodeName))
+			e2efixture.By("verifying resources allocation correctness for NRT target: %q", targetNodeName)
 			nrtAfterDPCreation, err := e2enrt.GetUpdated(fxt.Client, nrtInitial, timeout)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -980,13 +980,13 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 			Expect(match).ToNot(BeEmpty(), "inconsistent accounting when checking NRTs consumed resources")
 
-			By(fmt.Sprintf("comparing scheduling times between %q and %q", corev1.DefaultSchedulerName, serialconfig.Config.SchedulerName))
+			e2efixture.By("comparing scheduling times between %q and %q", corev1.DefaultSchedulerName, serialconfig.Config.SchedulerName)
 			diff := int64(math.Abs(float64(schedTimeWithTopologyScheduler.Milliseconds() - schedTimeWithDefaultScheduler.Milliseconds())))
 			// 2000 milliseconds diff seems reasonable, but can evaluate later if needed.
 			d := time.Millisecond * 2000
 			Expect(diff).To(BeNumerically("<", d.Milliseconds()), "expected the difference between scheduling times to be %d at max; actual diff: %d milliseconds", d.Milliseconds(), diff)
 
-			By(fmt.Sprintf("deleting deployment %s/%s", fxt.Namespace.Name, rsName))
+			e2efixture.By("deleting deployment %s/%s", fxt.Namespace.Name, rsName)
 			err = fxt.Client.Delete(context.TODO(), rs)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -1192,11 +1192,11 @@ func matchLogLevelToKlog(cnt *corev1.Container, level operatorv1.LogLevel) (bool
 }
 
 func checkReplica(pod corev1.Pod, targetNodeName string, k8sClient *kubernetes.Clientset) {
-	By(fmt.Sprintf("checking the pod landed on the target node %q vs %q", pod.Spec.NodeName, targetNodeName))
+	e2efixture.By("checking the pod landed on the target node %q vs %q", pod.Spec.NodeName, targetNodeName)
 	Expect(pod.Spec.NodeName).To(Equal(targetNodeName),
 		"node landed on %q instead of on %v", pod.Spec.NodeName, targetNodeName)
 
-	By(fmt.Sprintf("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName))
+	e2efixture.By("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName)
 	schedOK, err := nrosched.CheckPODWasScheduledWith(context.TODO(), k8sClient, pod.Namespace, pod.Name, serialconfig.Config.SchedulerName)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", pod.Namespace, pod.Name, serialconfig.Config.SchedulerName)

--- a/test/e2e/serial/tests/workload_placement_nodelabel.go
+++ b/test/e2e/serial/tests/workload_placement_nodelabel.go
@@ -104,7 +104,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		var targetNrtListInitial nrtv1alpha2.NodeResourceTopologyList
 		BeforeEach(func() {
 			requiredNUMAZones := 2
-			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", requiredNUMAZones))
+			e2efixture.By("filtering available nodes with at least %d NUMA zones", requiredNUMAZones)
 			nrtCandidates = e2enrt.FilterZoneCountEqual(nrts, requiredNUMAZones)
 
 			neededNodes := 2
@@ -133,15 +133,15 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			var ok bool
 			targetNodeName, ok = e2efixture.PopNodeName(nrtCandidateNames)
 			Expect(ok).To(BeTrue(), "cannot select a target node among %#v", e2efixture.ListNodeNames(nrtCandidateNames))
-			By(fmt.Sprintf("selecting target node we expect the pod will be scheduled into: %q", targetNodeName))
+			e2efixture.By("selecting target node we expect the pod will be scheduled into: %q", targetNodeName)
 
 			alternativeNodeName, ok = nrtCandidateNames.PopAny()
 			Expect(ok).To(BeTrue(), "cannot select an alternative target node among %#v", e2efixture.ListNodeNames(nrtCandidateNames))
-			By(fmt.Sprintf("selecting alternative node candidate for the scheduling: %q", alternativeNodeName))
+			e2efixture.By("selecting alternative node candidate for the scheduling: %q", alternativeNodeName)
 
 			// we need to also pad one of the labeled nodes.
 			nrtToPadNames := append(e2efixture.ListNodeNames(nrtCandidateNames), alternativeNodeName)
-			By(fmt.Sprintf("Padding all other candidate nodes: %v", nrtToPadNames))
+			e2efixture.By("Padding all other candidate nodes: %v", nrtToPadNames)
 
 			var paddingPods []*corev1.Pod
 			for nIdx, nodeName := range nrtToPadNames {
@@ -183,7 +183,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 		})
 
 		It("[test_id:47598] should place the pod in the node with available resources in one NUMA zone and fulfilling node selector", Label(label.Tier2), func() {
-			By(fmt.Sprintf("Labeling nodes %q and %q with label %q:%q", targetNodeName, alternativeNodeName, labelName, labelValueMedium))
+			e2efixture.By("Labeling nodes %q and %q with label %q:%q", targetNodeName, alternativeNodeName, labelName, labelValueMedium)
 
 			unlabelTarget, err := labelNodeWithValue(fxt.Client, labelName, labelValueMedium, targetNodeName)
 			Expect(err).NotTo(HaveOccurred(), "unable to label node %q", targetNodeName)
@@ -223,7 +223,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			By("checking the pod has been scheduled in the proper node")
 			Expect(updatedPod.Spec.NodeName).To(Equal(targetNodeName))
 
-			By(fmt.Sprintf("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName))
+			e2efixture.By("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName)
 			schedOK, err := nrosched.CheckPODWasScheduledWith(context.TODO(), fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
@@ -249,7 +249,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			var unlabelTarget, unlabelAlternative func() error
 			nodesUnlabeled := false
 			BeforeEach(func() {
-				By(fmt.Sprintf("Labeling target node %q with label %q:%q and the alternative node %q with label %q:%q", targetNodeName, labelName, labelValueLarge, alternativeNodeName, labelName, labelValueMedium))
+				e2efixture.By("Labeling target node %q with label %q:%q and the alternative node %q with label %q:%q", targetNodeName, labelName, labelValueLarge, alternativeNodeName, labelName, labelValueMedium)
 
 				var err error
 				unlabelTarget, err = labelNodeWithValue(fxt.Client, labelName, labelValueLarge, targetNodeName)
@@ -281,7 +281,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			DescribeTable("a guaranteed deployment pod with nodeAffinity should be scheduled on one NUMA zone on a matching labeled node with enough resources", Serial, Label(label.Tier2),
 				func(getNodeAffFunc getNodeAffinityFunc) {
 					affinity := getNodeAffFunc(labelName, []string{labelValueLarge, labelValueMedium}, corev1.NodeSelectorOpIn)
-					By(fmt.Sprintf("create a deployment with one guaranteed pod with node affinity property: %+v ", affinity.NodeAffinity))
+					e2efixture.By("create a deployment with one guaranteed pod with node affinity property: %+v ", affinity.NodeAffinity)
 					deploymentName := "test-dp"
 					var replicas int32 = 1
 
@@ -301,7 +301,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 					_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(2*time.Minute).ForDeploymentComplete(context.TODO(), deployment)
 					Expect(err).NotTo(HaveOccurred(), "Deployment %q not up & running after %v", deployment.Name, 2*time.Minute)
 
-					By(fmt.Sprintf("checking deployment pods have been scheduled with the topology aware scheduler %q and in the proper node %q", serialconfig.Config.SchedulerName, targetNodeName))
+					e2efixture.By("checking deployment pods have been scheduled with the topology aware scheduler %q and in the proper node %q", serialconfig.Config.SchedulerName, targetNodeName)
 					pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *deployment)
 					Expect(err).NotTo(HaveOccurred(), "Unable to get pods from Deployment %q: %v", deployment.Name, err)
 					Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
@@ -343,7 +343,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 					}
 
 					//check that it didn't stop running for some time
-					By(fmt.Sprintf("ensuring the deployment %q keep being ready", deployment.Name))
+					e2efixture.By("ensuring the deployment %q keep being ready", deployment.Name)
 					Eventually(func() bool {
 						updatedDp := &appsv1.Deployment{}
 						err := fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(deployment), updatedDp)

--- a/test/e2e/serial/tests/workload_placement_resources.go
+++ b/test/e2e/serial/tests/workload_placement_resources.go
@@ -120,7 +120,7 @@ var _ = Describe("[serial][disruptive][scheduler][byres] numaresources workload 
 				By("checking the pod has been scheduled in the proper node")
 				Expect(updatedPod.Spec.NodeName).To(Equal(targetNodeName))
 
-				By(fmt.Sprintf("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName))
+				e2efixture.By("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName)
 				schedOK, err := nrosched.CheckPODWasScheduledWith(context.TODO(), fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
@@ -175,7 +175,7 @@ func setupNodes(fxt *e2efixture.Fixture, ctx context.Context, nrtCandidates []nr
 	var ok bool
 	targetNodeName, ok := e2efixture.PopNodeName(nrtCandidateNames)
 	Expect(ok).To(BeTrue(), "cannot select a target node among %#v", e2efixture.ListNodeNames(nrtCandidateNames))
-	By(fmt.Sprintf("selecting node to schedule the pod: %q", targetNodeName))
+	e2efixture.By("selecting node to schedule the pod: %q", targetNodeName)
 	// need to prepare all the other nodes so they cannot have any one NUMA zone with enough resources
 	// but have enough allocatable resources at node level to shedule the pod on it.
 	// If we pad each zone with a pod with 3/4 of the required resources, as those nodes have at least
@@ -190,7 +190,7 @@ func setupNodes(fxt *e2efixture.Fixture, ctx context.Context, nrtCandidates []nr
 
 		baseload, err := intbaseload.ForNode(fxt.Client, ctx, nodeName)
 		Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", nodeName)
-		By(fmt.Sprintf("computed base load: %s", baseload))
+		e2efixture.By("computed base load: %s", baseload)
 
 		for zIdx, zone := range nrtInfo.Zones {
 			padRes := expectedFreeResources.DeepCopy()
@@ -207,7 +207,7 @@ func setupNodes(fxt *e2efixture.Fixture, ctx context.Context, nrtCandidates []nr
 
 	baseload, err := intbaseload.ForNode(fxt.Client, ctx, targetNodeName)
 	Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", targetNodeName)
-	By(fmt.Sprintf("computed base load: %s", baseload))
+	e2efixture.By("computed base load: %s", baseload)
 
 	targetNrtInfo, err := e2enrt.FindFromList(nrtCandidates, targetNodeName)
 	Expect(err).NotTo(HaveOccurred(), "missing NRT info for target node %q", targetNodeName)
@@ -228,7 +228,7 @@ func setupNodes(fxt *e2efixture.Fixture, ctx context.Context, nrtCandidates []nr
 
 func createPaddingPod(fxt *e2efixture.Fixture, ctx context.Context, podName, nodeName string, zone nrtv1alpha2.Zone, expectedFreeRes corev1.ResourceList) *corev1.Pod {
 	GinkgoHelper()
-	By(fmt.Sprintf("creating padding pod %q for node %q zone %q with resource target %s", podName, nodeName, zone.Name, e2ereslist.ToString(expectedFreeRes)))
+	e2efixture.By("creating padding pod %q for node %q zone %q with resource target %s", podName, nodeName, zone.Name, e2ereslist.ToString(expectedFreeRes))
 
 	padPod, err := makePaddingPod(fxt.Namespace.Name, podName, zone, expectedFreeRes)
 	Expect(err).NotTo(HaveOccurred(), "unable to create padding pod %q on zone %q", podName, zone.Name)

--- a/test/e2e/serial/tests/workload_placement_taint.go
+++ b/test/e2e/serial/tests/workload_placement_taint.go
@@ -137,14 +137,14 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}
 			taintedNodeNames = updatedNodeNames
 
-			By(fmt.Sprintf("considering nodes: %v tainted with %q", updatedNodeNames, tnt.String()))
+			e2efixture.By("considering nodes: %v tainted with %q", updatedNodeNames, tnt.String())
 		})
 
 		AfterEach(func() {
 			tnt := &appliedTaints[0] // shortcut
 			// first untaint the nodes we know we tainted
 			untaintedNodeNames := untaintNodes(fxt.Client, taintedNodeNames, tnt)
-			By(fmt.Sprintf("cleaned taint %q from the nodes %v", tnt.String(), untaintedNodeNames))
+			e2efixture.By("cleaned taint %q from the nodes %v", tnt.String(), untaintedNodeNames)
 
 			// leaking taints is especially bad AND we had some bugs in the pass, so let's try our very bes
 			// to be really really sure we didn't pollute the cluster.
@@ -153,7 +153,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			nodeNames := objectnames.Nodes(nodes)
 			doubleCheckedNodeNames := untaintNodes(fxt.Client, nodeNames, tnt)
-			By(fmt.Sprintf("cleaned taint %q from the nodes %v", tnt.String(), doubleCheckedNodeNames))
+			e2efixture.By("cleaned taint %q from the nodes %v", tnt.String(), doubleCheckedNodeNames)
 
 			By("unpadding the nodes after test finish")
 			err = padder.Clean()
@@ -206,11 +206,11 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			}
 			Expect(err).ToNot(HaveOccurred())
 
-			By(fmt.Sprintf("checking the pod landed on the target node %q vs %q", updatedPod.Spec.NodeName, targetNodeName))
+			e2efixture.By("checking the pod landed on the target node %q vs %q", updatedPod.Spec.NodeName, targetNodeName)
 			Expect(updatedPod.Spec.NodeName).To(Equal(targetNodeName),
 				"node landed on %q instead of on %v", updatedPod.Spec.NodeName, targetNodeName)
 
-			By(fmt.Sprintf("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName))
+			e2efixture.By("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName)
 			schedOK, err := nrosched.CheckPODWasScheduledWith(context.TODO(), fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
@@ -236,7 +236,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			// the NRT updaters MAY be slow to react for a number of reasons including factors out of our control
 			// (kubelet, runtime). This is a known behavior. We can only tolerate some delay in reporting on pod removal.
 			Eventually(func() bool {
-				By(fmt.Sprintf("checking the resources are restored as expected on %q", updatedPod.Spec.NodeName))
+				e2efixture.By("checking the resources are restored as expected on %q", updatedPod.Spec.NodeName)
 
 				nrtPostDelete, err := e2enrt.GetUpdatedForNode(fxt.Client, context.TODO(), nrtPostCreate, 1*time.Minute)
 				Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -104,7 +104,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			GinkgoHelper()
 
 			requiredNUMAZones := 2
-			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", requiredNUMAZones))
+			e2efixture.By("filtering available nodes with at least %d NUMA zones", requiredNUMAZones)
 			nrtCandidates = e2enrt.FilterZoneCountEqual(nrtList.Items, requiredNUMAZones)
 
 			neededNodes := 2
@@ -128,7 +128,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			var ok bool
 			targetNodeName, ok = e2efixture.PopNodeName(nrtCandidateNames)
 			Expect(ok).To(BeTrue(), "cannot select a target node among %#v", e2efixture.ListNodeNames(nrtCandidateNames))
-			By(fmt.Sprintf("selecting node to schedule the pod: %q", targetNodeName))
+			e2efixture.By("selecting node to schedule the pod: %q", targetNodeName)
 			// need to prepare all the other nodes so they cannot have any one NUMA zone with enough resources
 			// but have enough allocatable resources at node level to shedule the pod on it.
 			// If we pad each zone with a pod with 3/4 of the required resources, as those nodes have at least
@@ -202,7 +202,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				By("checking the pod has been scheduled in the proper node")
 				Expect(updatedPod.Spec.NodeName).To(Equal(targetNodeName))
 
-				By(fmt.Sprintf("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName))
+				e2efixture.By("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName)
 				schedOK, err := nrosched.CheckPODWasScheduledWith(context.TODO(), fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
@@ -301,7 +301,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				_, err = wait.With(fxt.Client).Interval(10*time.Second).Timeout(time.Minute).ForDeploymentComplete(context.TODO(), deployment)
 				Expect(err).NotTo(HaveOccurred(), "Deployment %q not up & running after %v", deployment.Name, time.Minute)
 
-				By(fmt.Sprintf("checking deployment pods have been scheduled with the topology aware scheduler %q and in the proper node %q", serialconfig.Config.SchedulerName, targetNodeName))
+				e2efixture.By("checking deployment pods have been scheduled with the topology aware scheduler %q and in the proper node %q", serialconfig.Config.SchedulerName, targetNodeName)
 				pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *deployment)
 				Expect(err).NotTo(HaveOccurred(), "Unable to get pods from Deployment %q:  %v", deployment.Name, err)
 				Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
@@ -491,7 +491,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			By("wait for NRT data to settle")
 			e2efixture.MustSettleNRT(fxt)
 
-			By(fmt.Sprintf("checking the resources are accounted as expected on %q", updatedPod.Spec.NodeName))
+			e2efixture.By("checking the resources are accounted as expected on %q", updatedPod.Spec.NodeName)
 			nrtPostCreate, err := e2enrt.GetUpdatedForNode(fxt.Client, context.TODO(), nrtInitial, 1*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -511,7 +511,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			// the NRT updaters MAY be slow to react for a number of reasons including factors out of our control
 			// (kubelet, runtime). This is a known behavior. We can only tolerate some delay in reporting on pod removal.
 			Eventually(func() bool {
-				By(fmt.Sprintf("checking the resources are restored as expected on %q", updatedPod.Spec.NodeName))
+				e2efixture.By("checking the resources are restored as expected on %q", updatedPod.Spec.NodeName)
 
 				nrtPostDelete, err := e2enrt.GetUpdatedForNode(fxt.Client, context.TODO(), nrtPostCreate, 1*time.Minute)
 				Expect(err).ToNot(HaveOccurred())
@@ -1345,7 +1345,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 
 			numaZonesRequired := 2
 
-			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", numaZonesRequired))
+			e2efixture.By("filtering available nodes with at least %d NUMA zones", numaZonesRequired)
 			nrtCandidates := e2enrt.FilterZoneCountEqual(nrts, numaZonesRequired)
 			if len(nrtCandidates) < hostsRequired {
 				e2efixture.Skipf(fxt, "not enough nodes with %d NUMA Zones: found %d", numaZonesRequired, len(nrtCandidates))
@@ -1362,7 +1362,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(ok).To(BeTrue(), "cannot select a target node among %#v", e2efixture.ListNodeNames(candidateNodeNames))
 			unsuitableNodeNames := e2efixture.ListNodeNames(candidateNodeNames)
 
-			By(fmt.Sprintf("selecting target node %q and unsuitable nodes %#v (random pick)", targetNodeName, unsuitableNodeNames))
+			e2efixture.By("selecting target node %q and unsuitable nodes %#v (random pick)", targetNodeName, unsuitableNodeNames)
 
 			// make targetFreeResPerNUMA the complement of the test pod's resources
 			// IOW targetFreeResPerNUMA + baseload + podResourcesRequest equals to all node's allocatable resources
@@ -2113,9 +2113,9 @@ func setupPadding(fxt *e2efixture.Fixture, nrtList nrtv1alpha2.NodeResourceTopol
 
 	baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), padInfo.targetNodeName)
 	Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", padInfo.targetNodeName)
-	By(fmt.Sprintf("computed base load: %s", baseload))
+	e2efixture.By("computed base load: %s", baseload)
 
-	By(fmt.Sprintf("preparing target node %q to fit the test case", padInfo.targetNodeName))
+	e2efixture.By("preparing target node %q to fit the test case", padInfo.targetNodeName)
 	// first, let's make sure that ONLY the required res can fit in either zone on the target node
 	nrtInfo, err := e2enrt.FindFromList(nrtList.Items, padInfo.targetNodeName)
 	Expect(err).ToNot(HaveOccurred(), "missing NRT info for %q", padInfo.targetNodeName)
@@ -2133,7 +2133,7 @@ func setupPadding(fxt *e2efixture.Fixture, nrtList nrtv1alpha2.NodeResourceTopol
 			baseload.Apply(numaRes)
 		}
 
-		By(fmt.Sprintf("padding node %q zone %q to fit only %s", nrtInfo.Name, zone.Name, e2ereslist.ToString(numaRes)))
+		e2efixture.By("padding node %q zone %q to fit only %s", nrtInfo.Name, zone.Name, e2ereslist.ToString(numaRes))
 		padPod, err := makePaddingPod(fxt.Namespace.Name, "target", zone, numaRes)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -2160,16 +2160,16 @@ func setupPaddingForUnsuitableNodes(fxt *e2efixture.Fixture, nrtList nrtv1alpha2
 
 		baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), unsuitableNodeName)
 		Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", unsuitableNodeName)
-		By(fmt.Sprintf("computed base load: %s", baseload))
+		e2efixture.By("computed base load: %s", baseload)
 
 		for zoneIdx, zone := range nrtInfo.Zones {
 			padRes := padInfo.unsuitableFreeRes[zoneIdx].DeepCopy()
 			name := fmt.Sprintf("unsuitable%d", nodeIdx)
 
-			By(fmt.Sprintf("saturating node %q -> %q zone %q to fit only (vanilla) %s", nrtInfo.Name, name, zone.Name, e2ereslist.ToString(padRes)))
+			e2efixture.By("saturating node %q -> %q zone %q to fit only (vanilla) %s", nrtInfo.Name, name, zone.Name, e2ereslist.ToString(padRes))
 			if zoneIdx == 0 { // any random zone is actually fine
 				baseload.Apply(padRes)
-				By(fmt.Sprintf("saturating node %q -> %q zone %q to fit only (adjusted) %s", nrtInfo.Name, name, zone.Name, e2ereslist.ToString(padRes)))
+				e2efixture.By("saturating node %q -> %q zone %q to fit only (adjusted) %s", nrtInfo.Name, name, zone.Name, e2ereslist.ToString(padRes))
 			}
 
 			padPod, err := makePaddingPod(fxt.Namespace.Name, name, zone, padRes)

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -117,7 +117,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 		BeforeEach(func() {
 			neededNodes := 1
 
-			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", requiredNUMAZones))
+			e2efixture.By("filtering available nodes with at least %d NUMA zones", requiredNUMAZones)
 			nrtCandidates = e2enrt.FilterZoneCountEqual(nrts, requiredNUMAZones)
 			if len(nrtCandidates) < neededNodes {
 				e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d, needed %d", len(nrtCandidates), neededNodes)
@@ -197,7 +197,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			By("waiting for the NRT data to settle")
 			e2efixture.MustSettleNRT(fxt)
 
-			By(fmt.Sprintf("checking the pod was handled by the topology aware scheduler %q but failed to be scheduled on any node", serialconfig.Config.SchedulerName))
+			e2efixture.By("checking the pod was handled by the topology aware scheduler %q but failed to be scheduled on any node", serialconfig.Config.SchedulerName)
 			isFailed, err := nrosched.CheckPODSchedulingFailedForAlignment(context.TODO(), fxt.K8sClient, pod.Namespace, pod.Name, serialconfig.Config.SchedulerName, tmScope)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isFailed).To(BeTrue(), "pod %s/%s with scheduler %s did NOT fail", pod.Namespace, pod.Name, serialconfig.Config.SchedulerName)
@@ -224,7 +224,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			deployment, err = wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDeploymentReplicasCreation(context.TODO(), deployment, replicas)
 			Expect(err).NotTo(HaveOccurred())
 
-			By(fmt.Sprintf("checking deployment pods have been handled by the topology aware scheduler %q but failed to be scheduled on any node", serialconfig.Config.SchedulerName))
+			e2efixture.By("checking deployment pods have been handled by the topology aware scheduler %q but failed to be scheduled on any node", serialconfig.Config.SchedulerName)
 			pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *deployment)
 			Expect(err).ToNot(HaveOccurred(), "Unable to get pods from Deployment %q:  %v", deployment.Name, err)
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
@@ -264,7 +264,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			ds, err = wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDaemonsetPodsCreation(context.TODO(), wait.ObjectKeyFromObject(ds), len(nrtCandidates))
 			Expect(err).NotTo(HaveOccurred())
 
-			By(fmt.Sprintf("checking daemonset pods have been handled by the topology aware scheduler %q but failed to be scheduled on any node", serialconfig.Config.SchedulerName))
+			e2efixture.By("checking daemonset pods have been handled by the topology aware scheduler %q but failed to be scheduled on any node", serialconfig.Config.SchedulerName)
 			pods, err := podlist.With(fxt.Client).ByDaemonset(context.TODO(), *ds)
 			Expect(err).ToNot(HaveOccurred(), "Unable to get pods from daemonset %q:  %v", ds.Name, err)
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DS %s/%s", ds.Namespace, ds.Name)
@@ -303,7 +303,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			deployment, err = wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDeploymentReplicasCreation(context.TODO(), deployment, replicas)
 			Expect(err).NotTo(HaveOccurred())
 
-			By(fmt.Sprintf("checking deployment pods have been handled by the default scheduler %q but failed to be scheduled", corev1.DefaultSchedulerName))
+			e2efixture.By("checking deployment pods have been handled by the default scheduler %q but failed to be scheduled", corev1.DefaultSchedulerName)
 			pods, err := podlist.With(fxt.Client).ByDeployment(context.TODO(), *deployment)
 			Expect(err).ToNot(HaveOccurred(), "Unable to get pods from Deployment %q:  %v", deployment.Name, err)
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", deployment.Namespace, deployment.Name)
@@ -323,7 +323,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 
 	Context("with at least two nodes with two numa zones and enough resources in one numa zone", func() {
 		It("[test_id:47592] a daemonset with a guaranteed pod resources available on one node/one single numa zone but not in any other node", Label(label.Tier2, "unsched", "failalign"), func() {
-			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", requiredNUMAZones))
+			e2efixture.By("filtering available nodes with at least %d NUMA zones", requiredNUMAZones)
 			nrtCandidates := e2enrt.FilterZoneCountEqual(nrts, requiredNUMAZones)
 
 			neededNodes := 2
@@ -410,7 +410,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			ds, err = wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDaemonsetPodsCreation(context.TODO(), wait.ObjectKeyFromObject(ds), len(nrtCandidates))
 			Expect(err).NotTo(HaveOccurred())
 
-			By(fmt.Sprintf("checking daemonset pods have been scheduled with the topology aware scheduler %q ", serialconfig.Config.SchedulerName))
+			e2efixture.By("checking daemonset pods have been scheduled with the topology aware scheduler %q ", serialconfig.Config.SchedulerName)
 			pods, err := podlist.With(fxt.Client).ByDaemonset(context.TODO(), *ds)
 			Expect(err).ToNot(HaveOccurred(), "Unable to get pods from daemonset %q:  %v", ds.Name, err)
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DS %s/%s", ds.Namespace, ds.Name)
@@ -418,11 +418,11 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			By("waiting for the NRT data to settle")
 			e2efixture.MustSettleNRT(fxt)
 
-			By(fmt.Sprintf("checking only daemonset pod in targetNode:%q is up and running", targetNodeName))
+			e2efixture.By("checking only daemonset pod in targetNode:%q is up and running", targetNodeName)
 			podRunningTimeout := 3 * time.Minute
 			for _, pod := range pods {
 				if pod.Spec.NodeName == targetNodeName {
-					By(fmt.Sprintf("verify events for pod %s/%s node: %q", pod.Namespace, pod.Name, pod.Spec.NodeName))
+					e2efixture.By("verify events for pod %s/%s node: %q", pod.Namespace, pod.Name, pod.Spec.NodeName)
 					scheduledWithTAS, err := nrosched.CheckPODWasScheduledWith(context.TODO(), fxt.K8sClient, pod.Namespace, pod.Name, serialconfig.Config.SchedulerName)
 					if err != nil {
 						_ = objects.LogEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
@@ -466,7 +466,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			}
 
 			// Filter by number of numa zones
-			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", requiredNUMAZones))
+			e2efixture.By("filtering available nodes with at least %d NUMA zones", requiredNUMAZones)
 			nrtCandidates = e2enrt.FilterZoneCountEqual(nrtCandidates, requiredNUMAZones)
 			if len(nrtCandidates) < neededNodes {
 				e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d, needed %d", len(nrtCandidates), neededNodes)
@@ -493,7 +493,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			nrtCandidateNames := e2enrt.AccumulateNames(nrtCandidates)
 			targetNodeName, ok := e2efixture.PopNodeName(nrtCandidateNames)
 			Expect(ok).To(BeTrue(), "cannot select a target node among %#v", e2efixture.ListNodeNames(nrtCandidateNames))
-			By(fmt.Sprintf("selecting node to schedule the pod: %q", targetNodeName))
+			e2efixture.By("selecting node to schedule the pod: %q", targetNodeName)
 
 			By("Padding all other candidate nodes")
 			var paddingPods []*corev1.Pod
@@ -585,14 +585,14 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(err).NotTo(HaveOccurred(), "unable to create pod %q", pod.Name)
 
 			interval := 10 * time.Second
-			By(fmt.Sprintf("Checking pod %q keeps in %q state for at least %v seconds ...", pod.Name, string(corev1.PodPending), interval*3))
+			e2efixture.By("Checking pod %q keeps in %q state for at least %v seconds ...", pod.Name, string(corev1.PodPending), interval*3)
 			_, err = wait.With(fxt.Client).Interval(interval).Steps(3).WhileInPodPhase(context.TODO(), pod.Namespace, pod.Name, corev1.PodPending)
 			if err != nil {
 				_ = objects.LogEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
 			}
 			Expect(err).ToNot(HaveOccurred())
 
-			By(fmt.Sprintf("checking the pod was handled by the topology aware scheduler %q but failed to be scheduled", serialconfig.Config.SchedulerName))
+			e2efixture.By("checking the pod was handled by the topology aware scheduler %q but failed to be scheduled", serialconfig.Config.SchedulerName)
 			isFailed, err := nrosched.CheckPODSchedulingFailedForAlignment(context.TODO(), fxt.K8sClient, pod.Namespace, pod.Name, serialconfig.Config.SchedulerName, tmScope)
 			Expect(err).ToNot(HaveOccurred())
 			if !isFailed {
@@ -671,7 +671,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 
 			dpName := "test-dp-47615"
 			replicas := int32(len(nrts)*requiredNUMAZones + 1) // at least 1 replica won't fit
-			By(fmt.Sprintf("creating a deployment %q with replicas %d candidate nodes %d", dpName, replicas, len(nrts)))
+			e2efixture.By("creating a deployment %q with replicas %d candidate nodes %d", dpName, replicas, len(nrts))
 
 			nroSchedObj := nrosched.CheckNROSchedulerAvailable(ctx, fxt.Client, objectnames.DefaultNUMAResourcesSchedulerCrName)
 
@@ -709,7 +709,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			dp, err = wait.With(fxt.Client).Interval(time.Second).Timeout(time.Minute).ForDeploymentReplicasCreation(ctx, dp, replicas)
 			Expect(err).NotTo(HaveOccurred())
 
-			By(fmt.Sprintf("checking deployment pods failed to be scheduled by %q ", schedulerName))
+			e2efixture.By("checking deployment pods failed to be scheduled by %q ", schedulerName)
 			pods, err := podlist.With(fxt.Client).ByDeployment(ctx, *dp)
 			Expect(err).ToNot(HaveOccurred(), "unable to get pods from deployment %q:  %v", dp.Name, err)
 			Expect(pods).ToNot(BeEmpty(), "cannot find any pods for DP %s/%s", dp.Namespace, dp.Name)
@@ -830,7 +830,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 		var err error
 
 		BeforeEach(func() {
-			By(fmt.Sprintf("filtering available nodes with at least %d NUMA zones", requiredNUMAZones))
+			e2efixture.By("filtering available nodes with at least %d NUMA zones", requiredNUMAZones)
 			nrtCandidates = e2enrt.FilterZoneCountEqual(nrts, requiredNUMAZones)
 
 			const neededNodes = 1
@@ -842,7 +842,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			var ok bool
 			targetNodeName, ok = e2efixture.PopNodeName(nrtCandidateNames)
 			Expect(ok).To(BeTrue(), "cannot select a node among %#v", e2efixture.ListNodeNames(nrtCandidateNames))
-			By(fmt.Sprintf("selecting node to schedule the test pod: %q", targetNodeName))
+			e2efixture.By("selecting node to schedule the test pod: %q", targetNodeName)
 
 			err = fxt.Client.Get(context.TODO(), client.ObjectKey{Name: targetNodeName}, &targetNrtInitial)
 			Expect(err).ToNot(HaveOccurred())
@@ -872,7 +872,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 				Expect(err).ToNot(HaveOccurred(), "could not get padding resources for node %q", nrtInfo.Name)
 
 				for _, zone := range nrtInfo.Zones {
-					By(fmt.Sprintf("fully padding node %q zone %q ", nrtInfo.Name, zone.Name))
+					e2efixture.By("fully padding node %q zone %q ", nrtInfo.Name, zone.Name)
 					padPod := newPaddingPod(nrtInfo.Name, zone.Name, fxt.Namespace.Name, paddingRes[zone.Name])
 
 					padPod, err = pinPodTo(padPod, nrtInfo.Name, zone.Name)


### PR DESCRIPTION
Trivial mechanical change, but lot of instances.
e2efixture.By() was introduced exactly to address this pattern.