### PR TITLE
e2e: serial: dump scheduler log on test failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -423,7 +423,7 @@ goversion:
 build-tools: goversion bin/buildhelper bin/envsubst bin/lsplatform update-buildinfo ## create the helper tools necessary for building the project
 
 .PHONY: build-tools-all
-build-tools-all: goversion bin/buildhelper bin/envsubst bin/lsplatform bin/catkubeletconfmap bin/watchnrtattr bin/mkginkgolabelfilter bin/pfpsyncchk bin/make-job-foreach-ds update-buildinfo ## create all the helper tools
+build-tools-all: goversion bin/buildhelper bin/envsubst bin/lsplatform bin/catkubeletconfmap bin/watchnrtattr bin/mkginkgolabelfilter bin/pfpsyncchk bin/make-job-foreach-ds bin/schedlogs update-buildinfo ## create all the helper tools
 
 pkg/version/_buildinfo.json: bin/buildhelper
 	@bin/buildhelper inspect > pkg/version/_buildinfo.json
@@ -455,6 +455,9 @@ bin/pfpsyncchk: tools/pfpsyncchk/pfpsyncchk.go
 	LDFLAGS="-s -w" go build -mod=vendor -o $@ -ldflags "$$LDFLAGS" -tags "$$GOTAGS" $<
 
 bin/make-job-foreach-ds: tools/make-job-foreach-ds/main.go
+	@go build -o $@ $<
+
+bin/schedlogs: tools/schedlogs/schedlogs.go
 	@go build -o $@ $<
 
 verify-generated: bundle generate

--- a/internal/podlogs/podlogs.go
+++ b/internal/podlogs/podlogs.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -39,6 +40,17 @@ func GetSince(ctx context.Context, k8sCli *kubernetes.Clientset, podNamespace, p
 	opts := &corev1.PodLogOptions{
 		Container:    containerName,
 		SinceSeconds: &sinceSeconds,
+	}
+	return get(ctx, k8sCli, podNamespace, podName, opts)
+}
+
+// GetSinceTime fetches log output for a pod container starting from the given absolute time,
+// using the server-side sinceTime filter to avoid transferring the full log.
+func GetSinceTime(ctx context.Context, k8sCli *kubernetes.Clientset, podNamespace, podName, containerName string, since time.Time) (string, error) {
+	sinceTime := metav1.NewTime(since)
+	opts := &corev1.PodLogOptions{
+		Container: containerName,
+		SinceTime: &sinceTime,
 	}
 	return get(ctx, k8sCli, podNamespace, podName, opts)
 }

--- a/internal/podlogs/podlogs.go
+++ b/internal/podlogs/podlogs.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package podlogs
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Get fetches the full log output for a pod container.
+func Get(ctx context.Context, k8sCli *kubernetes.Clientset, podNamespace, podName, containerName string) (string, error) {
+	opts := &corev1.PodLogOptions{
+		Container: containerName,
+	}
+	return get(ctx, k8sCli, podNamespace, podName, opts)
+}
+
+// GetSince fetches log output for a pod container limited to the last `since` duration,
+// using the server-side sinceSeconds filter to avoid transferring the full log.
+func GetSince(ctx context.Context, k8sCli *kubernetes.Clientset, podNamespace, podName, containerName string, since time.Duration) (string, error) {
+	sinceSeconds := int64(since.Seconds())
+	opts := &corev1.PodLogOptions{
+		Container:    containerName,
+		SinceSeconds: &sinceSeconds,
+	}
+	return get(ctx, k8sCli, podNamespace, podName, opts)
+}
+
+func get(ctx context.Context, k8sCli *kubernetes.Clientset, podNamespace, podName string, opts *corev1.PodLogOptions) (string, error) {
+	request := k8sCli.CoreV1().Pods(podNamespace).GetLogs(podName, opts)
+	logs, err := request.Do(ctx).Raw()
+	if err != nil {
+		return "", err
+	}
+	return string(logs), nil
+}

--- a/pkg/numaresourcesscheduler/controlplane/discover.go
+++ b/pkg/numaresourcesscheduler/controlplane/discover.go
@@ -1,4 +1,6 @@
 /*
+ * Copyright 2021 Red Hat, Inc.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -10,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Copyright 2021 Red Hat, Inc.
  */
 
 package controlplane

--- a/pkg/numaresourcesscheduler/controlplane/leader.go
+++ b/pkg/numaresourcesscheduler/controlplane/leader.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controlplane
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	nrs "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler"
+)
+
+// GetLeaderPod returns the namespace/name of the scheduler pod currently holding the leader
+// election lease. Typically used for the scheduler pods, but meant to work with any pod using
+// the standard kubernetes leader election.
+// The kube-scheduler framework sets the lease HolderIdentity to
+// "<hostname>_<uuid>", where hostname is the pod name inside a Kubernetes pod.
+func GetLeaderPod(ctx context.Context, k8sCli kubernetes.Interface, namespace string) (types.NamespacedName, error) {
+	lease, err := k8sCli.CoordinationV1().Leases(namespace).Get(ctx, nrs.LeaderElectionResourceName, metav1.GetOptions{})
+	if err != nil {
+		return types.NamespacedName{}, fmt.Errorf("failed to get lease %s/%s: %w", namespace, nrs.LeaderElectionResourceName, err)
+	}
+	if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity == "" {
+		return types.NamespacedName{}, fmt.Errorf("lease %s/%s has no holder", namespace, nrs.LeaderElectionResourceName)
+	}
+	holderIdentity := *lease.Spec.HolderIdentity
+	// HolderIdentity format is "<pod-name>_<uuid>", split at the last "_" to extract the pod name
+	idx := strings.LastIndex(holderIdentity, "_")
+	if idx == -1 {
+		return types.NamespacedName{}, fmt.Errorf("unexpected holder identity format: %q", holderIdentity)
+	}
+	podName := holderIdentity[:idx]
+	return types.NamespacedName{Namespace: namespace, Name: podName}, nil
+}

--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -43,6 +43,7 @@ import (
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
 	inthelper "github.com/openshift-kni/numaresources-operator/internal/api/annotations/helper"
 	nropmcp "github.com/openshift-kni/numaresources-operator/internal/machineconfigpools"
+	"github.com/openshift-kni/numaresources-operator/internal/podlogs"
 	nrowait "github.com/openshift-kni/numaresources-operator/internal/wait"
 	"github.com/openshift-kni/numaresources-operator/pkg/status"
 	rteconfig "github.com/openshift-kni/numaresources-operator/rte/pkg/config"
@@ -443,7 +444,7 @@ func logRTEPodsLogs(cli client.Client, k8sCli *kubernetes.Clientset, ctx context
 		}
 
 		for _, pod := range podList.Items {
-			logs, err := objects.GetLogsForPod(k8sCli, pod.Namespace, pod.Name, containerNameRTE)
+			logs, err := podlogs.Get(ctx, k8sCli, pod.Namespace, pod.Name, containerNameRTE)
 			if err != nil {
 				klog.ErrorS(err, "cannot fetch logs", "dsNamespace", ds.Namespace, "dsName", ds.Name, "podNamespace", pod.Namespace, "podName", pod.Name)
 				continue

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	corev1qos "k8s.io/kubectl/pkg/util/qos"
 	"k8s.io/utils/ptr"
@@ -38,9 +39,12 @@ import (
 	intbaseload "github.com/openshift-kni/numaresources-operator/internal/baseload"
 	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
+	"github.com/openshift-kni/numaresources-operator/internal/podlogs"
 	"github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
+	schedcp "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/controlplane"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
+	schedupdate "github.com/openshift-kni/numaresources-operator/pkg/objectupdate/sched"
 	"github.com/openshift-kni/numaresources-operator/test/e2e/label"
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/internal/clients"
@@ -200,6 +204,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			By(fmt.Sprintf("checking the pod was handled by the topology aware scheduler %q but failed to be scheduled on any node", serialconfig.Config.SchedulerName))
 			isFailed, err := nrosched.CheckPODSchedulingFailedForAlignment(context.TODO(), fxt.K8sClient, pod.Namespace, pod.Name, serialconfig.Config.SchedulerName, tmScope)
 			Expect(err).ToNot(HaveOccurred())
+			if !isFailed {
+				dumpSchedulerLogs(context.TODO(), fxt.K8sClient, serialconfig.Config.NROSchedObj.Status.Deployment.Namespace, *pod)
+			}
 			Expect(isFailed).To(BeTrue(), "pod %s/%s with scheduler %s did NOT fail", pod.Namespace, pod.Name, serialconfig.Config.SchedulerName)
 		})
 
@@ -238,6 +245,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 					_ = objects.LogEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
 				}
 				Expect(err).ToNot(HaveOccurred())
+				if !isFailed {
+					dumpSchedulerLogs(context.TODO(), fxt.K8sClient, serialconfig.Config.NROSchedObj.Status.Deployment.Namespace, pod)
+				}
 				Expect(isFailed).To(BeTrue(), "pod %s/%s with scheduler %s did NOT fail", pod.Namespace, pod.Name, serialconfig.Config.SchedulerName)
 			}
 		})
@@ -278,6 +288,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 					_ = objects.LogEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
 				}
 				Expect(err).ToNot(HaveOccurred())
+				if !isFailed {
+					dumpSchedulerLogs(context.TODO(), fxt.K8sClient, serialconfig.Config.NROSchedObj.Status.Deployment.Namespace)
+				}
 				Expect(isFailed).To(BeTrue(), "pod %s/%s with scheduler %s did NOT fail", pod.Namespace, pod.Name, serialconfig.Config.SchedulerName)
 			}
 		})
@@ -439,6 +452,9 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 						_ = objects.LogEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
 					}
 					Expect(err).ToNot(HaveOccurred())
+					if !isFailed {
+						dumpSchedulerLogs(context.TODO(), fxt.K8sClient, serialconfig.Config.NROSchedObj.Status.Deployment.Namespace)
+					}
 					Expect(isFailed).To(BeTrue(), "pod %s/%s with scheduler %s did NOT fail", pod.Namespace, pod.Name, serialconfig.Config.SchedulerName)
 				}
 
@@ -597,6 +613,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			Expect(err).ToNot(HaveOccurred())
 			if !isFailed {
 				_ = objects.LogEventsForPod(fxt.K8sClient, pod.Namespace, pod.Name)
+				dumpSchedulerLogs(context.TODO(), fxt.K8sClient, serialconfig.Config.NROSchedObj.Status.Deployment.Namespace, *pod)
 			}
 			Expect(isFailed).To(BeTrue(), "pod %s/%s with scheduler %s did NOT fail", pod.Namespace, pod.Name, serialconfig.Config.SchedulerName)
 
@@ -981,6 +998,48 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 		})
 	})
 })
+
+// educated guess. "far enough" in the past but without dumping too much. Subjected to further review.
+const schedLogWindow = 30 * time.Second
+
+// schedLogSafetyMargin is the margin subtracted from the earliest pod creation timestamp
+// to account for clock skew between the API server and test runner.
+const schedLogSafetyMargin = 5 * time.Second
+
+// dumpSchedulerLogs fetches and logs the scheduler leader's recent logs.
+// When targetPods are provided, the log window is anchored to the earliest pod creation
+// timestamp (minus a safety margin), giving a precise lower bound instead of an arbitrary duration.
+// When no targetPods are provided, it falls back to fetching the last schedLogWindow.
+func dumpSchedulerLogs(ctx context.Context, k8sCli *kubernetes.Clientset, schedNamespace string, targetPods ...corev1.Pod) {
+	leaderPod, err := schedcp.GetLeaderPod(ctx, k8sCli, schedNamespace)
+	if err != nil {
+		klog.ErrorS(err, "cannot find scheduler leader pod")
+		return
+	}
+	klog.Infof("scheduler leader pod: %s/%s", leaderPod.Namespace, leaderPod.Name)
+
+	var logs string
+	var logRef string
+	if len(targetPods) > 0 {
+		earliest := targetPods[0].CreationTimestamp.Time
+		for _, p := range targetPods[1:] {
+			if p.CreationTimestamp.Time.Before(earliest) {
+				earliest = p.CreationTimestamp.Time
+			}
+		}
+		since := earliest.Add(-schedLogSafetyMargin)
+		logRef = fmt.Sprintf("since %s", since.UTC().Format(time.RFC3339))
+		logs, err = podlogs.GetSinceTime(ctx, k8sCli, leaderPod.Namespace, leaderPod.Name, schedupdate.MainContainerName, since)
+	} else {
+		logRef = fmt.Sprintf("last %v", schedLogWindow)
+		logs, err = podlogs.GetSince(ctx, k8sCli, leaderPod.Namespace, leaderPod.Name, schedupdate.MainContainerName, schedLogWindow)
+	}
+	if err != nil {
+		klog.ErrorS(err, "cannot fetch scheduler logs", "podNamespace", leaderPod.Namespace, "podName", leaderPod.Name)
+		return
+	}
+	klog.Infof("begin scheduler logs for %s/%s (%s)\n%send scheduler logs for %s/%s", leaderPod.Namespace, leaderPod.Name, logRef, logs, leaderPod.Namespace, leaderPod.Name)
+}
 
 // Return only those NRTs where each request could fit into a different zone.
 func filterNRTsEachRequestOnADifferentZone(nrts []nrtv1alpha2.NodeResourceTopology, r1, r2 corev1.ResourceList) []nrtv1alpha2.NodeResourceTopology {

--- a/test/internal/objects/pod.go
+++ b/test/internal/objects/pod.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -101,19 +100,6 @@ func GetEventsForPod(k8sCli kubernetes.Interface, podNamespace, podName string) 
 		return nil, err
 	}
 	return events.Items, nil
-}
-
-func GetLogsForPod(k8sCli *kubernetes.Clientset, podNamespace, podName, containerName string) (string, error) {
-	previous := false
-	request := k8sCli.CoreV1().RESTClient().Get().Resource("pods").Namespace(podNamespace).Name(podName).SubResource("log").Param("container", containerName).Param("previous", strconv.FormatBool(previous))
-	logs, err := request.Do(context.TODO()).Raw()
-	if err != nil {
-		return "", err
-	}
-	if strings.Contains(string(logs), "Internal Error") {
-		return "", fmt.Errorf("Fetched log contains \"Internal Error\": %q", string(logs))
-	}
-	return string(logs), err
 }
 
 func DumpPODResourceRequirements(pod *corev1.Pod) string {

--- a/tools/schedlogs/schedlogs.go
+++ b/tools/schedlogs/schedlogs.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/openshift-kni/numaresources-operator/internal/podlogs"
+	schedcp "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler/controlplane"
+	schedupdate "github.com/openshift-kni/numaresources-operator/pkg/objectupdate/sched"
+)
+
+func main() {
+	containerName := schedupdate.MainContainerName
+	namespace := "numaresources"
+	since := 5 * time.Minute
+
+	flag.StringVar(&namespace, "namespace", namespace, "namespace where the scheduler is deployed")
+	flag.StringVar(&containerName, "container", containerName, "name of the scheduler container")
+	flag.DurationVar(&since, "since", since, "fetch logs from the last duration (e.g. 30s, 5m)")
+	flag.Parse()
+
+	kubeconfig, ok := os.LookupEnv("KUBECONFIG")
+	if !ok {
+		kubeconfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
+		log.Printf("using default kubeconfig: %q", kubeconfig)
+	}
+
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		log.Fatalf("error building kubeconfig: %v", err)
+	}
+
+	k8sCli, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		log.Fatalf("error creating kubernetes client: %v", err)
+	}
+
+	ctx := context.Background()
+
+	leaderPod, err := schedcp.GetLeaderPod(ctx, k8sCli, namespace)
+	if err != nil {
+		log.Fatalf("error finding leader pod: %v", err)
+	}
+	log.Printf("leader pod: %s/%s", leaderPod.Namespace, leaderPod.Name)
+
+	logs, err := podlogs.GetSince(ctx, k8sCli, leaderPod.Namespace, leaderPod.Name, containerName, since)
+	if err != nil {
+		log.Fatalf("error fetching logs: %v", err)
+	}
+
+	fmt.Println("-------8<-------")
+	fmt.Print(logs)
+	fmt.Println("-------8<-------")
+}


### PR DESCRIPTION
When a serial scheduler-related test fail, it is useful to see also the scheduler side.
Add utilities to dump the most recent X seconds of test logs, because we don't have primitives to just find the logs pertaining a pod scheduling attempt.

Use the utilties in the workload_unschedulable tests.