### PR TITLE
e2e: serial: add Log and Dump interfaces in the fixture

### DIFF
--- a/hack/run-test-serial-e2e.sh
+++ b/hack/run-test-serial-e2e.sh
@@ -39,6 +39,7 @@ if [ -n "${E2E_SERIAL_SKIP}" ]; then
 	SKIP="-ginkgo.skip=${E2E_SERIAL_SKIP}"
 fi
 
+VERBOSE=""
 DRY_RUN="false"
 REPORT_FILE=""
 
@@ -98,6 +99,14 @@ while [[ $# -gt 0 ]]; do
 			shift
 			shift
 			;;
+		--verbose)
+			VERBOSE="${VERBOSE} -ginkgo.v"
+			shift
+			;;
+		--debug)
+			VERBOSE="${VERBOSE} -ginkgo.vv -test.v"
+			shift
+			;;
 		--help)
 			echo "usage: $0 [options]"
 			echo "[options] are always '--opt val' and never '--opt=val'"
@@ -112,6 +121,8 @@ while [[ $# -gt 0 ]]; do
 			echo "--skip <regex>          skip cases matching <regex> (passed to -ginkgo.skip)"
 			echo "--label-filter <query>  filter cases based on the matching <query> (passed to -ginkgo.label-filter)"
 			echo "--report-file <file>    write report file for this suite on <file>"
+			echo "--verbose               add debug output (becomes -ginkgo.v)"
+			echo "--debug                 add even more debug output (becomes -ginkgo.vv + other settings)"
 			echo "--help                  shows this message and helps correctly"
 			exit 0
 			;;
@@ -187,10 +198,10 @@ function runtests() {
 	fi
 	echo "Running Serial, disruptive E2E Tests"
 	runcmd ${BIN_DIR}/e2e-nrop-serial.test \
-		--ginkgo.v \
 		--ginkgo.timeout="5h" \
 		--ginkgo.junit-report=${REPORT_FILE} \
 		${NO_COLOR} \
+		${VERBOSE} \
 		${SKIP} \
 		${LABEL_FILTER} \
 		${FOCUS}

--- a/hack/test-e2e-runner.sh
+++ b/hack/test-e2e-runner.sh
@@ -28,7 +28,7 @@ echo "[TEST] --dry-run produces expected output"
 GOT=$( $RUNNER --dry-run --no-color)
 EXPECTED="Ensuring: /tmp/artifacts/nrop
 Running Serial, disruptive E2E Tests
-Running: /usr/local/bin/e2e-nrop-serial.test --ginkgo.v --ginkgo.timeout=5h --ginkgo.junit-report=/tmp/artifacts/nrop/e2e-serial-run.xml --ginkgo.no-color"
+Running: /usr/local/bin/e2e-nrop-serial.test --ginkgo.timeout=5h --ginkgo.junit-report=/tmp/artifacts/nrop/e2e-serial-run.xml --ginkgo.no-color"
 if [ "${GOT}" != "${EXPECTED}" ]; then
 	echo -e "[FAIL] --dry-run unexpected output:\n${GOT}"
 	echo -e "[FAIL] --dry-run expected output:\n${EXPECTED}"

--- a/test/e2e/serial/config/fixture.go
+++ b/test/e2e/serial/config/fixture.go
@@ -56,8 +56,7 @@ func (cfg *E2EConfig) RecordNRTReference() error {
 	if err != nil {
 		return err
 	}
-	// TODO: multi-line value in structured log
-	klog.InfoS("recorded reference NRT data", "data", intnrt.ListToString(cfg.NRTList.Items, " reference"))
+	cfg.Fixture.Dump.Infof(intnrt.ListToString(cfg.NRTList.Items, " reference"), "recorded reference NRT data")
 	return nil
 }
 

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -383,11 +383,9 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 				// the operator may take nonzero time to populate the status, and this is still fine.\
 				// NOTE HERE: we need to match the types as well (ptr and ptr)
 				matchFromMCP := cmp.Equal(statusConfFromMCP, &specConf)
-				// TODO: multi-line value in structured log
-				klog.InfoS("result of checking the status from MachineConfigPools", "NRO Object", nroKey.String(), "status", toJSON(statusConfFromMCP), "spec", toJSON(specConf), "match", matchFromMCP)
+				fxt.Dump.Infof(fmt.Sprintf("NRO Object: %s\nstatus: %s\nspec: %s\nmatch: %t", nroKey.String(), toJSON(statusConfFromMCP), toJSON(specConf), matchFromMCP), "result of checking the status from MachineConfigPools")
 				matchFromGroupStatus := cmp.Equal(statusConfFromGroupStatus, specConf)
-				// TODO: multi-line value in structured log
-				klog.InfoS("result of checking the status from NodeGroupStatus", "NRO Object", nroKey.String(), "status", toJSON(statusConfFromGroupStatus), "spec", toJSON(specConf), "match", matchFromGroupStatus)
+				fxt.Dump.Infof(fmt.Sprintf("NRO Object: %s\nstatus: %s\nspec: %s\nmatch: %t", nroKey.String(), toJSON(statusConfFromGroupStatus), toJSON(specConf), matchFromGroupStatus), "result of checking the status from NodeGroupStatus")
 
 				return matchFromMCP && matchFromGroupStatus, nil
 			})
@@ -1098,7 +1096,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 
 				Eventually(func(g Gomega) {
 					g.Expect(ng.PoolName).ToNot(BeNil())
-					verifyStatusUpdate(fxt.Client, ctx, nroKey, updatedNRO, *ng.PoolName, specConf)
+					verifyStatusUpdate(fxt, ctx, nroKey, updatedNRO, *ng.PoolName, specConf)
 				}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 
 				By("update the same node group config and ensure it's updated in the operator status")
@@ -1128,7 +1126,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 				By("wait for NodeGroupStatus to reflect config changes")
 				Eventually(func(g Gomega) {
 					g.Expect(ng.PoolName).ToNot(BeNil())
-					verifyStatusUpdate(fxt.Client, ctx, nroKey, updatedNRO, *ng.PoolName, newSpecConf)
+					verifyStatusUpdate(fxt, ctx, nroKey, updatedNRO, *ng.PoolName, newSpecConf)
 				}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 
 				Expect(fxt.Client.Get(ctx, nroKey, &updatedNRO)).To(Succeed())
@@ -1303,8 +1301,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 					rteConfigMap = &updatedConfigMaps.Items[0]
 					return true
 				}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(BeTrue())
-				// TODO: multi-line value in structured log
-				klog.InfoS("found RTE configmap", "rteConfigMap", rteConfigMap)
+				fxt.Dump.Infof(fmt.Sprintf("rteConfigMap: %+v", rteConfigMap), "found RTE configmap")
 
 				poolName := rteConfigMap.Labels[rteconfig.LabelNodeGroupName+"/"+rteconfig.LabelNodeGroupKindMachineConfigPool]
 				nodeSelector, err := nodegroups.NodeSelectorFromPoolName(ctx, e2eclient.Client, poolName)
@@ -1456,8 +1453,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 					rteConfigMap = updatedConfigMap
 					return true
 				}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(BeTrue())
-				// TODO: multi-line value in structured log
-				klog.InfoS("found RTE configmap", "rteConfigMap", rteConfigMap)
+				fxt.Dump.Infof(fmt.Sprintf("rteConfigMap: %+v", rteConfigMap), "found RTE configmap")
 
 				poolName := rteConfigMap.Labels[rteconfig.LabelNodeGroupName+"/"+rteconfig.LabelNodeGroupKindMachineConfigPool]
 				nodeSelector, err := nodegroups.NodeSelectorFromPoolName(ctx, e2eclient.Client, poolName)
@@ -1575,11 +1571,11 @@ func nodeWithoutCustomRole(nodes []corev1.Node) *corev1.Node {
 	return nil
 }
 
-func verifyStatusUpdate(cli client.Client, ctx context.Context, key client.ObjectKey, appliedObj nropv1.NUMAResourcesOperator, expectedPoolName string, expectedConf nropv1.NodeGroupConfig) {
+func verifyStatusUpdate(fxt *e2efixture.Fixture, ctx context.Context, key client.ObjectKey, appliedObj nropv1.NUMAResourcesOperator, expectedPoolName string, expectedConf nropv1.NodeGroupConfig) {
 	klog.InfoS("fetch NRO object", "key", key.String())
 	var updatedNRO nropv1.NUMAResourcesOperator
 	Eventually(func(g Gomega) {
-		g.Expect(cli.Get(ctx, key, &updatedNRO)).To(Succeed())
+		g.Expect(fxt.Client.Get(ctx, key, &updatedNRO)).To(Succeed())
 		g.Expect(isNROOperSyncedAt(&updatedNRO.Status, status.ConditionAvailable, updatedNRO.Generation)).To(Succeed())
 		g.Expect(updatedNRO.Status.NodeGroups).To(HaveLen(len(appliedObj.Spec.NodeGroups)),
 			"NodeGroups Status mismatch: found %d, expected %d", len(updatedNRO.Status.NodeGroups), len(appliedObj.Spec.NodeGroups))
@@ -1628,11 +1624,9 @@ func verifyStatusUpdate(cli client.Client, ctx context.Context, key client.Objec
 	// the operator may take nonzero time to populate the status, and this is still fine.\
 	// NOTE HERE: we need to match the types as well (ptr and ptr)
 	matchFromMCP := cmp.Equal(statusConfFromMCP, &expectedConf)
-	// TODO: multi-line value in structured log
-	klog.InfoS("result of checking the status from MachineConfigPools", "NRO Object", key.String(), "status", toJSON(statusConfFromMCP), "spec", toJSON(expectedConf), "match", matchFromMCP)
+	fxt.Dump.Infof(fmt.Sprintf("NRO Object: %s\nstatus: %s\nspec: %s\nmatch: %t", key.String(), toJSON(statusConfFromMCP), toJSON(expectedConf), matchFromMCP), "result of checking the status from MachineConfigPools")
 	matchFromGroupStatus := cmp.Equal(statusFromNodeGroups.Config, expectedConf)
-	// TODO: multi-line value in structured log
-	klog.InfoS("result of checking the status from NodeGroupStatus", "NRO Object", key.String(), "status", toJSON(statusFromNodeGroups), "spec", toJSON(expectedConf), "match", matchFromGroupStatus)
+	fxt.Dump.Infof(fmt.Sprintf("NRO Object: %s\nstatus: %s\nspec: %s\nmatch: %t", key.String(), toJSON(statusFromNodeGroups), toJSON(expectedConf), matchFromGroupStatus), "result of checking the status from NodeGroupStatus")
 	Expect(matchFromMCP && matchFromGroupStatus).To(BeTrue(), "config status mismatch")
 }
 

--- a/test/e2e/serial/tests/non_regression.go
+++ b/test/e2e/serial/tests/non_regression.go
@@ -277,8 +277,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(schedOK).To(BeFalse(), "pod %s/%s not assigned to a specific node without a scheduler %s", updatedPod.Namespace, updatedPod.Name, nonExistingSchedulerName)
 
 			rl := e2ereslist.FromGuaranteedPod(updatedPod)
-			// TODO: multi-line value in structured log
-			klog.InfoS("post-create pod resource list", "spec", e2ereslist.ToString(e2ereslist.FromContainerLimits(podSpec.Containers)), "updated", e2ereslist.ToString(rl))
+			fxt.Dump.Infof(fmt.Sprintf("spec: %s\nupdated: %s", e2ereslist.ToString(e2ereslist.FromContainerLimits(podSpec.Containers)), e2ereslist.ToString(rl)), "post-create pod resource list")
 
 			nrtInitial, err := e2enrt.FindFromList(nrtInitialList.Items, updatedPod.Spec.NodeName)
 			Expect(err).ToNot(HaveOccurred())
@@ -343,8 +342,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				//calculate base load on the node
 				baseload, err := baseload.ForNode(fxt.Client, context.TODO(), nodeName)
 				Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", nodeName)
-				// TODO: multi-line value in structured log
-				klog.InfoS("computed base load", "value", baseload)
+				fxt.Dump.Infof(baseload.String(), "computed base load")
 
 				//get nrt info of the node
 				klog.InfoS("preparing node to fit the test case", "nodeName", nodeName)

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -148,7 +148,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 
 			for _, zone := range nrtInfo.Zones {
 				e2efixture.By("padding node %q zone %q", nrtInfo.Name, zone.Name)
-				padPod, err := makePaddingPod(fxt.Namespace.Name, "target", zone, requiredRes)
+				padPod, err := makePaddingPod(fxt, fxt.Namespace.Name, "target", zone, requiredRes)
 				Expect(err).ToNot(HaveOccurred())
 
 				padPod, err = pinPodTo(padPod, nrtInfo.Name, zone.Name)
@@ -210,7 +210,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 				for _, zone := range nrtInfo.Zones {
 					name := fmt.Sprintf("unsuitable%d", idx)
 					e2efixture.By("saturating node %q -> %q zone %q", nrtInfo.Name, name, zone.Name)
-					padPod, err := makePaddingPod(fxt.Namespace.Name, name, zone, unsuitableFreeRes)
+					padPod, err := makePaddingPod(fxt, fxt.Namespace.Name, name, zone, unsuitableFreeRes)
 					Expect(err).ToNot(HaveOccurred())
 
 					padPod, err = pinPodTo(padPod, nrtInfo.Name, zone.Name)
@@ -334,13 +334,11 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			// TODO: just use nrtList?
 			err = fxt.Client.List(context.TODO(), &targetNrtListInitial)
 			Expect(err).ToNot(HaveOccurred())
-			// TODO: multi-line value in structured log
-			klog.InfoS("initial NRT List", "list", intnrt.ListToString(targetNrtListInitial.Items, " initial list"))
+			fxt.Dump.Infof(intnrt.ListToString(targetNrtListInitial.Items, " initial list"), "initial NRT List")
 
 			targetNrtInitial, err = e2enrt.FindFromList(targetNrtListInitial.Items, targetNodeName)
 			Expect(err).NotTo(HaveOccurred())
-			// TODO: multi-line value in structured log
-			klog.InfoS("initial NRT target", "nrt", intnrt.ToString(*targetNrtInitial))
+			fxt.Dump.Infof(intnrt.ToString(*targetNrtInitial), "initial NRT target")
 
 			//calculate base load on the target node
 			baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), targetNodeName)
@@ -369,8 +367,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 				//calculate base load on the node
 				baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), nodeName)
 				Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", nodeName)
-				// TODO: multi-line value in structured log
-				klog.InfoS("computed base load", "value", baseload)
+				fxt.Dump.Infof(baseload.String(), "computed base load")
 
 				//get nrt info of the node
 				klog.InfoS("preparing node to fit the test case", "node", nodeName)
@@ -403,13 +400,11 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			By("Getting the reference NRT list post padding")
 			targetNrtListReference, err = e2enrt.GetUpdated(fxt.Client, targetNrtListInitial, 1*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
-			// TODO: multi-line value in structured log
-			klog.InfoS("reference NRT List", "list", intnrt.ListToString(targetNrtListReference.Items, " reference list"))
+			fxt.Dump.Infof(intnrt.ListToString(targetNrtListReference.Items, " reference list"), "reference NRT List")
 
 			targetNrtReference, err = e2enrt.FindFromList(targetNrtListReference.Items, targetNodeName)
 			Expect(err).NotTo(HaveOccurred())
-			// TODO: multi-line value in structured log
-			klog.InfoS("reference NRT target", "nrt", intnrt.ToString(*targetNrtReference))
+			fxt.Dump.Infof(intnrt.ToString(*targetNrtReference), "reference NRT target")
 		})
 
 		It("[test_id:48685] should properly schedule a best-effort pod with no changes in NRTs", Label(label.Tier1), func() {
@@ -486,8 +481,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			// make it burstable
 			deployment.Spec.Template.Spec.Containers[0].Resources.Requests = reqResources
 
-			// TODO: multi-line value in structured log
-			klog.InfoS("create the bustable test deployment with requests", "requests", e2ereslist.ToString(reqResources))
+			fxt.Dump.Infof(e2ereslist.ToString(reqResources), "create the bustable test deployment with requests")
 			err = fxt.Client.Create(context.TODO(), deployment)
 			Expect(err).NotTo(HaveOccurred(), "unable to create deployment %q", deployment.Name)
 
@@ -525,8 +519,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			//calculate base load on the target node
 			baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), targetNodeName)
 			Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", targetNodeName)
-			// TODO: multi-line value in structured log
-			klog.InfoS("computed base load", "value", baseload)
+			fxt.Dump.Infof(baseload.String(), "computed base load")
 
 			var reqResPerNUMA []corev1.ResourceList
 			for _, zone := range targetNrtInitial.Zones {
@@ -565,8 +558,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 
 			err = fxt.Client.Create(context.TODO(), pod)
 			Expect(err).ToNot(HaveOccurred())
-			// TODO: multi-line value in structured log
-			klog.InfoS("create the burstable test pod with requests", "requests", e2ereslist.ToString(reqResources))
+			fxt.Dump.Infof(objects.DumpPODResourceRequirements(pod), "create the burstable test pod with requests")
 
 			By("waiting for the pod to be scheduled")
 			// 3 minutes is plenty, should never timeout
@@ -685,8 +677,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			Expect(err).ToNot(HaveOccurred())
 
 			rl := e2ereslist.FromGuaranteedPod(*updatedPod2)
-			// TODO: multi-line value in structured log
-			klog.InfoS("post-create pod resource list", "spec", e2ereslist.ToString(e2ereslist.FromContainerLimits(podGuanranteed.Spec.Containers)), "updated", e2ereslist.ToString(rl))
+			fxt.Dump.Infof(fmt.Sprintf("spec: %s\nupdated: %s", e2ereslist.ToString(e2ereslist.FromContainerLimits(podGuanranteed.Spec.Containers)), e2ereslist.ToString(rl)), "post-create pod resource list")
 
 			scope, ok := attribute.Get(targetNrtInitial.Attributes, intnrt.TopologyManagerScopeAttribute)
 			Expect(ok).To(BeTrue(), fmt.Sprintf("Unable to find required attribute %q on NRT %q", intnrt.TopologyManagerScopeAttribute, targetNrtInitial.Name))
@@ -742,8 +733,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			// make it burstable
 			ds.Spec.Template.Spec.Containers[0].Resources.Requests = reqResources
 
-			// TODO: multi-line value in structured log
-			klog.InfoS("create the bustable test daemonset with requests", "requests", e2ereslist.ToString(reqResources))
+			fxt.Dump.Infof(e2ereslist.ToString(reqResources), "create the bustable test daemonset with requests")
 			err = fxt.Client.Create(context.TODO(), ds)
 			Expect(err).NotTo(HaveOccurred(), "unable to create daemonset %q", ds.Name)
 
@@ -786,8 +776,7 @@ func checkNRTConsumedResources(fxt *e2efixture.Fixture, targetNrtInitial nrtv1al
 	match, err := e2enrt.CheckZoneConsumedResourcesAtLeast(targetNrtInitial, targetNrtCurrent, requiredRes, corev1qos.GetPodQOS(updatedPod))
 	Expect(err).ToNot(HaveOccurred())
 	if match == "" {
-		// TODO: multi-line value in structured log
-		klog.InfoS("inconsistent accounting: no resources consumed by the running pod", "nrtBefore", intnrt.ToString(targetNrtInitial), "nrtAfter", intnrt.ToString(targetNrtCurrent), "podResources", e2ereslist.ToString(requiredRes))
+		fxt.Dump.Infof(fmt.Sprintf("nrtBefore: %s\nnrtAfter: %s\npodResources: %s", intnrt.ToString(targetNrtInitial), intnrt.ToString(targetNrtCurrent), e2ereslist.ToString(requiredRes)), "inconsistent accounting: no resources consumed by the running pod")
 	}
 	return targetNrtCurrent, match
 }

--- a/test/e2e/serial/tests/resource_hostlevel.go
+++ b/test/e2e/serial/tests/resource_hostlevel.go
@@ -23,7 +23,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -104,8 +103,7 @@ var _ = Describe("[serial][hostlevel] numaresources host-level resources", Seria
 				}
 				Expect(err).NotTo(HaveOccurred(), "Pod %q not up&running after %v", pod.Name, time.Minute)
 
-				// TODO: multi-line value in structured log
-				klog.InfoS("pod resources", "namespace", updatedPod.Namespace, "name", updatedPod.Name, "resources", intreslist.ToString(intreslist.FromContainerRequests(pod.Spec.Containers)))
+				fxt.Dump.Infof(fmt.Sprintf("namespace: %s\nname: %s\nresources: %s", updatedPod.Namespace, updatedPod.Name, intreslist.ToString(intreslist.FromContainerRequests(pod.Spec.Containers))), "pod resources")
 				Expect(updatedPod.Status.QOSClass).To(Equal(expectedQOS), "pod QOS mismatch")
 
 				e2efixture.By("checking the pod was scheduled with the topology aware scheduler %q", serialconfig.Config.SchedulerName)
@@ -123,8 +121,7 @@ var _ = Describe("[serial][hostlevel] numaresources host-level resources", Seria
 				if expectedQOS == corev1.PodQOSGuaranteed {
 					accumulatedRes = intreslist.Accumulate(requiredRes, intreslist.FilterExclusive)
 				}
-				// TODO: multi-line value in structured log
-				klog.InfoS("expected required resources to reflect in NRT", "resources", accumulatedRes)
+				fxt.Dump.Infof(intreslist.ToString(accumulatedRes), "expected required resources to reflect in NRT")
 				expectNRTConsumedResources(fxt, *targetNrtInitial, accumulatedRes, updatedPod)
 			},
 			Entry("[test_id:84015][qos:gu] with ephemeral storage, single-container",
@@ -302,8 +299,7 @@ var _ = Describe("[serial][hostlevel] numaresources host-level resources", Seria
 						corev1.ResourceEphemeralStorage: *storageEphemeralQty,
 					}
 
-					// TODO: multi-line value in structured log
-					klog.InfoS("pad node with", "node", nodeName, "resources", intreslist.ToString(paddingResources))
+					fxt.Dump.Infof(fmt.Sprintf("node: %s\nresources: %s", nodeName, intreslist.ToString(paddingResources)), "pad node with")
 					pod := newPaddingPod(nodeName, "all", fxt.Namespace.Name, paddingResources)
 					pod.Spec.NodeName = nodeName // TODO: pinPodToNode?
 
@@ -339,8 +335,7 @@ var _ = Describe("[serial][hostlevel] numaresources host-level resources", Seria
 				}
 				Expect(err).NotTo(HaveOccurred(), "Pod %s/%s was found in state %q while expected to be Pending", updatedPod.Namespace, updatedPod.Name, updatedPod.Status.Phase)
 
-				// TODO: multi-line value in structured log
-				klog.InfoS("pod resources", "namespace", updatedPod.Namespace, "name", updatedPod.Name, "resources", intreslist.ToString(intreslist.FromContainerRequests(pod.Spec.Containers)))
+				fxt.Dump.Infof(fmt.Sprintf("namespace: %s\nname: %s\nresources: %s", updatedPod.Namespace, updatedPod.Name, intreslist.ToString(intreslist.FromContainerRequests(pod.Spec.Containers))), "pod resources")
 				Expect(updatedPod.Status.QOSClass).To(Equal(expectedQOS), "pod QoS mismatch")
 				e2efixture.By("checking the pod is handled by the topology aware scheduler %q but failed to be scheduled on any node", serialconfig.Config.SchedulerName)
 				isFailed, err := nrosched.CheckPodSchedulingFailedWithMsg(context.TODO(), fxt.K8sClient, updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName, fmt.Sprintf("%d Insufficient ephemeral-storage", len(candidateNodeNames)))

--- a/test/e2e/serial/tests/scheduler_cache_stall.go
+++ b/test/e2e/serial/tests/scheduler_cache_stall.go
@@ -497,8 +497,7 @@ var _ = Describe("[serial][scheduler][cache] scheduler cache stall", Label("sche
 					// but it's not the behavior we expect. A conforming scheduler is expected to send first two pods,
 					// wait for reconciliation, then send the missing two.
 
-					// TODO: multi-line value in structured log
-					klog.InfoS("Creating pods each requiring", "podCount", desiredPods, "resources", e2ereslist.ToString(podRequiredRes))
+					fxt.Dump.Infof(fmt.Sprintf("podCount: %d\nresources: %s", desiredPods, e2ereslist.ToString(podRequiredRes)), "Creating pods each requiring")
 					for _, testPod := range testPods {
 						err := fxt.Client.Create(ctx, testPod)
 						Expect(err).ToNot(HaveOccurred())
@@ -510,8 +509,7 @@ var _ = Describe("[serial][scheduler][cache] scheduler cache stall", Label("sche
 					failedPods, updatedPods := wait.With(fxt.Client).Timeout(3*time.Minute).ForPodsAllRunning(ctx, testPods)
 					if len(failedPods) > 0 {
 						nrtListFailed, _ := e2enrt.GetUpdated(fxt.Client, nrtv1alpha2.NodeResourceTopologyList{}, time.Minute)
-						// TODO: multi-line value in structured log
-						klog.InfoS("NRT list", "content", intnrt.ListToString(nrtListFailed.Items, "post failure"))
+						fxt.Dump.Infof(intnrt.ListToString(nrtListFailed.Items, "post failure"), "NRT list")
 
 						for _, failedPod := range failedPods {
 							_ = objects.LogEventsForPod(fxt.K8sClient, failedPod.Namespace, failedPod.Name)
@@ -539,8 +537,7 @@ var _ = Describe("[serial][scheduler][cache] scheduler cache stall", Label("sche
 							Requests: jobRequiredRes,
 						}
 					}
-					// TODO: multi-line value in structured log
-					klog.InfoS("Creating a job whose containers have requests", "resources", e2ereslist.ToString(jobRequiredRes))
+					fxt.Dump.Infof(e2ereslist.ToString(jobRequiredRes), "Creating a job whose containers have requests")
 				}),
 				// GAP: pinnable cpu (but not memory)
 				// however with the recommended config, we can't have pinnable CPUs without pinnable memory;
@@ -556,8 +553,7 @@ var _ = Describe("[serial][scheduler][cache] scheduler cache stall", Label("sche
 							Limits: jobRequiredRes,
 						}
 					}
-					// TODO: multi-line value in structured log
-					klog.InfoS("Creating a job whose containers have limits", "resources", e2ereslist.ToString(jobRequiredRes))
+					fxt.Dump.Infof(e2ereslist.ToString(jobRequiredRes), "Creating a job whose containers have limits")
 				}),
 				Entry("[test_id:85783] vs guaranteed pods with pinnable memory and CPU", func(job *batchv1.Job) {
 					jobRequiredRes := corev1.ResourceList{
@@ -570,8 +566,7 @@ var _ = Describe("[serial][scheduler][cache] scheduler cache stall", Label("sche
 							Limits: jobRequiredRes,
 						}
 					}
-					// TODO: multi-line value in structured log
-					klog.InfoS("Creating a job whose containers have limits", "resources", e2ereslist.ToString(jobRequiredRes))
+					fxt.Dump.Infof(e2ereslist.ToString(jobRequiredRes), "Creating a job whose containers have limits")
 				}),
 			)
 

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -153,23 +153,20 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				}
 
 				// need a zone with resources for overhead, pod and a little bit more to avoid zone saturation
-				// TODO: multi-line value in structured log
-				klog.InfoS("kubernetes pod fixed overhead", "overhead", resourcelist.ToString(rtClass.Overhead.PodFixed))
+				fxt.Dump.Infof(resourcelist.ToString(rtClass.Overhead.PodFixed), "kubernetes pod fixed overhead")
 				podFixedOverheadCPU, podFixedOverheadMem := resourcelist.RoundUpCoreResources(*rtClass.Overhead.PodFixed.Cpu(), *rtClass.Overhead.PodFixed.Memory())
 				podFixedOverhead := corev1.ResourceList{
 					corev1.ResourceCPU:    podFixedOverheadCPU,
 					corev1.ResourceMemory: podFixedOverheadMem,
 				}
-				// TODO: multi-line value in structured log
-				klog.InfoS("kubernetes pod fixed overhead rounded to", "overhead", resourcelist.ToString(podFixedOverhead))
+				fxt.Dump.Infof(resourcelist.ToString(podFixedOverhead), "kubernetes pod fixed overhead rounded to")
 
 				zoneRequiredResources := podResources.DeepCopy()
 				resourcelist.AddInPlace(zoneRequiredResources, podFixedOverhead)
 				resourcelist.AddInPlace(zoneRequiredResources, minRes)
 
 				resStr := resourcelist.ToString(zoneRequiredResources)
-				// TODO: multi-line value in structured log
-				klog.InfoS("kubernetes final zone required resources", "resources", resStr)
+				fxt.Dump.Infof(resStr, "kubernetes final zone required resources")
 
 				nrtCandidates := e2enrt.FilterAnyZoneMatchingResources(nrtTwoZoneCandidates, zoneRequiredResources)
 				minCandidates := 1
@@ -197,7 +194,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 							baseload.AddTo(zoneRes)
 						}
 
-						padPod, err := makePaddingPod(fxt.Namespace.Name, nodeName, zone, zoneRes)
+						padPod, err := makePaddingPod(fxt, fxt.Namespace.Name, nodeName, zone, zoneRes)
 						Expect(err).NotTo(HaveOccurred())
 
 						pinnedPadPod, err := pinPodTo(padPod, nodeName, zone.Name)
@@ -295,8 +292,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				}
 
 				// need a zone with resources for overhead, pod and a little bit more to avoid zone saturation
-				// TODO: multi-line value in structured log
-				klog.InfoS("kubernetes pod fixed overhead", "overhead", resourcelist.ToString(rtClass.Overhead.PodFixed))
+				fxt.Dump.Infof(resourcelist.ToString(rtClass.Overhead.PodFixed), "kubernetes pod fixed overhead")
 
 				candidateNodeNames := e2enrt.AccumulateNames(nrtTwoZoneCandidates)
 
@@ -327,16 +323,14 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 					corev1.ResourceCPU:    podFixedOverheadCPU,
 					corev1.ResourceMemory: podFixedOverheadMem,
 				}
-				// TODO: multi-line value in structured log
-				klog.InfoS("kubernetes pod fixed overhead rounded to", "overhead", resourcelist.ToString(podFixedOverhead))
+				fxt.Dump.Infof(resourcelist.ToString(podFixedOverhead), "kubernetes pod fixed overhead rounded to")
 
 				zoneRequiredResources := podResources.DeepCopy()
 				resourcelist.AddInPlace(zoneRequiredResources, podFixedOverhead)
 				resourcelist.AddInPlace(zoneRequiredResources, minRes)
 
 				resStr := resourcelist.ToString(zoneRequiredResources)
-				// TODO: multi-line value in structured log
-				klog.InfoS("kubernetes final zone required resources", "resources", resStr)
+				fxt.Dump.Infof(resStr, "kubernetes final zone required resources")
 
 				By("padding non-target nodes")
 				var paddingPods []*corev1.Pod
@@ -354,7 +348,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 							baseload.AddTo(zoneRes)
 						}
 
-						padPod, err := makePaddingPod(fxt.Namespace.Name, nodeName, zone, zoneRes)
+						padPod, err := makePaddingPod(fxt, fxt.Namespace.Name, nodeName, zone, zoneRes)
 						Expect(err).NotTo(HaveOccurred())
 
 						pinnedPadPod, err := pinPodTo(padPod, nodeName, zone.Name)
@@ -383,7 +377,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 					if zIdx == 0 {               // any zone is fine
 						baseload.AddTo(zoneRes)
 
-						padPod, err := makePaddingPod(fxt.Namespace.Name, targetNodeName, zone, zoneRes)
+						padPod, err := makePaddingPod(fxt, fxt.Namespace.Name, targetNodeName, zone, zoneRes)
 						Expect(err).NotTo(HaveOccurred())
 
 						pinnedPadPod, err := pinPodTo(padPod, targetNodeName, zone.Name)

--- a/test/e2e/serial/tests/workload_placement.go
+++ b/test/e2e/serial/tests/workload_placement.go
@@ -226,8 +226,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(err).ToNot(HaveOccurred())
 
 			rl := e2ereslist.FromGuaranteedPod(updatedPod)
-			// TODO: multi-line value in structured log
-			klog.InfoS("post-create pod resource list", "spec", e2ereslist.ToString(e2ereslist.FromContainerLimits(podSpec.Containers)), "updated", e2ereslist.ToString(rl))
+			fxt.Dump.Infof(fmt.Sprintf("spec: %s\nupdated: %s", e2ereslist.ToString(e2ereslist.FromContainerLimits(podSpec.Containers)), e2ereslist.ToString(rl)), "post-create pod resource list")
 
 			nrtInitial, err := e2enrt.FindFromList(nrtInitialList.Items, updatedPod.Spec.NodeName)
 			Expect(err).ToNot(HaveOccurred())
@@ -314,8 +313,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 
 			rl = e2ereslist.FromGuaranteedPod(updatedPod)
-			// TODO: multi-line value in structured log
-			klog.InfoS("post-update pod resource list", "spec", e2ereslist.ToString(e2ereslist.FromContainerLimits(podSpec.Containers)), "updated", e2ereslist.ToString(rl))
+			fxt.Dump.Infof(fmt.Sprintf("spec: %s\nupdated: %s", e2ereslist.ToString(e2ereslist.FromContainerLimits(podSpec.Containers)), e2ereslist.ToString(rl)), "post-update pod resource list")
 
 			By("wait for NRT data to settle")
 			e2efixture.MustSettleNRT(fxt)
@@ -426,8 +424,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			Expect(schedOK).To(BeTrue(), "pod %s/%s not scheduled with expected scheduler %s", updatedPod.Namespace, updatedPod.Name, serialconfig.Config.SchedulerName)
 
 			rl = e2ereslist.FromGuaranteedPod(updatedPod)
-			// TODO: multi-line value in structured log
-			klog.InfoS("post-reroute pod resource list", "spec", e2ereslist.ToString(e2ereslist.FromContainerLimits(podSpec.Containers)), "updated", e2ereslist.ToString(rl))
+			fxt.Dump.Infof(fmt.Sprintf("spec: %s\nupdated: %s", e2ereslist.ToString(e2ereslist.FromContainerLimits(podSpec.Containers)), e2ereslist.ToString(rl)), "post-reroute pod resource list")
 
 			nrtReorganized, err := e2enrt.FindFromList(nrtReorganizedList.Items, updatedPod.Spec.NodeName)
 			Expect(err).ToNot(HaveOccurred())
@@ -562,8 +559,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 			// calculate base load on the target node
 			baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), targetNodeName)
 			Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", targetNodeName)
-			// TODO: multi-line value in structured log
-			klog.InfoS("computed base load", "baseload", baseload)
+			fxt.Dump.Infof(baseload.String(), "computed base load")
 
 			// get least available CPU and Memory on each NUMA node while taking baseload into consideration
 			cpus := leastAvailableResourceQtyInAllZone(*targetNrtInitial, baseload, corev1.ResourceCPU)
@@ -993,17 +989,15 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 	})
 })
 
-func makePaddingPod(namespace, nodeName string, zone nrtv1alpha2.Zone, podReqs corev1.ResourceList) (*corev1.Pod, error) {
-	// TODO: multi-line value in structured log
-	klog.InfoS("want to have zone with allocatable", "zone", zone.Name, "allocatable", e2ereslist.ToString(podReqs))
+func makePaddingPod(fxt *e2efixture.Fixture, namespace, nodeName string, zone nrtv1alpha2.Zone, podReqs corev1.ResourceList) (*corev1.Pod, error) {
+	fxt.Dump.Infof(fmt.Sprintf("zone: %s\nallocatable: %s", zone.Name, e2ereslist.ToString(podReqs)), "want to have zone with allocatable")
 
 	paddingReqs, err := e2enrt.SaturateZoneUntilLeft(zone, podReqs, e2enrt.DropHostLevelResources)
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO: multi-line value in structured log
-	klog.InfoS("padding resource to saturate", "nodeName", nodeName, "paddingReqs", e2ereslist.ToString(paddingReqs))
+	fxt.Dump.Infof(fmt.Sprintf("nodeName: %s\npaddingReqs: %s", nodeName, e2ereslist.ToString(paddingReqs)), "padding resource to saturate")
 
 	padPod := newPaddingPod(nodeName, zone.Name, namespace, paddingReqs)
 	return padPod, nil

--- a/test/e2e/serial/tests/workload_placement_nodelabel.go
+++ b/test/e2e/serial/tests/workload_placement_nodelabel.go
@@ -159,7 +159,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 					}
 
 					podName := fmt.Sprintf("padding%d-%d", nIdx, zIdx)
-					padPod, err := makePaddingPod(fxt.Namespace.Name, podName, zone, zoneRes)
+					padPod, err := makePaddingPod(fxt, fxt.Namespace.Name, podName, zone, zoneRes)
 					Expect(err).NotTo(HaveOccurred(), "unable to create padding pod %q on zone %q", podName, zone.Name)
 
 					padPod, err = pinPodTo(padPod, nodeName, zone.Name)
@@ -292,8 +292,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 					deployment.Spec.Template.Spec.SchedulerName = serialconfig.Config.SchedulerName
 					deployment.Spec.Template.Spec.Containers[0].Resources.Limits = requiredRes
 					deployment.Spec.Template.Spec.Affinity = affinity
-					// TODO: multi-line value in structured log
-					klog.InfoS("create the test deployment with requests", "requests", e2ereslist.ToString(requiredRes))
+					fxt.Dump.Infof(e2ereslist.ToString(requiredRes), "create the test deployment with requests")
 					err := fxt.Client.Create(context.TODO(), deployment)
 					Expect(err).NotTo(HaveOccurred(), "unable to create deployment %q", deployment.Name)
 

--- a/test/e2e/serial/tests/workload_placement_resources.go
+++ b/test/e2e/serial/tests/workload_placement_resources.go
@@ -230,7 +230,7 @@ func createPaddingPod(fxt *e2efixture.Fixture, ctx context.Context, podName, nod
 	GinkgoHelper()
 	e2efixture.By("creating padding pod %q for node %q zone %q with resource target %s", podName, nodeName, zone.Name, e2ereslist.ToString(expectedFreeRes))
 
-	padPod, err := makePaddingPod(fxt.Namespace.Name, podName, zone, expectedFreeRes)
+	padPod, err := makePaddingPod(fxt, fxt.Namespace.Name, podName, zone, expectedFreeRes)
 	Expect(err).NotTo(HaveOccurred(), "unable to create padding pod %q on zone %q", podName, zone.Name)
 
 	padPod, err = pinPodTo(padPod, nodeName, zone.Name)

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -144,8 +144,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				//calculate a base load on the node
 				baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), nodeName)
 				Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", nodeName)
-				// TODO: multi-line value in structured log
-				klog.InfoS("computed base load", "value", baseload)
+				fxt.Dump.Infof(baseload.String(), "computed base load")
 				paddingResWithBaseload := paddingRes.DeepCopy()
 				baseload.AddTo(paddingResWithBaseload)
 				var zonePaddingRes corev1.ResourceList
@@ -155,7 +154,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 						zonePaddingRes = paddingResWithBaseload
 					}
 					podName := fmt.Sprintf("padding-%d-%d", nIdx, zIdx)
-					padPod, err := makePaddingPod(fxt.Namespace.Name, podName, zone, zonePaddingRes)
+					padPod, err := makePaddingPod(fxt, fxt.Namespace.Name, podName, zone, zonePaddingRes)
 					Expect(err).NotTo(HaveOccurred(), "unable to create padding pod %q on zone %q", podName, zone.Name)
 
 					padPod, err = pinPodTo(padPod, nodeName, zone.Name)
@@ -2134,7 +2133,7 @@ func setupPadding(fxt *e2efixture.Fixture, nrtList nrtv1alpha2.NodeResourceTopol
 		}
 
 		e2efixture.By("padding node %q zone %q to fit only %s", nrtInfo.Name, zone.Name, e2ereslist.ToString(numaRes))
-		padPod, err := makePaddingPod(fxt.Namespace.Name, "target", zone, numaRes)
+		padPod, err := makePaddingPod(fxt, fxt.Namespace.Name, "target", zone, numaRes)
 		Expect(err).ToNot(HaveOccurred())
 
 		padPod, err = pinPodTo(padPod, nrtInfo.Name, zone.Name)
@@ -2172,7 +2171,7 @@ func setupPaddingForUnsuitableNodes(fxt *e2efixture.Fixture, nrtList nrtv1alpha2
 				e2efixture.By("saturating node %q -> %q zone %q to fit only (adjusted) %s", nrtInfo.Name, name, zone.Name, e2ereslist.ToString(padRes))
 			}
 
-			padPod, err := makePaddingPod(fxt.Namespace.Name, name, zone, padRes)
+			padPod, err := makePaddingPod(fxt, fxt.Namespace.Name, name, zone, padRes)
 			Expect(err).ToNot(HaveOccurred())
 
 			padPod, err = pinPodTo(padPod, nrtInfo.Name, zone.Name)

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -158,7 +158,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 					}
 
 					podName := fmt.Sprintf("padding%s-%d", nodeName, idx)
-					padPod, err := makePaddingPod(fxt.Namespace.Name, podName, zone, zoneRes)
+					padPod, err := makePaddingPod(fxt, fxt.Namespace.Name, podName, zone, zoneRes)
 					Expect(err).NotTo(HaveOccurred(), "unable to create padding pod %q on zone", podName, zone.Name)
 
 					padPod, err = pinPodTo(padPod, nodeName, zone.Name)
@@ -378,7 +378,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 					}
 
 					podName := fmt.Sprintf("padding%d-%d", nodeIdx, zoneIdx)
-					padPod, err := makePaddingPod(fxt.Namespace.Name, podName, zone, zoneRes)
+					padPod, err := makePaddingPod(fxt, fxt.Namespace.Name, podName, zone, zoneRes)
 					Expect(err).NotTo(HaveOccurred(), "unable to create padding pod %q on zone", podName, zone.Name)
 
 					padPod, err = pinPodTo(padPod, nodeName, zone.Name)
@@ -647,8 +647,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 				e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA Zones: found %d, needed %d", len(nrts), neededNodes)
 			}
 
-			// TODO: multi-line value in structured log
-			klog.InfoS("reference NRT", "zone", intnrt.ZoneToString(nrts[0].Zones[0]))
+			fxt.Dump.Infof(intnrt.ZoneToString(nrts[0].Zones[0]), "reference NRT")
 
 			ress := make([]corev1.ResourceList, 0, len(nrts))
 			for idx := range nrts {
@@ -659,8 +658,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 				ress = append(ress, bl.Resources)
 			}
 			xload := resourcelist.Highest(ress...)
-			// TODO: multi-line value in structured log
-			klog.InfoS("highest base load resource cost", "resources", resourcelist.ToString(xload))
+			fxt.Dump.Infof(resourcelist.ToString(xload), "highest base load resource cost")
 
 			labSel, err := labels.Parse(fmt.Sprintf("%s=%d", serialconfig.MultiNUMALabel, requiredNUMAZones))
 			Expect(err).ToNot(HaveOccurred())
@@ -669,16 +667,13 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			// note about the factors. We need to use prime numbers and we need to avoid exact multiples.
 			// other than that, we use the smallest meaningful prime numbers
 			numaLevelFreeRes := resourcelist.ScaleCoreResources(xload, 7, 3)
-			// TODO: multi-line value in structured log
-			klog.InfoS("available resources", "resources", resourcelist.ToString(numaLevelFreeRes))
+			fxt.Dump.Infof(resourcelist.ToString(numaLevelFreeRes), "available resources")
 
 			numaLevelFitRequiredRes := resourcelist.ScaleCoreResources(xload, 5, 3)
-			// TODO: multi-line value in structured log
-			klog.InfoS("target resources", "resources", resourcelist.ToString(numaLevelFitRequiredRes))
+			fxt.Dump.Infof(resourcelist.ToString(numaLevelFitRequiredRes), "target resources")
 
 			unfitRequiredRes := resourcelist.ScaleCoreResources(xload, 11, 3) // numaLevelFreeRes 5 3
-			// TODO: multi-line value in structured log
-			klog.InfoS("blocked resources", "resources", resourcelist.ToString(unfitRequiredRes))
+			fxt.Dump.Infof(resourcelist.ToString(unfitRequiredRes), "blocked resources")
 
 			By("padding all the nodes")
 			Expect(padder.Nodes(len(nrts)).UntilAvailableIsResourceListPerZone(numaLevelFreeRes).Pad(time.Minute*2, e2epadder.PaddingOptions{LabelSelector: labSel})).To(Succeed())
@@ -877,8 +872,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 				//calculate base load on the node
 				baseload, err := intbaseload.ForNode(fxt.Client, context.TODO(), nodeName)
 				Expect(err).ToNot(HaveOccurred(), "missing node load info for %q", nodeName)
-				// TODO: multi-line value in structured log
-				klog.InfoS("computed base load", "value", baseload)
+				fxt.Dump.Infof(baseload.String(), "computed base load")
 
 				//get nrt info of the node
 				klog.InfoS("preparing node to fit the test case", "node", nodeName)

--- a/test/internal/fixture/dumpr/dumper.go
+++ b/test/internal/fixture/dumpr/dumper.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dumpr
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+)
+
+// Dumper sends multi-line output to the logging sink, bypassing the slog interface.
+type Dumper interface {
+	Infof(data string, format string, values ...any)
+	Errorf(data string, err error, format string, values ...any)
+}
+
+type discarder struct{}
+
+func (_ discarder) Infof(data string, format string, values ...any) {
+}
+
+func (_ discarder) Errorf(data string, err error, format string, values ...any) {
+}
+
+func Discard() Dumper {
+	return discarder{}
+}
+
+type formatter struct {
+	sink io.Writer
+}
+
+func (fr formatter) Infof(data string, format string, values ...any) {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, format, values...)
+	buf.WriteString("\n")
+	buf.WriteString(data)
+	buf.WriteString("\n")
+	_, _ = fr.sink.Write(buf.Bytes())
+}
+
+func (fr formatter) Errorf(data string, err error, format string, values ...any) {
+	var buf bytes.Buffer
+	buf.WriteString(err.Error())
+	buf.WriteString(": ")
+	fmt.Fprintf(&buf, format, values...)
+	buf.WriteString("\n")
+	buf.WriteString(data)
+	buf.WriteString("\n")
+	_, _ = fr.sink.Write(buf.Bytes())
+}
+
+func NewFormatter(w io.Writer) Dumper {
+	return formatter{
+		sink: w,
+	}
+}

--- a/test/internal/fixture/dumpr/dumper.go
+++ b/test/internal/fixture/dumpr/dumper.go
@@ -55,7 +55,11 @@ func (fr formatter) Infof(data string, format string, values ...any) {
 
 func (fr formatter) Errorf(data string, err error, format string, values ...any) {
 	var buf bytes.Buffer
-	buf.WriteString(err.Error())
+	if err != nil {
+		buf.WriteString(err.Error())
+	} else {
+		buf.WriteString("<NIL ERROR>")
+	}
 	buf.WriteString(": ")
 	fmt.Fprintf(&buf, format, values...)
 	buf.WriteString("\n")

--- a/test/internal/fixture/fixture.go
+++ b/test/internal/fixture/fixture.go
@@ -46,6 +46,7 @@ import (
 	intwait "github.com/openshift-kni/numaresources-operator/internal/wait"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/internal/clients"
+	"github.com/openshift-kni/numaresources-operator/test/internal/fixture/dumpr"
 	"github.com/openshift-kni/numaresources-operator/test/internal/noderesourcetopologies"
 
 	. "github.com/onsi/gomega"
@@ -60,6 +61,8 @@ type Fixture struct {
 	InitialNRTList nrtv1alpha2.NodeResourceTopologyList
 	Skipped        bool
 	IsRebootTest   bool
+	Log            logr.Logger
+	Dump           dumpr.Dumper
 	avoidCooldown  bool
 }
 
@@ -182,6 +185,8 @@ func SetupWithOptions(name string, nrtList nrtv1alpha2.NodeResourceTopologyList,
 		Namespace:      ns,
 		InitialNRTList: nrtList,
 		avoidCooldown:  avoidCooldown,
+		Log:            ginkgo.GinkgoLogr,
+		Dump:           dumpr.NewFormatter(ginkgo.GinkgoWriter),
 	}, nil
 }
 


### PR DESCRIPTION
Prepare for future transition to ginkgo unified logger adding a logr.Logger interface in the fixture, currently intentionally unused.

Add a Dump interface to handle multi-line logs, and fix longstanding TODOs in the suite