### PR TITLE
e2e: test: internal: make sure to retry on conflicts

### DIFF
--- a/test/internal/nodepools/nodepools.go
+++ b/test/internal/nodepools/nodepools.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/retry"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -38,15 +39,14 @@ func AttachConfigObject(ctx context.Context, cli client.Client, object client.Ob
 	if err != nil {
 		return err
 	}
-	np, err := GetByClusterName(ctx, cli, hostedClusterName)
-	if err != nil {
-		return err
-	}
-	np.Spec.Config = addObjectRef(object, np.Spec.Config)
-	if cli.Update(ctx, np) != nil {
-		return err
-	}
-	return nil
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		np, err := GetByClusterName(ctx, cli, hostedClusterName)
+		if err != nil {
+			return err
+		}
+		np.Spec.Config = addObjectRef(object, np.Spec.Config)
+		return cli.Update(ctx, np)
+	})
 }
 
 func addObjectRef(object client.Object, config []corev1.LocalObjectReference) []corev1.LocalObjectReference {
@@ -75,13 +75,12 @@ func DeAttachConfigObject(ctx context.Context, cli client.Client, object client.
 	if err != nil {
 		return err
 	}
-	np, err := GetByClusterName(ctx, cli, hostedClusterName)
-	if err != nil {
-		return err
-	}
-	np.Spec.Config = removeObjectRef(object, np.Spec.Config)
-	if cli.Update(ctx, np) != nil {
-		return err
-	}
-	return nil
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		np, err := GetByClusterName(ctx, cli, hostedClusterName)
+		if err != nil {
+			return err
+		}
+		np.Spec.Config = removeObjectRef(object, np.Spec.Config)
+		return cli.Update(ctx, np)
+	})
 }

--- a/test/internal/objects/pause/mcps.go
+++ b/test/internal/objects/pause/mcps.go
@@ -20,6 +20,12 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/client-go/util/retry"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
+
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
 	nropmcp "github.com/openshift-kni/numaresources-operator/internal/machineconfigpools"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/internal/clients"
@@ -35,8 +41,16 @@ func MachineConfigPoolsByNodeGroups(nodeGroups []nropv1.NodeGroup) (func() error
 	}
 
 	for i := range mcps {
-		mcps[i].Spec.Paused = true
-		if err = e2eclient.Client.Update(context.TODO(), mcps[i]); err != nil {
+		key := client.ObjectKeyFromObject(mcps[i])
+		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			updatedMcp := &machineconfigv1.MachineConfigPool{}
+			if err := e2eclient.Client.Get(context.TODO(), key, updatedMcp); err != nil {
+				return err
+			}
+			updatedMcp.Spec.Paused = true
+			return e2eclient.Client.Update(context.TODO(), updatedMcp)
+		})
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -47,9 +61,18 @@ func MachineConfigPoolsByNodeGroups(nodeGroups []nropv1.NodeGroup) (func() error
 			return err
 		}
 		for i := range mcps {
-			mcps[i].Spec.Paused = false
-			err = e2eclient.Client.Update(context.TODO(), mcps[i])
-			return err
+			key := client.ObjectKeyFromObject(mcps[i])
+			err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				updatedMcp := &machineconfigv1.MachineConfigPool{}
+				if err := e2eclient.Client.Get(context.TODO(), key, updatedMcp); err != nil {
+					return err
+				}
+				updatedMcp.Spec.Paused = false
+				return e2eclient.Client.Update(context.TODO(), updatedMcp)
+			})
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	}


### PR DESCRIPTION
all the utilities in the testing call tree (and for kube clients in general) should wrap get+modify+update on a retry loop to handle optmistic concurrency conflicts.

Make sure to do so for all the code called by install_test. We use RetryOnConflict because utility code should not call Eventually directly - and yes, there is plenty of dirty code in the codebase which we should fix eventually (no pun intended).

AI-attribution: AIA PAI SeCe Hin R claude-4.6-opus-1M v1.0