### PR TITLE
tekton: point to release-4.22 instead of main

### DIFF
--- a/.tekton/numaresources-must-gather-4-22-pull-request.yaml
+++ b/.tekton/numaresources-must-gather-4-22-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "main" &&
+      target_branch == "release-4.22" &&
       (".konflux/must-gather/***".pathChanged() ||
       ".tekton/numaresources-must-gather-4-22-pull-request.yaml".pathChanged() ||
       "must-gather/***".pathChanged())

--- a/.tekton/numaresources-must-gather-4-22-push.yaml
+++ b/.tekton/numaresources-must-gather-4-22-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "main" &&
+      target_branch == "release-4.22" &&
       (".konflux/must-gather/***".pathChanged() ||
       ".tekton/numaresources-must-gather-4-22-push.yaml".pathChanged() ||
       "must-gather/***".pathChanged())

--- a/.tekton/numaresources-operator-4-22-pull-request.yaml
+++ b/.tekton/numaresources-operator-4-22-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "main" &&
+      target_branch == "release-4.22" &&
       (
         '.konflux/container-build.args'.pathChanged() ||
         '.konflux/operator/***'.pathChanged() ||

--- a/.tekton/numaresources-operator-4-22-push.yaml
+++ b/.tekton/numaresources-operator-4-22-push.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "main" &&
+      target_branch == "release-4.22" &&
       (
         '.konflux/container-build.args'.pathChanged() ||
         '.konflux/operator/***'.pathChanged() ||

--- a/.tekton/numaresources-operator-bundle-4-22-pull-request.yaml
+++ b/.tekton/numaresources-operator-bundle-4-22-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "main" &&
+      target_branch == "release-4.22" &&
       (
         '.konflux/bundle/bundle.konflux.Dockerfile'.pathChanged() ||
         '.konflux/bundle/overlay/***'.pathChanged() ||

--- a/.tekton/numaresources-operator-bundle-4-22-push.yaml
+++ b/.tekton/numaresources-operator-bundle-4-22-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "main" &&
+      target_branch == "release-4.22" &&
       (
         '.konflux/bundle/bundle.konflux.Dockerfile'.pathChanged() ||
         '.konflux/bundle/overlay/***'.pathChanged() ||

--- a/.tekton/numaresources-operator-fbc-4-22-pull-request.yaml
+++ b/.tekton/numaresources-operator-fbc-4-22-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "main" &&
+      target_branch == "release-4.22" &&
       (
         '.konflux/Dockerfile.catalog'.pathChanged() ||
         '.konflux/catalog/bundle.builds.in.yaml'.pathChanged() ||

--- a/.tekton/numaresources-operator-fbc-4-22-push.yaml
+++ b/.tekton/numaresources-operator-fbc-4-22-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "main" &&
+      target_branch == "release-4.22" &&
       (
         '.konflux/Dockerfile.catalog'.pathChanged() ||
         '.konflux/catalog/bundle.builds.in.yaml'.pathChanged() ||


### PR DESCRIPTION
Use release-4.22 branch name for 4.22 tektons.

Assisted-by: Cursor v2.3.37
AIA Attribution: AIA Human-AI blend, Content edits, Human-initiated, Reviewed, Cursor 2.3.37 v1.0

Made-with: Cursor