### PR TITLE
e2e serial: fix overhead computation and usage

### DIFF
--- a/internal/baseload/baseload.go
+++ b/internal/baseload/baseload.go
@@ -86,15 +86,15 @@ func (nl Load) String() string {
 	return fmt.Sprintf("load for node %q: %s", nl.Name, resourcelist.ToString(nl.Resources))
 }
 
-// Apply adjust the given ResourceList with the current node load by mutating
-// the parameter in place
-func (nl Load) Apply(res corev1.ResourceList) {
+// AddTo adds the current node load to the given ResourceList,
+// mutating the parameter in place.
+func (nl Load) AddTo(res corev1.ResourceList) {
 	resourcelist.AddInPlace(res, nl.Resources)
 }
 
-// Deduct subtract the current node load from the given ResourceList by mutating
-// the parameter in place
-func (nl Load) Deduct(res corev1.ResourceList) error {
+// SubtractFrom subtracts the current node load from the given ResourceList,
+// mutating the parameter in place.
+func (nl Load) SubtractFrom(res corev1.ResourceList) error {
 	return resourcelist.SubInPlace(res, nl.Resources)
 }
 

--- a/test/e2e/serial/tests/resource_accounting.go
+++ b/test/e2e/serial/tests/resource_accounting.go
@@ -355,7 +355,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 			e2efixture.By("considering maximum available resources: %s", e2ereslist.ToString(reqResources))
 
 			By("prepare the test's pod resources as maximum available resources on the target node with the baselaod deducted")
-			err = baseload.Deduct(reqResources)
+			err = baseload.SubtractFrom(reqResources)
 			Expect(err).ToNot(HaveOccurred(), "failed deducting resources from baseload: %v", err)
 
 			e2efixture.By("padding all other candidate nodes leaving room for the baseload only (updated maximum available resources: %s)", e2ereslist.ToString(reqResources))
@@ -539,7 +539,7 @@ var _ = Describe("[serial][disruptive][scheduler][resacct] numaresources workloa
 						numaRes[resName] = quan
 					}
 				}
-				err = baseload.Deduct(numaRes)
+				err = baseload.SubtractFrom(numaRes)
 				Expect(err).ToNot(HaveOccurred(), "failed deducting resources from baseload: %v", err)
 				reqResPerNUMA = append(reqResPerNUMA, numaRes)
 			}

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -354,7 +354,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 							baseload.Apply(zoneRes)
 						}
 
-						padPod, err := makePaddingPod(fxt.Namespace.Name, nodeName, zone, baseload.Resources)
+						padPod, err := makePaddingPod(fxt.Namespace.Name, nodeName, zone, zoneRes)
 						Expect(err).NotTo(HaveOccurred())
 
 						pinnedPadPod, err := pinPodTo(padPod, nodeName, zone.Name)
@@ -383,7 +383,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 					if zIdx == 0 {               // any zone is fine
 						baseload.Apply(zoneRes)
 
-						padPod, err := makePaddingPod(fxt.Namespace.Name, targetNodeName, zone, baseload.Resources)
+						padPod, err := makePaddingPod(fxt.Namespace.Name, targetNodeName, zone, zoneRes)
 						Expect(err).NotTo(HaveOccurred())
 
 						pinnedPadPod, err := pinPodTo(padPod, targetNodeName, zone.Name)

--- a/test/e2e/serial/tests/workload_overhead.go
+++ b/test/e2e/serial/tests/workload_overhead.go
@@ -194,7 +194,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 					for zIdx, zone := range nrtInfo.Zones {
 						zoneRes := minRes.DeepCopy() // to be extra safe
 						if zIdx == 0 {               // any zone is fine
-							baseload.Apply(zoneRes)
+							baseload.AddTo(zoneRes)
 						}
 
 						padPod, err := makePaddingPod(fxt.Namespace.Name, nodeName, zone, zoneRes)
@@ -351,7 +351,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 					for zIdx, zone := range nrtInfo.Zones {
 						zoneRes := minRes.DeepCopy() // to be extra safe
 						if zIdx == 0 {               // any zone is fine
-							baseload.Apply(zoneRes)
+							baseload.AddTo(zoneRes)
 						}
 
 						padPod, err := makePaddingPod(fxt.Namespace.Name, nodeName, zone, zoneRes)
@@ -381,7 +381,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload overhea
 				for zIdx, zone := range targetNrtInitial.Zones {
 					zoneRes := minRes.DeepCopy() // to be extra safe
 					if zIdx == 0 {               // any zone is fine
-						baseload.Apply(zoneRes)
+						baseload.AddTo(zoneRes)
 
 						padPod, err := makePaddingPod(fxt.Namespace.Name, targetNodeName, zone, zoneRes)
 						Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/serial/tests/workload_placement_nodelabel.go
+++ b/test/e2e/serial/tests/workload_placement_nodelabel.go
@@ -155,7 +155,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				for zIdx, zone := range nrtInfo.Zones {
 					zoneRes := paddingRes.DeepCopy() // to be extra safe
 					if zIdx == 0 {                   // any zone is fine
-						baseload.Apply(zoneRes)
+						baseload.AddTo(zoneRes)
 					}
 
 					podName := fmt.Sprintf("padding%d-%d", nIdx, zIdx)

--- a/test/e2e/serial/tests/workload_placement_resources.go
+++ b/test/e2e/serial/tests/workload_placement_resources.go
@@ -196,7 +196,7 @@ func setupNodes(fxt *e2efixture.Fixture, ctx context.Context, nrtCandidates []nr
 			padRes := expectedFreeResources.DeepCopy()
 
 			if zIdx == 0 { // any random zone is actually fine
-				baseload.Apply(padRes)
+				baseload.AddTo(padRes)
 			}
 
 			paddingPods = append(paddingPods, createPaddingPod(fxt, ctx, fmt.Sprintf("padding-%d-%d", nIdx, zIdx), nodeName, zone, padRes))

--- a/test/e2e/serial/tests/workload_placement_tmpol.go
+++ b/test/e2e/serial/tests/workload_placement_tmpol.go
@@ -147,7 +147,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 				// TODO: multi-line value in structured log
 				klog.InfoS("computed base load", "value", baseload)
 				paddingResWithBaseload := paddingRes.DeepCopy()
-				baseload.Apply(paddingResWithBaseload)
+				baseload.AddTo(paddingResWithBaseload)
 				var zonePaddingRes corev1.ResourceList
 				for zIdx, zone := range nrtInfo.Zones {
 					zonePaddingRes = paddingRes
@@ -2130,7 +2130,7 @@ func setupPadding(fxt *e2efixture.Fixture, nrtList nrtv1alpha2.NodeResourceTopol
 		zone := nrtInfo.Zones[numaIdx]
 		numaRes := padInfo.targetFreeResPerNUMA[idx]
 		if idx == 0 { // any random zone is actually fine
-			baseload.Apply(numaRes)
+			baseload.AddTo(numaRes)
 		}
 
 		e2efixture.By("padding node %q zone %q to fit only %s", nrtInfo.Name, zone.Name, e2ereslist.ToString(numaRes))
@@ -2168,7 +2168,7 @@ func setupPaddingForUnsuitableNodes(fxt *e2efixture.Fixture, nrtList nrtv1alpha2
 
 			e2efixture.By("saturating node %q -> %q zone %q to fit only (vanilla) %s", nrtInfo.Name, name, zone.Name, e2ereslist.ToString(padRes))
 			if zoneIdx == 0 { // any random zone is actually fine
-				baseload.Apply(padRes)
+				baseload.AddTo(padRes)
 				e2efixture.By("saturating node %q -> %q zone %q to fit only (adjusted) %s", nrtInfo.Name, name, zone.Name, e2ereslist.ToString(padRes))
 			}
 

--- a/test/e2e/serial/tests/workload_unschedulable.go
+++ b/test/e2e/serial/tests/workload_unschedulable.go
@@ -150,7 +150,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 				for idx, zone := range nrtInfo.Zones {
 					zoneRes := paddingRes.DeepCopy() // extra safety
 					if idx == 0 {                    // any zone is fine
-						baseload.Apply(zoneRes)
+						baseload.AddTo(zoneRes)
 					}
 
 					podName := fmt.Sprintf("padding%s-%d", nodeName, idx)
@@ -361,7 +361,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 				for zoneIdx, zone := range nrtInfo.Zones {
 					zoneRes := paddingRes.DeepCopy() // extra safety
 					if zoneIdx == 0 {                // any zone is fine
-						baseload.Apply(zoneRes)
+						baseload.AddTo(zoneRes)
 					}
 
 					podName := fmt.Sprintf("padding%d-%d", nodeIdx, zoneIdx)
@@ -542,7 +542,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload unsched
 			for zoneIdx, zone := range targetNrt.Zones {
 				zoneRes := paddingResources.DeepCopy()
 				if zoneIdx == 0 { //any zone would do it, we just choose one.
-					targetNodeBaseLoad.Apply(zoneRes)
+					targetNodeBaseLoad.AddTo(zoneRes)
 				}
 
 				paddingRes, err := e2enrt.SaturateZoneUntilLeft(zone, zoneRes, e2enrt.DropHostLevelResources)


### PR DESCRIPTION
Suggested by coderabbit AI in https://github.com/openshift-kni/numaresources-operator/pull/3640#discussion_r3091087191
This code
```
baseload.Apply(zoneRes)
```
Adds the baseload to zoneRes, so the latter carries the up-to-date information. Previously the code was using baseload as load footprint, which was not what the intent was - the intent was always to use the zone-adjusted baseload. This is ultimately caused by a misleading API, which we fix in the second commit.