### PR TITLE
konflux: CNF-22577: Update skipRange lower bound to >=4.20.0 for 4.22

### DIFF
--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -11,11 +11,11 @@ entries:
   # Channel entries should contain all the releases
   - entries:
       - name: numaresources-operator.v4.22.0
-        skipRange: '>=4.21.0 <4.22.0'
+        skipRange: '>=4.20.0 <4.22.0'
         # After 4.22.0 is released, add 4.22.1 back using the quay nudged bundle      
         # - name: numaresources-operator.v4.22.1
         #   replaces: numaresources-operator.v4.22.0
-        #   skipRange: '>=4.21.0 <4.22.1'
+        #   skipRange: '>=4.20.0 <4.22.1'
     name: "4.22"
     package: numaresources-operator
     schema: olm.channel

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -77,7 +77,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.21.0 <4.22.0'
+    olm.skipRange: '>=4.20.0 <4.22.0'
     operatorframework.io/cluster-monitoring: "true"
     operators.openshift.io/valid-subscription: |-
       [

--- a/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
@@ -14,7 +14,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.21.0 <4.22.0'
+    olm.skipRange: '>=4.20.0 <4.22.0'
     operatorframework.io/cluster-monitoring: "true"
     operators.openshift.io/valid-subscription: |-
       [


### PR DESCRIPTION
Update skiprange to allow EUS to EUS direct upgrades