### PR TITLE
[release-4.18] konflux: CNF-22577:Update skipRange lower bound to >=4.16.0 for 4.18

### DIFF
--- a/.konflux/bundle/overlay/overlay.bash
+++ b/.konflux/bundle/overlay/overlay.bash
@@ -271,7 +271,7 @@ overlay_release()
     local version="4.18.3"
     local name="numaresources-operator"
     local name_version="$name.v$version"
-    local skip_range=">=4.17.0 <4.18.3"
+    local skip_range=">=4.16.0 <4.18.3"
     local replaces="numaresources-operator.v4.18.2"
     local annotations='
     features.operators.openshift.io/disconnected: "true"

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -11,16 +11,16 @@ entries:
   # Channel entries should contain all the releases
   - entries:
       - name: numaresources-operator.v4.18.0
-        skipRange: '>=4.17.0 <4.18.0'
+        skipRange: '>=4.16.0 <4.18.0'
       - name: numaresources-operator.v4.18.1
         replaces: numaresources-operator.v4.18.0
-        skipRange: '>=4.17.0 <4.18.1'
+        skipRange: '>=4.16.0 <4.18.1'
       - name: numaresources-operator.v4.18.2
         replaces: numaresources-operator.v4.18.1
-        skipRange: '>=4.17.0 <4.18.2'
+        skipRange: '>=4.16.0 <4.18.2'
       - name: numaresources-operator.v4.18.3
         replaces: numaresources-operator.v4.18.2
-        skipRange: '>=4.17.0 <4.18.3'
+        skipRange: '>=4.16.0 <4.18.3'
     name: "4.18"
     package: numaresources-operator
     schema: olm.channel

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -75,7 +75,7 @@ metadata:
       ]
     capabilities: Basic Install
     createdAt: "2025-03-25T14:27:42Z"
-    olm.skipRange: '>=4.17.0 <4.18.0'
+    olm.skipRange: '>=4.16.0 <4.18.0'
     operatorframework.io/cluster-monitoring: "true"
     operators.operatorframework.io/builder: operator-sdk-v1.36.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    olm.skipRange: '>=4.17.0 <4.18.0'
+    olm.skipRange: '>=4.16.0 <4.18.0'
     operatorframework.io/cluster-monitoring: "true"
   name: numaresources-operator.v0.0.0
   namespace: placeholder


### PR DESCRIPTION
Update skiprange to allow EUS to EUS direct upgrades