### PR TITLE
[release-4.14] konflux: CNF-22577:Update skipRange lower bound to >=4.12.0 for 4.14

### DIFF
--- a/.konflux/bundle/overlay/overlay.bash
+++ b/.konflux/bundle/overlay/overlay.bash
@@ -271,7 +271,7 @@ overlay_release()
     local version="4.14.11"
     local name="numaresources-operator"
     local name_version="$name.v$version"
-    local skip_range=">=4.13.0 <4.14.11"
+    local skip_range=">=4.12.0 <4.14.11"
     local replaces="numaresources-operator.v4.14.10"
     local annotations='
     features.operators.openshift.io/disconnected: "true"

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -11,37 +11,37 @@ entries:
     # Channel entries should contain all the releases
   - entries:
       - name: numaresources-operator.v4.14.1
-        skipRange: '>=4.13.0 <4.14.1'
+        skipRange: '>=4.12.0 <4.14.1'
       - name: numaresources-operator.v4.14.2
         replaces: numaresources-operator.v4.14.1
-        skipRange: '>=4.13.0 <4.14.2'
+        skipRange: '>=4.12.0 <4.14.2'
       - name: numaresources-operator.v4.14.3
         replaces: numaresources-operator.v4.14.2
-        skipRange: '>=4.13.0 <4.14.3'
+        skipRange: '>=4.12.0 <4.14.3'
       - name: numaresources-operator.v4.14.4
         replaces: numaresources-operator.v4.14.3
-        skipRange: '>=4.13.0 <4.14.4'
+        skipRange: '>=4.12.0 <4.14.4'
       - name: numaresources-operator.v4.14.5
         replaces: numaresources-operator.v4.14.4
-        skipRange: '>=4.13.0 <4.14.5'
+        skipRange: '>=4.12.0 <4.14.5'
       - name: numaresources-operator.v4.14.6
         replaces: numaresources-operator.v4.14.5
-        skipRange: '>=4.13.0 <4.14.6'
+        skipRange: '>=4.12.0 <4.14.6'
       - name: numaresources-operator.v4.14.7
         replaces: numaresources-operator.v4.14.6
-        skipRange: '>=4.13.0 <4.14.7'
+        skipRange: '>=4.12.0 <4.14.7'
       - name: numaresources-operator.v4.14.8
         replaces: numaresources-operator.v4.14.7
-        skipRange: '>=4.13.0 <4.14.8'
+        skipRange: '>=4.12.0 <4.14.8'
       - name: numaresources-operator.v4.14.9
         replaces: numaresources-operator.v4.14.8
-        skipRange: '>=4.13.0 <4.14.9'
+        skipRange: '>=4.12.0 <4.14.9'
       - name: numaresources-operator.v4.14.10
         replaces: numaresources-operator.v4.14.9
-        skipRange: '>=4.13.0 <4.14.10'
+        skipRange: '>=4.12.0 <4.14.10'
       - name: numaresources-operator.v4.14.11
         replaces: numaresources-operator.v4.14.10
-        skipRange: '>=4.13.0 <4.14.11'
+        skipRange: '>=4.12.0 <4.14.11'
     name: "4.14"
     package: numaresources-operator
     schema: olm.channel

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    olm.skipRange: '>=4.13.0 <4.14.0'
+    olm.skipRange: '>=4.12.0 <4.14.0'
     operators.operatorframework.io/builder: operator-sdk-v1.25.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     features.operators.openshift.io/disconnected: "true"

--- a/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    olm.skipRange: '>=4.13.0 <4.14.0'
+    olm.skipRange: '>=4.12.0 <4.14.0'
   name: numaresources-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
Update skiprange to allow EUS to EUS direct upgrades