### PR TITLE
[release-4.16] konflux: CNF-22577:Update skipRange lower bound to >=4.14.0 for 4.16

### DIFF
--- a/.konflux/bundle/overlay/overlay.bash
+++ b/.konflux/bundle/overlay/overlay.bash
@@ -271,7 +271,7 @@ overlay_release()
     local version="4.16.8"
     local name="numaresources-operator"
     local name_version="$name.v$version"
-    local skip_range=">=4.15.0 <4.16.8"
+    local skip_range=">=4.14.0 <4.16.8"
     local replaces="numaresources-operator.v4.16.7"
     local annotations='
     features.operators.openshift.io/disconnected: "true"

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -11,35 +11,34 @@ entries:
     # Channel entries should contain all the releases
   - entries:
       - name: numaresources-operator.v4.16.0
-        skipRange: '>=4.15.0 <4.16.0'
+        skipRange: '>=4.14.0 <4.16.0'
       - name: numaresources-operator.v4.16.1
         replaces: numaresources-operator.v4.16.0
-        skipRange: '>=4.15.0 <4.16.1'
+        skipRange: '>=4.14.0 <4.16.1'
       - name: numaresources-operator.v4.16.2
         replaces: numaresources-operator.v4.16.1
-        skipRange: '>=4.15.0 <4.16.2'
+        skipRange: '>=4.14.0 <4.16.2'
       - name: numaresources-operator.v4.16.3
         replaces: numaresources-operator.v4.16.2
-        skipRange: '>=4.15.0 <4.16.3'
+        skipRange: '>=4.14.0 <4.16.3'
       - name: numaresources-operator.v4.16.4
         replaces: numaresources-operator.v4.16.3
-        skipRange: '>=4.15.0 <4.16.4'
+        skipRange: '>=4.14.0 <4.16.4'
       - name: numaresources-operator.v4.16.5
         replaces: numaresources-operator.v4.16.4
-        skipRange: '>=4.15.0 <4.16.5'
+        skipRange: '>=4.14.0 <4.16.5'
       - name: numaresources-operator.v4.16.6
         replaces: numaresources-operator.v4.16.5
-        skipRange: '>=4.15.0 <4.16.6'
+        skipRange: '>=4.14.0 <4.16.6'
       - name: numaresources-operator.v4.16.7
         replaces: numaresources-operator.v4.16.6
-        skipRange: '>=4.15.0 <4.16.7'
+        skipRange: '>=4.14.0 <4.16.7'
       - name: numaresources-operator.v4.16.8
         replaces: numaresources-operator.v4.16.7
-        skipRange: '>=4.15.0 <4.16.8'
-      # v4.16.9
+        skipRange: '>=4.14.0 <4.16.8'
       - name: numaresources-operator.v4.16.9
         replaces: numaresources-operator.v4.16.8
-        skipRange: '>=4.15.0 <4.16.9'
+        skipRange: '>=4.14.0 <4.16.9'
     name: "4.16"
     package: numaresources-operator
     schema: olm.channel

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    olm.skipRange: '>=4.15.0 <4.16.0'
+    olm.skipRange: '>=4.14.0 <4.16.0'
     operators.operatorframework.io/builder: operator-sdk-v1.25.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     features.operators.openshift.io/disconnected: "true"

--- a/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    olm.skipRange: '>=4.15.0 <4.16.0'
+    olm.skipRange: '>=4.14.0 <4.16.0'
   name: numaresources-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
Update skiprange to allow EUS to EUS direct upgrades