### PR TITLE
[release-4.14] Makefile: bump setup-envtest to release-0.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,7 @@ kustomize: ## Download kustomize locally if necessary.
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
 	# this is the last version before the bump golang 1.20 -> 1.22. We want to avoid the go.mod version format changes - for now.
-	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20230927023946-553bd00cfec5)
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.19)
 
 # go-install-tool will 'go get' any package $2 and install it to $1.
 define go-install-tool


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift-kni/numaresources-operator/pull/3270

The GCS bucket (storage.googleapis.com/kubebuilder-tools) used by setup-envtest release-0.18 to download envtest binaries is deprecated and now returns 401 Unauthorized, causing controller tests to fail.

Release-0.19 downloads binaries from the new location (GitHub releases) as recommended by the kubebuilder maintainers.

Ref: kubernetes-sigs/kubebuilder#4082