### PR TITLE
wait: drop DaemonSets vs nodeGroups check from NRO wait helper

### DIFF
--- a/internal/wait/numaresources.go
+++ b/internal/wait/numaresources.go
@@ -18,13 +18,11 @@ package wait
 
 import (
 	"context"
-	"reflect"
 
 	k8swait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
-	testobjs "github.com/openshift-kni/numaresources-operator/internal/objects"
 )
 
 func (wt Waiter) ForNUMAResourcesOperatorDeleted(ctx context.Context, nrop *nropv1.NUMAResourcesOperator) error {
@@ -62,12 +60,6 @@ func (wt Waiter) ForDaemonsetInNUMAResourcesOperatorStatus(ctx context.Context, 
 
 		if len(updatedNRO.Status.DaemonSets) == 0 {
 			klog.Warningf("failed to get the DaemonSet from NUMAResourcesOperator %s", key.String())
-			return false, nil
-		}
-
-		dssFromNodeGroupStatus := testobjs.GetDaemonSetListFromNodeGroupStatuses(updatedNRO.Status.NodeGroups)
-		if !reflect.DeepEqual(updatedNRO.Status.DaemonSets, dssFromNodeGroupStatus) {
-			klog.Warningf("daemonset list mismatch: from NodeGroupStatus'es:\n%+v\n from operator status:\n%+v\n", dssFromNodeGroupStatus, updatedNRO.Status.NodeGroups)
 			return false, nil
 		}
 

--- a/test/e2e/rte/rte_test.go
+++ b/test/e2e/rte/rte_test.go
@@ -149,8 +149,12 @@ var _ = Describe("with a running cluster with all the components", func() {
 			err := clients.Client.Get(context.TODO(), client.ObjectKey{Name: objectnames.DefaultNUMAResourcesOperatorCrName}, nropObj)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(nropObj.Status.DaemonSets).ToNot(BeEmpty())
-			dssFromNodeGroupStatus := testobjs.GetDaemonSetListFromNodeGroupStatuses(nropObj.Status.NodeGroups)
-			Expect(reflect.DeepEqual(nropObj.Status.DaemonSets, dssFromNodeGroupStatus)).To(BeTrue())
+			// When status.nodeGroups is populated, it must match the legacy daemonSets list; when it is
+			// empty the operator may still report daemonSets only
+			if len(nropObj.Status.NodeGroups) > 0 {
+				dssFromNodeGroupStatus := testobjs.GetDaemonSetListFromNodeGroupStatuses(nropObj.Status.NodeGroups)
+				Expect(reflect.DeepEqual(nropObj.Status.DaemonSets, dssFromNodeGroupStatus)).To(BeTrue())
+			}
 			klog.InfoS("using NRO instance", "name", nropObj.Name)
 
 			// NROP guarantees all the daemonsets are in the same namespace,
@@ -198,8 +202,12 @@ var _ = Describe("with a running cluster with all the components", func() {
 			err := clients.Client.Get(context.TODO(), client.ObjectKey{Name: objectnames.DefaultNUMAResourcesOperatorCrName}, nropObj)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(nropObj.Status.DaemonSets).ToNot(BeEmpty())
-			dssFromNodeGroupStatus := testobjs.GetDaemonSetListFromNodeGroupStatuses(nropObj.Status.NodeGroups)
-			Expect(reflect.DeepEqual(nropObj.Status.DaemonSets, dssFromNodeGroupStatus)).To(BeTrue())
+			// When status.nodeGroups is populated, it must match the legacy daemonSets list; when it is
+			// empty the operator may still report daemonSets only (backward-compatible status).
+			if len(nropObj.Status.NodeGroups) > 0 {
+				dssFromNodeGroupStatus := testobjs.GetDaemonSetListFromNodeGroupStatuses(nropObj.Status.NodeGroups)
+				Expect(reflect.DeepEqual(nropObj.Status.DaemonSets, dssFromNodeGroupStatus)).To(BeTrue())
+			}
 			klog.InfoS("Using NRO instance", "name", nropObj.Name)
 
 			// NROP guarantees all the daemonsets are in the same namespace,


### PR DESCRIPTION
`ForDaemonsetInNUMAResourcesOperatorStatus` now only waits until `status.daemonSets` is non-empty.
Cross-field consistency belongs in e2e.

rte: assert daemonSets matches nodeGroups only when `status.nodeGroups`
is non-empty (backward-compatible status when it is empty).


Assisted-by: Claude