### PR TITLE
cleanup: remove unused `IsCustomPolicyEnabled` variable

### DIFF
--- a/pkg/objectstate/rte/machineconfigpool.go
+++ b/pkg/objectstate/rte/machineconfigpool.go
@@ -92,13 +92,12 @@ func (obj machineConfigPoolFinder) FindState(mf Manifests, tree nodegroupv1.Tree
 		}
 
 		gdm := GeneratedDesiredManifest{
-			ClusterPlatform:       obj.em.plat,
-			MachineConfigPool:     mcp.DeepCopy(),
-			NodeGroup:             tree.NodeGroup.DeepCopy(),
-			DaemonSet:             desiredDaemonSet,
-			RTEConfigHash:         rteConfigHash,
-			IsCustomPolicyEnabled: annotations.IsCustomPolicyEnabled(tree.NodeGroup.Annotations),
-			SecOpts:               mf.securityContextOptions(annotations.IsCustomPolicyEnabled(tree.NodeGroup.Annotations)),
+			ClusterPlatform:   obj.em.plat,
+			MachineConfigPool: mcp.DeepCopy(),
+			NodeGroup:         tree.NodeGroup.DeepCopy(),
+			DaemonSet:         desiredDaemonSet,
+			RTEConfigHash:     rteConfigHash,
+			SecOpts:           mf.securityContextOptions(annotations.IsCustomPolicyEnabled(tree.NodeGroup.Annotations)),
 		}
 
 		err := obj.em.updater(mcp.Name, &gdm)

--- a/pkg/objectstate/rte/nodegroup.go
+++ b/pkg/objectstate/rte/nodegroup.go
@@ -73,13 +73,12 @@ func (obj nodeGroupFinder) FindState(mf Manifests, tree nodegroupv1.Tree) []obje
 	}
 
 	gdm := GeneratedDesiredManifest{
-		ClusterPlatform:       obj.em.plat,
-		MachineConfigPool:     nil,
-		NodeGroup:             tree.NodeGroup.DeepCopy(),
-		DaemonSet:             desiredDaemonSet,
-		RTEConfigHash:         rteConfigHash,
-		IsCustomPolicyEnabled: annotations.IsCustomPolicyEnabled(tree.NodeGroup.Annotations),
-		SecOpts:               mf.securityContextOptions(annotations.IsCustomPolicyEnabled(tree.NodeGroup.Annotations)),
+		ClusterPlatform:   obj.em.plat,
+		MachineConfigPool: nil,
+		NodeGroup:         tree.NodeGroup.DeepCopy(),
+		DaemonSet:         desiredDaemonSet,
+		RTEConfigHash:     rteConfigHash,
+		SecOpts:           mf.securityContextOptions(annotations.IsCustomPolicyEnabled(tree.NodeGroup.Annotations)),
 	}
 
 	err := obj.em.updater(poolName, &gdm)

--- a/pkg/objectstate/rte/rte.go
+++ b/pkg/objectstate/rte/rte.go
@@ -157,10 +157,9 @@ type GeneratedDesiredManifest struct {
 	NodeGroup         *nropv1.NodeGroup
 	SecOpts           k8swgrteupdate.SecurityContextOptions
 	// generated manifests
-	DaemonSet             *appsv1.DaemonSet
-	RTEConfigHash         string
-	ConfigMap             *corev1.ConfigMap
-	IsCustomPolicyEnabled bool
+	DaemonSet     *appsv1.DaemonSet
+	RTEConfigHash string
+	ConfigMap     *corev1.ConfigMap
 }
 
 type GenerateDesiredManifestUpdater func(mcpName string, gdm *GeneratedDesiredManifest) error


### PR DESCRIPTION
During the work of fixing https://redhat.atlassian.net/browse/OCPBUGS-84226 it was found that `IsCustomPolicyEnabled` variable never used (only the function did).

Deleted it on separate PR because we want to minimize backport changes.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>