### PR TITLE
NO-JIRA:Dockerfile: disable RHEL repos when installing hwdata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/
 COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/buildinfo.json /usr/local/share
 RUN mkdir /etc/resource-topology-exporter/ && \
     touch /etc/resource-topology-exporter/config.yaml
-RUN microdnf install -y hwdata && \
+RUN microdnf install -y --disablerepo='rhel-*' hwdata && \
     microdnf clean -y all
 USER 65532:65532
 ENTRYPOINT ["/bin/numaresources-operator"]


### PR DESCRIPTION
The UBI9 minimal base image ships with both RHEL subscription repos (rhel-9-for-x86_64-baseos-rpms, rhel-9-for-x86_64-appstream-rpms) and freely accessible UBI repos. When building outside of a subscribed RHEL host, microdnf fails with a 403 because the RHEL CDN requires valid entitlements.

The hwdata package is available in the UBI repos, so we can safely disable the rhel-* repos and still install it without a subscription. The subscription-aware Dockerfile.openshift, used for official builds in entitled environments, remains unchanged.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>