### PR TITLE
add feature introspection topic for supported versions

### DIFF
--- a/internal/api/features/_topics.json
+++ b/internal/api/features/_topics.json
@@ -22,6 +22,7 @@
     "metrics",
     "nrtcrdanns",
     "netpols",
+    "introspection",
     "mgselinuxcollect",
     "tlscompliance"
   ]


### PR DESCRIPTION
Register the introspection feature in the active topics list so that the skip-list mechanism can gate the introspection tests on operator versions that predate the feature (< 4.21). So we need to backport this until 4.21 where it was first introduced.