### PR TITLE
CNF-23355: Upstream release-config version bump — NUMA Resources Operator 4.16.8

### DIFF
--- a/.konflux/bundle/overlay/release.in.yaml
+++ b/.konflux/bundle/overlay/release.in.yaml
@@ -6,8 +6,8 @@ variables:
 
       You can find additional guidance in the upstream repository: https://github.com/openshift-kni/numaresources-operator
   display_name: "NUMA Resources Operator"
-  manager_version: "numaresources-operator.v4.16.8"
+  manager_version: "numaresources-operator.v4.16.9"
   # min_kube_version should match ocp
   # https://access.redhat.com/solutions/4870701
   min_kube_version: "1.23.0"
-  version: "4.16.8"
+  version: "4.16.9"


### PR DESCRIPTION
Automated post-release update for NUMA Resources Operator 4.16.8 → 4.16.9.

Generated by release-automator-konflux.