### PR TITLE
CNF-23355: Upstream catalog-template update — NUMA Resources Operator 4.16.8

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-16@sha256:f4c2dc80a0ebc4291de2ac5a5d4e1195be7d366cf5fa3f7aede0bf145cca66d9
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-16@sha256:d2aa4fbd9c354a0692f1a0da50c114aec5b401549df4516cd33e4a52d3a7a126

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -36,6 +36,10 @@ entries:
       - name: numaresources-operator.v4.16.8
         replaces: numaresources-operator.v4.16.7
         skipRange: '>=4.15.0 <4.16.8'
+      # v4.16.9
+      - name: numaresources-operator.v4.16.9
+        replaces: numaresources-operator.v4.16.8
+        skipRange: '>=4.15.0 <4.16.9'
     name: "4.16"
     package: numaresources-operator
     schema: olm.channel


### PR DESCRIPTION
Automated post-release update for NUMA Resources Operator 4.16.8 → 4.16.9.

Generated by release-automator-konflux.