### PR TITLE
tools: add helper tool about verify backports

### DIFF
--- a/tools/verify-backport/README.md
+++ b/tools/verify-backport/README.md
@@ -1,0 +1,293 @@
+# verify-backport
+
+Verifies that a backport branch carries commits whose content is identical to their
+counterparts on the main branch.
+
+## Problem
+
+When commits are cherry-picked or rebased onto a release branch, the commit hashes change.
+Cherry-pick trailers (`cherry picked from commit ...`) may be missing or incorrect.
+This tool provides **ex-post verification** that the backport commits match their originals
+by comparing the actual patch content, not metadata.
+
+## How it works
+
+The tool uses `git patch-id --stable` to compute a content-based hash of each commit's diff.
+Two commits that introduce the same code changes produce the same patch-id, regardless of
+their commit hash or surrounding context line numbers. Whitespace is normalized by default
+in all patch-id modes except `--verbatim`; `--stable` ensures the hash is also independent
+of the order in which files and hunks appear in the diff.
+
+For each backport commit:
+1. Compute its patch-id
+2. Find a main-branch commit with the same patch-id
+3. Verify the backport commit message **contains** the original commit message
+   (the backport may add extra text such as backport-specific notes)
+
+When a backport commit doesn't match by patch-id, the tool tries to find a likely
+counterpart on main by matching the commit subject line, and reports it as a
+closest match (`~>`) so the user knows which main commit to compare against.
+
+For unmatched commits, the tool performs a file-level comparison and classifies
+each file by the type of review effort required (see "Change classification" below).
+
+## Usage
+
+### Branch mode
+
+Point the tool at a local branch that is a checkout of a backport PR:
+
+```bash
+# Fetch the PR locally
+git fetch origin pull/1234/head:pr-1234
+
+# Verify the backport (targeting release-4.18)
+bin/verify-backport \
+  --backport-branch pr-1234 \
+  --base-branch origin/release-4.18
+```
+
+This derives backport commits as `origin/release-4.18..pr-1234` and searches
+the last 100 commits on main for matches.
+
+### Range mode
+
+Specify explicit git revision ranges for full control:
+
+```bash
+bin/verify-backport \
+  --backport-range release-4.18~5..release-4.18 \
+  --main-range main~20..main
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--backport-branch` | | Local branch name (pseudo-PR mode) |
+| `--base-branch` | | Branch the backport is based on (e.g. `release-4.18`); required with `--backport-branch` |
+| `--backport-range` | | Git revision range for backport commits |
+| `--main-range` | | Git revision range for main commits |
+| `--main-branch` | `main` | Name of the main branch where originals live |
+| `--main-depth` | `100` | How many main commits to search (branch mode) |
+| `--check-missing` | `false` | Report main commits with no backport counterpart |
+| `--verbose` | `false` | Show structured diff for unmatched commits |
+| `--color` | `true` | Enable colored output (auto-disabled when not a terminal) |
+| `--json` | `false` | Output results as JSON (for scripting and LLM consumption) |
+
+Exactly one of `--backport-branch` or `--backport-range` must be provided.
+When using `--backport-branch`, `--base-branch` is required.
+When using `--backport-range`, `--main-range` is required.
+
+## Output
+
+### Default mode
+
+Each backport commit gets one status line:
+
+```
+MATCH:            abc1234 Fix the widget       <-->  def5678
+MISMATCH-MESSAGE: abc1234 Update docs          <-->  def5678
+UNMATCHED:        abc1234 Adapted change       (~>   def5678)  [2 identical, 1 moved, 1 additive, 1 edits]
+  identical (2):
+    internal/controller/nro_controller.go -> controllers/nro_controller.go (renamed)
+    pkg/status/status_test.go
+  moved (1):
+    machineconfigpool.go -> rte.go (95% overlap)
+  additive (1):
+    pkg/status/status.go (+1 only in backport)
+  edits (1):
+    test/e2e/serial/tests/configuration.go (+4 only in backport, +2 only in main)
+```
+
+The `~>` arrow indicates a closest match found by commit subject. The bracketed tag
+shows the reviewer triage summary. Files are grouped by change type (see below).
+
+With `--check-missing`, main commits with no backport counterpart are also shown:
+
+```
+MISSING-BACKPORT: def5678 Original commit subject
+```
+
+### Verbose mode (`--verbose`)
+
+Adds the actual differing lines for `additive` and `edits` files, and residual (non-overlapping)
+lines for `moved` files.
+
+```
+  edits (1):
+    test/e2e/serial/tests/configuration.go (+4 only in backport, +2 only in main)
+      only in backport:
+        + import "github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+        + cond := status.FindCondition(updatedOperObj.Status.Conditions, status.ConditionAvailable)
+        ...
+      only in main:
+        + dss, err := objects.GetDaemonSetsByNamespacedName(fxt.Client, ctx, ...)
+        ...
+```
+
+### JSON mode (`--json`)
+
+Outputs a single JSON object to stdout, suitable for scripting or LLM consumption.
+No color codes, no padding, no verbose preamble — just structured data.
+
+```json
+{
+  "summary": {
+    "matched": 3,
+    "total": 4,
+    "unmatched_main": 1
+  },
+  "results": [
+    {
+      "status": "MATCH",
+      "backport": {"hash": "abc1234...", "subject": "Fix the widget"},
+      "main":     {"hash": "def5678...", "subject": "Fix the widget"}
+    },
+    {
+      "status": "UNMATCHED",
+      "backport": {"hash": "aaa1111...", "subject": "Adapted change"},
+      "closest":  {"hash": "bbb2222...", "subject": "Adapted change"},
+      "patch_comparison": {
+        "identical": 2,
+        "moved": 1,
+        "additive": 1,
+        "edits": 0
+      }
+    }
+  ],
+  "missing_backports": [
+    {"hash": "ccc3333...", "subject": "Original commit subject"}
+  ]
+}
+```
+
+Field presence rules:
+- `main`: present only for `MATCH` and `MISMATCH-MESSAGE` results
+- `closest` and `patch_comparison`: present only for `UNMATCHED` results with a subject match
+- `missing_backports`: present only when `--check-missing` is set and there are unmatched main commits
+
+#### LLM token efficiency estimate
+
+Without this tool, an LLM verifying a 10-commit backport against 100 main commits needs
+to run ~4 git commands (log + patch-id for each side), ingest their output (~4000-6000
+tokens of raw git data), and cross-reference patch-ids and messages in-context.
+
+With `--json`, it is a single command producing ~500-800 tokens of pre-correlated output.
+The estimated saving is **3-5x fewer tokens** for the ingestion step, plus elimination of
+the multi-step reasoning needed to correlate commits manually. The exit code alone (0 vs 2)
+answers "is this backport correct?" without parsing any output at all.
+
+These estimates are back-of-envelope (May 2026) and should be verified against actual
+token counts in representative backport reviews.
+
+### Change classification
+
+Files are classified by the type of review effort they require, from lowest to highest bandwidth:
+
+| Category | What it means | How to review | Color |
+|----------|---------------|---------------|-------|
+| **identical** | No differing lines (with or without rename) | Skip entirely | dim |
+| **moved** | File relocated between releases (>=50% content overlap) | Glance at residual lines (shown in verbose) | dim |
+| **additive** | Only one side has extra lines | Check that additions/deletions make sense for the target branch | yellow |
+| **edits** | Both sides have differing lines | Full review: substantive changes were made | yellow |
+
+This classification tells you **how** to review each file, not just whether to review it.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All backport commits match their main counterparts |
+| 1 | Usage error or runtime failure (bad flags, git command error) |
+| 2 | Verification failure (mismatches, unmatched, or missing backports) |
+
+## Design notes
+
+### Architecture
+
+The tool operates in three phases:
+
+1. **Commit-level matching**: Compute patch-ids for backport and main commits; match by patch-id or fall back to subject-line matching
+2. **File-level comparison**: For each unmatched commit pair, parse both patches and extract per-file added/removed lines. **Whitespace is intentionally treated as non-semantic**: lines are trimmed before comparison, so pure whitespace/indentation differences are not reported as edits. This matches the behavior of `git patch-id --stable` and avoids drowning reviewers in noise from reformatting or tab/space changes between branches.
+3. **Change classification**: Classify each file by change type (identical/moved/additive/edits) and present triage-friendly output
+
+### Code movement detection
+
+After pairing files by path and basename, leftover ONLY-IN-BACKPORT and ONLY-IN-MAIN files
+are tested for code movement using set intersection of their added lines:
+
+```
+overlap = |intersection(bpAdded, mainAdded)| / min(|bpAdded|, |mainAdded|)
+```
+
+If overlap >= 50%, the files are classified as a `moved` pair. The `min` denominator (not union)
+ensures that a small file fully contained in a larger one still registers as movement.
+
+**Why this is reliable:**
+- Compares actual code content, not filenames or heuristics
+- False positives (unrelated files sharing 50%+ of added lines) are extremely unlikely in practice
+- Real-world backports show near-100% overlap for genuine code movement (e.g., refactoring between releases)
+
+**Scope constraint:** Code movement is detected only within each commit. If code moves across
+commits within the same backport, that's a red flag indicating the backport diverged from the
+original structure, which itself is useful signal.
+
+### Why patch-id for commit matching
+
+`git patch-id` is purpose-built for detecting equivalent patches across rebases and cherry-picks.
+It normalizes away:
+- Context line numbers (hunks can shift without changing the patch-id)
+- Whitespace (default in all modes except `--verbatim`; there is no separate `--ignore-whitespace` flag)
+- File and hunk ordering (`--stable` mode ensures this; `--unstable` does not)
+- Commit metadata (author, date, hash)
+
+But it remains sensitive to:
+- Actual code changes (even one character difference produces a different patch-id)
+- File renames (a renamed file produces a different patch)
+
+This is the right level of strictness: we want to catch any substantive changes while allowing
+mechanical differences like directory restructuring or import path updates.
+
+### Design constraints
+
+- **Local-only, no network access**: The tool **never contacts remote servers**. All git operations run against the local clone using `exec.Command`. It does not fetch, push, or call any API (GitHub or otherwise). This is a deliberate trust boundary: the tool's output depends solely on what is already checked out locally, so there is no risk of leaking credentials, hitting rate limits, or trusting data from an external service. The user controls what is in the local clone; the tool only reads it.
+- **No external dependencies beyond git**: The tool uses only stdlib + `golang.org/x/term` (for color detection). No go-git, no GitHub API.
+- **Stateless**: Each run is independent; no caching or persistent state between runs.
+- **Colored by default**: Color is a high-ROI UX improvement for dense output. Auto-disabled when not a terminal or when `--color=false`.
+
+### Future iteration notes
+
+- **Cross-commit movement detection**: Currently not implemented (by design). If needed, pool all ONLY-IN-BACKPORT and ONLY-IN-MAIN files across all commits and match globally. But this may hide backport structure divergence, so default should remain within-commit.
+- **Mechanical change detection**: Import path substitutions (e.g., `api/numaresourcesoperator/v1` → `api/v1`) are currently shown as diffs. Could detect and label these as "mechanical" to further reduce reviewer bandwidth.
+- **Diff output format**: Currently shows +/- lines inline. Could add side-by-side or unified diff views.
+- **Performance**: For very large backport PRs (50+ commits), computing patch-ids and parsing patches is the bottleneck. Could parallelize per-commit processing if needed.
+
+## Key assumptions
+
+- **Local clone required, no network access**: The tool operates exclusively on a local git
+  repository and **never makes network calls**. Both the backport branch/range and the main
+  branch must be fetched locally before running the tool. This eliminates any need to trust
+  remote services or configure authentication.
+- **No merge commits**: Merge commits are excluded from comparison (`--no-merges`) since
+  they don't carry meaningful patch content.
+- **Message containment, not equality**: The backport commit message must *contain* the
+  main commit message as a substring. This allows backport-specific additions (e.g.,
+  "Backport to release-4.18" notes) while ensuring the original message is preserved.
+- **Whitespace normalization**: Trailing whitespace per line and trailing newlines are
+  normalized before message comparison.
+- **Patch-id stability**: `git patch-id --stable` is used for reproducible results
+  across git versions.
+- **Closest match by subject**: When patch-ids don't match, the tool falls back to
+  matching by commit subject line to suggest a likely counterpart for investigation.
+
+## Building
+
+```bash
+make bin/verify-backport
+```
+
+## Requirements
+
+- Git (any reasonably modern version with `patch-id --stable` support, i.e., >= 2.0)
+- Go 1.25+ (for building)

--- a/tools/verify-backport/testdata/json_all_matched.golden.json
+++ b/tools/verify-backport/testdata/json_all_matched.golden.json
@@ -1,0 +1,30 @@
+{
+  "summary": {
+    "matched": 2,
+    "total": 2
+  },
+  "results": [
+    {
+      "status": "MATCH",
+      "backport": {
+        "hash": "aaa1111",
+        "subject": "fix: alpha"
+      },
+      "main": {
+        "hash": "bbb2222",
+        "subject": "fix: alpha"
+      }
+    },
+    {
+      "status": "MATCH",
+      "backport": {
+        "hash": "ccc3333",
+        "subject": "fix: beta"
+      },
+      "main": {
+        "hash": "ddd4444",
+        "subject": "fix: beta"
+      }
+    }
+  ]
+}

--- a/tools/verify-backport/testdata/json_githistory_matched.golden.json
+++ b/tools/verify-backport/testdata/json_githistory_matched.golden.json
@@ -1,0 +1,30 @@
+{
+  "summary": {
+    "matched": 2,
+    "total": 2
+  },
+  "results": [
+    {
+      "status": "MATCH",
+      "backport": {
+        "hash": "cbb2ea559ef9e54ae4815dc21359ec35a1619d15",
+        "subject": "makefile: add version to golangci-lint make target"
+      },
+      "main": {
+        "hash": "cbb2ea559ef9e54ae4815dc21359ec35a1619d15",
+        "subject": "makefile: add version to golangci-lint make target"
+      }
+    },
+    {
+      "status": "MATCH",
+      "backport": {
+        "hash": "ff92eec65d2fc7c03177e288a5e57d8133894220",
+        "subject": "Dockerfile: disable RHEL repos when installing hwdata"
+      },
+      "main": {
+        "hash": "ff92eec65d2fc7c03177e288a5e57d8133894220",
+        "subject": "Dockerfile: disable RHEL repos when installing hwdata"
+      }
+    }
+  ]
+}

--- a/tools/verify-backport/testdata/json_githistory_unmatched_closest.golden.json
+++ b/tools/verify-backport/testdata/json_githistory_unmatched_closest.golden.json
@@ -1,0 +1,25 @@
+{
+  "summary": {
+    "matched": 0,
+    "total": 1
+  },
+  "results": [
+    {
+      "status": "UNMATCHED",
+      "backport": {
+        "hash": "1c1afa7512e2da2c67953ff776cf49f7714cb6ac",
+        "subject": "controller: sched: conditionally enable Shared informer by default"
+      },
+      "closest": {
+        "hash": "6a56840544a420c1393c39fc61e3580f563c1d1f",
+        "subject": "controller: sched: conditionally enable Shared informer by default"
+      },
+      "patch_comparison": {
+        "identical": 2,
+        "moved": 0,
+        "additive": 0,
+        "edits": 2
+      }
+    }
+  ]
+}

--- a/tools/verify-backport/testdata/json_mismatch_message.golden.json
+++ b/tools/verify-backport/testdata/json_mismatch_message.golden.json
@@ -1,0 +1,19 @@
+{
+  "summary": {
+    "matched": 0,
+    "total": 1
+  },
+  "results": [
+    {
+      "status": "MISMATCH-MESSAGE",
+      "backport": {
+        "hash": "aaa1111",
+        "subject": "fix: alpha (backport note)"
+      },
+      "main": {
+        "hash": "bbb2222",
+        "subject": "fix: alpha"
+      }
+    }
+  ]
+}

--- a/tools/verify-backport/testdata/json_missing_backports.golden.json
+++ b/tools/verify-backport/testdata/json_missing_backports.golden.json
@@ -1,0 +1,30 @@
+{
+  "summary": {
+    "matched": 1,
+    "total": 1,
+    "unmatched_main": 2
+  },
+  "results": [
+    {
+      "status": "MATCH",
+      "backport": {
+        "hash": "aaa1111",
+        "subject": "fix: alpha"
+      },
+      "main": {
+        "hash": "bbb2222",
+        "subject": "fix: alpha"
+      }
+    }
+  ],
+  "missing_backports": [
+    {
+      "hash": "eee5555",
+      "subject": "fix: missing thing"
+    },
+    {
+      "hash": "fff6666",
+      "subject": "fix: another missing"
+    }
+  ]
+}

--- a/tools/verify-backport/testdata/json_missing_not_reported.golden.json
+++ b/tools/verify-backport/testdata/json_missing_not_reported.golden.json
@@ -1,0 +1,19 @@
+{
+  "summary": {
+    "matched": 1,
+    "total": 1
+  },
+  "results": [
+    {
+      "status": "MATCH",
+      "backport": {
+        "hash": "aaa1111",
+        "subject": "fix: alpha"
+      },
+      "main": {
+        "hash": "bbb2222",
+        "subject": "fix: alpha"
+      }
+    }
+  ]
+}

--- a/tools/verify-backport/testdata/json_mixed_statuses.golden.json
+++ b/tools/verify-backport/testdata/json_mixed_statuses.golden.json
@@ -1,0 +1,37 @@
+{
+  "summary": {
+    "matched": 1,
+    "total": 3
+  },
+  "results": [
+    {
+      "status": "MATCH",
+      "backport": {
+        "hash": "aaa1111",
+        "subject": "fix: alpha"
+      },
+      "main": {
+        "hash": "bbb2222",
+        "subject": "fix: alpha"
+      }
+    },
+    {
+      "status": "MISMATCH-MESSAGE",
+      "backport": {
+        "hash": "ccc3333",
+        "subject": "fix: beta (reworded)"
+      },
+      "main": {
+        "hash": "ddd4444",
+        "subject": "fix: beta"
+      }
+    },
+    {
+      "status": "UNMATCHED",
+      "backport": {
+        "hash": "eee5555",
+        "subject": "fix: gamma"
+      }
+    }
+  ]
+}

--- a/tools/verify-backport/testdata/json_unmatched_no_closest.golden.json
+++ b/tools/verify-backport/testdata/json_unmatched_no_closest.golden.json
@@ -1,0 +1,15 @@
+{
+  "summary": {
+    "matched": 0,
+    "total": 1
+  },
+  "results": [
+    {
+      "status": "UNMATCHED",
+      "backport": {
+        "hash": "aaa1111",
+        "subject": "fix: orphan"
+      }
+    }
+  ]
+}

--- a/tools/verify-backport/verify-backport.go
+++ b/tools/verify-backport/verify-backport.go
@@ -1,0 +1,983 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+var useColor bool
+
+const (
+	colorReset  = "\033[0m"
+	colorRed    = "\033[31m"
+	colorGreen  = "\033[32m"
+	colorYellow = "\033[33m"
+	colorDim    = "\033[2m"
+)
+
+func color(c, text string) string {
+	if !useColor {
+		return text
+	}
+	return c + text + colorReset
+}
+
+func red(format string, v ...any) string    { return color(colorRed, fmt.Sprintf(format, v...)) }
+func green(format string, v ...any) string  { return color(colorGreen, fmt.Sprintf(format, v...)) }
+func yellow(format string, v ...any) string { return color(colorYellow, fmt.Sprintf(format, v...)) }
+func dim(format string, v ...any) string    { return color(colorDim, fmt.Sprintf(format, v...)) }
+
+type MatchStatus int
+
+const (
+	StatusMatch MatchStatus = iota
+	StatusMismatchMessage
+	StatusUnmatched
+)
+
+func (s MatchStatus) String() string {
+	switch s {
+	case StatusMatch:
+		return "MATCH"
+	case StatusMismatchMessage:
+		return "MISMATCH-MESSAGE"
+	case StatusUnmatched:
+		return "UNMATCHED"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+type CommitInfo struct {
+	Hash    string
+	PatchID string
+	Message string
+}
+
+func (ci CommitInfo) ShortHash() string {
+	if len(ci.Hash) >= 7 {
+		return ci.Hash[:7]
+	}
+	return ci.Hash
+}
+
+func (ci CommitInfo) Subject() string {
+	if idx := strings.IndexByte(ci.Message, '\n'); idx >= 0 {
+		return ci.Message[:idx]
+	}
+	return ci.Message
+}
+
+type MatchResult struct {
+	Backport     CommitInfo
+	MainMatch    *CommitInfo
+	ClosestMatch *CommitInfo
+	Status       MatchStatus
+}
+
+type ReportOptions struct {
+	Verbose      bool
+	CheckMissing bool
+	JSON         bool
+}
+
+type Options struct {
+	BackportBranch string
+	BackportRange  string
+	BaseBranch     string
+	MainRange      string
+	MainBranch     string
+	MainDepth      int
+	CheckMissing   bool
+	Verbose        bool
+	Color          bool
+	JSON           bool
+}
+
+func main() {
+	var opts Options
+	flag.StringVar(&opts.BackportBranch, "backport-branch", "", "local branch name containing backport commits")
+	flag.StringVar(&opts.BackportRange, "backport-range", "", "git revision range for backport commits")
+	flag.StringVar(&opts.BaseBranch, "base-branch", "", "branch the backport is based on (e.g. release-4.18); required with --backport-branch")
+	flag.StringVar(&opts.MainRange, "main-range", "", "git revision range for main commits")
+	flag.StringVar(&opts.MainBranch, "main-branch", "main", "name of the main branch where originals live")
+	flag.IntVar(&opts.MainDepth, "main-depth", 100, "number of recent main commits to search (used with --backport-branch)")
+	flag.BoolVar(&opts.CheckMissing, "check-missing", false, "report main commits with no backport counterpart")
+	flag.BoolVar(&opts.Verbose, "verbose", false, "enable detailed output")
+	flag.BoolVar(&opts.Color, "color", true, "enable colored output (auto-disabled when not a terminal)")
+	flag.BoolVar(&opts.JSON, "json", false, "output results as JSON")
+	flag.Parse()
+
+	useColor = opts.Color && term.IsTerminal(int(os.Stdout.Fd()))
+
+	exitCode, err := run(opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+	}
+	os.Exit(exitCode)
+}
+
+func run(opts Options) (int, error) {
+	if err := validateOptions(opts); err != nil {
+		return 1, err
+	}
+
+	backportRange := opts.BackportRange
+	mainRange := opts.MainRange
+
+	if opts.BackportBranch != "" {
+		backportRange = fmt.Sprintf("%s..%s", opts.BaseBranch, opts.BackportBranch)
+		if mainRange == "" {
+			mainRange = fmt.Sprintf("%s~%d..%s", opts.MainBranch, opts.MainDepth, opts.MainBranch)
+		}
+	}
+
+	if opts.Verbose && !opts.JSON {
+		fmt.Printf("backport range: %s\n", backportRange)
+		fmt.Printf("main range:     %s\n", mainRange)
+	}
+
+	backportCommits, err := getCommitsFromRange(backportRange)
+	if err != nil {
+		return 1, fmt.Errorf("getting backport commits: %w", err)
+	}
+
+	if len(backportCommits) == 0 {
+		return 1, fmt.Errorf("no commits found in backport range %q", backportRange)
+	}
+
+	mainCommits, err := getCommitsFromRange(mainRange)
+	if err != nil {
+		return 1, fmt.Errorf("getting main commits: %w", err)
+	}
+
+	if len(mainCommits) == 0 {
+		return 1, fmt.Errorf("no commits found in main range %q", mainRange)
+	}
+
+	if opts.Verbose && !opts.JSON {
+		fmt.Printf("backport commits: %d\n", len(backportCommits))
+		fmt.Printf("main commits:     %d\n", len(mainCommits))
+		fmt.Println()
+	}
+
+	results, unmatchedMain := matchCommits(backportCommits, mainCommits)
+	printReport(results, unmatchedMain, ReportOptions{
+		Verbose:      opts.Verbose,
+		CheckMissing: opts.CheckMissing,
+		JSON:         opts.JSON,
+	})
+
+	for _, r := range results {
+		if r.Status != StatusMatch {
+			return 2, nil
+		}
+	}
+	if opts.CheckMissing && len(unmatchedMain) > 0 {
+		return 2, nil
+	}
+	return 0, nil
+}
+
+func validateOptions(opts Options) error {
+	hasBranch := opts.BackportBranch != ""
+	hasRange := opts.BackportRange != ""
+
+	if !hasBranch && !hasRange {
+		return fmt.Errorf("one of --backport-branch or --backport-range is required")
+	}
+	if hasBranch && hasRange {
+		return fmt.Errorf("--backport-branch and --backport-range are mutually exclusive")
+	}
+	if hasBranch && opts.BaseBranch == "" {
+		return fmt.Errorf("--base-branch is required when using --backport-branch (e.g. --base-branch release-4.18)")
+	}
+	if hasRange && opts.MainRange == "" {
+		return fmt.Errorf("--main-range is required when using --backport-range")
+	}
+	return nil
+}
+
+func getCommitsFromRange(gitRange string) ([]CommitInfo, error) {
+	if strings.TrimSpace(gitRange) == "" {
+		return nil, fmt.Errorf("empty git range")
+	}
+	patchIDs, err := getPatchIDs(gitRange)
+	if err != nil {
+		return nil, fmt.Errorf("computing patch-ids: %w", err)
+	}
+
+	messages, err := getMessages(gitRange)
+	if err != nil {
+		return nil, fmt.Errorf("getting messages: %w", err)
+	}
+
+	hashes, err := getHashes(gitRange)
+	if err != nil {
+		return nil, fmt.Errorf("getting hashes: %w", err)
+	}
+
+	var commits []CommitInfo
+	for _, hash := range hashes {
+		ci := CommitInfo{
+			Hash:    hash,
+			PatchID: patchIDs[hash],
+			Message: messages[hash],
+		}
+		commits = append(commits, ci)
+	}
+	return commits, nil
+}
+
+func getHashes(gitRange string) ([]string, error) {
+	cmd := exec.Command("git", "log", "--no-merges", "--format=%H", gitRange, "--")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git log: %w: %s", err, cmdStderr(err))
+	}
+
+	var hashes []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			hashes = append(hashes, line)
+		}
+	}
+	return hashes, nil
+}
+
+func getPatchIDs(gitRange string) (map[string]string, error) {
+	logCmd := exec.Command("git", "log", "-p", "--no-merges", gitRange, "--")
+	patchIDCmd := exec.Command("git", "patch-id", "--stable")
+
+	pipe, err := logCmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("creating pipe: %w", err)
+	}
+	patchIDCmd.Stdin = pipe
+
+	var out bytes.Buffer
+	patchIDCmd.Stdout = &out
+
+	if err := logCmd.Start(); err != nil {
+		return nil, fmt.Errorf("starting git log: %w", err)
+	}
+	if err := patchIDCmd.Start(); err != nil {
+		return nil, fmt.Errorf("starting git patch-id: %w", err)
+	}
+
+	logErr := logCmd.Wait()
+	patchIDErr := patchIDCmd.Wait()
+	if logErr != nil {
+		return nil, fmt.Errorf("git log: %w: %s", logErr, cmdStderr(logErr))
+	}
+	if patchIDErr != nil {
+		return nil, fmt.Errorf("git patch-id: %w: %s", patchIDErr, cmdStderr(patchIDErr))
+	}
+
+	result := make(map[string]string)
+	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) != 2 {
+			continue
+		}
+		patchID, commitHash := parts[0], parts[1]
+		result[commitHash] = patchID
+	}
+	return result, nil
+}
+
+func getMessages(gitRange string) (map[string]string, error) {
+	cmd := exec.Command("git", "log", "--no-merges", "--format=%H%x00%B%x00", gitRange, "--")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git log messages: %w: %s", err, cmdStderr(err))
+	}
+
+	result := make(map[string]string)
+	records := strings.Split(string(out), "\x00")
+	for i := 0; i+1 < len(records); i += 2 {
+		hash := strings.TrimSpace(records[i])
+		message := records[i+1]
+		if hash == "" {
+			continue
+		}
+		result[hash] = message
+	}
+	return result, nil
+}
+
+func matchCommits(backport, main []CommitInfo) ([]MatchResult, []CommitInfo) {
+	mainByPatchID := make(map[string]*CommitInfo)
+	mainBySubject := make(map[string]*CommitInfo)
+	for i := range main {
+		if main[i].PatchID != "" {
+			mainByPatchID[main[i].PatchID] = &main[i]
+		}
+		subj := main[i].Subject()
+		if subj != "" {
+			mainBySubject[subj] = &main[i]
+		}
+	}
+
+	matchedMainPatchIDs := make(map[string]bool)
+	var results []MatchResult
+
+	for _, bp := range backport {
+		r := MatchResult{Backport: bp}
+
+		if bp.PatchID == "" {
+			r.Status = StatusUnmatched
+			r.ClosestMatch = mainBySubject[bp.Subject()]
+			results = append(results, r)
+			continue
+		}
+
+		mainCommit, found := mainByPatchID[bp.PatchID]
+		if !found {
+			r.Status = StatusUnmatched
+			r.ClosestMatch = mainBySubject[bp.Subject()]
+			results = append(results, r)
+			continue
+		}
+
+		matchedMainPatchIDs[bp.PatchID] = true
+		r.MainMatch = mainCommit
+
+		if strings.Contains(normalizeMessage(bp.Message), normalizeMessage(mainCommit.Message)) {
+			r.Status = StatusMatch
+		} else {
+			r.Status = StatusMismatchMessage
+		}
+		results = append(results, r)
+	}
+
+	var unmatchedMain []CommitInfo
+	for _, mc := range main {
+		if mc.PatchID != "" && !matchedMainPatchIDs[mc.PatchID] {
+			unmatchedMain = append(unmatchedMain, mc)
+		}
+	}
+
+	return results, unmatchedMain
+}
+
+func printReport(results []MatchResult, unmatchedMain []CommitInfo, opts ReportOptions) {
+	if opts.JSON {
+		printJSONReport(results, unmatchedMain, opts)
+		return
+	}
+	matchCount := 0
+	for _, r := range results {
+		switch r.Status {
+		case StatusMatch:
+			matchCount++
+			fmt.Printf("%s %s %s  <-->  %s\n",
+				statusColor(r.Status).Fmt("%-18s", r.Status.String()+":"),
+				dim("%s", r.Backport.ShortHash()),
+				r.Backport.Subject(),
+				dim("%s", r.MainMatch.ShortHash()),
+			)
+		case StatusMismatchMessage:
+			fmt.Printf("%s %s %s  <-->  %s\n",
+				statusColor(r.Status).Fmt("%-18s", r.Status.String()+":"),
+				dim("%s", r.Backport.ShortHash()),
+				r.Backport.Subject(),
+				dim("%s", r.MainMatch.ShortHash()),
+			)
+			if opts.Verbose {
+				fmt.Printf("  main message:\n")
+				printIndented(normalizeMessage(r.MainMatch.Message))
+				fmt.Printf("  backport message:\n")
+				printIndented(normalizeMessage(r.Backport.Message))
+			}
+		case StatusUnmatched:
+			if r.ClosestMatch != nil {
+				pc := comparePatchContent(r.Backport.Hash, r.ClosestMatch.Hash)
+				fmt.Printf("%s %s %s  (~>  %s)  %s\n",
+					statusColor(r.Status).Fmt("%-18s", r.Status.String()+":"),
+					dim("%s", r.Backport.ShortHash()),
+					r.Backport.Subject(),
+					dim("%s", r.ClosestMatch.ShortHash()),
+					pc.summaryTag(),
+				)
+				printPatchComparison(pc, opts)
+			} else {
+				fmt.Printf("%s %s %s\n",
+					statusColor(r.Status).Fmt("%-18s", r.Status.String()+":"),
+					dim("%s", r.Backport.ShortHash()),
+					r.Backport.Subject(),
+				)
+			}
+		}
+	}
+
+	if opts.CheckMissing {
+		for _, mc := range unmatchedMain {
+			fmt.Printf("%s %s %s\n",
+				red("%-18s", "MISSING-BACKPORT:"),
+				dim("%s", mc.ShortHash()), mc.Subject())
+		}
+	}
+
+	allMatch := matchCount == len(results) && (!opts.CheckMissing || len(unmatchedMain) == 0)
+	summaryFn := red
+	if allMatch {
+		summaryFn = green
+	}
+	fmt.Printf("\n%s", summaryFn("summary: %d/%d backport commits matched", matchCount, len(results)))
+	if opts.CheckMissing && len(unmatchedMain) > 0 {
+		fmt.Printf(", %s", red("%d main commits missing backport", len(unmatchedMain)))
+	}
+	fmt.Println()
+}
+
+type colorizer func(string, ...any) string
+
+func (c colorizer) Fmt(format string, v ...any) string { return c(format, v...) }
+
+func statusColor(s MatchStatus) colorizer {
+	switch s {
+	case StatusMatch:
+		return green
+	case StatusMismatchMessage, StatusUnmatched:
+		return red
+	default:
+		return fmt.Sprintf
+	}
+}
+
+func normalizeMessage(msg string) string {
+	lines := strings.Split(msg, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, " \t")
+	}
+	result := strings.Join(lines, "\n")
+	return strings.TrimRight(result, "\n")
+}
+
+type filePatch struct {
+	path         string
+	addedLines   []string
+	removedLines []string
+}
+
+type changeType int
+
+const (
+	changeIdentical changeType = iota
+	changeMoved
+	changeAdditive
+	changeEdits
+)
+
+type fileResult struct {
+	bpPath     string
+	mainPath   string
+	relation   string // COMMON, RENAMED
+	changeType changeType
+	overlap    int
+	onlyBP     []string
+	onlyMain   []string
+}
+
+type moveResult struct {
+	bpPath   string
+	mainPath string
+	overlap  int      // percentage
+	onlyBP   []string // residual lines not in the other
+	onlyMain []string
+}
+
+func (fr fileResult) label() string {
+	path := fr.bpPath
+	if fr.mainPath != "" && fr.relation == "RENAMED" {
+		path = fmt.Sprintf("%s -> %s", fr.mainPath, fr.bpPath)
+	}
+
+	bpCount := len(fr.onlyBP)
+	mainCount := len(fr.onlyMain)
+
+	switch fr.changeType {
+	case changeIdentical:
+		if fr.relation == "RENAMED" {
+			return fmt.Sprintf("%s (renamed)", path)
+		}
+		return path
+	case changeAdditive:
+		if bpCount > 0 && mainCount == 0 {
+			return fmt.Sprintf("%s (+%d only in backport)", path, bpCount)
+		}
+		if mainCount > 0 && bpCount == 0 {
+			return fmt.Sprintf("%s (+%d only in main)", path, mainCount)
+		}
+		return path
+	case changeMoved:
+		return fmt.Sprintf("%s (%d%% overlap)", path, fr.overlap)
+	case changeEdits:
+		return fmt.Sprintf("%s (+%d only in backport, +%d only in main)", path, bpCount, mainCount)
+	default:
+		return path
+	}
+}
+
+type patchComparison struct {
+	identical []fileResult
+	moved     []moveResult
+	additive  []fileResult
+	edits     []fileResult
+	err       error
+}
+
+func (pc patchComparison) summaryTag() string {
+	parts := []string{}
+	if len(pc.identical) > 0 {
+		parts = append(parts, dim("%d identical", len(pc.identical)))
+	}
+	if len(pc.moved) > 0 {
+		parts = append(parts, dim("%d moved", len(pc.moved)))
+	}
+	if len(pc.additive) > 0 {
+		parts = append(parts, yellow("%d additive", len(pc.additive)))
+	}
+	if len(pc.edits) > 0 {
+		parts = append(parts, yellow("%d edits", len(pc.edits)))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("[%s]", strings.Join(parts, ", "))
+}
+
+func comparePatchContent(backportHash, mainHash string) patchComparison {
+	bpPatch, err := getCommitPatch(backportHash)
+	if err != nil {
+		return patchComparison{err: fmt.Errorf("backport patch: %w", err)}
+	}
+	mainPatch, err := getCommitPatch(mainHash)
+	if err != nil {
+		return patchComparison{err: fmt.Errorf("main patch: %w", err)}
+	}
+	return comparePatches(bpPatch, mainPatch)
+}
+
+func comparePatches(bpPatch, mainPatch string) patchComparison {
+	bpFiles := parsePatchFiles(bpPatch)
+	mainFiles := parsePatchFiles(mainPatch)
+
+	bpByPath := make(map[string]filePatch)
+	bpByBase := make(map[string]filePatch)
+	for _, fp := range bpFiles {
+		bpByPath[fp.path] = fp
+		bpByBase[filepath.Base(fp.path)] = fp
+	}
+
+	mainByPath := make(map[string]filePatch)
+	mainByBase := make(map[string]filePatch)
+	for _, fp := range mainFiles {
+		mainByPath[fp.path] = fp
+		mainByBase[filepath.Base(fp.path)] = fp
+	}
+
+	type pairedFile struct {
+		bpPath   string
+		mainPath string
+		relation string
+		bpFile   filePatch
+		mainFile filePatch
+	}
+
+	var paired []pairedFile
+	matchedBP := make(map[string]bool)
+	matchedMain := make(map[string]bool)
+
+	for _, bp := range bpFiles {
+		if mf, ok := mainByPath[bp.path]; ok {
+			paired = append(paired, pairedFile{
+				bpPath: bp.path, mainPath: mf.path,
+				relation: "COMMON", bpFile: bp, mainFile: mf,
+			})
+			matchedBP[bp.path] = true
+			matchedMain[mf.path] = true
+			continue
+		}
+		base := filepath.Base(bp.path)
+		if mf, ok := mainByBase[base]; ok && !matchedMain[mf.path] {
+			paired = append(paired, pairedFile{
+				bpPath: bp.path, mainPath: mf.path,
+				relation: "RENAMED", bpFile: bp, mainFile: mf,
+			})
+			matchedBP[bp.path] = true
+			matchedMain[mf.path] = true
+		}
+	}
+
+	var result patchComparison
+
+	// Classify paired files
+	for _, p := range paired {
+		onlyBP, onlyMain := diffLinesSets(p.bpFile, p.mainFile)
+		fr := fileResult{
+			bpPath:   p.bpPath,
+			mainPath: p.mainPath,
+			relation: p.relation,
+			onlyBP:   onlyBP,
+			onlyMain: onlyMain,
+		}
+
+		switch {
+		case len(onlyBP) == 0 && len(onlyMain) == 0:
+			fr.changeType = changeIdentical
+			result.identical = append(result.identical, fr)
+		case len(onlyBP) > 0 && len(onlyMain) == 0,
+			len(onlyBP) == 0 && len(onlyMain) > 0:
+			fr.changeType = changeAdditive
+			result.additive = append(result.additive, fr)
+		default:
+			fr.changeType = changeEdits
+			result.edits = append(result.edits, fr)
+		}
+	}
+
+	// Collect unpaired files
+	var unpairedBP []filePatch
+	var unpairedMain []filePatch
+	for _, bp := range bpFiles {
+		if !matchedBP[bp.path] {
+			unpairedBP = append(unpairedBP, bp)
+		}
+	}
+	for _, mf := range mainFiles {
+		if !matchedMain[mf.path] {
+			unpairedMain = append(unpairedMain, mf)
+		}
+	}
+
+	// Detect code movement between unpaired files
+	matchedUnpairedBP := make(map[string]bool)
+	matchedUnpairedMain := make(map[string]bool)
+
+	for _, bp := range unpairedBP {
+		bpSet := toSet(bp.addedLines)
+		for _, mf := range unpairedMain {
+			if matchedUnpairedMain[mf.path] {
+				continue
+			}
+			mainSet := toSet(mf.addedLines)
+			overlapCount := intersectionSize(bpSet, mainSet)
+			minSize := min(len(bp.addedLines), len(mf.addedLines))
+			if minSize == 0 {
+				continue
+			}
+			overlapPct := (overlapCount * 100) / minSize
+			if overlapPct >= 50 {
+				// Code movement detected
+				onlyBP, onlyMain := diffLinesSets(bp, mf)
+				result.moved = append(result.moved, moveResult{
+					bpPath:   bp.path,
+					mainPath: mf.path,
+					overlap:  overlapPct,
+					onlyBP:   onlyBP,
+					onlyMain: onlyMain,
+				})
+				matchedUnpairedBP[bp.path] = true
+				matchedUnpairedMain[mf.path] = true
+				break
+			}
+		}
+	}
+
+	// Remaining unpaired files are edits (files added/removed, no movement)
+	for _, bp := range unpairedBP {
+		if !matchedUnpairedBP[bp.path] {
+			result.edits = append(result.edits, fileResult{
+				bpPath:     bp.path,
+				changeType: changeEdits,
+				onlyBP:     extractAddRemove(bp),
+			})
+		}
+	}
+	for _, mf := range unpairedMain {
+		if !matchedUnpairedMain[mf.path] {
+			result.edits = append(result.edits, fileResult{
+				mainPath:   mf.path,
+				changeType: changeEdits,
+				onlyMain:   extractAddRemove(mf),
+			})
+		}
+	}
+
+	return result
+}
+
+func intersectionSize(a, b map[string]bool) int {
+	count := 0
+	for k := range a {
+		if b[k] {
+			count++
+		}
+	}
+	return count
+}
+
+func extractAddRemove(fp filePatch) []string {
+	var result []string
+	for _, line := range fp.addedLines {
+		result = append(result, "+ "+line)
+	}
+	for _, line := range fp.removedLines {
+		result = append(result, "- "+line)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func printPatchComparison(pc patchComparison, opts ReportOptions) {
+	if pc.err != nil {
+		fmt.Printf("  (could not compare patches: %v)\n", pc.err)
+		return
+	}
+
+	if len(pc.identical) > 0 {
+		fmt.Printf("  %s\n", dim("identical (%d):", len(pc.identical)))
+		for _, f := range pc.identical {
+			fmt.Printf("    %s\n", dim("%s", f.label()))
+		}
+	}
+
+	movedFiles := make([]fileResult, 0, len(pc.moved))
+	for _, m := range pc.moved {
+		movedFiles = append(movedFiles, fileResult{
+			bpPath:     m.bpPath,
+			mainPath:   m.mainPath,
+			relation:   "RENAMED",
+			changeType: changeMoved,
+			overlap:    m.overlap,
+			onlyBP:     m.onlyBP,
+			onlyMain:   m.onlyMain,
+		})
+	}
+	printFileResults("moved", dim, movedFiles, opts.Verbose)
+	printFileResults("additive", yellow, pc.additive, opts.Verbose)
+	printFileResults("edits", yellow, pc.edits, opts.Verbose)
+}
+
+func printFileResults(title string, colorFn colorizer, files []fileResult, verbose bool) {
+	if len(files) == 0 {
+		return
+	}
+	fmt.Printf("  %s\n", colorFn("%s (%d):", title, len(files)))
+	for _, f := range files {
+		fmt.Printf("    %s\n", colorFn("%s", f.label()))
+		if !verbose {
+			continue
+		}
+		if len(f.onlyBP) > 0 {
+			fmt.Printf("      only in backport:\n")
+			for _, line := range f.onlyBP {
+				fmt.Printf("        %s\n", line)
+			}
+		}
+		if len(f.onlyMain) > 0 {
+			fmt.Printf("      only in main:\n")
+			for _, line := range f.onlyMain {
+				fmt.Printf("        %s\n", line)
+			}
+		}
+	}
+}
+
+type jsonReport struct {
+	Summary          jsonSummary  `json:"summary"`
+	Results          []jsonResult `json:"results"`
+	MissingBackports []jsonCommit `json:"missing_backports,omitempty"`
+}
+
+type jsonSummary struct {
+	Matched       int `json:"matched"`
+	Total         int `json:"total"`
+	UnmatchedMain int `json:"unmatched_main,omitempty"`
+}
+
+type jsonCommit struct {
+	Hash    string `json:"hash"`
+	Subject string `json:"subject"`
+}
+
+type jsonResult struct {
+	Status          string            `json:"status"`
+	Backport        jsonCommit        `json:"backport"`
+	Main            *jsonCommit       `json:"main,omitempty"`
+	Closest         *jsonCommit       `json:"closest,omitempty"`
+	PatchComparison *jsonPatchSummary `json:"patch_comparison,omitempty"`
+}
+
+type jsonPatchSummary struct {
+	Identical int `json:"identical"`
+	Moved     int `json:"moved"`
+	Additive  int `json:"additive"`
+	Edits     int `json:"edits"`
+}
+
+func printJSONReport(results []MatchResult, unmatchedMain []CommitInfo, opts ReportOptions) {
+	report := buildJSONReport(results, unmatchedMain, opts)
+	json.NewEncoder(os.Stdout).Encode(report) //nolint:errcheck
+}
+
+func buildJSONReport(results []MatchResult, unmatchedMain []CommitInfo, opts ReportOptions) jsonReport {
+	report := jsonReport{
+		Summary: jsonSummary{Total: len(results)},
+	}
+
+	for _, r := range results {
+		jr := jsonResult{
+			Status:   r.Status.String(),
+			Backport: jsonCommit{Hash: r.Backport.Hash, Subject: r.Backport.Subject()},
+		}
+
+		switch r.Status {
+		case StatusMatch:
+			report.Summary.Matched++
+			jr.Main = &jsonCommit{Hash: r.MainMatch.Hash, Subject: r.MainMatch.Subject()}
+		case StatusMismatchMessage:
+			jr.Main = &jsonCommit{Hash: r.MainMatch.Hash, Subject: r.MainMatch.Subject()}
+		case StatusUnmatched:
+			if r.ClosestMatch != nil {
+				jr.Closest = &jsonCommit{Hash: r.ClosestMatch.Hash, Subject: r.ClosestMatch.Subject()}
+				pc := comparePatchContent(r.Backport.Hash, r.ClosestMatch.Hash)
+				if pc.err == nil {
+					jr.PatchComparison = &jsonPatchSummary{
+						Identical: len(pc.identical),
+						Moved:     len(pc.moved),
+						Additive:  len(pc.additive),
+						Edits:     len(pc.edits),
+					}
+				}
+			}
+		}
+
+		report.Results = append(report.Results, jr)
+	}
+
+	if opts.CheckMissing && len(unmatchedMain) > 0 {
+		report.Summary.UnmatchedMain = len(unmatchedMain)
+		for _, mc := range unmatchedMain {
+			report.MissingBackports = append(report.MissingBackports, jsonCommit{
+				Hash:    mc.Hash,
+				Subject: mc.Subject(),
+			})
+		}
+	}
+
+	return report
+}
+
+func getCommitPatch(hash string) (string, error) {
+	if strings.TrimSpace(hash) == "" {
+		return "", fmt.Errorf("empty commit hash")
+	}
+	cmd := exec.Command("git", "diff-tree", "-p", hash, "--")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git diff-tree: %w: %s", err, cmdStderr(err))
+	}
+	return string(out), nil
+}
+
+func parsePatchFiles(patch string) []filePatch {
+	chunks := strings.Split(patch, "diff --git ")
+	var files []filePatch
+	for _, chunk := range chunks[1:] {
+		fp := filePatch{}
+		lines := strings.Split(chunk, "\n")
+		if len(lines) > 0 {
+			parts := strings.Fields(lines[0])
+			if len(parts) >= 2 {
+				fp.path = strings.TrimPrefix(parts[1], "b/")
+			}
+		}
+		for _, line := range lines {
+			if len(line) == 0 {
+				continue
+			}
+			if strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---") {
+				continue
+			}
+			if line[0] == '+' {
+				fp.addedLines = append(fp.addedLines, strings.TrimSpace(line[1:]))
+			} else if line[0] == '-' {
+				fp.removedLines = append(fp.removedLines, strings.TrimSpace(line[1:]))
+			}
+		}
+		files = append(files, fp)
+	}
+	return files
+}
+
+func diffLinesSets(bp, main filePatch) (onlyBP, onlyMain []string) {
+	bpAdded := toSet(bp.addedLines)
+	mainAdded := toSet(main.addedLines)
+	bpRemoved := toSet(bp.removedLines)
+	mainRemoved := toSet(main.removedLines)
+
+	for line := range bpAdded {
+		if !mainAdded[line] {
+			onlyBP = append(onlyBP, "+ "+line)
+		}
+	}
+	for line := range bpRemoved {
+		if !mainRemoved[line] {
+			onlyBP = append(onlyBP, "- "+line)
+		}
+	}
+	for line := range mainAdded {
+		if !bpAdded[line] {
+			onlyMain = append(onlyMain, "+ "+line)
+		}
+	}
+	for line := range mainRemoved {
+		if !bpRemoved[line] {
+			onlyMain = append(onlyMain, "- "+line)
+		}
+	}
+
+	sort.Strings(onlyBP)
+	sort.Strings(onlyMain)
+	return onlyBP, onlyMain
+}
+
+func toSet(lines []string) map[string]bool {
+	s := make(map[string]bool, len(lines))
+	for _, l := range lines {
+		s[l] = true
+	}
+	return s
+}
+
+func printIndented(text string) {
+	for _, line := range strings.Split(text, "\n") {
+		fmt.Printf("    %s\n", line)
+	}
+}
+
+func cmdStderr(err error) string {
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return strings.TrimSpace(string(exitErr.Stderr))
+	}
+	return ""
+}

--- a/tools/verify-backport/verify-backport_githistory_test.go
+++ b/tools/verify-backport/verify-backport_githistory_test.go
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// These tests use real commits from this repository's git history.
+// They require git to be available and the test to run inside the repo.
+// Commit hashes are pinned to known-good commits that will not change.
+
+const (
+	// A small Makefile-only commit (1 file, 1 line changed)
+	commitMakefileHash    = "cbb2ea559ef9e54ae4815dc21359ec35a1619d15"
+	commitMakefileSubj    = "makefile: add version to golangci-lint make target"
+	commitMakefilePatchID = "68e81d5626f5809a643dbe8ef9e3b4a186119f75"
+
+	// A small Dockerfile-only commit (1 file, 1 line changed)
+	commitDockerfileHash    = "ff92eec65d2fc7c03177e288a5e57d8133894220"
+	commitDockerfilePatchID = "505adf50d61d342228109401150afbf55aa3ad55"
+
+	// A cherry-picked commit on release-4.18 whose patch-id differs from main
+	commitCherryPickHash    = "1c1afa7512e2da2c67953ff776cf49f7714cb6ac"
+	commitCherryPickPatchID = "d287db5c017f16c2429e096c1e19e646d678a460"
+
+	// The original commit on main that the above was cherry-picked from
+	commitOriginalHash    = "6a56840544a420c1393c39fc61e3580f563c1d1f"
+	commitOriginalPatchID = "26ad3aeee5defc95bafba21335baf2a97e771c6d"
+)
+
+func skipIfNoGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	if err := cmd.Run(); err != nil {
+		t.Skip("not inside a git repository")
+	}
+}
+
+func commitExists(hash string) bool {
+	cmd := exec.Command("git", "cat-file", "-t", hash)
+	return cmd.Run() == nil
+}
+
+func TestParsePatchFilesFromGitHistory(t *testing.T) {
+	skipIfNoGit(t)
+	if !commitExists(commitMakefileHash) {
+		t.Skipf("commit %s not found in local history", commitMakefileHash)
+	}
+
+	t.Run("makefile commit has one file", func(t *testing.T) {
+		patch, err := getCommitPatch(commitMakefileHash)
+		if err != nil {
+			t.Fatalf("getCommitPatch: %v", err)
+		}
+
+		files := parsePatchFiles(patch)
+
+		if len(files) != 1 {
+			t.Fatalf("expected 1 file, got %d", len(files))
+		}
+		if files[0].path != "Makefile" {
+			t.Errorf("path = %q, want %q", files[0].path, "Makefile")
+		}
+		if len(files[0].addedLines) != 1 {
+			t.Errorf("expected 1 added line, got %d", len(files[0].addedLines))
+		}
+		if len(files[0].removedLines) != 1 {
+			t.Errorf("expected 1 removed line, got %d", len(files[0].removedLines))
+		}
+	})
+
+	t.Run("dockerfile commit has one file", func(t *testing.T) {
+		if !commitExists(commitDockerfileHash) {
+			t.Skipf("commit %s not found in local history", commitDockerfileHash)
+		}
+
+		patch, err := getCommitPatch(commitDockerfileHash)
+		if err != nil {
+			t.Fatalf("getCommitPatch: %v", err)
+		}
+
+		files := parsePatchFiles(patch)
+
+		if len(files) != 1 {
+			t.Fatalf("expected 1 file, got %d", len(files))
+		}
+		if files[0].path != "Dockerfile" {
+			t.Errorf("path = %q, want %q", files[0].path, "Dockerfile")
+		}
+	})
+}
+
+func TestDiffLinesSetsFromGitHistory(t *testing.T) {
+	skipIfNoGit(t)
+	if !commitExists(commitMakefileHash) || !commitExists(commitDockerfileHash) {
+		t.Skip("required commits not found in local history")
+	}
+
+	t.Run("same commit against itself has no diffs", func(t *testing.T) {
+		patch, err := getCommitPatch(commitMakefileHash)
+		if err != nil {
+			t.Fatalf("getCommitPatch: %v", err)
+		}
+
+		files := parsePatchFiles(patch)
+		if len(files) == 0 {
+			t.Fatal("no files in patch")
+		}
+
+		onlyBP, onlyMain := diffLinesSets(files[0], files[0])
+		if len(onlyBP) != 0 || len(onlyMain) != 0 {
+			t.Errorf("same file diffed against itself should have no diffs, got onlyBP=%v onlyMain=%v", onlyBP, onlyMain)
+		}
+	})
+
+	t.Run("different commits have diffs", func(t *testing.T) {
+		makefilePatch, err := getCommitPatch(commitMakefileHash)
+		if err != nil {
+			t.Fatalf("getCommitPatch(makefile): %v", err)
+		}
+		dockerfilePatch, err := getCommitPatch(commitDockerfileHash)
+		if err != nil {
+			t.Fatalf("getCommitPatch(dockerfile): %v", err)
+		}
+
+		makefileFiles := parsePatchFiles(makefilePatch)
+		dockerfileFiles := parsePatchFiles(dockerfilePatch)
+		if len(makefileFiles) == 0 || len(dockerfileFiles) == 0 {
+			t.Fatal("no files in one of the patches")
+		}
+
+		onlyBP, onlyMain := diffLinesSets(makefileFiles[0], dockerfileFiles[0])
+		if len(onlyBP) == 0 && len(onlyMain) == 0 {
+			t.Errorf("different commits should produce diffs")
+		}
+	})
+}
+
+func TestMatchCommitsFromGitHistory(t *testing.T) {
+	skipIfNoGit(t)
+
+	t.Run("same commit matches itself", func(t *testing.T) {
+		if !commitExists(commitMakefileHash) {
+			t.Skipf("commit %s not found", commitMakefileHash)
+		}
+
+		msg := getCommitMessage(t, commitMakefileHash)
+		ci := CommitInfo{Hash: commitMakefileHash, PatchID: commitMakefilePatchID, Message: msg}
+
+		results, unmatched := matchCommits([]CommitInfo{ci}, []CommitInfo{ci})
+
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+		if results[0].Status != StatusMatch {
+			t.Errorf("status = %v, want StatusMatch", results[0].Status)
+		}
+		if len(unmatched) != 0 {
+			t.Errorf("expected 0 unmatched, got %d", len(unmatched))
+		}
+	})
+
+	t.Run("cherry-pick with diverged patch-id is unmatched", func(t *testing.T) {
+		if !commitExists(commitCherryPickHash) || !commitExists(commitOriginalHash) {
+			t.Skip("cherry-pick or original commit not found in local history")
+		}
+
+		cpMsg := getCommitMessage(t, commitCherryPickHash)
+		origMsg := getCommitMessage(t, commitOriginalHash)
+
+		bp := []CommitInfo{{Hash: commitCherryPickHash, PatchID: commitCherryPickPatchID, Message: cpMsg}}
+		main := []CommitInfo{{Hash: commitOriginalHash, PatchID: commitOriginalPatchID, Message: origMsg}}
+
+		results, _ := matchCommits(bp, main)
+
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+		if results[0].Status != StatusUnmatched {
+			t.Errorf("status = %v, want StatusUnmatched (different patch-ids)", results[0].Status)
+		}
+		if results[0].ClosestMatch == nil {
+			t.Errorf("ClosestMatch should be set via subject fallback (same subject)")
+		}
+	})
+
+	t.Run("two commits with distinct patch-ids produce correct unmatched main", func(t *testing.T) {
+		if !commitExists(commitMakefileHash) || !commitExists(commitDockerfileHash) {
+			t.Skip("required commits not found")
+		}
+
+		makefileMsg := getCommitMessage(t, commitMakefileHash)
+		dockerfileMsg := getCommitMessage(t, commitDockerfileHash)
+
+		bp := []CommitInfo{
+			{Hash: commitMakefileHash, PatchID: commitMakefilePatchID, Message: makefileMsg},
+		}
+		main := []CommitInfo{
+			{Hash: commitMakefileHash, PatchID: commitMakefilePatchID, Message: makefileMsg},
+			{Hash: commitDockerfileHash, PatchID: commitDockerfilePatchID, Message: dockerfileMsg},
+		}
+
+		results, unmatched := matchCommits(bp, main)
+
+		if len(results) != 1 || results[0].Status != StatusMatch {
+			t.Errorf("expected 1 MATCH result, got %v", results)
+		}
+		if len(unmatched) != 1 || unmatched[0].Hash != commitDockerfileHash {
+			t.Errorf("expected dockerfile commit as unmatched main, got %v", unmatched)
+		}
+	})
+}
+
+func TestGetCommitsFromRangeFromGitHistory(t *testing.T) {
+	skipIfNoGit(t)
+	if !commitExists(commitMakefileHash) {
+		t.Skipf("commit %s not found", commitMakefileHash)
+	}
+
+	t.Run("single commit range", func(t *testing.T) {
+		gitRange := commitMakefileHash + "~1.." + commitMakefileHash
+
+		commits, err := getCommitsFromRange(gitRange)
+		if err != nil {
+			t.Fatalf("getCommitsFromRange: %v", err)
+		}
+
+		if len(commits) != 1 {
+			t.Fatalf("expected 1 commit, got %d", len(commits))
+		}
+		if commits[0].Hash != commitMakefileHash {
+			t.Errorf("hash = %q, want %q", commits[0].Hash, commitMakefileHash)
+		}
+		if commits[0].PatchID != commitMakefilePatchID {
+			t.Errorf("patch-id = %q, want %q", commits[0].PatchID, commitMakefilePatchID)
+		}
+		if !strings.HasPrefix(commits[0].Message, commitMakefileSubj) {
+			t.Errorf("message should start with %q, got %q", commitMakefileSubj, commits[0].Subject())
+		}
+	})
+}
+
+func TestComparePatchesFromGitHistory(t *testing.T) {
+	skipIfNoGit(t)
+
+	t.Run("same commit patch against itself is all identical", func(t *testing.T) {
+		if !commitExists(commitMakefileHash) {
+			t.Skipf("commit %s not found", commitMakefileHash)
+		}
+
+		patch, err := getCommitPatch(commitMakefileHash)
+		if err != nil {
+			t.Fatalf("getCommitPatch: %v", err)
+		}
+
+		pc := comparePatches(patch, patch)
+
+		if pc.err != nil {
+			t.Fatalf("unexpected error: %v", pc.err)
+		}
+		if len(pc.identical) == 0 {
+			t.Errorf("expected at least 1 identical file")
+		}
+		if len(pc.edits)+len(pc.additive)+len(pc.moved) != 0 {
+			t.Errorf("expected no edits/additive/moved, got edits=%d additive=%d moved=%d",
+				len(pc.edits), len(pc.additive), len(pc.moved))
+		}
+	})
+
+	t.Run("different commits produce edits or moved", func(t *testing.T) {
+		if !commitExists(commitMakefileHash) || !commitExists(commitDockerfileHash) {
+			t.Skip("required commits not found")
+		}
+
+		bpPatch, err := getCommitPatch(commitMakefileHash)
+		if err != nil {
+			t.Fatalf("getCommitPatch(makefile): %v", err)
+		}
+		mainPatch, err := getCommitPatch(commitDockerfileHash)
+		if err != nil {
+			t.Fatalf("getCommitPatch(dockerfile): %v", err)
+		}
+
+		pc := comparePatches(bpPatch, mainPatch)
+
+		if pc.err != nil {
+			t.Fatalf("unexpected error: %v", pc.err)
+		}
+		if len(pc.identical) != 0 {
+			t.Errorf("different files should not be identical, got %d", len(pc.identical))
+		}
+		totalClassified := len(pc.edits) + len(pc.moved) + len(pc.additive)
+		if totalClassified == 0 {
+			t.Errorf("expected at least 1 classified file difference")
+		}
+	})
+
+	t.Run("cherry-pick vs original produces diffs", func(t *testing.T) {
+		if !commitExists(commitCherryPickHash) || !commitExists(commitOriginalHash) {
+			t.Skip("cherry-pick or original commit not found")
+		}
+
+		bpPatch, err := getCommitPatch(commitCherryPickHash)
+		if err != nil {
+			t.Fatalf("getCommitPatch(cherry-pick): %v", err)
+		}
+		mainPatch, err := getCommitPatch(commitOriginalHash)
+		if err != nil {
+			t.Fatalf("getCommitPatch(original): %v", err)
+		}
+
+		pc := comparePatches(bpPatch, mainPatch)
+
+		if pc.err != nil {
+			t.Fatalf("unexpected error: %v", pc.err)
+		}
+		totalFiles := len(pc.identical) + len(pc.edits) + len(pc.additive) + len(pc.moved)
+		if totalFiles == 0 {
+			t.Errorf("expected at least 1 file in comparison")
+		}
+	})
+}
+
+func getCommitMessage(t *testing.T, hash string) string {
+	t.Helper()
+	cmd := exec.Command("git", "log", "--format=%B", "-1", hash)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git log for %s: %v", hash, err)
+	}
+	return string(out)
+}

--- a/tools/verify-backport/verify-backport_json_test.go
+++ b/tools/verify-backport/verify-backport_json_test.go
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func TestBuildJSONReportGolden(t *testing.T) {
+	tests := []struct {
+		name          string
+		results       []MatchResult
+		unmatchedMain []CommitInfo
+		opts          ReportOptions
+		goldenFile    string
+	}{
+		{
+			name: "all matched",
+			results: []MatchResult{
+				{
+					Backport:  CommitInfo{Hash: "aaa1111", Message: "fix: alpha\n\nSigned-off-by: dev"},
+					MainMatch: &CommitInfo{Hash: "bbb2222", Message: "fix: alpha\n\nSigned-off-by: dev"},
+					Status:    StatusMatch,
+				},
+				{
+					Backport:  CommitInfo{Hash: "ccc3333", Message: "fix: beta"},
+					MainMatch: &CommitInfo{Hash: "ddd4444", Message: "fix: beta"},
+					Status:    StatusMatch,
+				},
+			},
+			opts:       ReportOptions{},
+			goldenFile: "json_all_matched.golden.json",
+		},
+		{
+			name: "mismatch message",
+			results: []MatchResult{
+				{
+					Backport:  CommitInfo{Hash: "aaa1111", Message: "fix: alpha (backport note)"},
+					MainMatch: &CommitInfo{Hash: "bbb2222", Message: "fix: alpha"},
+					Status:    StatusMismatchMessage,
+				},
+			},
+			opts:       ReportOptions{},
+			goldenFile: "json_mismatch_message.golden.json",
+		},
+		{
+			name: "unmatched no closest",
+			results: []MatchResult{
+				{
+					Backport: CommitInfo{Hash: "aaa1111", Message: "fix: orphan"},
+					Status:   StatusUnmatched,
+				},
+			},
+			opts:       ReportOptions{},
+			goldenFile: "json_unmatched_no_closest.golden.json",
+		},
+		{
+			name: "missing backports",
+			results: []MatchResult{
+				{
+					Backport:  CommitInfo{Hash: "aaa1111", Message: "fix: alpha"},
+					MainMatch: &CommitInfo{Hash: "bbb2222", Message: "fix: alpha"},
+					Status:    StatusMatch,
+				},
+			},
+			unmatchedMain: []CommitInfo{
+				{Hash: "eee5555", Message: "fix: missing thing\n\nDetails"},
+				{Hash: "fff6666", Message: "fix: another missing"},
+			},
+			opts:       ReportOptions{CheckMissing: true},
+			goldenFile: "json_missing_backports.golden.json",
+		},
+		{
+			name: "missing backports not reported without flag",
+			results: []MatchResult{
+				{
+					Backport:  CommitInfo{Hash: "aaa1111", Message: "fix: alpha"},
+					MainMatch: &CommitInfo{Hash: "bbb2222", Message: "fix: alpha"},
+					Status:    StatusMatch,
+				},
+			},
+			unmatchedMain: []CommitInfo{
+				{Hash: "eee5555", Message: "fix: missing thing"},
+			},
+			opts:       ReportOptions{CheckMissing: false},
+			goldenFile: "json_missing_not_reported.golden.json",
+		},
+		{
+			name: "mixed statuses",
+			results: []MatchResult{
+				{
+					Backport:  CommitInfo{Hash: "aaa1111", Message: "fix: alpha"},
+					MainMatch: &CommitInfo{Hash: "bbb2222", Message: "fix: alpha"},
+					Status:    StatusMatch,
+				},
+				{
+					Backport:  CommitInfo{Hash: "ccc3333", Message: "fix: beta (reworded)"},
+					MainMatch: &CommitInfo{Hash: "ddd4444", Message: "fix: beta"},
+					Status:    StatusMismatchMessage,
+				},
+				{
+					Backport: CommitInfo{Hash: "eee5555", Message: "fix: gamma"},
+					Status:   StatusUnmatched,
+				},
+			},
+			opts:       ReportOptions{},
+			goldenFile: "json_mixed_statuses.golden.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := buildJSONReport(tt.results, tt.unmatchedMain, tt.opts)
+
+			got, err := json.MarshalIndent(report, "", "  ")
+			if err != nil {
+				t.Fatalf("json.MarshalIndent: %v", err)
+			}
+			got = append(got, '\n')
+
+			goldenPath := filepath.Join("testdata", tt.goldenFile)
+
+			if *update {
+				if err := os.WriteFile(goldenPath, got, 0644); err != nil {
+					t.Fatalf("writing golden file: %v", err)
+				}
+				t.Logf("updated %s", goldenPath)
+				return
+			}
+
+			want, err := os.ReadFile(goldenPath)
+			if err != nil {
+				t.Fatalf("reading golden file %s: %v (run with -update to create)", goldenPath, err)
+			}
+
+			if string(got) != string(want) {
+				t.Errorf("JSON output mismatch (run with -update to refresh)\ngot:\n%s\nwant:\n%s", got, want)
+			}
+		})
+	}
+}
+
+func TestBuildJSONReportGoldenFromGitHistory(t *testing.T) {
+	skipIfNoGit(t)
+
+	t.Run("matched commits from real history", func(t *testing.T) {
+		if !commitExists(commitMakefileHash) || !commitExists(commitDockerfileHash) {
+			t.Skip("required commits not found")
+		}
+
+		makefileMsg := getCommitMessage(t, commitMakefileHash)
+		dockerfileMsg := getCommitMessage(t, commitDockerfileHash)
+
+		results := []MatchResult{
+			{
+				Backport:  CommitInfo{Hash: commitMakefileHash, PatchID: commitMakefilePatchID, Message: makefileMsg},
+				MainMatch: &CommitInfo{Hash: commitMakefileHash, PatchID: commitMakefilePatchID, Message: makefileMsg},
+				Status:    StatusMatch,
+			},
+			{
+				Backport:  CommitInfo{Hash: commitDockerfileHash, PatchID: commitDockerfilePatchID, Message: dockerfileMsg},
+				MainMatch: &CommitInfo{Hash: commitDockerfileHash, PatchID: commitDockerfilePatchID, Message: dockerfileMsg},
+				Status:    StatusMatch,
+			},
+		}
+
+		report := buildJSONReport(results, nil, ReportOptions{})
+
+		got, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			t.Fatalf("json.MarshalIndent: %v", err)
+		}
+		got = append(got, '\n')
+
+		goldenPath := filepath.Join("testdata", "json_githistory_matched.golden.json")
+
+		if *update {
+			if err := os.WriteFile(goldenPath, got, 0644); err != nil {
+				t.Fatalf("writing golden file: %v", err)
+			}
+			t.Logf("updated %s", goldenPath)
+			return
+		}
+
+		want, err := os.ReadFile(goldenPath)
+		if err != nil {
+			t.Fatalf("reading golden file %s: %v (run with -update to create)", goldenPath, err)
+		}
+
+		if string(got) != string(want) {
+			t.Errorf("JSON output mismatch (run with -update to refresh)\ngot:\n%s\nwant:\n%s", got, want)
+		}
+	})
+
+	t.Run("cherry-pick unmatched with closest match", func(t *testing.T) {
+		if !commitExists(commitCherryPickHash) || !commitExists(commitOriginalHash) {
+			t.Skip("cherry-pick or original commit not found")
+		}
+
+		cpMsg := getCommitMessage(t, commitCherryPickHash)
+		origMsg := getCommitMessage(t, commitOriginalHash)
+
+		results := []MatchResult{
+			{
+				Backport:     CommitInfo{Hash: commitCherryPickHash, PatchID: commitCherryPickPatchID, Message: cpMsg},
+				ClosestMatch: &CommitInfo{Hash: commitOriginalHash, PatchID: commitOriginalPatchID, Message: origMsg},
+				Status:       StatusUnmatched,
+			},
+		}
+
+		report := buildJSONReport(results, nil, ReportOptions{})
+
+		got, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			t.Fatalf("json.MarshalIndent: %v", err)
+		}
+		got = append(got, '\n')
+
+		goldenPath := filepath.Join("testdata", "json_githistory_unmatched_closest.golden.json")
+
+		if *update {
+			if err := os.WriteFile(goldenPath, got, 0644); err != nil {
+				t.Fatalf("writing golden file: %v", err)
+			}
+			t.Logf("updated %s", goldenPath)
+			return
+		}
+
+		want, err := os.ReadFile(goldenPath)
+		if err != nil {
+			t.Fatalf("reading golden file %s: %v (run with -update to create)", goldenPath, err)
+		}
+
+		if string(got) != string(want) {
+			t.Errorf("JSON output mismatch (run with -update to refresh)\ngot:\n%s\nwant:\n%s", got, want)
+		}
+	})
+}

--- a/tools/verify-backport/verify-backport_test.go
+++ b/tools/verify-backport/verify-backport_test.go
@@ -1,0 +1,826 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestCommitInfoShortHash(t *testing.T) {
+	tests := []struct {
+		name string
+		hash string
+		want string
+	}{
+		{name: "normal", hash: "abc1234def5678", want: "abc1234"},
+		{name: "exactly seven", hash: "abc1234", want: "abc1234"},
+		{name: "shorter than seven", hash: "abc", want: "abc"},
+		{name: "empty", hash: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ci := CommitInfo{Hash: tt.hash}
+			if got := ci.ShortHash(); got != tt.want {
+				t.Errorf("ShortHash() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommitInfoSubject(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		want    string
+	}{
+		{name: "single line", message: "fix: thing", want: "fix: thing"},
+		{name: "multi line", message: "fix: thing\n\nLong description here", want: "fix: thing"},
+		{name: "empty", message: "", want: ""},
+		{name: "newline only", message: "\n", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ci := CommitInfo{Message: tt.message}
+			if got := ci.Subject(); got != tt.want {
+				t.Errorf("Subject() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want string
+	}{
+		{name: "clean", msg: "hello\nworld", want: "hello\nworld"},
+		{name: "trailing spaces", msg: "hello   \nworld\t\t", want: "hello\nworld"},
+		{name: "trailing newlines", msg: "hello\nworld\n\n\n", want: "hello\nworld"},
+		{name: "both", msg: "hello   \nworld  \n\n", want: "hello\nworld"},
+		{name: "empty", msg: "", want: ""},
+		{name: "only whitespace", msg: "   \n\t\n\n", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeMessage(tt.msg); got != tt.want {
+				t.Errorf("normalizeMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    Options
+		wantErr bool
+	}{
+		{
+			name:    "valid branch mode",
+			opts:    Options{BackportBranch: "pr-1234", BaseBranch: "release-4.18"},
+			wantErr: false,
+		},
+		{
+			name:    "valid range mode",
+			opts:    Options{BackportRange: "a..b", MainRange: "c..d"},
+			wantErr: false,
+		},
+		{
+			name:    "neither branch nor range",
+			opts:    Options{},
+			wantErr: true,
+		},
+		{
+			name:    "both branch and range",
+			opts:    Options{BackportBranch: "pr-1234", BackportRange: "a..b"},
+			wantErr: true,
+		},
+		{
+			name:    "branch without base",
+			opts:    Options{BackportBranch: "pr-1234"},
+			wantErr: true,
+		},
+		{
+			name:    "range without main-range",
+			opts:    Options{BackportRange: "a..b"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOptions(tt.opts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateOptions() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMatchCommits(t *testing.T) {
+	t.Run("patch-id match with identical messages", func(t *testing.T) {
+		bp := []CommitInfo{{Hash: "aaa", PatchID: "p1", Message: "fix: thing"}}
+		main := []CommitInfo{{Hash: "bbb", PatchID: "p1", Message: "fix: thing"}}
+
+		results, unmatched := matchCommits(bp, main)
+
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+		if results[0].Status != StatusMatch {
+			t.Errorf("status = %v, want StatusMatch", results[0].Status)
+		}
+		if results[0].MainMatch == nil || results[0].MainMatch.Hash != "bbb" {
+			t.Errorf("MainMatch not set correctly")
+		}
+		if len(unmatched) != 0 {
+			t.Errorf("expected 0 unmatched main, got %d", len(unmatched))
+		}
+	})
+
+	t.Run("patch-id match with backport adding notes", func(t *testing.T) {
+		bp := []CommitInfo{{Hash: "aaa", PatchID: "p1", Message: "fix: thing\n\nBackport note\nfix: thing"}}
+		main := []CommitInfo{{Hash: "bbb", PatchID: "p1", Message: "fix: thing"}}
+
+		results, _ := matchCommits(bp, main)
+
+		if results[0].Status != StatusMatch {
+			t.Errorf("status = %v, want StatusMatch (message containment)", results[0].Status)
+		}
+	})
+
+	t.Run("patch-id match with diverged messages", func(t *testing.T) {
+		bp := []CommitInfo{{Hash: "aaa", PatchID: "p1", Message: "completely different message"}}
+		main := []CommitInfo{{Hash: "bbb", PatchID: "p1", Message: "original message"}}
+
+		results, _ := matchCommits(bp, main)
+
+		if results[0].Status != StatusMismatchMessage {
+			t.Errorf("status = %v, want StatusMismatchMessage", results[0].Status)
+		}
+	})
+
+	t.Run("no patch-id match with subject fallback", func(t *testing.T) {
+		bp := []CommitInfo{{Hash: "aaa", PatchID: "p1", Message: "fix: thing"}}
+		main := []CommitInfo{{Hash: "bbb", PatchID: "p2", Message: "fix: thing"}}
+
+		results, unmatched := matchCommits(bp, main)
+
+		if results[0].Status != StatusUnmatched {
+			t.Errorf("status = %v, want StatusUnmatched", results[0].Status)
+		}
+		if results[0].ClosestMatch == nil || results[0].ClosestMatch.Hash != "bbb" {
+			t.Errorf("ClosestMatch not set via subject fallback")
+		}
+		if len(unmatched) != 1 {
+			t.Errorf("expected 1 unmatched main, got %d", len(unmatched))
+		}
+	})
+
+	t.Run("no match at all", func(t *testing.T) {
+		bp := []CommitInfo{{Hash: "aaa", PatchID: "p1", Message: "fix: alpha"}}
+		main := []CommitInfo{{Hash: "bbb", PatchID: "p2", Message: "fix: beta"}}
+
+		results, _ := matchCommits(bp, main)
+
+		if results[0].Status != StatusUnmatched {
+			t.Errorf("status = %v, want StatusUnmatched", results[0].Status)
+		}
+		if results[0].ClosestMatch != nil {
+			t.Errorf("ClosestMatch should be nil when no subject match")
+		}
+	})
+
+	t.Run("empty patch-id on backport", func(t *testing.T) {
+		bp := []CommitInfo{{Hash: "aaa", PatchID: "", Message: "fix: thing"}}
+		main := []CommitInfo{{Hash: "bbb", PatchID: "p1", Message: "fix: thing"}}
+
+		results, _ := matchCommits(bp, main)
+
+		if results[0].Status != StatusUnmatched {
+			t.Errorf("status = %v, want StatusUnmatched for empty patch-id", results[0].Status)
+		}
+		if results[0].ClosestMatch == nil {
+			t.Errorf("should still find closest match by subject")
+		}
+	})
+
+	t.Run("multiple commits mixed statuses", func(t *testing.T) {
+		bp := []CommitInfo{
+			{Hash: "a1", PatchID: "p1", Message: "fix: alpha"},
+			{Hash: "a2", PatchID: "p2", Message: "fix: beta"},
+			{Hash: "a3", PatchID: "p3", Message: "fix: gamma"},
+		}
+		main := []CommitInfo{
+			{Hash: "b1", PatchID: "p1", Message: "fix: alpha"},
+			{Hash: "b2", PatchID: "p2", Message: "different message"},
+			{Hash: "b4", PatchID: "p4", Message: "fix: delta"},
+		}
+
+		results, unmatched := matchCommits(bp, main)
+
+		if len(results) != 3 {
+			t.Fatalf("expected 3 results, got %d", len(results))
+		}
+		if results[0].Status != StatusMatch {
+			t.Errorf("result[0] status = %v, want StatusMatch", results[0].Status)
+		}
+		if results[1].Status != StatusMismatchMessage {
+			t.Errorf("result[1] status = %v, want StatusMismatchMessage", results[1].Status)
+		}
+		if results[2].Status != StatusUnmatched {
+			t.Errorf("result[2] status = %v, want StatusUnmatched", results[2].Status)
+		}
+		if len(unmatched) != 1 || unmatched[0].Hash != "b4" {
+			t.Errorf("expected 1 unmatched main (b4), got %v", unmatched)
+		}
+	})
+}
+
+func TestParsePatchFiles(t *testing.T) {
+	t.Run("single file with adds and removes", func(t *testing.T) {
+		patch := `commit abc1234
+Author: Test User <test@example.com>
+
+    fix: thing
+
+diff --git a/pkg/foo.go b/pkg/foo.go
+index 1234567..abcdefg 100644
+--- a/pkg/foo.go
++++ b/pkg/foo.go
+@@ -10,7 +10,7 @@ func Foo() {
+-	old := getValue()
++	new := getValue()
+ 	return result
+`
+		files := parsePatchFiles(patch)
+
+		if len(files) != 1 {
+			t.Fatalf("expected 1 file, got %d", len(files))
+		}
+		if files[0].path != "pkg/foo.go" {
+			t.Errorf("path = %q, want %q", files[0].path, "pkg/foo.go")
+		}
+		if len(files[0].addedLines) != 1 || files[0].addedLines[0] != "new := getValue()" {
+			t.Errorf("addedLines = %v, want [\"new := getValue()\"]", files[0].addedLines)
+		}
+		if len(files[0].removedLines) != 1 || files[0].removedLines[0] != "old := getValue()" {
+			t.Errorf("removedLines = %v, want [\"old := getValue()\"]", files[0].removedLines)
+		}
+	})
+
+	t.Run("multi-file patch", func(t *testing.T) {
+		patch := `diff --git a/file1.go b/file1.go
+index 1111111..2222222 100644
+--- a/file1.go
++++ b/file1.go
+@@ -1,3 +1,3 @@
++added line in file1
+diff --git a/pkg/file2.go b/pkg/file2.go
+index 3333333..4444444 100644
+--- a/pkg/file2.go
++++ b/pkg/file2.go
+@@ -5,3 +5,4 @@
++added line in file2
+-removed line in file2
+`
+		files := parsePatchFiles(patch)
+
+		if len(files) != 2 {
+			t.Fatalf("expected 2 files, got %d", len(files))
+		}
+		if files[0].path != "file1.go" {
+			t.Errorf("file[0].path = %q, want %q", files[0].path, "file1.go")
+		}
+		if files[1].path != "pkg/file2.go" {
+			t.Errorf("file[1].path = %q, want %q", files[1].path, "pkg/file2.go")
+		}
+		if len(files[1].addedLines) != 1 {
+			t.Errorf("file[1] should have 1 added line, got %d", len(files[1].addedLines))
+		}
+		if len(files[1].removedLines) != 1 {
+			t.Errorf("file[1] should have 1 removed line, got %d", len(files[1].removedLines))
+		}
+	})
+
+	t.Run("skips +++ and --- headers", func(t *testing.T) {
+		patch := `diff --git a/foo.go b/foo.go
+--- a/foo.go
++++ b/foo.go
+@@ -1,3 +1,3 @@
++real addition
+`
+		files := parsePatchFiles(patch)
+
+		if len(files) != 1 {
+			t.Fatalf("expected 1 file, got %d", len(files))
+		}
+		if len(files[0].addedLines) != 1 {
+			t.Errorf("should have 1 added line (not count +++ header), got %d", len(files[0].addedLines))
+		}
+	})
+
+	t.Run("whitespace trimming", func(t *testing.T) {
+		patch := `diff --git a/foo.go b/foo.go
+--- a/foo.go
++++ b/foo.go
+@@ -1,3 +1,3 @@
++	indented := true
+-	old := false
+`
+		files := parsePatchFiles(patch)
+
+		if len(files) != 1 {
+			t.Fatalf("expected 1 file, got %d", len(files))
+		}
+		if files[0].addedLines[0] != "indented := true" {
+			t.Errorf("added line not trimmed: %q", files[0].addedLines[0])
+		}
+		if files[0].removedLines[0] != "old := false" {
+			t.Errorf("removed line not trimmed: %q", files[0].removedLines[0])
+		}
+	})
+
+	t.Run("empty patch", func(t *testing.T) {
+		files := parsePatchFiles("")
+		if len(files) != 0 {
+			t.Errorf("expected 0 files from empty patch, got %d", len(files))
+		}
+	})
+
+	t.Run("new file patch", func(t *testing.T) {
+		patch := `diff --git a/newfile.go b/newfile.go
+new file mode 100644
+index 0000000..1234567
+--- /dev/null
++++ b/newfile.go
+@@ -0,0 +1,3 @@
++package main
++
++func New() {}
+`
+		files := parsePatchFiles(patch)
+
+		if len(files) != 1 {
+			t.Fatalf("expected 1 file, got %d", len(files))
+		}
+		if files[0].path != "newfile.go" {
+			t.Errorf("path = %q, want %q", files[0].path, "newfile.go")
+		}
+		if len(files[0].addedLines) != 3 {
+			t.Errorf("expected 3 added lines (blank line becomes empty string), got %d: %v", len(files[0].addedLines), files[0].addedLines)
+		}
+	})
+}
+
+func TestDiffLinesSets(t *testing.T) {
+	t.Run("identical patches", func(t *testing.T) {
+		bp := filePatch{addedLines: []string{"a", "b"}, removedLines: []string{"c"}}
+		main := filePatch{addedLines: []string{"a", "b"}, removedLines: []string{"c"}}
+
+		onlyBP, onlyMain := diffLinesSets(bp, main)
+
+		if len(onlyBP) != 0 {
+			t.Errorf("expected empty onlyBP, got %v", onlyBP)
+		}
+		if len(onlyMain) != 0 {
+			t.Errorf("expected empty onlyMain, got %v", onlyMain)
+		}
+	})
+
+	t.Run("added lines only in bp", func(t *testing.T) {
+		bp := filePatch{addedLines: []string{"a", "b", "c"}}
+		main := filePatch{addedLines: []string{"a"}}
+
+		onlyBP, onlyMain := diffLinesSets(bp, main)
+
+		if len(onlyBP) != 2 {
+			t.Errorf("expected 2 onlyBP, got %v", onlyBP)
+		}
+		if len(onlyMain) != 0 {
+			t.Errorf("expected 0 onlyMain, got %v", onlyMain)
+		}
+	})
+
+	t.Run("removed lines only in main", func(t *testing.T) {
+		bp := filePatch{removedLines: []string{"x"}}
+		main := filePatch{removedLines: []string{"x", "y"}}
+
+		onlyBP, onlyMain := diffLinesSets(bp, main)
+
+		if len(onlyBP) != 0 {
+			t.Errorf("expected 0 onlyBP, got %v", onlyBP)
+		}
+		if len(onlyMain) != 1 {
+			t.Errorf("expected 1 onlyMain, got %v", onlyMain)
+		}
+	})
+
+	t.Run("results are sorted", func(t *testing.T) {
+		bp := filePatch{addedLines: []string{"z", "a", "m"}}
+		main := filePatch{addedLines: []string{}}
+
+		onlyBP, _ := diffLinesSets(bp, main)
+
+		if !sort.StringsAreSorted(onlyBP) {
+			t.Errorf("onlyBP not sorted: %v", onlyBP)
+		}
+	})
+
+	t.Run("mixed adds and removes", func(t *testing.T) {
+		bp := filePatch{
+			addedLines:   []string{"new1", "common"},
+			removedLines: []string{"old1", "oldcommon"},
+		}
+		main := filePatch{
+			addedLines:   []string{"new2", "common"},
+			removedLines: []string{"old2", "oldcommon"},
+		}
+
+		onlyBP, onlyMain := diffLinesSets(bp, main)
+
+		expectBP := []string{"+ new1", "- old1"}
+		expectMain := []string{"+ new2", "- old2"}
+		if !reflect.DeepEqual(onlyBP, expectBP) {
+			t.Errorf("onlyBP = %v, want %v", onlyBP, expectBP)
+		}
+		if !reflect.DeepEqual(onlyMain, expectMain) {
+			t.Errorf("onlyMain = %v, want %v", onlyMain, expectMain)
+		}
+	})
+}
+
+func TestIntersectionSize(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b map[string]bool
+		want int
+	}{
+		{name: "full overlap", a: map[string]bool{"x": true, "y": true}, b: map[string]bool{"x": true, "y": true}, want: 2},
+		{name: "partial overlap", a: map[string]bool{"x": true, "y": true}, b: map[string]bool{"y": true, "z": true}, want: 1},
+		{name: "no overlap", a: map[string]bool{"x": true}, b: map[string]bool{"y": true}, want: 0},
+		{name: "empty sets", a: map[string]bool{}, b: map[string]bool{}, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := intersectionSize(tt.a, tt.b); got != tt.want {
+				t.Errorf("intersectionSize() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToSet(t *testing.T) {
+	t.Run("deduplicates", func(t *testing.T) {
+		s := toSet([]string{"a", "b", "a"})
+		if len(s) != 2 {
+			t.Errorf("expected 2 entries, got %d", len(s))
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		s := toSet(nil)
+		if len(s) != 0 {
+			t.Errorf("expected 0 entries, got %d", len(s))
+		}
+	})
+}
+
+func TestFileResultLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		fr   fileResult
+		want string
+	}{
+		{
+			name: "identical",
+			fr:   fileResult{bpPath: "foo.go", changeType: changeIdentical},
+			want: "foo.go",
+		},
+		{
+			name: "identical renamed",
+			fr:   fileResult{bpPath: "new/foo.go", mainPath: "old/foo.go", relation: "RENAMED", changeType: changeIdentical},
+			want: "old/foo.go -> new/foo.go (renamed)",
+		},
+		{
+			name: "moved with overlap",
+			fr:   fileResult{bpPath: "new/foo.go", mainPath: "old/foo.go", relation: "RENAMED", changeType: changeMoved, overlap: 85},
+			want: "old/foo.go -> new/foo.go (85% overlap)",
+		},
+		{
+			name: "additive bp only",
+			fr:   fileResult{bpPath: "foo.go", changeType: changeAdditive, onlyBP: []string{"a", "b"}},
+			want: "foo.go (+2 only in backport)",
+		},
+		{
+			name: "additive main only",
+			fr:   fileResult{bpPath: "foo.go", changeType: changeAdditive, onlyMain: []string{"a"}},
+			want: "foo.go (+1 only in main)",
+		},
+		{
+			name: "edits both sides",
+			fr:   fileResult{bpPath: "foo.go", changeType: changeEdits, onlyBP: []string{"a"}, onlyMain: []string{"b", "c"}},
+			want: "foo.go (+1 only in backport, +2 only in main)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.fr.label(); got != tt.want {
+				t.Errorf("label() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchStatusString(t *testing.T) {
+	tests := []struct {
+		status MatchStatus
+		want   string
+	}{
+		{StatusMatch, "MATCH"},
+		{StatusMismatchMessage, "MISMATCH-MESSAGE"},
+		{StatusUnmatched, "UNMATCHED"},
+		{MatchStatus(99), "UNKNOWN"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.status.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestComparePatches(t *testing.T) {
+	t.Run("identical single-file patches", func(t *testing.T) {
+		patch := `diff --git a/pkg/foo.go b/pkg/foo.go
+--- a/pkg/foo.go
++++ b/pkg/foo.go
+@@ -1,3 +1,3 @@
+-old := getValue()
++new := getValue()
+`
+		pc := comparePatches(patch, patch)
+
+		if pc.err != nil {
+			t.Fatalf("unexpected error: %v", pc.err)
+		}
+		if len(pc.identical) != 1 {
+			t.Errorf("expected 1 identical, got %d", len(pc.identical))
+		}
+		if len(pc.additive) != 0 || len(pc.edits) != 0 || len(pc.moved) != 0 {
+			t.Errorf("expected no additive/edits/moved, got additive=%d edits=%d moved=%d",
+				len(pc.additive), len(pc.edits), len(pc.moved))
+		}
+	})
+
+	t.Run("additive: backport has extra lines", func(t *testing.T) {
+		bpPatch := `diff --git a/pkg/foo.go b/pkg/foo.go
+--- a/pkg/foo.go
++++ b/pkg/foo.go
+@@ -1,3 +1,5 @@
+-old := getValue()
++new := getValue()
++extra := true
+`
+		mainPatch := `diff --git a/pkg/foo.go b/pkg/foo.go
+--- a/pkg/foo.go
++++ b/pkg/foo.go
+@@ -1,3 +1,3 @@
+-old := getValue()
++new := getValue()
+`
+		pc := comparePatches(bpPatch, mainPatch)
+
+		if pc.err != nil {
+			t.Fatalf("unexpected error: %v", pc.err)
+		}
+		if len(pc.identical) != 0 {
+			t.Errorf("expected 0 identical, got %d", len(pc.identical))
+		}
+		if len(pc.additive) != 1 {
+			t.Errorf("expected 1 additive, got %d", len(pc.additive))
+		}
+	})
+
+	t.Run("edits: both sides differ", func(t *testing.T) {
+		bpPatch := `diff --git a/pkg/foo.go b/pkg/foo.go
+--- a/pkg/foo.go
++++ b/pkg/foo.go
+@@ -1,3 +1,3 @@
+-old := getValue()
++bp := getValue()
+`
+		mainPatch := `diff --git a/pkg/foo.go b/pkg/foo.go
+--- a/pkg/foo.go
++++ b/pkg/foo.go
+@@ -1,3 +1,3 @@
+-old := getValue()
++main := getValue()
+`
+		pc := comparePatches(bpPatch, mainPatch)
+
+		if pc.err != nil {
+			t.Fatalf("unexpected error: %v", pc.err)
+		}
+		if len(pc.edits) != 1 {
+			t.Errorf("expected 1 edits, got %d", len(pc.edits))
+		}
+		if len(pc.identical) != 0 || len(pc.additive) != 0 {
+			t.Errorf("expected no identical/additive, got identical=%d additive=%d",
+				len(pc.identical), len(pc.additive))
+		}
+	})
+
+	t.Run("file renamed with same content", func(t *testing.T) {
+		bpPatch := `diff --git a/new/foo.go b/new/foo.go
+--- a/new/foo.go
++++ b/new/foo.go
+@@ -1,3 +1,3 @@
+-old := getValue()
++new := getValue()
+`
+		mainPatch := `diff --git a/old/foo.go b/old/foo.go
+--- a/old/foo.go
++++ b/old/foo.go
+@@ -1,3 +1,3 @@
+-old := getValue()
++new := getValue()
+`
+		pc := comparePatches(bpPatch, mainPatch)
+
+		if pc.err != nil {
+			t.Fatalf("unexpected error: %v", pc.err)
+		}
+		if len(pc.identical) != 1 {
+			t.Errorf("expected 1 identical (renamed), got %d", len(pc.identical))
+		}
+		if pc.identical[0].relation != "RENAMED" {
+			t.Errorf("relation = %q, want RENAMED", pc.identical[0].relation)
+		}
+	})
+
+	t.Run("multi-file: mixed classification", func(t *testing.T) {
+		bpPatch := `diff --git a/common.go b/common.go
+--- a/common.go
++++ b/common.go
+@@ -1,3 +1,3 @@
+-old := 1
++new := 1
+diff --git a/changed.go b/changed.go
+--- a/changed.go
++++ b/changed.go
+@@ -1,3 +1,3 @@
+-x := 1
++bp_x := 1
+`
+		mainPatch := `diff --git a/common.go b/common.go
+--- a/common.go
++++ b/common.go
+@@ -1,3 +1,3 @@
+-old := 1
++new := 1
+diff --git a/changed.go b/changed.go
+--- a/changed.go
++++ b/changed.go
+@@ -1,3 +1,3 @@
+-x := 1
++main_x := 1
+`
+		pc := comparePatches(bpPatch, mainPatch)
+
+		if pc.err != nil {
+			t.Fatalf("unexpected error: %v", pc.err)
+		}
+		if len(pc.identical) != 1 {
+			t.Errorf("expected 1 identical (common.go), got %d", len(pc.identical))
+		}
+		if len(pc.edits) != 1 {
+			t.Errorf("expected 1 edits (changed.go), got %d", len(pc.edits))
+		}
+	})
+
+	t.Run("code movement detection", func(t *testing.T) {
+		bpPatch := `diff --git a/newfile.go b/newfile.go
+--- /dev/null
++++ b/newfile.go
+@@ -0,0 +1,5 @@
++func Foo() {}
++func Bar() {}
++func Baz() {}
++func Qux() {}
+`
+		mainPatch := `diff --git a/oldfile.go b/oldfile.go
+--- /dev/null
++++ b/oldfile.go
+@@ -0,0 +1,5 @@
++func Foo() {}
++func Bar() {}
++func Baz() {}
++func Qux() {}
+`
+		pc := comparePatches(bpPatch, mainPatch)
+
+		if pc.err != nil {
+			t.Fatalf("unexpected error: %v", pc.err)
+		}
+		if len(pc.moved) != 1 {
+			t.Errorf("expected 1 moved, got %d", len(pc.moved))
+		}
+		if len(pc.moved) == 1 && pc.moved[0].overlap != 100 {
+			t.Errorf("overlap = %d%%, want 100%%", pc.moved[0].overlap)
+		}
+	})
+
+	t.Run("code movement below threshold is edits", func(t *testing.T) {
+		bpPatch := `diff --git a/newfile.go b/newfile.go
+--- /dev/null
++++ b/newfile.go
+@@ -0,0 +1,5 @@
++func Foo() {}
++func Completely() {}
++func Different() {}
++func Code() {}
+`
+		mainPatch := `diff --git a/oldfile.go b/oldfile.go
+--- /dev/null
++++ b/oldfile.go
+@@ -0,0 +1,5 @@
++func Bar() {}
++func Totally() {}
++func Other() {}
++func Stuff() {}
+`
+		pc := comparePatches(bpPatch, mainPatch)
+
+		if pc.err != nil {
+			t.Fatalf("unexpected error: %v", pc.err)
+		}
+		if len(pc.moved) != 0 {
+			t.Errorf("expected 0 moved (below threshold), got %d", len(pc.moved))
+		}
+		if len(pc.edits) != 2 {
+			t.Errorf("expected 2 edits (one per unpaired file), got %d", len(pc.edits))
+		}
+	})
+
+	t.Run("file only in backport", func(t *testing.T) {
+		bpPatch := `diff --git a/common.go b/common.go
+--- a/common.go
++++ b/common.go
+@@ -1,3 +1,3 @@
+-old := 1
++new := 1
+diff --git a/extra.go b/extra.go
+--- /dev/null
++++ b/extra.go
+@@ -0,0 +1,2 @@
++package extra
+`
+		mainPatch := `diff --git a/common.go b/common.go
+--- a/common.go
++++ b/common.go
+@@ -1,3 +1,3 @@
+-old := 1
++new := 1
+`
+		pc := comparePatches(bpPatch, mainPatch)
+
+		if pc.err != nil {
+			t.Fatalf("unexpected error: %v", pc.err)
+		}
+		if len(pc.identical) != 1 {
+			t.Errorf("expected 1 identical, got %d", len(pc.identical))
+		}
+		if len(pc.edits) != 1 {
+			t.Errorf("expected 1 edits (extra.go only in bp), got %d", len(pc.edits))
+		}
+	})
+
+	t.Run("empty patches", func(t *testing.T) {
+		pc := comparePatches("", "")
+
+		if pc.err != nil {
+			t.Fatalf("unexpected error: %v", pc.err)
+		}
+		if len(pc.identical)+len(pc.moved)+len(pc.additive)+len(pc.edits) != 0 {
+			t.Errorf("expected all empty categories for empty patches")
+		}
+	})
+}
+
+func TestExtractAddRemove(t *testing.T) {
+	fp := filePatch{
+		addedLines:   []string{"new1", "new2"},
+		removedLines: []string{"old1"},
+	}
+
+	result := extractAddRemove(fp)
+
+	expected := []string{"+ new1", "+ new2", "- old1"}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("extractAddRemove() = %v, want %v", result, expected)
+	}
+}


### PR DESCRIPTION
Add an (AI-assisted) tool to help users verify a backport.
The tool scans all the commits in a backport branch,
summarize the changes, flags the language-agnostic mechanical changes
(e.g. file rename) and code movements, and helps prioritize
the review effort.

The tool intentionally builds on `git` tooling, acting
an orchestrator and custom-built porcelain layer.

The tool includes a LLM-optimized JSON output.
This can help LLM-driven review in the folling ways:
1. Reducing orchestration (single command vs multi-step git pipelines)
2. Returning pre-correlated commit relationships 
3. Providing stable machine-parseable output

Token savings are possible but scenario-dependent and are not guaranteed
for every run; benchmarking and measuring over time and multiple usages
are the only way to know for sure.

See the included README.md for the full details.