### PR TITLE
[manual] [release-4.18] OCPBUGS-84977: objectstate/rte: per-pool MachineConfig state with paused MCP awareness

### DIFF
--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 
@@ -247,7 +248,7 @@ func (r *NUMAResourcesOperatorReconciler) reconcileResourceAPI(ctx context.Conte
 func (r *NUMAResourcesOperatorReconciler) reconcileResourceMachineConfig(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, trees []nodegroupv1.Tree) intreconcile.Step {
 	// we need to sync machine configs first and wait for the MachineConfigPool updates
 	// before checking additional components for updates
-	waitByPool, err := r.syncMachineConfigs(ctx, instance, existing, trees)
+	waitByPool, _, err := r.syncMachineConfigs(ctx, instance, existing, trees)
 	if err != nil {
 		r.Recorder.Eventf(instance, corev1.EventTypeWarning, "FailedMCSync", "Failed to set up machine configuration for worker nodes: %v", err)
 		err = fmt.Errorf("failed to sync machine configs: %w", err)
@@ -305,7 +306,8 @@ func (r *NUMAResourcesOperatorReconciler) reconcileResource(ctx context.Context,
 	existing := rtestate.FromClient(ctx, r.Client, r.Platform, r.RTEManifests, instance, trees, r.Namespace)
 
 	if r.Platform == platform.OpenShift {
-		if step := r.reconcileResourceMachineConfig(ctx, instance, existing, trees); step.EarlyStop() {
+		step := r.reconcileResourceMachineConfig(ctx, instance, existing, trees)
+		if step.EarlyStop() {
 			updateStatusConditionsIfNeeded(instance, step.ConditionInfo)
 			return step
 		}
@@ -408,7 +410,7 @@ func (r *NUMAResourcesOperatorReconciler) syncNodeResourceTopologyAPI(ctx contex
 	return (updatedCount == len(objStates)), err
 }
 
-func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, trees []nodegroupv1.Tree) (map[string]rtestate.MCPWaitForUpdatedFunc, error) {
+func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, trees []nodegroupv1.Tree) (map[string]rtestate.MCPWaitForUpdatedFunc, sets.Set[string], error) {
 	klog.V(4).InfoS("Machine Config Sync start", "trees", len(trees))
 	defer klog.V(4).Info("Machine Config Sync stop")
 
@@ -418,11 +420,10 @@ func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context
 	// In case of operator upgrade from 4.1X → 4.18, it's necessary to remove the old MachineConfig,
 	// unless an emergency annotation is provided which forces the operator to use custom policy
 
-	mcObjStates := existing.MachineConfigsState(r.RTEManifests)
+	mcObjStates, pausedMCPNames := existing.MachineConfigsState(r.RTEManifests)
 	waitByPool := make(map[string]rtestate.MCPWaitForUpdatedFunc, len(mcObjStates))
 	for _, mcObjState := range mcObjStates {
 		waitByPool[mcObjState.PoolName] = mcObjState.WaitForUpdated
-
 		objState := mcObjState.ObjectState
 		klog.InfoS("objState", "desired", objState.Desired, "existing", objState.Existing, "createOrUpdate", objState.IsCreateOrUpdate())
 		if objState.IsCreateOrUpdate() {
@@ -442,7 +443,7 @@ func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context
 			break
 		}
 	}
-	return waitByPool, err
+	return waitByPool, pausedMCPNames, err
 }
 
 func syncMachineConfigPoolsStatuses(instanceName string, trees []nodegroupv1.Tree, forwardMCPConds bool, waitByPool map[string]rtestate.MCPWaitForUpdatedFunc) ([]nropv1.MachineConfigPool, string) {
@@ -617,7 +618,8 @@ func (r *NUMAResourcesOperatorReconciler) SetupWithManager(mgr ctrl.Manager) err
 			return !reflect.DeepEqual(mcpOld.Status.Conditions, mcpNew.Status.Conditions) ||
 				!apiequality.Semantic.DeepEqual(mcpOld.Labels, mcpNew.Labels) ||
 				!apiequality.Semantic.DeepEqual(mcpOld.Spec.MachineConfigSelector, mcpNew.Spec.MachineConfigSelector) ||
-				!apiequality.Semantic.DeepEqual(mcpOld.Spec.NodeSelector, mcpNew.Spec.NodeSelector)
+				!apiequality.Semantic.DeepEqual(mcpOld.Spec.NodeSelector, mcpNew.Spec.NodeSelector) ||
+				mcpOld.Spec.Paused != mcpNew.Spec.Paused
 		},
 	}
 

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -141,6 +142,14 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 
+	initialStatus := *instance.Status.DeepCopy()
+	if len(initialStatus.Conditions) == 0 {
+		instance.Status.Conditions = status.NewNUMAResourcesOperatorConditions()
+	} else {
+		// on upgrade, backfill conditions added in newer versions
+		instance.Status.Conditions = status.EnsureNUMAResourcesOperatorConditions(instance.Status.Conditions)
+	}
+
 	if req.Name != objectnames.DefaultNUMAResourcesOperatorCrName {
 		err := fmt.Errorf("incorrect NUMAResourcesOperator resource name: %s", instance.Name)
 		return r.degradeStatus(ctx, instance, status.ConditionTypeIncorrectNUMAResourcesOperatorResourceName, err)
@@ -248,7 +257,7 @@ func (r *NUMAResourcesOperatorReconciler) reconcileResourceAPI(ctx context.Conte
 func (r *NUMAResourcesOperatorReconciler) reconcileResourceMachineConfig(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, trees []nodegroupv1.Tree) intreconcile.Step {
 	// we need to sync machine configs first and wait for the MachineConfigPool updates
 	// before checking additional components for updates
-	waitByPool, _, err := r.syncMachineConfigs(ctx, instance, existing, trees)
+	waitByPool, pausedMCPNames, err := r.syncMachineConfigs(ctx, instance, existing, trees)
 	if err != nil {
 		r.Recorder.Eventf(instance, corev1.EventTypeWarning, "FailedMCSync", "Failed to set up machine configuration for worker nodes: %v", err)
 		err = fmt.Errorf("failed to sync machine configs: %w", err)
@@ -260,6 +269,7 @@ func (r *NUMAResourcesOperatorReconciler) reconcileResourceMachineConfig(ctx con
 	// It can take a while.
 	mcpStatuses, mcpNamePending := syncMachineConfigPoolsStatuses(instance.Name, trees, r.ForwardMCPConds, waitByPool)
 	instance.Status.MachineConfigPools = mcpStatuses
+	instance.Status.Conditions = updateMachineConfigPoolPausedCondition(instance.Status.Conditions, instance.Generation, pausedMCPNames)
 
 	if mcpNamePending != "" {
 		// the Machine Config Pool still did not apply the machine config, wait for one minute
@@ -816,6 +826,26 @@ func isDaemonSetReady(ds *appsv1.DaemonSet) bool {
 		return true
 	}
 	return ds.Status.DesiredNumberScheduled > 0 && ds.Status.DesiredNumberScheduled == ds.Status.NumberReady
+}
+
+func updateMachineConfigPoolPausedCondition(conditions []metav1.Condition, generation int64, pausedMCPNames sets.Set[string]) []metav1.Condition {
+	pausedStatus := metav1.ConditionFalse
+	message := ""
+	if pausedMCPNames.Len() > 0 {
+		klog.InfoS("detected paused MCPs", "pausedMCPs", pausedMCPNames)
+		pausedStatus = metav1.ConditionTrue
+		message = "detected paused MCPs: " + strings.Join(pausedMCPNames.UnsortedList(), ", ")
+	}
+	condition := metav1.Condition{
+		Type:               status.ConditionMachineConfigPoolPaused,
+		Status:             pausedStatus,
+		Reason:             status.ConditionMachineConfigPoolPaused,
+		Message:            message,
+		ObservedGeneration: generation,
+		LastTransitionTime: metav1.Now(),
+	}
+	conditions, _ = status.ComputeConditions(conditions, condition, time.Now())
+	return conditions
 }
 
 func getTreesByNodeGroup(ctx context.Context, cli client.Client, nodeGroups []nropv1.NodeGroup, platf platform.Platform) ([]nodegroupv1.Tree, error) {

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -247,7 +247,7 @@ func (r *NUMAResourcesOperatorReconciler) reconcileResourceAPI(ctx context.Conte
 func (r *NUMAResourcesOperatorReconciler) reconcileResourceMachineConfig(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, trees []nodegroupv1.Tree) intreconcile.Step {
 	// we need to sync machine configs first and wait for the MachineConfigPool updates
 	// before checking additional components for updates
-	mcpUpdatedFunc, err := r.syncMachineConfigs(ctx, instance, existing, trees)
+	waitByPool, err := r.syncMachineConfigs(ctx, instance, existing, trees)
 	if err != nil {
 		r.Recorder.Eventf(instance, corev1.EventTypeWarning, "FailedMCSync", "Failed to set up machine configuration for worker nodes: %v", err)
 		err = fmt.Errorf("failed to sync machine configs: %w", err)
@@ -257,7 +257,7 @@ func (r *NUMAResourcesOperatorReconciler) reconcileResourceMachineConfig(ctx con
 
 	// MCO needs to update the SELinux context removal and other stuff, and need to trigger a reboot.
 	// It can take a while.
-	mcpStatuses, mcpNamePending := syncMachineConfigPoolsStatuses(instance.Name, trees, r.ForwardMCPConds, mcpUpdatedFunc)
+	mcpStatuses, mcpNamePending := syncMachineConfigPoolsStatuses(instance.Name, trees, r.ForwardMCPConds, waitByPool)
 	instance.Status.MachineConfigPools = mcpStatuses
 
 	if mcpNamePending != "" {
@@ -408,7 +408,7 @@ func (r *NUMAResourcesOperatorReconciler) syncNodeResourceTopologyAPI(ctx contex
 	return (updatedCount == len(objStates)), err
 }
 
-func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, trees []nodegroupv1.Tree) (rtestate.MCPWaitForUpdatedFunc, error) {
+func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, trees []nodegroupv1.Tree) (map[string]rtestate.MCPWaitForUpdatedFunc, error) {
 	klog.V(4).InfoS("Machine Config Sync start", "trees", len(trees))
 	defer klog.V(4).Info("Machine Config Sync stop")
 
@@ -418,8 +418,12 @@ func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context
 	// In case of operator upgrade from 4.1X → 4.18, it's necessary to remove the old MachineConfig,
 	// unless an emergency annotation is provided which forces the operator to use custom policy
 
-	objStates, waitFunc := existing.MachineConfigsState(r.RTEManifests)
-	for _, objState := range objStates {
+	mcObjStates := existing.MachineConfigsState(r.RTEManifests)
+	waitByPool := make(map[string]rtestate.MCPWaitForUpdatedFunc, len(mcObjStates))
+	for _, mcObjState := range mcObjStates {
+		waitByPool[mcObjState.PoolName] = mcObjState.WaitForUpdated
+
+		objState := mcObjState.ObjectState
 		klog.InfoS("objState", "desired", objState.Desired, "existing", objState.Existing, "createOrUpdate", objState.IsCreateOrUpdate())
 		if objState.IsCreateOrUpdate() {
 			if err2 := controllerutil.SetControllerReference(instance, objState.Desired, r.Scheme); err2 != nil {
@@ -438,19 +442,24 @@ func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context
 			break
 		}
 	}
-	return waitFunc, err
+	return waitByPool, err
 }
 
-func syncMachineConfigPoolsStatuses(instanceName string, trees []nodegroupv1.Tree, forwardMCPConds bool, updatedFunc rtestate.MCPWaitForUpdatedFunc) ([]nropv1.MachineConfigPool, string) {
-	klog.V(4).InfoS("Machine Config Status Sync start", "trees", len(trees))
-	defer klog.V(4).Info("Machine Config Status Sync stop")
+func syncMachineConfigPoolsStatuses(instanceName string, trees []nodegroupv1.Tree, forwardMCPConds bool, waitByPool map[string]rtestate.MCPWaitForUpdatedFunc) ([]nropv1.MachineConfigPool, string) {
+	klog.V(4).InfoS("Machine Config Pools Status Sync start", "trees", len(trees))
+	defer klog.V(4).Info("Machine Config Pools Status Sync stop")
 
 	mcpStatuses := []nropv1.MachineConfigPool{}
 	for _, tree := range trees {
 		for _, mcp := range tree.MachineConfigPools {
 			mcpStatuses = append(mcpStatuses, extractMCPStatus(mcp, forwardMCPConds))
 
-			isUpdated := updatedFunc(instanceName, mcp)
+			waitFunc, ok := waitByPool[mcp.Name]
+			if !ok {
+				continue
+			}
+
+			isUpdated := waitFunc(instanceName, mcp)
 			klog.V(5).InfoS("Machine Config Pool state", "name", mcp.Name, "instance", instanceName, "updated", isUpdated)
 
 			if !isUpdated {
@@ -664,27 +673,33 @@ func (r *NUMAResourcesOperatorReconciler) mcpToNUMAResourceOperator(ctx context.
 		nro := &nros.Items[i]
 		mcpLabels := labels.Set(mcp.Labels)
 		for _, nodeGroup := range nro.Spec.NodeGroups {
-			if nodeGroup.MachineConfigPoolSelector == nil {
-				continue
-			}
-
-			nodeGroupSelector, err := metav1.LabelSelectorAsSelector(nodeGroup.MachineConfigPoolSelector)
-			if err != nil {
-				klog.Errorf("failed to parse the selector %v", mcp.Spec.NodeSelector)
-				return nil
-			}
-
-			if nodeGroupSelector.Matches(mcpLabels) {
+			if nodeGroupMatchesMCP(nodeGroup, mcp.Name, mcpLabels) {
 				requests = append(requests, reconcile.Request{
 					NamespacedName: client.ObjectKey{
 						Name: nro.Name,
 					},
 				})
+				break
 			}
 		}
 	}
 
 	return requests
+}
+
+func nodeGroupMatchesMCP(nodeGroup nropv1.NodeGroup, mcpName string, mcpLabels labels.Set) bool {
+	if nodeGroup.PoolName != nil {
+		return mcpName == *nodeGroup.PoolName
+	}
+	if nodeGroup.MachineConfigPoolSelector == nil {
+		return false
+	}
+	selector, err := metav1.LabelSelectorAsSelector(nodeGroup.MachineConfigPoolSelector)
+	if err != nil {
+		klog.Errorf("failed to parse the selector %v", nodeGroup.MachineConfigPoolSelector)
+		return false
+	}
+	return selector.Matches(mcpLabels)
 }
 
 func (r *NUMAResourcesOperatorReconciler) configMapToNUMAResourceOperator(ctx context.Context, cmObj client.Object) []reconcile.Request {

--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -29,6 +29,7 @@ import (
 	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -212,6 +213,12 @@ func updateStatusConditionsIfNeeded(instance *nropv1.NUMAResourcesOperator, cond
 	klog.InfoS("updateStatus", "condition", cond.Type, "reason", cond.Reason, "message", cond.Message)
 	conditions, ok := status.UpdateConditions(instance.Status.Conditions, cond.Type, cond.Reason, cond.Message)
 	if ok {
+		// UpdateConditions replaces with base conditions only; preserve extras
+		for _, c := range instance.Status.Conditions {
+			if status.FindCondition(conditions, c.Type) == nil {
+				conditions = append(conditions, c)
+			}
+		}
 		instance.Status.Conditions = conditions
 	}
 }
@@ -844,7 +851,8 @@ func updateMachineConfigPoolPausedCondition(conditions []metav1.Condition, gener
 		ObservedGeneration: generation,
 		LastTransitionTime: metav1.Now(),
 	}
-	conditions, _ = status.ComputeConditions(conditions, condition, time.Now())
+	// status.ComputeConditions (489a3175) is not available on 4.18
+	apimeta.SetStatusCondition(&conditions, condition)
 	return conditions
 }
 

--- a/controllers/numaresourcesoperator_controller_test.go
+++ b/controllers/numaresourcesoperator_controller_test.go
@@ -2127,12 +2127,12 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 				reconciler = checkSELinuxPolicyProcessing(ctx, nro, mcp1, mcp2)
 
 				By("upgrading from 4.1X to 4.18")
-				Expect(reconciler.Client.Get(context.TODO(), client.ObjectKeyFromObject(nro), nro)).To(Succeed())
+				Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(nro), nro)).To(Succeed())
 				clearSELinuxPolicyCustomAnnotations(nro)
 				Expect(reconciler.Client.Update(context.TODO(), nro)).To(Succeed())
 			})
 
-			It("should delete existing mc", func() {
+			It("should delete existing mc", func(ctx context.Context) {
 				key := client.ObjectKeyFromObject(nro)
 				// removing the annotation will trigger reboot which requires resync after 1 min
 				Expect(reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: key})).To(CauseRequeue())
@@ -2141,13 +2141,13 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 					Name: objectnames.GetMachineConfigName(nro.Name, mcp1.Name),
 				}
 				mc := &machineconfigv1.MachineConfig{}
-				err := reconciler.Client.Get(context.TODO(), mc1Key, mc)
+				err := reconciler.Client.Get(ctx, mc1Key, mc)
 				Expect(apierrors.IsNotFound(err)).To(BeTrue(), "MachineConfig %s expected to be deleted; err=%v", mc1Key.Name, err)
 
 				mc2Key := client.ObjectKey{
 					Name: objectnames.GetMachineConfigName(nro.Name, mcp2.Name),
 				}
-				err = reconciler.Client.Get(context.TODO(), mc2Key, mc)
+				err = reconciler.Client.Get(ctx, mc2Key, mc)
 				Expect(apierrors.IsNotFound(err)).To(BeTrue(), "MachineConfig %s expected to be deleted; err=%v", mc2Key.Name, err)
 			})
 

--- a/controllers/numaresourcesoperator_controller_test.go
+++ b/controllers/numaresourcesoperator_controller_test.go
@@ -2191,9 +2191,13 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 				}
 				Expect(reconciler.Client.Get(ctx, mcp2DSKey, ds)).To(Succeed())
 
-				By("Verify NRO status is Available")
+				By("Verify NRO status is Available with no paused condition")
 				Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(nro), nro)).To(Succeed())
 				Expect(nro).To(BeInCondition(status.ConditionAvailable))
+
+				pausedCond := getConditionByType(nro.Status.Conditions, status.ConditionMachineConfigPoolPaused)
+				Expect(pausedCond).ToNot(BeNil())
+				Expect(pausedCond.Status).To(Equal(metav1.ConditionFalse))
 			})
 			It("should converge when one pool is paused", func(ctx context.Context) {
 				// neither pool has custom annotation -> both in MC deletion path
@@ -2222,9 +2226,35 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 				}
 				Expect(reconciler.Client.Get(ctx, mcp2DSKey, ds)).To(Succeed())
 
-				By("Verify NRO status is Available")
+				By("Verify NRO status is Available with paused condition")
 				Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(nro), nro)).To(Succeed())
 				Expect(nro).To(BeInCondition(status.ConditionAvailable))
+
+				pausedCond := getConditionByType(nro.Status.Conditions, status.ConditionMachineConfigPoolPaused)
+				Expect(pausedCond).ToNot(BeNil())
+				Expect(pausedCond.Status).To(Equal(metav1.ConditionTrue))
+			})
+
+			It("should report paused condition while Progressing", func(ctx context.Context) {
+				// pool1 has custom policy -> MC created, needs MCO rollout
+				// pool2 is paused -> skipped
+				nro.Spec.NodeGroups[0].Annotations[annotations.SELinuxPolicyConfigAnnotation] = annotations.SELinuxPolicyCustom
+				mcp2.Spec.Paused = true
+
+				var err error
+				reconciler, err = NewFakeNUMAResourcesOperatorReconciler(platform.OpenShift, defaultOCPVersion, nro, mcp1, mcp2)
+				Expect(err).ToNot(HaveOccurred())
+
+				key := client.ObjectKeyFromObject(nro)
+
+				By("First reconcile: MC created for pool1, pool2 skipped (paused), waiting for MCO on pool1")
+				Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})).To(CauseRequeue())
+
+				By("Verify paused condition is set even while Progressing")
+				Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(nro), nro)).To(Succeed())
+				pausedCond := getConditionByType(nro.Status.Conditions, status.ConditionMachineConfigPoolPaused)
+				Expect(pausedCond).ToNot(BeNil(), "paused condition should be set during Progressing phase")
+				Expect(pausedCond.Status).To(Equal(metav1.ConditionTrue))
 			})
 		})
 	})

--- a/controllers/numaresourcesoperator_controller_test.go
+++ b/controllers/numaresourcesoperator_controller_test.go
@@ -2150,6 +2150,51 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 				err = reconciler.Client.Get(context.TODO(), mc2Key, mc)
 				Expect(apierrors.IsNotFound(err)).To(BeTrue(), "MachineConfig %s expected to be deleted; err=%v", mc2Key.Name, err)
 			})
+
+			It("should converge with mixed policy: one pool custom, one pool default", func(ctx context.Context) {
+				nro.Spec.NodeGroups[0].Annotations[annotations.SELinuxPolicyConfigAnnotation] = annotations.SELinuxPolicyCustom
+				// ng2 has no custom annotation -> default policy (MC deletion)
+
+				var err error
+				reconciler, err = NewFakeNUMAResourcesOperatorReconciler(platform.OpenShift, defaultOCPVersion, nro, mcp1, mcp2)
+				Expect(err).ToNot(HaveOccurred())
+
+				key := client.ObjectKeyFromObject(nro)
+
+				By("First reconcile: MC created for pool1, MC deleted for pool2, waiting for MCO")
+				Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})).To(CauseRequeue())
+
+				By("Make pool1 ready with MC present (custom policy)")
+				Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(mcp1), mcp1)).To(Succeed())
+				ensureMCPIsReady(mcp1, nro.Name)
+				Expect(reconciler.Client.Update(ctx, mcp1)).To(Succeed())
+
+				By("Make pool2 ready after MC deletion (default policy)")
+				Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(mcp2), mcp2)).To(Succeed())
+				ensureMCPIsReadyAfterMCDeletion(mcp2)
+				Expect(reconciler.Client.Update(ctx, mcp2)).To(Succeed())
+
+				By("Second reconcile: should converge")
+				Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})).ToNot(CauseRequeue())
+
+				By("Verify DaemonSets for both pools exist")
+				ds := &appsv1.DaemonSet{}
+				mcp1DSKey := client.ObjectKey{
+					Name:      objectnames.GetComponentName(nro.Name, mcp1.Name),
+					Namespace: testNamespace,
+				}
+				Expect(reconciler.Client.Get(ctx, mcp1DSKey, ds)).To(Succeed())
+
+				mcp2DSKey := client.ObjectKey{
+					Name:      objectnames.GetComponentName(nro.Name, mcp2.Name),
+					Namespace: testNamespace,
+				}
+				Expect(reconciler.Client.Get(ctx, mcp2DSKey, ds)).To(Succeed())
+
+				By("Verify NRO status is Available")
+				Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(nro), nro)).To(Succeed())
+				Expect(nro).To(BeInCondition(status.ConditionAvailable))
+			})
 		})
 	})
 })
@@ -2171,8 +2216,10 @@ func checkSELinuxPolicyProcessing(ctx context.Context, nro *nropv1.NUMAResources
 	ensureMCPIsReady(mcp1, nro.Name)
 	Expect(reconciler.Client.Update(ctx, mcp1)).To(Succeed())
 
+	// Node group 2 has no custom SELinux policy: wait logic expects our MachineConfig to be *absent* from
+	// the pool, so do not put it in Configuration.Source (unlike the pool that has custom policy).
 	Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(mcp2), mcp2)).To(Succeed())
-	ensureMCPIsReady(mcp2, nro.Name)
+	ensureMCPIsReadyAfterMCDeletion(mcp2)
 	Expect(reconciler.Client.Update(ctx, mcp2)).To(Succeed())
 
 	// triggering a second reconcile will create the RTEs and fully update the statuses making the operator in Available condition -> no more reconciliation needed thus the result is clean
@@ -2279,6 +2326,16 @@ func ensureMCPIsReady(mcp *machineconfigv1.MachineConfigPool, nroName string) {
 			Name: objectnames.GetMachineConfigName(nroName, mcp.Name),
 		},
 	}
+	mcp.Status.Conditions = []machineconfigv1.MachineConfigPoolCondition{
+		{
+			Type:   machineconfigv1.MachineConfigPoolUpdated,
+			Status: corev1.ConditionTrue,
+		},
+	}
+}
+
+func ensureMCPIsReadyAfterMCDeletion(mcp *machineconfigv1.MachineConfigPool) {
+	mcp.Status.Configuration.Source = nil
 	mcp.Status.Conditions = []machineconfigv1.MachineConfigPoolCondition{
 		{
 			Type:   machineconfigv1.MachineConfigPoolUpdated,

--- a/controllers/numaresourcesoperator_controller_test.go
+++ b/controllers/numaresourcesoperator_controller_test.go
@@ -2195,6 +2195,37 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 				Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(nro), nro)).To(Succeed())
 				Expect(nro).To(BeInCondition(status.ConditionAvailable))
 			})
+			It("should converge when one pool is paused", func(ctx context.Context) {
+				// neither pool has custom annotation -> both in MC deletion path
+				mcp2.Spec.Paused = true
+
+				var err error
+				reconciler, err = NewFakeNUMAResourcesOperatorReconciler(platform.OpenShift, defaultOCPVersion, nro, mcp1, mcp2)
+				Expect(err).ToNot(HaveOccurred())
+
+				key := client.ObjectKeyFromObject(nro)
+
+				By("Reconcile: pool1 converges (default policy, no MC to wait for), pool2 skipped (paused)")
+				Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})).ToNot(CauseRequeue())
+
+				By("Verify DaemonSets for both pools exist")
+				ds := &appsv1.DaemonSet{}
+				mcp1DSKey := client.ObjectKey{
+					Name:      objectnames.GetComponentName(nro.Name, mcp1.Name),
+					Namespace: testNamespace,
+				}
+				Expect(reconciler.Client.Get(ctx, mcp1DSKey, ds)).To(Succeed())
+
+				mcp2DSKey := client.ObjectKey{
+					Name:      objectnames.GetComponentName(nro.Name, mcp2.Name),
+					Namespace: testNamespace,
+				}
+				Expect(reconciler.Client.Get(ctx, mcp2DSKey, ds)).To(Succeed())
+
+				By("Verify NRO status is Available")
+				Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(nro), nro)).To(Succeed())
+				Expect(nro).To(BeInCondition(status.ConditionAvailable))
+			})
 		})
 	})
 })

--- a/pkg/objectstate/rte/machineconfigpool_test.go
+++ b/pkg/objectstate/rte/machineconfigpool_test.go
@@ -1,0 +1,322 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2025 Red Hat, Inc.
+ */
+
+package rte
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
+	rtemanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte"
+
+	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
+	nodegroupv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1/helper/nodegroup"
+	"github.com/openshift-kni/numaresources-operator/internal/api/annotations"
+	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
+)
+
+const testInstanceName = "test-nro"
+
+func newTestMCP(name string) *machineconfigv1.MachineConfigPool {
+	labels := map[string]string{name: name}
+	return &machineconfigv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Spec: machineconfigv1.MachineConfigPoolSpec{
+			MachineConfigSelector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			NodeSelector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+		},
+	}
+}
+
+func newTestTree(mcp *machineconfigv1.MachineConfigPool, annots map[string]string) nodegroupv1.Tree {
+	return nodegroupv1.Tree{
+		NodeGroup: &nropv1.NodeGroup{
+			Annotations: annots,
+		},
+		MachineConfigPools: []*machineconfigv1.MachineConfigPool{mcp},
+	}
+}
+
+func newTestExistingManifests(trees []nodegroupv1.Tree, mcNames ...string) *ExistingManifests {
+	machineConfigs := make(map[string]machineConfigManifest, len(mcNames))
+	for _, mcName := range mcNames {
+		machineConfigs[mcName] = machineConfigManifest{
+			machineConfig: &machineconfigv1.MachineConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: mcName,
+				},
+			},
+		}
+	}
+	return &ExistingManifests{
+		instance: &nropv1.NUMAResourcesOperator{
+			ObjectMeta: metav1.ObjectMeta{Name: testInstanceName},
+		},
+		trees:          trees,
+		machineConfigs: machineConfigs,
+		namespace:      "test-ns",
+	}
+}
+
+func newTestManifests() Manifests {
+	return Manifests{
+		Core: rtemanifests.Manifests{
+			MachineConfig: &machineconfigv1.MachineConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "base-mc",
+				},
+			},
+		},
+	}
+}
+
+func mcpWithSourceAndCondition(name, instanceName string, hasSource bool, updatedStatus corev1.ConditionStatus) *machineconfigv1.MachineConfigPool {
+	mcp := newTestMCP(name)
+	if hasSource {
+		mcp.Status.Configuration.Source = []corev1.ObjectReference{
+			{Name: objectnames.GetMachineConfigName(instanceName, name)},
+		}
+	}
+	mcp.Status.Conditions = []machineconfigv1.MachineConfigPoolCondition{
+		{
+			Type:   machineconfigv1.MachineConfigPoolUpdated,
+			Status: updatedStatus,
+		},
+	}
+	return mcp
+}
+
+func TestMachineConfigsState(t *testing.T) {
+	t.Run("nil core MachineConfig", func(t *testing.T) {
+		mcp := newTestMCP("pool-a")
+		tree := newTestTree(mcp, nil)
+		mcName := objectnames.GetMachineConfigName(testInstanceName, mcp.Name)
+		em := newTestExistingManifests([]nodegroupv1.Tree{tree}, mcName)
+
+		mf := Manifests{}
+		got, _ := em.MachineConfigsState(mf)
+		if len(got) != 0 {
+			t.Fatalf("expected empty result, got %d entries", len(got))
+		}
+	})
+
+	t.Run("single pool custom policy", func(t *testing.T) {
+		mcp := newTestMCP("pool-a")
+		tree := newTestTree(mcp, map[string]string{
+			annotations.SELinuxPolicyConfigAnnotation: annotations.SELinuxPolicyCustom,
+		})
+		mcName := objectnames.GetMachineConfigName(testInstanceName, mcp.Name)
+		em := newTestExistingManifests([]nodegroupv1.Tree{tree}, mcName)
+
+		got, _ := em.MachineConfigsState(newTestManifests())
+		if len(got) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(got))
+		}
+		if got[0].PoolName != "pool-a" {
+			t.Fatalf("expected pool name %q, got %q", "pool-a", got[0].PoolName)
+		}
+		if got[0].Paused {
+			t.Fatal("expected Paused to be false")
+		}
+		if got[0].Desired == nil {
+			t.Fatal("expected non-nil Desired for custom policy pool")
+		}
+
+		mcpReady := mcpWithSourceAndCondition("pool-a", testInstanceName, true, corev1.ConditionTrue)
+		if !got[0].WaitForUpdated(testInstanceName, mcpReady) {
+			t.Fatal("expected WaitForUpdated to return true when MC is present")
+		}
+		mcpNotReady := mcpWithSourceAndCondition("pool-a", testInstanceName, false, corev1.ConditionTrue)
+		if got[0].WaitForUpdated(testInstanceName, mcpNotReady) {
+			t.Fatal("expected WaitForUpdated to return false when MC is absent")
+		}
+	})
+
+	t.Run("single pool default policy", func(t *testing.T) {
+		mcp := newTestMCP("pool-a")
+		tree := newTestTree(mcp, nil)
+		mcName := objectnames.GetMachineConfigName(testInstanceName, mcp.Name)
+		em := newTestExistingManifests([]nodegroupv1.Tree{tree}, mcName)
+
+		got, _ := em.MachineConfigsState(newTestManifests())
+		if len(got) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(got))
+		}
+		if got[0].PoolName != "pool-a" {
+			t.Fatalf("expected pool name %q, got %q", "pool-a", got[0].PoolName)
+		}
+		if got[0].Paused {
+			t.Fatal("expected Paused to be false")
+		}
+		if got[0].Desired != nil {
+			t.Fatal("expected nil Desired for default policy pool")
+		}
+
+		mcpReady := mcpWithSourceAndCondition("pool-a", testInstanceName, false, corev1.ConditionTrue)
+		if !got[0].WaitForUpdated(testInstanceName, mcpReady) {
+			t.Fatal("expected WaitForUpdated to return true when MC is absent")
+		}
+		mcpNotReady := mcpWithSourceAndCondition("pool-a", testInstanceName, true, corev1.ConditionTrue)
+		if got[0].WaitForUpdated(testInstanceName, mcpNotReady) {
+			t.Fatal("expected WaitForUpdated to return false when MC is still present")
+		}
+	})
+
+	t.Run("mixed pools", func(t *testing.T) {
+		mcpCustom := newTestMCP("pool-custom")
+		treeCustom := newTestTree(mcpCustom, map[string]string{
+			annotations.SELinuxPolicyConfigAnnotation: annotations.SELinuxPolicyCustom,
+		})
+
+		mcpDefault := newTestMCP("pool-default")
+		treeDefault := newTestTree(mcpDefault, nil)
+
+		mcNameCustom := objectnames.GetMachineConfigName(testInstanceName, mcpCustom.Name)
+		mcNameDefault := objectnames.GetMachineConfigName(testInstanceName, mcpDefault.Name)
+		em := newTestExistingManifests(
+			[]nodegroupv1.Tree{treeCustom, treeDefault},
+			mcNameCustom, mcNameDefault,
+		)
+
+		got, _ := em.MachineConfigsState(newTestManifests())
+		if len(got) != 2 {
+			t.Fatalf("expected 2 entries, got %d", len(got))
+		}
+
+		var customEntry, defaultEntry MachineConfigObjectState
+		for _, entry := range got {
+			switch entry.PoolName {
+			case "pool-custom":
+				customEntry = entry
+			case "pool-default":
+				defaultEntry = entry
+			default:
+				t.Fatalf("unexpected pool name %q", entry.PoolName)
+			}
+		}
+
+		if customEntry.Desired == nil {
+			t.Fatal("expected non-nil Desired for custom policy pool")
+		}
+		if defaultEntry.Desired != nil {
+			t.Fatal("expected nil Desired for default policy pool")
+		}
+
+		mcpPresent := mcpWithSourceAndCondition("pool-custom", testInstanceName, true, corev1.ConditionTrue)
+		if !customEntry.WaitForUpdated(testInstanceName, mcpPresent) {
+			t.Fatal("custom pool: expected true when MC is present")
+		}
+		mcpAbsent := mcpWithSourceAndCondition("pool-custom", testInstanceName, false, corev1.ConditionTrue)
+		if customEntry.WaitForUpdated(testInstanceName, mcpAbsent) {
+			t.Fatal("custom pool: expected false when MC is absent")
+		}
+
+		mcpDeleted := mcpWithSourceAndCondition("pool-default", testInstanceName, false, corev1.ConditionTrue)
+		if !defaultEntry.WaitForUpdated(testInstanceName, mcpDeleted) {
+			t.Fatal("default pool: expected true when MC is absent")
+		}
+		mcpStillPresent := mcpWithSourceAndCondition("pool-default", testInstanceName, true, corev1.ConditionTrue)
+		if defaultEntry.WaitForUpdated(testInstanceName, mcpStillPresent) {
+			t.Fatal("default pool: expected false when MC is still present")
+		}
+	})
+
+	t.Run("pool without MachineConfigSelector", func(t *testing.T) {
+		mcp := newTestMCP("pool-no-selector")
+		mcp.Spec.MachineConfigSelector = nil
+
+		tree := newTestTree(mcp, nil)
+		mcName := objectnames.GetMachineConfigName(testInstanceName, mcp.Name)
+		em := newTestExistingManifests([]nodegroupv1.Tree{tree}, mcName)
+
+		got, _ := em.MachineConfigsState(newTestManifests())
+		if len(got) != 0 {
+			t.Fatalf("expected empty result for pool without selector, got %d entries", len(got))
+		}
+	})
+
+	t.Run("pool not in machineConfigs cache", func(t *testing.T) {
+		mcp := newTestMCP("pool-uncached")
+		tree := newTestTree(mcp, nil)
+		em := newTestExistingManifests([]nodegroupv1.Tree{tree})
+
+		got, _ := em.MachineConfigsState(newTestManifests())
+		if len(got) != 0 {
+			t.Fatalf("expected empty result for uncached pool, got %d entries", len(got))
+		}
+	})
+
+	t.Run("paused pool", func(t *testing.T) {
+		mcp := newTestMCP("pool-paused")
+		mcp.Spec.Paused = true
+
+		tree := newTestTree(mcp, nil)
+		mcName := objectnames.GetMachineConfigName(testInstanceName, mcp.Name)
+		em := newTestExistingManifests([]nodegroupv1.Tree{tree}, mcName)
+
+		got, pausedMCPNames := em.MachineConfigsState(newTestManifests())
+		if len(got) != 0 {
+			t.Fatalf("expected 0 entries for paused pool, got %d entries", len(got))
+		}
+		if !pausedMCPNames.Has("pool-paused") {
+			t.Fatal("expected pool-paused to be in pausedMCPNames set")
+		}
+	})
+
+	t.Run("mixed pools with paused", func(t *testing.T) {
+		mcpCustom := newTestMCP("pool-custom")
+		treeCustom := newTestTree(mcpCustom, map[string]string{
+			annotations.SELinuxPolicyConfigAnnotation: annotations.SELinuxPolicyCustom,
+		})
+
+		mcpDefault := newTestMCP("pool-default")
+		treeDefault := newTestTree(mcpDefault, nil)
+
+		mcpPaused := newTestMCP("pool-paused")
+		mcpPaused.Spec.Paused = true
+		treePaused := newTestTree(mcpPaused, nil)
+
+		mcNameCustom := objectnames.GetMachineConfigName(testInstanceName, mcpCustom.Name)
+		mcNameDefault := objectnames.GetMachineConfigName(testInstanceName, mcpDefault.Name)
+		mcNamePaused := objectnames.GetMachineConfigName(testInstanceName, mcpPaused.Name)
+		em := newTestExistingManifests(
+			[]nodegroupv1.Tree{treeCustom, treeDefault, treePaused},
+			mcNameCustom, mcNameDefault, mcNamePaused,
+		)
+
+		got, pausedMCPNames := em.MachineConfigsState(newTestManifests())
+		if len(got) != 2 {
+			t.Fatalf("expected 2 active entries, got %d", len(got))
+		}
+		if !pausedMCPNames.Has("pool-paused") {
+			t.Fatal("expected pool-paused to be in pausedMCPNames set")
+		}
+		if pausedMCPNames.Len() != 1 {
+			t.Fatalf("expected 1 paused pool, got %d", pausedMCPNames.Len())
+		}
+	})
+}

--- a/pkg/objectstate/rte/rte.go
+++ b/pkg/objectstate/rte/rte.go
@@ -22,6 +22,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -128,17 +129,24 @@ type MCPWaitForUpdatedFunc func(string, *machineconfigv1.MachineConfigPool) bool
 type MachineConfigObjectState struct {
 	objectstate.ObjectState
 	PoolName       string
+	Paused         bool
 	WaitForUpdated MCPWaitForUpdatedFunc
 }
 
-func (em *ExistingManifests) MachineConfigsState(mf Manifests) []MachineConfigObjectState {
+func (em *ExistingManifests) MachineConfigsState(mf Manifests) ([]MachineConfigObjectState, sets.Set[string]) {
 	var ret []MachineConfigObjectState
+	pausedMCPNames := sets.New[string]()
 	if mf.Core.MachineConfig == nil {
-		return ret
+		return ret, pausedMCPNames
 	}
 	for _, tree := range em.trees {
 		isCustomPolicy := annotations.IsCustomPolicyEnabled(tree.NodeGroup.Annotations)
 		for _, mcp := range tree.MachineConfigPools {
+			if mcp.Spec.Paused {
+				pausedMCPNames.Insert(mcp.Name)
+				continue
+			}
+
 			mcName := objectnames.GetMachineConfigName(em.instance.Name, mcp.Name)
 			if mcp.Spec.MachineConfigSelector == nil {
 				klog.Warningf("the machine config pool %q does not have machine config selector", mcp.Name)
@@ -185,7 +193,7 @@ func (em *ExistingManifests) MachineConfigsState(mf Manifests) []MachineConfigOb
 			})
 		}
 	}
-	return ret
+	return ret, pausedMCPNames
 }
 
 func IsMachineConfigPoolUpdated(instanceName string, mcp *machineconfigv1.MachineConfigPool) bool {

--- a/pkg/objectstate/rte/rte.go
+++ b/pkg/objectstate/rte/rte.go
@@ -125,13 +125,19 @@ func DaemonSetNamespacedNameFromObject(obj client.Object) (nropv1.NamespacedName
 
 type MCPWaitForUpdatedFunc func(string, *machineconfigv1.MachineConfigPool) bool
 
-func (em *ExistingManifests) MachineConfigsState(mf Manifests) ([]objectstate.ObjectState, MCPWaitForUpdatedFunc) {
-	var ret []objectstate.ObjectState
+type MachineConfigObjectState struct {
+	objectstate.ObjectState
+	PoolName       string
+	WaitForUpdated MCPWaitForUpdatedFunc
+}
+
+func (em *ExistingManifests) MachineConfigsState(mf Manifests) []MachineConfigObjectState {
+	var ret []MachineConfigObjectState
 	if mf.Core.MachineConfig == nil {
-		return ret, nullMachineConfigPoolUpdated
+		return ret
 	}
-	enabledMCCount := 0
 	for _, tree := range em.trees {
+		isCustomPolicy := annotations.IsCustomPolicyEnabled(tree.NodeGroup.Annotations)
 		for _, mcp := range tree.MachineConfigPools {
 			mcName := objectnames.GetMachineConfigName(em.instance.Name, mcp.Name)
 			if mcp.Spec.MachineConfigSelector == nil {
@@ -145,48 +151,41 @@ func (em *ExistingManifests) MachineConfigsState(mf Manifests) ([]objectstate.Ob
 				continue
 			}
 
-			if !annotations.IsCustomPolicyEnabled(tree.NodeGroup.Annotations) {
+			if !isCustomPolicy {
 				// caution here: we want a *nil interface value*, not an *interface which points to nil*.
 				// the latter would lead to apparently correct code leading to runtime panics. See:
 				// https://trstringer.com/go-nil-interface-and-interface-with-nil-concrete-value/
 				// (and many other docs like this)
-				ret = append(ret,
-					objectstate.ObjectState{
+				ret = append(ret, MachineConfigObjectState{
+					ObjectState: objectstate.ObjectState{
 						Existing: existingMachineConfig.machineConfig,
 						Error:    existingMachineConfig.machineConfigError,
 						Desired:  nil,
 					},
-				)
+					PoolName:       mcp.Name,
+					WaitForUpdated: IsMachineConfigPoolUpdatedAfterDeletion,
+				})
 				continue
 			}
 
 			desiredMachineConfig := mf.Core.MachineConfig.DeepCopy()
-			// prefix machine config name to guarantee that we will have an option to override it
 			desiredMachineConfig.Name = mcName
 			desiredMachineConfig.Labels = GetMachineConfigLabel(mcp)
 
-			ret = append(ret,
-				objectstate.ObjectState{
+			ret = append(ret, MachineConfigObjectState{
+				ObjectState: objectstate.ObjectState{
 					Existing: existingMachineConfig.machineConfig,
 					Error:    existingMachineConfig.machineConfigError,
 					Desired:  desiredMachineConfig,
 					Compare:  compare.Object,
 					Merge:    merge.ObjectForUpdate,
 				},
-			)
-			enabledMCCount++
+				PoolName:       mcp.Name,
+				WaitForUpdated: IsMachineConfigPoolUpdated,
+			})
 		}
 	}
-
-	klog.V(4).InfoS("machineConfigsState", "enabledMachineConfigs", enabledMCCount)
-	if enabledMCCount > 0 {
-		return ret, IsMachineConfigPoolUpdated
-	}
-	return ret, IsMachineConfigPoolUpdatedAfterDeletion
-}
-
-func nullMachineConfigPoolUpdated(instanceName string, mcp *machineconfigv1.MachineConfigPool) bool {
-	return true
+	return ret
 }
 
 func IsMachineConfigPoolUpdated(instanceName string, mcp *machineconfigv1.MachineConfigPool) bool {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
+	metahelper "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
@@ -38,7 +39,13 @@ const (
 )
 
 const (
+	// scheduler conditions
 	ConditionDedicatedInformerActive = "DedicatedInformerActive"
+)
+
+const (
+	// operator conditions
+	ConditionMachineConfigPoolPaused = "MachineConfigPoolPaused"
 )
 
 // TODO: are we duping these?
@@ -154,6 +161,35 @@ func newBaseConditions() []metav1.Condition {
 	}
 }
 
+// NewNUMAResourcesOperatorConditions creates specific operator conditions on
+// top of DefaultBaseConditions.
+func NewNUMAResourcesOperatorConditions() []metav1.Condition {
+	now := time.Now()
+	return append(DefaultBaseConditions(now), operatorExtraConditions(now)...)
+}
+
+// EnsureNUMAResourcesOperatorConditions backfills operator-specific conditions
+// that may be missing after an upgrade from an older version.
+func EnsureNUMAResourcesOperatorConditions(conditions []metav1.Condition) []metav1.Condition {
+	now := time.Now()
+	for _, cond := range operatorExtraConditions(now) {
+		if metahelper.FindStatusCondition(conditions, cond.Type) == nil {
+			conditions = append(conditions, cond)
+		}
+	}
+	return conditions
+}
+
+func operatorExtraConditions(now time.Time) []metav1.Condition {
+	return []metav1.Condition{
+		{
+			Type:               ConditionMachineConfigPoolPaused,
+			Status:             metav1.ConditionUnknown,
+			LastTransitionTime: metav1.Time{Time: now},
+			Reason:             ConditionMachineConfigPoolPaused,
+		},
+	}
+}
 func NewNUMAResourcesSchedulerBaseConditions() []metav1.Condition {
 	now := time.Now()
 	return []metav1.Condition{

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -162,17 +162,15 @@ func newBaseConditions() []metav1.Condition {
 }
 
 // NewNUMAResourcesOperatorConditions creates specific operator conditions on
-// top of DefaultBaseConditions.
+// top of newBaseConditions.
 func NewNUMAResourcesOperatorConditions() []metav1.Condition {
-	now := time.Now()
-	return append(DefaultBaseConditions(now), operatorExtraConditions(now)...)
+	return append(newBaseConditions(), operatorExtraConditions()...)
 }
 
 // EnsureNUMAResourcesOperatorConditions backfills operator-specific conditions
 // that may be missing after an upgrade from an older version.
 func EnsureNUMAResourcesOperatorConditions(conditions []metav1.Condition) []metav1.Condition {
-	now := time.Now()
-	for _, cond := range operatorExtraConditions(now) {
+	for _, cond := range operatorExtraConditions() {
 		if metahelper.FindStatusCondition(conditions, cond.Type) == nil {
 			conditions = append(conditions, cond)
 		}
@@ -180,7 +178,8 @@ func EnsureNUMAResourcesOperatorConditions(conditions []metav1.Condition) []meta
 	return conditions
 }
 
-func operatorExtraConditions(now time.Time) []metav1.Condition {
+func operatorExtraConditions() []metav1.Condition {
+	now := time.Now()
 	return []metav1.Condition{
 		{
 			Type:               ConditionMachineConfigPoolPaused,

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -336,6 +336,38 @@ func TestMessageFromError(t *testing.T) {
 	}
 }
 
+func TestNewNUMAResourcesOperatorConditions(t *testing.T) {
+	conds := NewNUMAResourcesOperatorConditions()
+
+	baseTypes := []string{ConditionAvailable, ConditionUpgradeable, ConditionProgressing, ConditionDegraded}
+	for _, ct := range baseTypes {
+		found := false
+		for _, c := range conds {
+			if c.Type == ct {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("missing base condition %q", ct)
+		}
+	}
+
+	var pausedCond *metav1.Condition
+	for i := range conds {
+		if conds[i].Type == ConditionMachineConfigPoolPaused {
+			pausedCond = &conds[i]
+			break
+		}
+	}
+	if pausedCond == nil {
+		t.Fatal("missing MachineConfigPoolPaused condition")
+	}
+	if pausedCond.Status != metav1.ConditionUnknown {
+		t.Fatalf("expected MachineConfigPoolPaused status %q, got %q", metav1.ConditionUnknown, pausedCond.Status)
+	}
+}
+
 func TestGetUpdatedSchedulerConditions(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -373,7 +373,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			Expect(fxt.Client.Get(ctx, nroKey, &initialNroOperObj)).To(Succeed())
 
 			testMCP := objects.TestMCP()
-			e2efixture.By("creating new MCP: %q with zero machine count", testMCP.Name)
+			By(fmt.Sprintf("creating new MCP: %q with zero machine count", testMCP.Name))
 			testMCP.Labels = map[string]string{"machineconfiguration.openshift.io/role": roleMCPTest}
 			testMCP.Spec.MachineConfigSelector = &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
@@ -390,7 +390,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 
 			Expect(fxt.Client.Create(ctx, testMCP)).To(Succeed())
 			defer func(dctx context.Context) {
-				e2efixture.By("CLEANUP: deleting mcp: %q", testMCP.Name)
+				By(fmt.Sprintf("CLEANUP: deleting mcp: %q", testMCP.Name))
 				Expect(fxt.Client.Delete(dctx, testMCP)).To(Succeed())
 
 				err := wait.With(fxt.Client).
@@ -430,10 +430,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 			updatedOperObj := &nropv1.NUMAResourcesOperator{}
 			Eventually(func(g Gomega) {
 				g.Expect(fxt.Client.Get(ctx, nroKey, updatedOperObj)).To(Succeed())
-				cond := status.FindCondition(updatedOperObj.Status.Conditions, status.ConditionAvailable)
-				g.Expect(cond).ToNot(BeNil(), "Available condition not found")
-				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue), "operator not yet available")
-				g.Expect(cond.ObservedGeneration).To(Equal(updatedOperObj.Generation), "condition not yet updated for current generation")
+				g.Expect(isNROOperSyncedAt(&updatedOperObj.Status, status.ConditionAvailable, updatedOperObj.Generation)).To(BeTrue())
 			}).WithTimeout(10 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
 
 			By("verifying DaemonSet count matches NodeGroup count")
@@ -1408,6 +1405,20 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 		})
 	})
 })
+
+func isNROOperSyncedAt(nropStatus *nropv1.NUMAResourcesOperatorStatus, conditionType string, gen int64) bool {
+	if nropStatus == nil {
+		return false
+	}
+	cond := status.FindCondition(nropStatus.Conditions, conditionType)
+	if cond == nil {
+		return false
+	}
+	if cond.Status != metav1.ConditionTrue {
+		return false
+	}
+	return cond.ObservedGeneration == gen
+}
 
 func verifyStatusUpdate(cli client.Client, ctx context.Context, key client.ObjectKey, appliedObj nropv1.NUMAResourcesOperator, expectedPoolName string, expectedConf nropv1.NodeGroupConfig) {
 	klog.InfoS("fetch NRO object", "key", key.String())

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -51,7 +51,10 @@ import (
 	perfprof "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/numaresourcesoperator/v1"
+	"github.com/openshift-kni/numaresources-operator/internal/api/annotations"
 	nropmcp "github.com/openshift-kni/numaresources-operator/internal/machineconfigpools"
 	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	intobjs "github.com/openshift-kni/numaresources-operator/internal/objects"
@@ -353,6 +356,90 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 				return true, nil
 			}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).Should(BeTrue(), "failed to update RTE container with LogLevel %q", operatorv1.Trace)
 
+		})
+
+		It("should converge with mixed SELinux policy across node groups", Label("tier2"), func(ctx context.Context) {
+			const minCustomSupportingVString = "4.18"
+			minCustomSupportingVersion, err := platform.ParseVersion(minCustomSupportingVString)
+			Expect(err).NotTo(HaveOccurred())
+			customSupportAvailable, err := configuration.PlatVersion.AtLeast(minCustomSupportingVersion)
+			Expect(err).NotTo(HaveOccurred())
+			if !customSupportAvailable {
+				Skip("mixed SELinux policy test requires platform >= 4.18")
+			}
+
+			nroKey := objects.NROObjectKey()
+			var initialNroOperObj nropv1.NUMAResourcesOperator
+			Expect(fxt.Client.Get(ctx, nroKey, &initialNroOperObj)).To(Succeed())
+
+			testMCP := objects.TestMCP()
+			e2efixture.By("creating new MCP: %q with zero machine count", testMCP.Name)
+			testMCP.Labels = map[string]string{"machineconfiguration.openshift.io/role": roleMCPTest}
+			testMCP.Spec.MachineConfigSelector = &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "machineconfiguration.openshift.io/role",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{roleMCPTest, depnodes.RoleWorker},
+					},
+				},
+			}
+			testMCP.Spec.NodeSelector = &metav1.LabelSelector{
+				MatchLabels: map[string]string{getLabelRoleMCPTest(): ""},
+			}
+
+			Expect(fxt.Client.Create(ctx, testMCP)).To(Succeed())
+			defer func(dctx context.Context) {
+				e2efixture.By("CLEANUP: deleting mcp: %q", testMCP.Name)
+				Expect(fxt.Client.Delete(dctx, testMCP)).To(Succeed())
+
+				err := wait.With(fxt.Client).
+					Interval(configuration.MachineConfigPoolUpdateInterval).
+					Timeout(configuration.MachineConfigPoolUpdateTimeout).
+					ForMachineConfigPoolDeleted(dctx, testMCP)
+				Expect(err).ToNot(HaveOccurred())
+			}(context.Background())
+
+			By("adding a new node group with custom SELinux policy annotation")
+			testNG := nropv1.NodeGroup{
+				MachineConfigPoolSelector: &metav1.LabelSelector{
+					MatchLabels: testMCP.Labels,
+				},
+				Annotations: map[string]string{
+					annotations.SELinuxPolicyConfigAnnotation: annotations.SELinuxPolicyCustom,
+				},
+			}
+
+			var nroOperObj nropv1.NUMAResourcesOperator
+			Eventually(func(g Gomega) {
+				g.Expect(fxt.Client.Get(ctx, nroKey, &nroOperObj)).To(Succeed())
+				nroOperObj.Spec.NodeGroups = append(nroOperObj.Spec.NodeGroups, testNG)
+				g.Expect(fxt.Client.Update(ctx, &nroOperObj)).To(Succeed())
+			}).WithTimeout(5 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
+
+			defer func(dctx context.Context) {
+				By("CLEANUP: reverting the NUMAResourcesOperator object")
+				Eventually(func(g Gomega) {
+					g.Expect(fxt.Client.Get(dctx, nroKey, &nroOperObj)).To(Succeed())
+					nroOperObj.Spec = initialNroOperObj.Spec
+					g.Expect(fxt.Client.Update(dctx, &nroOperObj)).To(Succeed())
+				}).WithTimeout(10 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
+			}(context.Background())
+
+			By("waiting for operator to converge with mixed policy")
+			updatedOperObj := &nropv1.NUMAResourcesOperator{}
+			Eventually(func(g Gomega) {
+				g.Expect(fxt.Client.Get(ctx, nroKey, updatedOperObj)).To(Succeed())
+				cond := status.FindCondition(updatedOperObj.Status.Conditions, status.ConditionAvailable)
+				g.Expect(cond).ToNot(BeNil(), "Available condition not found")
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue), "operator not yet available")
+				g.Expect(cond.ObservedGeneration).To(Equal(updatedOperObj.Generation), "condition not yet updated for current generation")
+			}).WithTimeout(10 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
+
+			By("verifying DaemonSet count matches NodeGroup count")
+			dss, err := objects.GetDaemonSetsOwnedBy(fxt.Client, updatedOperObj.ObjectMeta)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dss).To(HaveLen(len(nroOperObj.Spec.NodeGroups)), "daemonsets found owned by NRO object doesn't align with specified NodeGroups")
 		})
 
 		It("[test_id:54916][tier2][schedrst] should be able to modify the configurable values under the NUMAResourcesScheduler CR", Label("tier2", "schedrst"), Label("feature:schedrst"), func() {


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift-kni/numaresources-operator/pull/3801