### PR TITLE
mcp: selinux: extend annotation to stop reconciling

### DIFF
--- a/internal/api/annotations/annotations.go
+++ b/internal/api/annotations/annotations.go
@@ -21,6 +21,7 @@ const (
 	// remove in: 4.24 (tentative) or when 4.18 becomes the last supported version
 	SELinuxPolicyConfigAnnotation = "config.node.openshift-kni.io/selinux-policy"
 	SELinuxPolicyCustom           = "custom"
+	SELinuxPolicyIgnore           = "ignore"
 
 	// introduced in: 4.18
 	// remove in: 5.2 (when branching 5.1 plan to address this https://redhat.atlassian.net/browse/CNF-23341 in main)
@@ -48,6 +49,13 @@ const (
 
 func IsCustomPolicyEnabled(annot map[string]string) bool {
 	if v, ok := annot[SELinuxPolicyConfigAnnotation]; ok && v == SELinuxPolicyCustom {
+		return true
+	}
+	return false
+}
+
+func MustIgnoreCustomPolicy(annot map[string]string) bool {
+	if v, ok := annot[SELinuxPolicyConfigAnnotation]; ok && v == SELinuxPolicyIgnore {
 		return true
 	}
 	return false

--- a/internal/api/annotations/annotations_test.go
+++ b/internal/api/annotations/annotations_test.go
@@ -37,6 +37,13 @@ func TestIsCustomPolicyEnabled(t *testing.T) {
 			expected: false,
 		},
 		{
+			description: "annotation set to ignore does not enable custom policy",
+			annotations: map[string]string{
+				SELinuxPolicyConfigAnnotation: "ignore",
+			},
+			expected: false,
+		},
+		{
 			description: "enabled custom policy",
 			annotations: map[string]string{
 				SELinuxPolicyConfigAnnotation: "custom",
@@ -47,6 +54,48 @@ func TestIsCustomPolicyEnabled(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.description, func(t *testing.T) {
 			if got := IsCustomPolicyEnabled(tc.annotations); got != tc.expected {
+				t.Errorf("expected %v got %v", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestMustIgnoreCustomPolicy(t *testing.T) {
+	testcases := []struct {
+		description string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			description: "empty map",
+			annotations: map[string]string{},
+			expected:    false,
+		},
+		{
+			description: "annotation set to custom does not trigger ignore",
+			annotations: map[string]string{
+				SELinuxPolicyConfigAnnotation: "custom",
+			},
+			expected: false,
+		},
+		{
+			description: "annotation set to arbitrary value does not trigger ignore",
+			annotations: map[string]string{
+				SELinuxPolicyConfigAnnotation: "true",
+			},
+			expected: false,
+		},
+		{
+			description: "annotation set to ignore",
+			annotations: map[string]string{
+				SELinuxPolicyConfigAnnotation: "ignore",
+			},
+			expected: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			if got := MustIgnoreCustomPolicy(tc.annotations); got != tc.expected {
 				t.Errorf("expected %v got %v", tc.expected, got)
 			}
 		})

--- a/internal/api/annotations/helper/helper.go
+++ b/internal/api/annotations/helper/helper.go
@@ -29,3 +29,12 @@ func IsCustomPolicyEnabled(instance *nropv1.NUMAResourcesOperator) bool {
 	}
 	return false
 }
+
+func MustIgnoreCustomPolicy(instance *nropv1.NUMAResourcesOperator) bool {
+	for _, ng := range instance.Spec.NodeGroups {
+		if anns.MustIgnoreCustomPolicy(ng.Annotations) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/annotations/helper/helper_test.go
+++ b/internal/api/annotations/helper/helper_test.go
@@ -139,3 +139,103 @@ func TestIsCustomPolicyEnabled(t *testing.T) {
 		})
 	}
 }
+
+func TestMustIgnoreCustomPolicy(t *testing.T) {
+	testcases := []struct {
+		description string
+		nodeGroups  []nropv1.NodeGroup
+		expected    bool
+	}{
+		{
+			description: "empty maps - single",
+			nodeGroups: []nropv1.NodeGroup{
+				{
+					Annotations: make(map[string]string),
+				},
+			},
+			expected: false,
+		},
+		{
+			description: "empty maps - multi",
+			nodeGroups: []nropv1.NodeGroup{
+				{
+					Annotations: make(map[string]string),
+				},
+				{
+					Annotations: make(map[string]string),
+				},
+				{
+					Annotations: make(map[string]string),
+				},
+			},
+			expected: false,
+		},
+		{
+			description: "annotation set to custom does not trigger ignore - single",
+			nodeGroups: []nropv1.NodeGroup{
+				{
+					Annotations: map[string]string{
+						anns.SELinuxPolicyConfigAnnotation: "custom",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			description: "annotation set to ignore - single",
+			nodeGroups: []nropv1.NodeGroup{
+				{
+					Annotations: map[string]string{
+						anns.SELinuxPolicyConfigAnnotation: "ignore",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			description: "annotation set to ignore - multi",
+			nodeGroups: []nropv1.NodeGroup{
+				{
+					Annotations: make(map[string]string),
+				},
+				{
+					Annotations: map[string]string{
+						anns.SELinuxPolicyConfigAnnotation: "ignore",
+					},
+				},
+				{
+					Annotations: make(map[string]string),
+				},
+			},
+			expected: true,
+		},
+		{
+			description: "annotation set to ignore - multi + mixed",
+			nodeGroups: []nropv1.NodeGroup{
+				{
+					Annotations: map[string]string{
+						anns.SELinuxPolicyConfigAnnotation: "custom",
+					},
+				},
+				{
+					Annotations: map[string]string{
+						anns.SELinuxPolicyConfigAnnotation: "ignore",
+					},
+				},
+				{
+					Annotations: make(map[string]string),
+				},
+			},
+			expected: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			nropObj := nropv1.NUMAResourcesOperator{}
+			nropObj.Spec.NodeGroups = tc.nodeGroups
+			if got := MustIgnoreCustomPolicy(&nropObj); got != tc.expected {
+				t.Errorf("expected %v got %v", tc.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/objectstate/rte/machineconfigpool.go
+++ b/pkg/objectstate/rte/machineconfigpool.go
@@ -145,6 +145,7 @@ func (em *ExistingManifests) MachineConfigsState(mf Manifests) ([]MachineConfigO
 	}
 	for _, tree := range em.trees {
 		isCustomPolicy := annotations.IsCustomPolicyEnabled(tree.NodeGroup.Annotations)
+		mustIgnore := annotations.MustIgnoreCustomPolicy(tree.NodeGroup.Annotations)
 		for _, mcp := range tree.MachineConfigPools {
 			// do not update state when MachineConfigPool is paused
 			if mcp.Spec.Paused {
@@ -161,6 +162,11 @@ func (em *ExistingManifests) MachineConfigsState(mf Manifests) ([]MachineConfigO
 			existingMachineConfig, ok := em.machineConfigs[mcName]
 			if !ok {
 				klog.Warningf("failed to find machine config %q in namespace %q", mcName, em.namespace)
+				continue
+			}
+
+			if mustIgnore {
+				klog.V(4).Infof("ignoring MachineConfig for pool %q", mcp.Name)
 				continue
 			}
 


### PR DESCRIPTION
Add another value to the custom selinux policy annotation: if this value is set, the operand (RTE DaemonSet) will use the builtin policy and SCC v2, but the relevant MachineConfig will *stop being reconciled*.

Operators can remove the annotation anytime to trigger the reconciliation, causing a MC deletion and therefore a reboot.

This way, we decouple the SELinux upgrade from the MachineConfig removal, which helps (or should help) in the upgrade flow.