### PR TITLE
controllers: requeue on status update failure

### DIFF
--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -192,6 +192,7 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 
 	if err := r.updateStatus(ctx, initialStatus, instance); err != nil {
 		klog.InfoS("Failed to update numaresources-operator status", "error", err)
+		return ctrl.Result{RequeueAfter: numaResourcesRetryPeriod}, nil
 	}
 
 	return step.Result, step.Error
@@ -220,9 +221,10 @@ func (r *NUMAResourcesOperatorReconciler) degradeStatus(ctx context.Context, ini
 	err := r.updateStatus(ctx, initialStatus, instance)
 	if err != nil {
 		klog.InfoS("Failed to update numaresourcesoperator status", "error", err)
+		return ctrl.Result{RequeueAfter: numaResourcesRetryPeriod}, nil
 	}
 
-	return ctrl.Result{}, err
+	return ctrl.Result{}, nil
 }
 
 func (r *NUMAResourcesOperatorReconciler) reconcileResourceAPI(ctx context.Context, instance *nropv1.NUMAResourcesOperator, trees []nodegroupv1.Tree) intreconcile.Step {

--- a/internal/controller/numaresourcesscheduler_controller.go
+++ b/internal/controller/numaresourcesscheduler_controller.go
@@ -65,6 +65,8 @@ import (
 const (
 	// MaxSchedulerReplicas is the maximum number of scheduler replicas that can be deployed
 	MaxSchedulerReplicas = 3
+
+	numaResourcesSchedulerRetryPeriod = 1 * time.Minute
 )
 
 // NUMAResourcesSchedulerReconciler reconciles a NUMAResourcesScheduler object
@@ -124,7 +126,7 @@ func (r *NUMAResourcesSchedulerReconciler) Reconcile(ctx context.Context, req ct
 
 	if req.Name != objectnames.DefaultNUMAResourcesSchedulerCrName {
 		message := fmt.Sprintf("incorrect NUMAResourcesScheduler resource name: %s", instance.Name)
-		return ctrl.Result{}, r.degradeStatus(ctx, initialStatus, instance, status.ConditionTypeIncorrectNUMAResourcesSchedulerResourceName, message)
+		return r.degradeStatus(ctx, initialStatus, instance, status.ConditionTypeIncorrectNUMAResourcesSchedulerResourceName, message)
 	}
 
 	if annotations.IsPauseReconciliationEnabled(instance.Annotations) {
@@ -136,12 +138,13 @@ func (r *NUMAResourcesSchedulerReconciler) Reconcile(ctx context.Context, req ct
 	instance.Status.Conditions, _ = status.ComputeConditions(instance.Status.Conditions, step.ConditionInfo.ToMetav1Condition(instance.Generation), time.Now())
 	if err := r.updateStatus(ctx, initialStatus, instance); err != nil {
 		klog.InfoS("Failed to update numaresourcesscheduler status", "error", err)
+		return ctrl.Result{RequeueAfter: numaResourcesSchedulerRetryPeriod}, nil
 	}
 
 	return step.Result, step.Error
 }
 
-func (r *NUMAResourcesSchedulerReconciler) degradeStatus(ctx context.Context, initialStatus nropv1.NUMAResourcesSchedulerStatus, instance *nropv1.NUMAResourcesScheduler, reason string, message string) error {
+func (r *NUMAResourcesSchedulerReconciler) degradeStatus(ctx context.Context, initialStatus nropv1.NUMAResourcesSchedulerStatus, instance *nropv1.NUMAResourcesScheduler, reason string, message string) (ctrl.Result, error) {
 	condition := metav1.Condition{
 		Type:               status.ConditionDegraded,
 		Status:             metav1.ConditionTrue,
@@ -154,9 +157,10 @@ func (r *NUMAResourcesSchedulerReconciler) degradeStatus(ctx context.Context, in
 
 	err := r.updateStatus(ctx, initialStatus, instance)
 	if err != nil {
-		klog.InfoS("Failed to update numaresourcesoperator status", "error", err)
+		klog.InfoS("Failed to update numaresourcesscheduler status", "error", err)
+		return ctrl.Result{RequeueAfter: numaResourcesSchedulerRetryPeriod}, nil
 	}
-	return err
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
make sure to not lose status updates: if we fail
to update the status subresource, we need to requeue the operation.