### PR TITLE
CNF-23239: controller: nrop: per-tree processing and progress

### DIFF
--- a/api/v1/helper/nodegroup/nodegroup.go
+++ b/api/v1/helper/nodegroup/nodegroup.go
@@ -40,6 +40,16 @@ type Tree struct {
 	MachineConfigPools []*mcov1.MachineConfigPool
 }
 
+func (ttr Tree) Name() string {
+	if ttr.NodeGroup == nil {
+		return "<nil>"
+	}
+	if ttr.NodeGroup.PoolName == nil {
+		return "<unknown>"
+	}
+	return *ttr.NodeGroup.PoolName
+}
+
 // Clone creates a deepcopy of a Tree
 func (ttr Tree) Clone() Tree {
 	ret := Tree{

--- a/api/v1/helper/nodegroup/nodegroup_test.go
+++ b/api/v1/helper/nodegroup/nodegroup_test.go
@@ -35,6 +35,45 @@ import (
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
 )
 
+func TestTreeName(t *testing.T) {
+	type testCase struct {
+		name     string
+		tree     Tree
+		expected string
+	}
+	testCases := []testCase{
+		{
+			name:     "zero value tree",
+			tree:     Tree{},
+			expected: "<nil>",
+		},
+		{
+			name: "nil PoolName",
+			tree: Tree{
+				NodeGroup: &nropv1.NodeGroup{},
+			},
+			expected: "<unknown>",
+		},
+		{
+			name: "with PoolName",
+			tree: Tree{
+				NodeGroup: &nropv1.NodeGroup{
+					PoolName: ptr.To("worker-cnf"),
+				},
+			},
+			expected: "worker-cnf",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.tree.Name()
+			if got != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}
+
 func TestFindTreesOpenshift(t *testing.T) {
 	mcpList := mcov1.MachineConfigPoolList{
 		Items: []mcov1.MachineConfigPool{

--- a/api/v1/helper/nodegroup/result.go
+++ b/api/v1/helper/nodegroup/result.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nodegroup
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
+	intreconcile "github.com/openshift-kni/numaresources-operator/internal/reconcile"
+)
+
+// PoolDaemonSet a struct to hold the target MCP of a configured node group and its created respective RTE daemonset
+type PoolDaemonSet struct {
+	PoolName  string
+	DaemonSet nropv1.NamespacedName
+}
+
+func CollectDaemonSets(dsInfos []PoolDaemonSet) []nropv1.NamespacedName {
+	dssReady := make([]nropv1.NamespacedName, 0, len(dsInfos))
+	for _, dsInfo := range dsInfos {
+		dssReady = append(dssReady, dsInfo.DaemonSet)
+	}
+	return dssReady
+}
+
+type PerTreeResult struct {
+	DSInfo         []PoolDaemonSet
+	NROMCPs        []nropv1.MachineConfigPool
+	PausedMCPNames sets.Set[string]
+	Step           intreconcile.Step
+}
+
+func ReducePerTreeResults(results []PerTreeResult) PerTreeResult {
+	acc := PerTreeResult{
+		PausedMCPNames: sets.New[string](),
+		Step:           intreconcile.StepSuccess(),
+	}
+
+	var errorCount, ongoingCount int
+	for _, result := range results {
+		acc.NROMCPs = append(acc.NROMCPs, result.NROMCPs...)
+		acc.PausedMCPNames = acc.PausedMCPNames.Union(result.PausedMCPNames)
+
+		if result.Step.Done() {
+			acc.DSInfo = append(acc.DSInfo, result.DSInfo...)
+			continue
+		}
+
+		if result.Step.Failed() {
+			errorCount++
+		} else if result.Step.Ongoing() {
+			ongoingCount++
+		}
+
+		if ShouldReplaceStep(acc.Step, result.Step) {
+			acc.Step = result.Step
+		}
+	}
+	if !acc.Step.Done() {
+		acc.Step = acc.Step.UpdateMessage(treeSummaryMessage(len(results), errorCount, ongoingCount))
+	}
+	return acc
+}
+
+func ShouldReplaceStep(current, candidate intreconcile.Step) bool {
+	if current.Done() {
+		return true
+	}
+	if candidate.Failed() && !current.Failed() {
+		return true
+	}
+	if candidate.Ongoing() && current.Ongoing() {
+		if candidate.Result.RequeueAfter != current.Result.RequeueAfter {
+			return candidate.Result.RequeueAfter > 0 && candidate.Result.RequeueAfter < current.Result.RequeueAfter
+		}
+		if candidate.ConditionInfo.Message != "" && candidate.ConditionInfo.Message != current.ConditionInfo.Message {
+			return true
+		}
+	}
+	return false
+}
+
+func treeSummaryMessage(total, errors, ongoing int) string {
+	done := total - errors - ongoing
+	parts := make([]string, 0, 3)
+	if done > 0 {
+		parts = append(parts, fmt.Sprintf("%d/%d completed", done, total))
+	}
+	if ongoing > 0 {
+		parts = append(parts, fmt.Sprintf("%d/%d updating", ongoing, total))
+	}
+	if errors > 0 {
+		parts = append(parts, fmt.Sprintf("%d/%d failed", errors, total))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/api/v1/helper/nodegroup/result_test.go
+++ b/api/v1/helper/nodegroup/result_test.go
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nodegroup
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	intreconcile "github.com/openshift-kni/numaresources-operator/internal/reconcile"
+)
+
+func TestShouldReplaceStep(t *testing.T) {
+	testCases := []struct {
+		name      string
+		current   intreconcile.Step
+		candidate intreconcile.Step
+		expected  bool
+	}{
+		{
+			name:      "replace completed current step",
+			current:   intreconcile.StepSuccess(),
+			candidate: intreconcile.StepOngoing(time.Second),
+			expected:  true,
+		},
+		{
+			name:      "replace ongoing current step with failed candidate",
+			current:   intreconcile.StepOngoing(time.Second),
+			candidate: intreconcile.StepFailed(errors.New("candidate failed")),
+			expected:  true,
+		},
+		{
+			name:      "keep failed current step over failed candidate",
+			current:   intreconcile.StepFailed(errors.New("current failed")),
+			candidate: intreconcile.StepFailed(errors.New("candidate failed")),
+			expected:  false,
+		},
+		{
+			name:      "replace ongoing current step with shorter requeue interval",
+			current:   intreconcile.StepOngoing(2 * time.Second),
+			candidate: intreconcile.StepOngoing(time.Second),
+			expected:  true,
+		},
+		{
+			name:      "keep ongoing current step with longer requeue interval",
+			current:   intreconcile.StepOngoing(time.Second),
+			candidate: intreconcile.StepOngoing(2 * time.Second),
+			expected:  false,
+		},
+		{
+			name:      "keep earlier requeue interval over different message",
+			current:   intreconcile.StepOngoing(time.Second).WithMessage("a"),
+			candidate: intreconcile.StepOngoing(2 * time.Second).WithMessage("b"),
+			expected:  false,
+		},
+		{
+			name:      "keep ongoing current step with equal requeue interval and message",
+			current:   intreconcile.StepOngoing(time.Second).WithMessage("same message"),
+			candidate: intreconcile.StepOngoing(time.Second).WithMessage("same message"),
+			expected:  false,
+		},
+		{
+			name:      "replace ongoing current step with equal requeue interval and different message",
+			current:   intreconcile.StepOngoing(time.Second).WithMessage("current message"),
+			candidate: intreconcile.StepOngoing(time.Second).WithMessage("candidate message"),
+			expected:  true,
+		},
+		{
+			name:      "keep failed current step over ongoing candidate",
+			current:   intreconcile.StepFailed(errors.New("current failed")),
+			candidate: intreconcile.StepOngoing(time.Second),
+			expected:  false,
+		},
+		{
+			name:      "keep ongoing current step over completed candidate",
+			current:   intreconcile.StepOngoing(time.Second),
+			candidate: intreconcile.StepSuccess(),
+			expected:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, ShouldReplaceStep(tc.current, tc.candidate))
+		})
+	}
+}

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -377,7 +377,7 @@ func (r *NUMAResourcesOperatorReconciler) syncMachineConfig(ctx context.Context,
 	// In case of operator upgrade from 4.1X → 4.18, it's necessary to remove the old MachineConfig,
 	// unless an emergency annotation is provided which forces the operator to use custom policy
 
-	mcObjStates, pausedMCPNames := existing.MachineConfigsStateForTree(r.RTEManifests, tree)
+	mcObjStates, pausedMCPNames := existing.MachineConfigsState(r.RTEManifests, tree)
 	waitByPool := make(map[string]rtestate.MCPWaitForUpdatedFunc, len(mcObjStates))
 	for _, mcObjState := range mcObjStates {
 		waitByPool[mcObjState.PoolName] = mcObjState.WaitForUpdated

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -403,56 +403,52 @@ func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context
 	return waitByPool, pausedMCPNames, err
 }
 
-func syncMachineConfigPoolsStatuses(instanceName string, forwardMCPConds bool, waitByPool map[string]rtestate.MCPWaitForUpdatedFunc, trees ...nodegroupv1.Tree) ([]nropv1.MachineConfigPool, string) {
-	klog.V(4).InfoS("Machine Config Pools Status Sync start", "trees", len(trees))
+func syncMachineConfigPoolsStatuses(instanceName string, forwardMCPConds bool, waitByPool map[string]rtestate.MCPWaitForUpdatedFunc, tree nodegroupv1.Tree) ([]nropv1.MachineConfigPool, string) {
+	klog.V(4).InfoS("Machine Config Pools Status Sync start", "tree", tree.Name())
 	defer klog.V(4).Info("Machine Config Pools Status Sync stop")
 
 	mcpStatuses := []nropv1.MachineConfigPool{}
-	for _, tree := range trees {
-		for _, mcp := range tree.MachineConfigPools {
-			mcpStatuses = append(mcpStatuses, extractMCPStatus(mcp, forwardMCPConds))
+	for _, mcp := range tree.MachineConfigPools {
+		mcpStatuses = append(mcpStatuses, extractMCPStatus(mcp, forwardMCPConds))
 
-			waitFunc, ok := waitByPool[mcp.Name]
-			if !ok {
-				continue
-			}
+		waitFunc, ok := waitByPool[mcp.Name]
+		if !ok {
+			continue
+		}
 
-			isUpdated := waitFunc(instanceName, mcp)
-			klog.V(5).InfoS("Machine Config Pool state", "name", mcp.Name, "instance", instanceName, "updated", isUpdated)
+		isUpdated := waitFunc(instanceName, mcp)
+		klog.V(5).InfoS("Machine Config Pool state", "name", mcp.Name, "instance", instanceName, "updated", isUpdated)
 
-			if !isUpdated {
-				return mcpStatuses, mcp.Name
-			}
+		if !isUpdated {
+			return mcpStatuses, mcp.Name
 		}
 	}
 	return mcpStatuses, ""
 }
 
-func syncMachineConfigPoolNodeGroupConfigStatuses(mcpStatuses []nropv1.MachineConfigPool, trees ...nodegroupv1.Tree) []nropv1.MachineConfigPool {
-	klog.V(4).InfoS("Machine Config Pool Node Group Status Sync start", "mcpStatuses", len(mcpStatuses), "trees", len(trees))
+func syncMachineConfigPoolNodeGroupConfigStatuses(mcpStatuses []nropv1.MachineConfigPool, tree nodegroupv1.Tree) []nropv1.MachineConfigPool {
+	klog.V(4).InfoS("Machine Config Pool Node Group Status Sync start", "mcpStatuses", len(mcpStatuses), "tree", tree.Name())
 	defer klog.V(4).Info("Machine Config Pool Node Group Status Sync stop")
 
 	updatedMcpStatuses := []nropv1.MachineConfigPool{}
-	for _, tree := range trees {
-		klog.V(5).InfoS("Machine Config Pool Node Group tree update", "mcps", len(tree.MachineConfigPools))
+	klog.V(5).InfoS("Machine Config Pool Node Group tree update", "mcps", len(tree.MachineConfigPools))
 
-		for _, mcp := range tree.MachineConfigPools {
-			mcpStatus := getMachineConfigPoolStatusByName(mcpStatuses, mcp.Name)
+	for _, mcp := range tree.MachineConfigPools {
+		mcpStatus := getMachineConfigPoolStatusByName(mcpStatuses, mcp.Name)
 
-			var confSource string
-			if tree.NodeGroup != nil && tree.NodeGroup.Config != nil {
-				confSource = "spec"
-				mcpStatus.Config = tree.NodeGroup.Config.DeepCopy()
-			} else {
-				confSource = "default"
-				ngc := nropv1.DefaultNodeGroupConfig()
-				mcpStatus.Config = &ngc
-			}
-
-			klog.V(6).InfoS("Machine Config Pool Node Group updated status config", "mcp", mcp.Name, "source", confSource, "data", mcpStatus.Config.ToString())
-
-			updatedMcpStatuses = append(updatedMcpStatuses, mcpStatus)
+		var confSource string
+		if tree.NodeGroup != nil && tree.NodeGroup.Config != nil {
+			confSource = "spec"
+			mcpStatus.Config = tree.NodeGroup.Config.DeepCopy()
+		} else {
+			confSource = "default"
+			ngc := nropv1.DefaultNodeGroupConfig()
+			mcpStatus.Config = &ngc
 		}
+
+		klog.V(6).InfoS("Machine Config Pool Node Group updated status config", "mcp", mcp.Name, "source", confSource, "data", mcpStatus.Config.ToString())
+
+		updatedMcpStatuses = append(updatedMcpStatuses, mcpStatus)
 	}
 	return updatedMcpStatuses
 }

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -249,98 +249,63 @@ func (r *NUMAResourcesOperatorReconciler) reconcileResourceAPI(ctx context.Conte
 	return intreconcile.StepSuccess()
 }
 
-func (r *NUMAResourcesOperatorReconciler) reconcileResourceMachineConfig(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, trees []nodegroupv1.Tree) intreconcile.Step {
-	// we need to sync machine configs first and wait for the MachineConfigPool updates
-	// before checking additional components for updates
-	waitByPool, pausedMCPNames, err := r.syncMachineConfigs(ctx, instance, existing, trees...)
-	if err != nil {
-		err = fmt.Errorf("failed to sync machine configs: %w", err)
-		return intreconcile.StepFailed(err)
-	}
-
-	// MCO needs to update the SELinux context removal and other stuff, and need to trigger a reboot.
-	// It can take a while.
-	mcpStatuses, mcpNamePending := syncMachineConfigPoolsStatuses(instance.Name, r.ForwardMCPConds, waitByPool, trees...)
-	instance.Status.MachineConfigPools = mcpStatuses
-	instance.Status.Conditions = updateMachineConfigPoolPausedCondition(instance.Status.Conditions, instance.Generation, pausedMCPNames)
-
-	if mcpNamePending != "" {
-		// the Machine Config Pool still did not apply the machine config, wait for one minute
-		return intreconcile.StepOngoing(numaResourcesRetryPeriod).WithReason("MachineConfigPoolIsUpdating").WithMessage(mcpNamePending + " is updating")
-	}
-	instance.Status.MachineConfigPools = syncMachineConfigPoolNodeGroupConfigStatuses(instance.Status.MachineConfigPools, trees...)
-
-	return intreconcile.StepSuccess()
-}
-
-func (r *NUMAResourcesOperatorReconciler) reconcileResourceDaemonSet(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, trees []nodegroupv1.Tree) ([]poolDaemonSet, intreconcile.Step) {
-	daemonSetsInfoPerPool, err := r.syncNUMAResourcesOperatorResources(ctx, instance, existing, trees)
-	if err != nil {
-		err = fmt.Errorf("FailedRTESync: %w", err)
-		return nil, intreconcile.StepFailed(err)
-	}
-
-	if len(daemonSetsInfoPerPool) == 0 {
-		return nil, intreconcile.StepSuccess()
-	}
-
-	dssWithReadyStatus, dsNamePending, err := r.syncDaemonSetsStatuses(ctx, r.Client, daemonSetsInfoPerPool)
-	instance.Status.DaemonSets = dssWithReadyStatus
-	instance.Status.RelatedObjects = relatedobjects.ResourceTopologyExporter(r.Namespace, dssWithReadyStatus)
-	if err != nil {
-		return nil, intreconcile.StepFailed(err)
-	}
-	if dsNamePending != "" {
-		return nil, intreconcile.StepOngoing(5 * time.Second).WithReason("DaemonSetIsUpdating").WithMessage(dsNamePending + " is updating")
-	}
-
-	return daemonSetsInfoPerPool, intreconcile.StepSuccess()
-}
-
 func (r *NUMAResourcesOperatorReconciler) reconcileResource(ctx context.Context, instance *nropv1.NUMAResourcesOperator, trees []nodegroupv1.Tree) intreconcile.Step {
 	if step := r.reconcileResourceAPI(ctx, instance, trees); step.EarlyStop() {
 		return step
 	}
 
-	existing := rtestate.FromClient(ctx, r.Client, r.Platform, r.RTEManifests, instance, trees, r.Namespace)
+	existing := rtestate.FromClientTreeAgnostic(ctx, r.Client, r.Platform, r.RTEManifests, instance, r.Namespace)
+	if err := r.setupTreeAgnosticManifests(ctx, instance); err != nil {
+		return intreconcile.StepFailed(fmt.Errorf("FailedSharedResourceSync: %w", err))
+	}
+	if err := r.applyObjects(ctx, instance, existing.TreeAgnostic(r.RTEManifests)); err != nil {
+		return intreconcile.StepFailed(fmt.Errorf("FailedSharedResourceSync: %w", err))
+	}
 
+	err := dangling.DeleteUnusedDaemonSets(r.Client, ctx, instance, trees)
+	if err != nil {
+		klog.ErrorS(err, "failed to deleted unused daemonsets")
+	}
 	if r.Platform == platform.OpenShift {
-		if step := r.reconcileResourceMachineConfig(ctx, instance, existing, trees); step.EarlyStop() {
-			return step
-		}
-	}
-
-	dsPerPool, step := r.reconcileResourceDaemonSet(ctx, instance, existing, trees)
-	if step.EarlyStop() {
-		return step
-	}
-
-	// all fields of NodeGroupStatus are required so publish the status only when all daemonset and MCPs are updated which
-	// is a certain thing if we got to this point otherwise the function would have returned already
-	instance.Status.NodeGroups = syncNodeGroupsStatus(instance, dsPerPool)
-
-	return intreconcile.StepSuccess()
-}
-
-func (r *NUMAResourcesOperatorReconciler) syncDaemonSetsStatuses(ctx context.Context, rd client.Reader, daemonSetsInfo []poolDaemonSet) ([]nropv1.NamespacedName, string, error) {
-	dssWithReadyStatus := []nropv1.NamespacedName{}
-	for _, dsInfo := range daemonSetsInfo {
-		ds := appsv1.DaemonSet{}
-		dsKey := client.ObjectKey{
-			Namespace: dsInfo.DaemonSet.Namespace,
-			Name:      dsInfo.DaemonSet.Name,
-		}
-		err := rd.Get(ctx, dsKey, &ds)
+		err = dangling.DeleteUnusedMachineConfigs(r.Client, ctx, instance, trees)
 		if err != nil {
-			return dssWithReadyStatus, dsKey.String(), err
+			klog.ErrorS(err, "failed to deleted unused machineconfigs")
 		}
-
-		if !isDaemonSetReady(&ds) {
-			return dssWithReadyStatus, dsKey.String(), nil
-		}
-		dssWithReadyStatus = append(dssWithReadyStatus, dsInfo.DaemonSet)
 	}
-	return dssWithReadyStatus, "", nil
+
+	// horizontal processing: all trees complete each step before moving to the next
+
+	// step 1: machine configs for all trees
+	var mcResults []perTreeResult
+	if r.Platform == platform.OpenShift {
+		for _, tree := range trees {
+			treeExisting := existing.PerTree(ctx, r.Client, tree)
+			mcResults = append(mcResults, r.reconcilePerTreeMachineConfig(ctx, instance, treeExisting, tree))
+		}
+	}
+	mcOverall := reducePerTreeResults(mcResults)
+	instance.Status.MachineConfigPools = mcOverall.mcpStatuses
+	instance.Status.Conditions = updateMachineConfigPoolPausedCondition(instance.Status.Conditions, instance.Generation, mcOverall.pausedMCPNames)
+	if mcOverall.step.EarlyStop() {
+		return mcOverall.step
+	}
+
+	// step 2: daemonsets for all trees
+	var dsResults []perTreeResult
+	for _, tree := range trees {
+		treeExisting := existing.PerTree(ctx, r.Client, tree)
+		dsResults = append(dsResults, r.reconcilePerTreeDaemonSet(ctx, instance, treeExisting, tree))
+	}
+	dsOverall := reducePerTreeResults(dsResults)
+	dssReady := collectDaemonSets(dsOverall.dsInfo)
+	instance.Status.DaemonSets = dssReady
+	instance.Status.RelatedObjects = relatedobjects.ResourceTopologyExporter(r.Namespace, dssReady)
+	if !dsOverall.step.Done() {
+		return dsOverall.step
+	}
+
+	instance.Status.NodeGroups = syncNodeGroupsStatus(instance, dsOverall.dsInfo)
+	return intreconcile.StepSuccess()
 }
 
 func syncNodeGroupsStatus(instance *nropv1.NUMAResourcesOperator, dsPerPool []poolDaemonSet) []nropv1.NodeGroupStatus {
@@ -412,7 +377,7 @@ func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context
 	// In case of operator upgrade from 4.1X → 4.18, it's necessary to remove the old MachineConfig,
 	// unless an emergency annotation is provided which forces the operator to use custom policy
 
-	mcObjStates, pausedMCPNames := existing.MachineConfigsState(r.RTEManifests)
+	mcObjStates, pausedMCPNames := existing.MachineConfigsStateForTree(r.RTEManifests, trees[0])
 	waitByPool := make(map[string]rtestate.MCPWaitForUpdatedFunc, len(mcObjStates))
 	for _, mcObjState := range mcObjStates {
 		waitByPool[mcObjState.PoolName] = mcObjState.WaitForUpdated
@@ -490,84 +455,6 @@ func syncMachineConfigPoolNodeGroupConfigStatuses(mcpStatuses []nropv1.MachineCo
 		}
 	}
 	return updatedMcpStatuses
-}
-
-func (r *NUMAResourcesOperatorReconciler) syncNUMAResourcesOperatorResources(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, trees []nodegroupv1.Tree) ([]poolDaemonSet, error) {
-	klog.V(4).InfoS("RTESync start", "trees", len(trees))
-	defer klog.V(4).Info("RTESync stop")
-
-	err := dangling.DeleteUnusedDaemonSets(r.Client, ctx, instance, trees)
-	if err != nil {
-		klog.ErrorS(err, "failed to deleted unused daemonsets")
-	}
-
-	if r.Platform == platform.OpenShift {
-		err = dangling.DeleteUnusedMachineConfigs(r.Client, ctx, instance, trees)
-		if err != nil {
-			klog.ErrorS(err, "failed to deleted unused machineconfigs")
-		}
-	}
-
-	rteupdate.DaemonSetRolloutSettings(r.RTEManifests.Core.DaemonSet)
-	err = rteupdate.DaemonSetAffinitySettings(r.RTEManifests.Core.DaemonSet, r.RTEManifests.Core.DaemonSet.Spec.Template.Labels)
-	if err != nil {
-		klog.ErrorS(err, "failed to update RTE affinity settings")
-	}
-
-	dsPoolPairs := []poolDaemonSet{}
-
-	// using a slice of poolDaemonSet instead of a map because Go maps assignment order is not consistent and non-deterministic
-	err = rteupdate.DaemonSetUserImageSettings(r.RTEManifests.Core.DaemonSet, instance.Spec.ExporterImage, r.Images.Preferred(), r.ImagePullPolicy)
-	if err != nil {
-		return dsPoolPairs, err
-	}
-
-	err = rteupdate.DaemonSetPauseContainerSettings(r.RTEManifests.Core.DaemonSet)
-	if err != nil {
-		return dsPoolPairs, err
-	}
-
-	err = loglevel.UpdatePodSpec(&r.RTEManifests.Core.DaemonSet.Spec.Template.Spec, manifests.ContainerNameRTE, instance.Spec.LogLevel)
-	if err != nil {
-		return dsPoolPairs, err
-	}
-
-	rteupdate.SecurityContextConstraint(r.RTEManifests.Core.SecurityContextConstraint, true) // force to legacy context
-	// SCC v2 needs no updates
-
-	existing = existing.WithManifestsUpdater(func(poolName string, gdm *rtestate.GeneratedDesiredManifest) error {
-		err := daemonsetUpdater(poolName, gdm, r.RTEMetricsTLS)
-		if err != nil {
-			return err
-		}
-		dsPoolPairs = append(dsPoolPairs, poolDaemonSet{poolName, namespacedname.FromObject(gdm.DaemonSet)})
-		return nil
-	})
-
-	for _, objState := range existing.State(r.RTEManifests) {
-		if objState.Error != nil {
-			// We are likely in the bootstrap scenario. In this case, which is expected once, everything is fine.
-			// If it happens past bootstrap, still carry on. We know what to do, and we do want to enforce the desired state.
-			klog.Warningf("error loading object: %v", objState.Error)
-		}
-		if objState.UpdateError != nil {
-			// this is an internal error. Should not happen. But if it happen, we don't want to send garbage to the cluster, so we abort
-			return nil, fmt.Errorf("failed to update (%s) %s/%s: %w", objState.Desired.GetObjectKind().GroupVersionKind(), objState.Desired.GetNamespace(), objState.Desired.GetName(), err)
-		}
-		err := controllerutil.SetControllerReference(instance, objState.Desired, r.Scheme)
-		if err != nil {
-			return nil, fmt.Errorf("failed to set controller reference to %s %s: %w", objState.Desired.GetNamespace(), objState.Desired.GetName(), err)
-		}
-		_, _, err = apply.ApplyObject(ctx, r.Client, objState)
-		if err != nil {
-			return nil, fmt.Errorf("failed to apply (%s) %s/%s: %w", objState.Desired.GetObjectKind().GroupVersionKind(), objState.Desired.GetNamespace(), objState.Desired.GetName(), err)
-		}
-	}
-
-	if len(dsPoolPairs) < len(trees) {
-		klog.Warningf("daemonset and tree size mismatch: expected %d got in daemonsets %d", len(trees), len(dsPoolPairs))
-	}
-	return dsPoolPairs, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -839,7 +839,9 @@ func (r *NUMAResourcesOperatorReconciler) applyObjects(ctx context.Context, inst
 	defer klog.V(4).InfoS("Applyied objects", "count", len(objStates))
 	for _, objState := range objStates {
 		if objState.Error != nil {
-			klog.Warningf("error loading object: %v", objState.Error)
+			if !objState.IsNotFoundError() {
+				return fmt.Errorf("failed to load object state for %s/%s: %w", objState.Desired.GetNamespace(), objState.Desired.GetName(), objState.Error)
+			}
 		}
 		if objState.UpdateError != nil {
 			return fmt.Errorf("failed to update (%s) %s/%s: %w", objState.Desired.GetObjectKind().GroupVersionKind(), objState.Desired.GetNamespace(), objState.Desired.GetName(), objState.UpdateError)
@@ -919,7 +921,7 @@ func shouldReplaceStep(current, candidate intreconcile.Step) bool {
 		return true
 	}
 	if candidate.Ongoing() && current.Ongoing() {
-		return candidate.Result.RequeueAfter < current.Result.RequeueAfter
+		return candidate.Result.RequeueAfter > 0 && candidate.Result.RequeueAfter < current.Result.RequeueAfter
 	}
 	return false
 }

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -367,8 +367,8 @@ func (r *NUMAResourcesOperatorReconciler) syncNodeResourceTopologyAPI(ctx contex
 	return (updatedCount == len(objStates)), err
 }
 
-func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, trees ...nodegroupv1.Tree) (map[string]rtestate.MCPWaitForUpdatedFunc, sets.Set[string], error) {
-	klog.V(4).InfoS("Machine Config Sync start", "trees", len(trees))
+func (r *NUMAResourcesOperatorReconciler) syncMachineConfig(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, tree nodegroupv1.Tree) (map[string]rtestate.MCPWaitForUpdatedFunc, sets.Set[string], error) {
+	klog.V(4).InfoS("Machine Config Sync start", "tree", tree.Name())
 	defer klog.V(4).Info("Machine Config Sync stop")
 
 	var err error
@@ -377,7 +377,7 @@ func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context
 	// In case of operator upgrade from 4.1X → 4.18, it's necessary to remove the old MachineConfig,
 	// unless an emergency annotation is provided which forces the operator to use custom policy
 
-	mcObjStates, pausedMCPNames := existing.MachineConfigsStateForTree(r.RTEManifests, trees[0])
+	mcObjStates, pausedMCPNames := existing.MachineConfigsStateForTree(r.RTEManifests, tree)
 	waitByPool := make(map[string]rtestate.MCPWaitForUpdatedFunc, len(mcObjStates))
 	for _, mcObjState := range mcObjStates {
 		waitByPool[mcObjState.PoolName] = mcObjState.WaitForUpdated
@@ -389,7 +389,7 @@ func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context
 				break
 			}
 
-			if err2 := validateMachineConfigLabels(objState.Desired, trees); err2 != nil {
+			if err2 := validateMachineConfigLabels(objState.Desired, tree); err2 != nil {
 				err = err2
 				break
 			}
@@ -609,7 +609,7 @@ func validateUpdateEvent(e *event.UpdateEvent) bool {
 	return true
 }
 
-func validateMachineConfigLabels(mc client.Object, trees []nodegroupv1.Tree) error {
+func validateMachineConfigLabels(mc client.Object, tree nodegroupv1.Tree) error {
 	mcLabels := mc.GetLabels()
 	v, ok := mcLabels[rtestate.MachineConfigLabelKey]
 	// the machine config does not have generated label, meaning the machine config pool has the matchLabels under
@@ -618,21 +618,19 @@ func validateMachineConfigLabels(mc client.Object, trees []nodegroupv1.Tree) err
 		return nil
 	}
 
-	for _, tree := range trees {
-		for _, mcp := range tree.MachineConfigPools {
-			if v != mcp.Name {
-				continue
-			}
+	for _, mcp := range tree.MachineConfigPools {
+		if v != mcp.Name {
+			continue
+		}
 
-			mcLabels := labels.Set(mcLabels)
-			mcSelector, err := metav1.LabelSelectorAsSelector(mcp.Spec.MachineConfigSelector)
-			if err != nil {
-				return fmt.Errorf("failed to represent machine config pool %q machine config selector as selector: %w", mcp.Name, err)
-			}
+		mcLabels := labels.Set(mcLabels)
+		mcSelector, err := metav1.LabelSelectorAsSelector(mcp.Spec.MachineConfigSelector)
+		if err != nil {
+			return fmt.Errorf("failed to represent machine config pool %q machine config selector as selector: %w", mcp.Name, err)
+		}
 
-			if !mcSelector.Matches(mcLabels) {
-				return fmt.Errorf("machine config %q labels does not match the machine config pool %q machine config selector", mc.GetName(), mcp.Name)
-			}
+		if !mcSelector.Matches(mcLabels) {
+			return fmt.Errorf("machine config %q labels does not match the machine config pool %q machine config selector", mc.GetName(), mcp.Name)
 		}
 	}
 	return nil
@@ -752,7 +750,7 @@ type perTreeResult struct {
 func (r *NUMAResourcesOperatorReconciler) reconcilePerTreeMachineConfig(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, tree nodegroupv1.Tree) perTreeResult {
 	result := perTreeResult{}
 
-	waitByPool, pausedMCPNames, err := r.syncMachineConfigs(ctx, instance, existing, tree)
+	waitByPool, pausedMCPNames, err := r.syncMachineConfig(ctx, instance, existing, tree)
 	result.pausedMCPNames = pausedMCPNames
 	if err != nil {
 		result.step = intreconcile.StepFailed(fmt.Errorf("failed to sync machine configs: %w", err))

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -200,11 +201,6 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 		return r.degradeStatus(ctx, initialInstance, instance, validation.NodeGroupsError, err)
 	}
 
-	for idx := range trees {
-		conf := trees[idx].NodeGroup.NormalizeConfig()
-		trees[idx].NodeGroup.Config = &conf
-	}
-
 	step := r.reconcileResource(ctx, instance, trees)
 	instance.Status.Conditions, _ = status.ComputeConditions(instance.Status.Conditions, step.ConditionInfo.ToMetav1Condition(instance.Generation), time.Now())
 
@@ -273,39 +269,39 @@ func (r *NUMAResourcesOperatorReconciler) reconcileResource(ctx context.Context,
 		}
 	}
 
-	// horizontal processing: all trees complete each step before moving to the next
-
-	// step 1: machine configs for all trees
-	var mcResults []perTreeResult
-	if r.Platform == platform.OpenShift {
-		for _, tree := range trees {
-			treeExisting := existing.PerTree(ctx, r.Client, tree)
-			mcResults = append(mcResults, r.reconcilePerTreeMachineConfig(ctx, instance, treeExisting, tree))
-		}
-	}
-	mcOverall := reducePerTreeResults(mcResults)
-	instance.Status.MachineConfigPools = mcOverall.mcpStatuses
-	instance.Status.Conditions = updateMachineConfigPoolPausedCondition(instance.Status.Conditions, instance.Generation, mcOverall.pausedMCPNames)
-	if mcOverall.step.EarlyStop() {
-		return mcOverall.step
-	}
-
-	// step 2: daemonsets for all trees
-	var dsResults []perTreeResult
+	var results []perTreeResult
 	for _, tree := range trees {
+		tree.NodeGroup.Config = ptr.To(tree.NodeGroup.NormalizeConfig())
+
 		treeExisting := existing.PerTree(ctx, r.Client, tree)
-		dsResults = append(dsResults, r.reconcilePerTreeDaemonSet(ctx, instance, treeExisting, tree))
+
+		mcResult := perTreeResult{}
+		if r.Platform == platform.OpenShift {
+			mcResult = r.reconcilePerTreeMachineConfig(ctx, instance, treeExisting, tree)
+			if mcResult.step.EarlyStop() {
+				results = append(results, mcResult)
+				continue
+			}
+		}
+
+		dsResult := r.reconcilePerTreeDaemonSet(ctx, instance, treeExisting, tree)
+		dsResult.mcpStatuses = mcResult.mcpStatuses
+		dsResult.pausedMCPNames = mcResult.pausedMCPNames
+		results = append(results, dsResult)
 	}
-	dsOverall := reducePerTreeResults(dsResults)
-	dssReady := collectDaemonSets(dsOverall.dsInfo)
+
+	overall := reducePerTreeResults(results)
+	dssReady := collectDaemonSets(overall.dsInfo)
+	instance.Status.MachineConfigPools = overall.mcpStatuses
+	instance.Status.Conditions = updateMachineConfigPoolPausedCondition(instance.Status.Conditions, instance.Generation, overall.pausedMCPNames)
 	instance.Status.DaemonSets = dssReady
 	instance.Status.RelatedObjects = relatedobjects.ResourceTopologyExporter(r.Namespace, dssReady)
-	if !dsOverall.step.Done() {
-		return dsOverall.step
+
+	if overall.step.Done() {
+		instance.Status.NodeGroups = syncNodeGroupsStatus(instance, overall.dsInfo)
 	}
 
-	instance.Status.NodeGroups = syncNodeGroupsStatus(instance, dsOverall.dsInfo)
-	return intreconcile.StepSuccess()
+	return overall.step
 }
 
 func syncNodeGroupsStatus(instance *nropv1.NUMAResourcesOperator, dsPerPool []poolDaemonSet) []nropv1.NodeGroupStatus {

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -462,17 +462,6 @@ func syncMachineConfigPoolsStatuses(instanceName string, trees []nodegroupv1.Tre
 	return mcpStatuses, ""
 }
 
-func extractMCPStatus(mcp *machineconfigv1.MachineConfigPool, forwardMCPConds bool) nropv1.MachineConfigPool {
-	mcpStatus := nropv1.MachineConfigPool{
-		Name: mcp.Name,
-	}
-	if !forwardMCPConds {
-		return mcpStatus
-	}
-	mcpStatus.Conditions = mcp.Status.Conditions
-	return mcpStatus
-}
-
 func syncMachineConfigPoolNodeGroupConfigStatuses(mcpStatuses []nropv1.MachineConfigPool, trees []nodegroupv1.Tree) []nropv1.MachineConfigPool {
 	klog.V(4).InfoS("Machine Config Pool Node Group Status Sync start", "mcpStatuses", len(mcpStatuses), "trees", len(trees))
 	defer klog.V(4).Info("Machine Config Pool Node Group Status Sync stop")
@@ -500,15 +489,6 @@ func syncMachineConfigPoolNodeGroupConfigStatuses(mcpStatuses []nropv1.MachineCo
 		}
 	}
 	return updatedMcpStatuses
-}
-
-func getMachineConfigPoolStatusByName(mcpStatuses []nropv1.MachineConfigPool, name string) nropv1.MachineConfigPool {
-	for _, mcpStatus := range mcpStatuses {
-		if mcpStatus.Name == name {
-			return mcpStatus
-		}
-	}
-	return nropv1.MachineConfigPool{Name: name}
 }
 
 func (r *NUMAResourcesOperatorReconciler) syncNUMAResourcesOperatorResources(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, trees []nodegroupv1.Tree) ([]poolDaemonSet, error) {
@@ -856,4 +836,24 @@ func IsRTEImageOverridable() bool {
 	}
 	klog.InfoS("Exporter image", "overridable", overridable)
 	return overridable
+}
+
+func extractMCPStatus(mcp *machineconfigv1.MachineConfigPool, forwardMCPConds bool) nropv1.MachineConfigPool {
+	mcpStatus := nropv1.MachineConfigPool{
+		Name: mcp.Name,
+	}
+	if !forwardMCPConds {
+		return mcpStatus
+	}
+	mcpStatus.Conditions = mcp.Status.Conditions
+	return mcpStatus
+}
+
+func getMachineConfigPoolStatusByName(mcpStatuses []nropv1.MachineConfigPool, name string) nropv1.MachineConfigPool {
+	for _, mcpStatus := range mcpStatuses {
+		if mcpStatus.Name == name {
+			return mcpStatus
+		}
+	}
+	return nropv1.MachineConfigPool{Name: name}
 }

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -251,7 +251,7 @@ func (r *NUMAResourcesOperatorReconciler) reconcileResourceAPI(ctx context.Conte
 func (r *NUMAResourcesOperatorReconciler) reconcileResourceMachineConfig(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, trees []nodegroupv1.Tree) intreconcile.Step {
 	// we need to sync machine configs first and wait for the MachineConfigPool updates
 	// before checking additional components for updates
-	waitByPool, pausedMCPNames, err := r.syncMachineConfigs(ctx, instance, existing, trees)
+	waitByPool, pausedMCPNames, err := r.syncMachineConfigs(ctx, instance, existing, trees...)
 	if err != nil {
 		err = fmt.Errorf("failed to sync machine configs: %w", err)
 		return intreconcile.StepFailed(err)
@@ -259,7 +259,7 @@ func (r *NUMAResourcesOperatorReconciler) reconcileResourceMachineConfig(ctx con
 
 	// MCO needs to update the SELinux context removal and other stuff, and need to trigger a reboot.
 	// It can take a while.
-	mcpStatuses, mcpNamePending := syncMachineConfigPoolsStatuses(instance.Name, trees, r.ForwardMCPConds, waitByPool)
+	mcpStatuses, mcpNamePending := syncMachineConfigPoolsStatuses(instance.Name, r.ForwardMCPConds, waitByPool, trees...)
 	instance.Status.MachineConfigPools = mcpStatuses
 	instance.Status.Conditions = updateMachineConfigPoolPausedCondition(instance.Status.Conditions, instance.Generation, pausedMCPNames)
 
@@ -267,7 +267,7 @@ func (r *NUMAResourcesOperatorReconciler) reconcileResourceMachineConfig(ctx con
 		// the Machine Config Pool still did not apply the machine config, wait for one minute
 		return intreconcile.StepOngoing(numaResourcesRetryPeriod).WithReason("MachineConfigPoolIsUpdating").WithMessage(mcpNamePending + " is updating")
 	}
-	instance.Status.MachineConfigPools = syncMachineConfigPoolNodeGroupConfigStatuses(instance.Status.MachineConfigPools, trees)
+	instance.Status.MachineConfigPools = syncMachineConfigPoolNodeGroupConfigStatuses(instance.Status.MachineConfigPools, trees...)
 
 	return intreconcile.StepSuccess()
 }
@@ -401,7 +401,7 @@ func (r *NUMAResourcesOperatorReconciler) syncNodeResourceTopologyAPI(ctx contex
 	return (updatedCount == len(objStates)), err
 }
 
-func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, trees []nodegroupv1.Tree) (map[string]rtestate.MCPWaitForUpdatedFunc, sets.Set[string], error) {
+func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, trees ...nodegroupv1.Tree) (map[string]rtestate.MCPWaitForUpdatedFunc, sets.Set[string], error) {
 	klog.V(4).InfoS("Machine Config Sync start", "trees", len(trees))
 	defer klog.V(4).Info("Machine Config Sync stop")
 
@@ -437,7 +437,7 @@ func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context
 	return waitByPool, pausedMCPNames, err
 }
 
-func syncMachineConfigPoolsStatuses(instanceName string, trees []nodegroupv1.Tree, forwardMCPConds bool, waitByPool map[string]rtestate.MCPWaitForUpdatedFunc) ([]nropv1.MachineConfigPool, string) {
+func syncMachineConfigPoolsStatuses(instanceName string, forwardMCPConds bool, waitByPool map[string]rtestate.MCPWaitForUpdatedFunc, trees ...nodegroupv1.Tree) ([]nropv1.MachineConfigPool, string) {
 	klog.V(4).InfoS("Machine Config Pools Status Sync start", "trees", len(trees))
 	defer klog.V(4).Info("Machine Config Pools Status Sync stop")
 
@@ -462,7 +462,7 @@ func syncMachineConfigPoolsStatuses(instanceName string, trees []nodegroupv1.Tre
 	return mcpStatuses, ""
 }
 
-func syncMachineConfigPoolNodeGroupConfigStatuses(mcpStatuses []nropv1.MachineConfigPool, trees []nodegroupv1.Tree) []nropv1.MachineConfigPool {
+func syncMachineConfigPoolNodeGroupConfigStatuses(mcpStatuses []nropv1.MachineConfigPool, trees ...nodegroupv1.Tree) []nropv1.MachineConfigPool {
 	klog.V(4).InfoS("Machine Config Pool Node Group Status Sync start", "mcpStatuses", len(mcpStatuses), "trees", len(trees))
 	defer klog.V(4).Info("Machine Config Pool Node Group Status Sync stop")
 

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -64,6 +64,7 @@ import (
 	"github.com/openshift-kni/numaresources-operator/pkg/images"
 	"github.com/openshift-kni/numaresources-operator/pkg/loglevel"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
+	"github.com/openshift-kni/numaresources-operator/pkg/objectstate"
 	apistate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/api"
 	rtestate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/rte"
 	rteupdate "github.com/openshift-kni/numaresources-operator/pkg/objectupdate/rte"
@@ -856,4 +857,192 @@ func getMachineConfigPoolStatusByName(mcpStatuses []nropv1.MachineConfigPool, na
 		}
 	}
 	return nropv1.MachineConfigPool{Name: name}
+}
+
+type perTreeResult struct {
+	dsInfo         []poolDaemonSet
+	mcpStatuses    []nropv1.MachineConfigPool
+	pausedMCPNames sets.Set[string]
+	step           intreconcile.Step
+}
+
+func (r *NUMAResourcesOperatorReconciler) reconcilePerTreeMachineConfig(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, tree nodegroupv1.Tree) perTreeResult {
+	result := perTreeResult{}
+
+	waitByPool, pausedMCPNames, err := r.syncMachineConfigs(ctx, instance, existing, tree)
+	result.pausedMCPNames = pausedMCPNames
+	if err != nil {
+		result.step = intreconcile.StepFailed(fmt.Errorf("failed to sync machine configs: %w", err))
+		return result
+	}
+
+	mcpStatuses, mcpNamePending := syncMachineConfigPoolsStatuses(instance.Name, r.ForwardMCPConds, waitByPool, tree)
+	result.mcpStatuses = mcpStatuses
+
+	if mcpNamePending != "" {
+		result.step = intreconcile.StepOngoing(numaResourcesRetryPeriod).WithReason("MachineConfigPoolIsUpdating").WithMessage(mcpNamePending + " is updating")
+		return result
+	}
+	result.mcpStatuses = syncMachineConfigPoolNodeGroupConfigStatuses(result.mcpStatuses, tree)
+
+	if result.pausedMCPNames.Len() > 0 {
+		result.step = intreconcile.StepOngoing(0)
+	} else {
+		result.step = intreconcile.StepSuccess()
+	}
+	return result
+}
+
+func (r *NUMAResourcesOperatorReconciler) reconcilePerTreeDaemonSet(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, tree nodegroupv1.Tree) perTreeResult {
+	result := perTreeResult{}
+
+	existing = existing.WithManifestsUpdater(func(poolName string, gdm *rtestate.GeneratedDesiredManifest) error {
+		err := daemonsetUpdater(poolName, gdm, r.RTEMetricsTLS)
+		if err != nil {
+			return err
+		}
+		result.dsInfo = append(result.dsInfo, poolDaemonSet{poolName, namespacedname.FromObject(gdm.DaemonSet)})
+		return nil
+	})
+
+	if err := r.applyObjects(ctx, instance, existing.PerTreeState(r.RTEManifests, tree)); err != nil {
+		result.step = intreconcile.StepFailed(fmt.Errorf("FailedRTESync: %w", err))
+		return result
+	}
+
+	for _, dsInfo := range result.dsInfo {
+		ds := appsv1.DaemonSet{}
+		dsKey := client.ObjectKey{
+			Namespace: dsInfo.DaemonSet.Namespace,
+			Name:      dsInfo.DaemonSet.Name,
+		}
+		if err := r.Client.Get(ctx, dsKey, &ds); err != nil {
+			result.step = intreconcile.StepFailed(err)
+			return result
+		}
+		if !isDaemonSetReady(&ds) {
+			result.step = intreconcile.StepOngoing(5 * time.Second).WithReason("DaemonSetIsUpdating").WithMessage(dsKey.String() + " is updating")
+			return result
+		}
+	}
+
+	result.step = intreconcile.StepSuccess()
+	return result
+}
+
+func (r *NUMAResourcesOperatorReconciler) setupTreeAgnosticManifests(ctx context.Context, instance *nropv1.NUMAResourcesOperator) error {
+	rteupdate.DaemonSetRolloutSettings(r.RTEManifests.Core.DaemonSet)
+	err := rteupdate.DaemonSetAffinitySettings(r.RTEManifests.Core.DaemonSet, r.RTEManifests.Core.DaemonSet.Spec.Template.Labels)
+	if err != nil {
+		klog.ErrorS(err, "failed to update RTE affinity settings")
+	}
+
+	err = rteupdate.DaemonSetUserImageSettings(r.RTEManifests.Core.DaemonSet, instance.Spec.ExporterImage, r.Images.Preferred(), r.ImagePullPolicy)
+	if err != nil {
+		return err
+	}
+
+	err = rteupdate.DaemonSetPauseContainerSettings(r.RTEManifests.Core.DaemonSet)
+	if err != nil {
+		return err
+	}
+
+	err = loglevel.UpdatePodSpec(&r.RTEManifests.Core.DaemonSet.Spec.Template.Spec, manifests.ContainerNameRTE, instance.Spec.LogLevel)
+	if err != nil {
+		return err
+	}
+
+	rteupdate.SecurityContextConstraint(r.RTEManifests.Core.SecurityContextConstraint, true) // force to legacy context
+
+	return nil
+}
+
+func (r *NUMAResourcesOperatorReconciler) applyObjects(ctx context.Context, instance *nropv1.NUMAResourcesOperator, objStates []objectstate.ObjectState) error {
+	klog.V(4).InfoS("Applying objects", "count", len(objStates))
+	defer klog.V(4).InfoS("Applyied objects", "count", len(objStates))
+	for _, objState := range objStates {
+		if objState.Error != nil {
+			klog.Warningf("error loading object: %v", objState.Error)
+		}
+		if objState.UpdateError != nil {
+			return fmt.Errorf("failed to update (%s) %s/%s: %w", objState.Desired.GetObjectKind().GroupVersionKind(), objState.Desired.GetNamespace(), objState.Desired.GetName(), objState.UpdateError)
+		}
+		err := controllerutil.SetControllerReference(instance, objState.Desired, r.Scheme)
+		if err != nil {
+			return fmt.Errorf("failed to set controller reference to %s %s: %w", objState.Desired.GetNamespace(), objState.Desired.GetName(), err)
+		}
+		_, _, err = apply.ApplyObject(ctx, r.Client, objState)
+		if err != nil {
+			return fmt.Errorf("failed to apply (%s) %s/%s: %w", objState.Desired.GetObjectKind().GroupVersionKind(), objState.Desired.GetNamespace(), objState.Desired.GetName(), err)
+		}
+	}
+	return nil
+}
+
+func collectDaemonSets(dsInfos []poolDaemonSet) []nropv1.NamespacedName {
+	dssReady := make([]nropv1.NamespacedName, 0, len(dsInfos))
+	for _, dsInfo := range dsInfos {
+		dssReady = append(dssReady, dsInfo.DaemonSet)
+	}
+	return dssReady
+}
+
+func reducePerTreeResults(results []perTreeResult) perTreeResult {
+	acc := perTreeResult{
+		pausedMCPNames: sets.New[string](),
+		step:           intreconcile.StepSuccess(),
+	}
+
+	var errorCount, ongoingCount int
+	for _, result := range results {
+		acc.mcpStatuses = append(acc.mcpStatuses, result.mcpStatuses...)
+		acc.pausedMCPNames = acc.pausedMCPNames.Union(result.pausedMCPNames)
+
+		if result.step.Done() {
+			acc.dsInfo = append(acc.dsInfo, result.dsInfo...)
+			continue
+		}
+
+		if result.step.Failed() {
+			errorCount++
+		} else if result.step.Ongoing() {
+			ongoingCount++
+		}
+
+		if shouldReplaceStep(acc.step, result.step) {
+			acc.step = result.step
+		}
+	}
+	if !acc.step.Done() {
+		acc.step = acc.step.UpdateMessage(treeSummaryMessage(len(results), errorCount, ongoingCount))
+	}
+	return acc
+}
+
+func treeSummaryMessage(total, errors, ongoing int) string {
+	done := total - errors - ongoing
+	parts := make([]string, 0, 3)
+	if done > 0 {
+		parts = append(parts, fmt.Sprintf("%d/%d completed", done, total))
+	}
+	if ongoing > 0 {
+		parts = append(parts, fmt.Sprintf("%d/%d updating", ongoing, total))
+	}
+	if errors > 0 {
+		parts = append(parts, fmt.Sprintf("%d/%d failed", errors, total))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func shouldReplaceStep(current, candidate intreconcile.Step) bool {
+	if current.Done() {
+		return true
+	}
+	if candidate.Failed() && !current.Failed() {
+		return true
+	}
+	if candidate.Ongoing() && current.Ongoing() {
+		return candidate.Result.RequeueAfter < current.Result.RequeueAfter
+	}
+	return false
 }

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -64,6 +64,7 @@ import (
 	"github.com/openshift-kni/numaresources-operator/pkg/images"
 	"github.com/openshift-kni/numaresources-operator/pkg/loglevel"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
+	"github.com/openshift-kni/numaresources-operator/pkg/objectstate"
 	apistate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/api"
 	rtestate "github.com/openshift-kni/numaresources-operator/pkg/objectstate/rte"
 	rteupdate "github.com/openshift-kni/numaresources-operator/pkg/objectupdate/rte"
@@ -441,10 +442,10 @@ func syncMachineConfigPoolsStatuses(instanceName string, forwardMCPConds bool, w
 	klog.V(4).InfoS("Machine Config Pools Status Sync start", "trees", len(trees))
 	defer klog.V(4).Info("Machine Config Pools Status Sync stop")
 
-	mcpStatuses := []nropv1.MachineConfigPool{}
+	nroMCPs := []nropv1.MachineConfigPool{}
 	for _, tree := range trees {
 		for _, mcp := range tree.MachineConfigPools {
-			mcpStatuses = append(mcpStatuses, extractMCPStatus(mcp, forwardMCPConds))
+			nroMCPs = append(nroMCPs, makeNROPMCP(mcp, forwardMCPConds))
 
 			waitFunc, ok := waitByPool[mcp.Name]
 			if !ok {
@@ -455,40 +456,40 @@ func syncMachineConfigPoolsStatuses(instanceName string, forwardMCPConds bool, w
 			klog.V(5).InfoS("Machine Config Pool state", "name", mcp.Name, "instance", instanceName, "updated", isUpdated)
 
 			if !isUpdated {
-				return mcpStatuses, mcp.Name
+				return nroMCPs, mcp.Name
 			}
 		}
 	}
-	return mcpStatuses, ""
+	return nroMCPs, ""
 }
 
-func syncMachineConfigPoolNodeGroupConfigStatuses(mcpStatuses []nropv1.MachineConfigPool, trees ...nodegroupv1.Tree) []nropv1.MachineConfigPool {
-	klog.V(4).InfoS("Machine Config Pool Node Group Status Sync start", "mcpStatuses", len(mcpStatuses), "trees", len(trees))
+func syncMachineConfigPoolNodeGroupConfigStatuses(mcpPools []nropv1.MachineConfigPool, trees ...nodegroupv1.Tree) []nropv1.MachineConfigPool {
+	klog.V(4).InfoS("Machine Config Pool Node Group Status Sync start", "mcpPools", len(mcpPools), "trees", len(trees))
 	defer klog.V(4).Info("Machine Config Pool Node Group Status Sync stop")
 
-	updatedMcpStatuses := []nropv1.MachineConfigPool{}
+	updatedMcpPools := []nropv1.MachineConfigPool{}
 	for _, tree := range trees {
 		klog.V(5).InfoS("Machine Config Pool Node Group tree update", "mcps", len(tree.MachineConfigPools))
 
 		for _, mcp := range tree.MachineConfigPools {
-			mcpStatus := getMachineConfigPoolStatusByName(mcpStatuses, mcp.Name)
+			mcpPool := findNROMCPByName(mcpPools, mcp.Name)
 
 			var confSource string
 			if tree.NodeGroup != nil && tree.NodeGroup.Config != nil {
 				confSource = "spec"
-				mcpStatus.Config = tree.NodeGroup.Config.DeepCopy()
+				mcpPool.Config = tree.NodeGroup.Config.DeepCopy()
 			} else {
 				confSource = "default"
 				ngc := nropv1.DefaultNodeGroupConfig()
-				mcpStatus.Config = &ngc
+				mcpPool.Config = &ngc
 			}
 
-			klog.V(6).InfoS("Machine Config Pool Node Group updated status config", "mcp", mcp.Name, "source", confSource, "data", mcpStatus.Config.ToString())
+			klog.V(6).InfoS("Machine Config Pool Node Group updated status config", "mcp", mcp.Name, "source", confSource, "data", mcpPool.Config.ToString())
 
-			updatedMcpStatuses = append(updatedMcpStatuses, mcpStatus)
+			updatedMcpPools = append(updatedMcpPools, mcpPool)
 		}
 	}
-	return updatedMcpStatuses
+	return updatedMcpPools
 }
 
 func (r *NUMAResourcesOperatorReconciler) syncNUMAResourcesOperatorResources(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, trees []nodegroupv1.Tree) ([]poolDaemonSet, error) {
@@ -838,22 +839,223 @@ func IsRTEImageOverridable() bool {
 	return overridable
 }
 
-func extractMCPStatus(mcp *machineconfigv1.MachineConfigPool, forwardMCPConds bool) nropv1.MachineConfigPool {
-	mcpStatus := nropv1.MachineConfigPool{
+func makeNROPMCP(mcp *machineconfigv1.MachineConfigPool, forwardMCPConds bool) nropv1.MachineConfigPool {
+	nroMcp := nropv1.MachineConfigPool{
 		Name: mcp.Name,
 	}
 	if !forwardMCPConds {
-		return mcpStatus
+		return nroMcp
 	}
-	mcpStatus.Conditions = mcp.Status.Conditions
-	return mcpStatus
+	nroMcp.Conditions = mcp.Status.Conditions
+	return nroMcp
 }
 
-func getMachineConfigPoolStatusByName(mcpStatuses []nropv1.MachineConfigPool, name string) nropv1.MachineConfigPool {
-	for _, mcpStatus := range mcpStatuses {
+func findNROMCPByName(nroMCPs []nropv1.MachineConfigPool, name string) nropv1.MachineConfigPool {
+	for _, mcpStatus := range nroMCPs {
 		if mcpStatus.Name == name {
 			return mcpStatus
 		}
 	}
 	return nropv1.MachineConfigPool{Name: name}
+}
+
+type perTreeResult struct {
+	dsInfo         []poolDaemonSet
+	nroMCPs        []nropv1.MachineConfigPool
+	pausedMCPNames sets.Set[string]
+	step           intreconcile.Step
+}
+
+// reconcilePerTreeMachineConfig wants to do as much work as possible and return the
+// work done in `perTreeResult`. Depending on cluster state, the `perTreeResult`
+// may be partially filled, but must be always internally consistent (e.g.
+// partial data needs still to be locally correct).
+// Note this function intentionally ignores `dsInfo`. See `reconcilePerTreeDaemonSet`.
+// Callers and downstream code must handle partially-filled perTreeResults.
+func (r *NUMAResourcesOperatorReconciler) reconcilePerTreeMachineConfig(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, tree nodegroupv1.Tree) perTreeResult {
+	result := perTreeResult{}
+
+	waitByPool, pausedMCPNames, err := r.syncMachineConfigs(ctx, instance, existing, tree)
+	result.pausedMCPNames = pausedMCPNames
+	if err != nil {
+		result.step = intreconcile.StepFailed(fmt.Errorf("failed to sync machine configs: %w", err))
+		return result
+	}
+
+	nroMCPs, mcpNamePending := syncMachineConfigPoolsStatuses(instance.Name, r.ForwardMCPConds, waitByPool, tree)
+	result.nroMCPs = nroMCPs
+
+	if mcpNamePending != "" {
+		result.step = intreconcile.StepOngoing(numaResourcesRetryPeriod).WithReason("MachineConfigPoolIsUpdating").WithMessage(mcpNamePending + " is updating")
+		return result
+	}
+	result.nroMCPs = syncMachineConfigPoolNodeGroupConfigStatuses(result.nroMCPs, tree)
+
+	if result.pausedMCPNames.Len() > 0 {
+		result.step = intreconcile.StepOngoing(0)
+	} else {
+		result.step = intreconcile.StepSuccess()
+	}
+	return result
+}
+
+// reconcilePerTreeDaemonSet wants to do as much work as possible and return the
+// work done in `perTreeResult`. Depending on cluster state, the `perTreeResult`
+// may be partially filled, but must be always internally consistent (e.g.
+// partial data needs still to be locally correct).
+// Note this function intentionally only changes `dsInfo` and `step`.
+// See `reconcilePerTreeMachineConfig`.
+// Callers and downstream code must handle partially-filled perTreeResults.
+func (r *NUMAResourcesOperatorReconciler) reconcilePerTreeDaemonSet(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, tree nodegroupv1.Tree) perTreeResult {
+	result := perTreeResult{}
+
+	existing = existing.WithManifestsUpdater(func(poolName string, gdm *rtestate.GeneratedDesiredManifest) error {
+		err := daemonsetUpdater(poolName, gdm, r.RTEMetricsTLS)
+		if err != nil {
+			return err
+		}
+		result.dsInfo = append(result.dsInfo, poolDaemonSet{poolName, namespacedname.FromObject(gdm.DaemonSet)})
+		return nil
+	})
+
+	if err := r.applyObjects(ctx, instance, existing.PerTreeState(r.RTEManifests, tree)); err != nil {
+		result.step = intreconcile.StepFailed(fmt.Errorf("FailedRTESync: %w", err))
+		return result
+	}
+
+	for _, dsInfo := range result.dsInfo {
+		ds := appsv1.DaemonSet{}
+		dsKey := client.ObjectKey{
+			Namespace: dsInfo.DaemonSet.Namespace,
+			Name:      dsInfo.DaemonSet.Name,
+		}
+		if err := r.Client.Get(ctx, dsKey, &ds); err != nil {
+			result.step = intreconcile.StepFailed(err)
+			return result
+		}
+		if !isDaemonSetReady(&ds) {
+			result.step = intreconcile.StepOngoing(5 * time.Second).WithReason("DaemonSetIsUpdating").WithMessage(dsKey.String() + " is updating")
+			return result
+		}
+	}
+
+	result.step = intreconcile.StepSuccess()
+	return result
+}
+
+func (r *NUMAResourcesOperatorReconciler) setupTreeAgnosticManifests(ctx context.Context, instance *nropv1.NUMAResourcesOperator) error {
+	rteupdate.DaemonSetRolloutSettings(r.RTEManifests.Core.DaemonSet)
+	err := rteupdate.DaemonSetAffinitySettings(r.RTEManifests.Core.DaemonSet, r.RTEManifests.Core.DaemonSet.Spec.Template.Labels)
+	if err != nil {
+		klog.ErrorS(err, "failed to update RTE affinity settings")
+	}
+
+	err = rteupdate.DaemonSetUserImageSettings(r.RTEManifests.Core.DaemonSet, instance.Spec.ExporterImage, r.Images.Preferred(), r.ImagePullPolicy)
+	if err != nil {
+		return err
+	}
+
+	err = rteupdate.DaemonSetPauseContainerSettings(r.RTEManifests.Core.DaemonSet)
+	if err != nil {
+		return err
+	}
+
+	err = loglevel.UpdatePodSpec(&r.RTEManifests.Core.DaemonSet.Spec.Template.Spec, manifests.ContainerNameRTE, instance.Spec.LogLevel)
+	if err != nil {
+		return err
+	}
+
+	rteupdate.SecurityContextConstraint(r.RTEManifests.Core.SecurityContextConstraint, true) // force to legacy context
+
+	return nil
+}
+
+func (r *NUMAResourcesOperatorReconciler) applyObjects(ctx context.Context, instance *nropv1.NUMAResourcesOperator, objStates []objectstate.ObjectState) error {
+	klog.V(4).InfoS("Applying objects", "count", len(objStates))
+	defer klog.V(4).InfoS("Applyied objects", "count", len(objStates))
+	for _, objState := range objStates {
+		if objState.Error != nil {
+			klog.Warningf("error loading object: %v", objState.Error)
+		}
+		if objState.UpdateError != nil {
+			return fmt.Errorf("failed to update (%s) %s/%s: %w", objState.Desired.GetObjectKind().GroupVersionKind(), objState.Desired.GetNamespace(), objState.Desired.GetName(), objState.UpdateError)
+		}
+		err := controllerutil.SetControllerReference(instance, objState.Desired, r.Scheme)
+		if err != nil {
+			return fmt.Errorf("failed to set controller reference to %s %s: %w", objState.Desired.GetNamespace(), objState.Desired.GetName(), err)
+		}
+		_, _, err = apply.ApplyObject(ctx, r.Client, objState)
+		if err != nil {
+			return fmt.Errorf("failed to apply (%s) %s/%s: %w", objState.Desired.GetObjectKind().GroupVersionKind(), objState.Desired.GetNamespace(), objState.Desired.GetName(), err)
+		}
+	}
+	return nil
+}
+
+func collectDaemonSets(dsInfos []poolDaemonSet) []nropv1.NamespacedName {
+	dssReady := make([]nropv1.NamespacedName, 0, len(dsInfos))
+	for _, dsInfo := range dsInfos {
+		dssReady = append(dssReady, dsInfo.DaemonSet)
+	}
+	return dssReady
+}
+
+func reducePerTreeResults(results []perTreeResult) perTreeResult {
+	acc := perTreeResult{
+		pausedMCPNames: sets.New[string](),
+		step:           intreconcile.StepSuccess(),
+	}
+
+	var errorCount, ongoingCount int
+	for _, result := range results {
+		acc.nroMCPs = append(acc.nroMCPs, result.nroMCPs...)
+		acc.pausedMCPNames = acc.pausedMCPNames.Union(result.pausedMCPNames)
+
+		if result.step.Done() {
+			acc.dsInfo = append(acc.dsInfo, result.dsInfo...)
+			continue
+		}
+
+		if result.step.Failed() {
+			errorCount++
+		} else if result.step.Ongoing() {
+			ongoingCount++
+		}
+
+		if shouldReplaceStep(acc.step, result.step) {
+			acc.step = result.step
+		}
+	}
+	if !acc.step.Done() {
+		acc.step = acc.step.UpdateMessage(treeSummaryMessage(len(results), errorCount, ongoingCount))
+	}
+	return acc
+}
+
+func treeSummaryMessage(total, errors, ongoing int) string {
+	done := total - errors - ongoing
+	parts := make([]string, 0, 3)
+	if done > 0 {
+		parts = append(parts, fmt.Sprintf("%d/%d completed", done, total))
+	}
+	if ongoing > 0 {
+		parts = append(parts, fmt.Sprintf("%d/%d updating", ongoing, total))
+	}
+	if errors > 0 {
+		parts = append(parts, fmt.Sprintf("%d/%d failed", errors, total))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func shouldReplaceStep(current, candidate intreconcile.Step) bool {
+	if current.Done() {
+		return true
+	}
+	if candidate.Failed() && !current.Failed() {
+		return true
+	}
+	if candidate.Ongoing() && current.Ongoing() {
+		return candidate.Result.RequeueAfter < current.Result.RequeueAfter
+	}
+	return false
 }

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -85,12 +85,6 @@ const (
 
 const numaResourcesRetryPeriod = 1 * time.Minute
 
-// poolDaemonSet a struct to hold the target MCP of a configured node group and its created respective RTE daemonset
-type poolDaemonSet struct {
-	PoolName  string
-	DaemonSet nropv1.NamespacedName
-}
-
 // NUMAResourcesOperatorReconciler reconciles a NUMAResourcesOperator object
 type NUMAResourcesOperatorReconciler struct {
 	client.Client
@@ -269,42 +263,42 @@ func (r *NUMAResourcesOperatorReconciler) reconcileResource(ctx context.Context,
 		}
 	}
 
-	var results []perTreeResult
+	var results []nodegroupv1.PerTreeResult
 	for _, tree := range trees {
 		tree.NodeGroup.Config = ptr.To(tree.NodeGroup.NormalizeConfig())
 
 		treeExisting := existing.PerTree(ctx, r.Client, tree)
 
-		mcResult := perTreeResult{}
+		mcResult := nodegroupv1.PerTreeResult{}
 		if r.Platform == platform.OpenShift {
 			mcResult = r.reconcilePerTreeMachineConfig(ctx, instance, treeExisting, tree)
-			if mcResult.step.EarlyStop() {
+			if mcResult.Step.EarlyStop() {
 				results = append(results, mcResult)
 				continue
 			}
 		}
 
 		dsResult := r.reconcilePerTreeDaemonSet(ctx, instance, treeExisting, tree)
-		dsResult.nroMCPs = mcResult.nroMCPs
-		dsResult.pausedMCPNames = mcResult.pausedMCPNames
+		dsResult.NROMCPs = mcResult.NROMCPs
+		dsResult.PausedMCPNames = mcResult.PausedMCPNames
 		results = append(results, dsResult)
 	}
 
-	overall := reducePerTreeResults(results)
-	dssReady := collectDaemonSets(overall.dsInfo)
-	instance.Status.MachineConfigPools = overall.nroMCPs
-	instance.Status.Conditions = updateMachineConfigPoolPausedCondition(instance.Status.Conditions, instance.Generation, overall.pausedMCPNames)
+	overall := nodegroupv1.ReducePerTreeResults(results)
+	dssReady := nodegroupv1.CollectDaemonSets(overall.DSInfo)
+	instance.Status.MachineConfigPools = overall.NROMCPs
+	instance.Status.Conditions = updateMachineConfigPoolPausedCondition(instance.Status.Conditions, instance.Generation, overall.PausedMCPNames)
 	instance.Status.DaemonSets = dssReady
 	instance.Status.RelatedObjects = relatedobjects.ResourceTopologyExporter(r.Namespace, dssReady)
 
-	if overall.step.Done() {
-		instance.Status.NodeGroups = syncNodeGroupsStatus(instance, overall.dsInfo)
+	if overall.Step.Done() {
+		instance.Status.NodeGroups = syncNodeGroupsStatus(instance, overall.DSInfo)
 	}
 
-	return overall.step
+	return overall.Step
 }
 
-func syncNodeGroupsStatus(instance *nropv1.NUMAResourcesOperator, dsPerPool []poolDaemonSet) []nropv1.NodeGroupStatus {
+func syncNodeGroupsStatus(instance *nropv1.NUMAResourcesOperator, dsPerPool []nodegroupv1.PoolDaemonSet) []nropv1.NodeGroupStatus {
 	ngStatuses := []nropv1.NodeGroupStatus{}
 
 	if len(instance.Status.MachineConfigPools) == 0 {
@@ -736,87 +730,83 @@ func findNROMCPByName(nroMCPs []nropv1.MachineConfigPool, name string) nropv1.Ma
 	return nropv1.MachineConfigPool{Name: name}
 }
 
-type perTreeResult struct {
-	dsInfo         []poolDaemonSet
-	nroMCPs        []nropv1.MachineConfigPool
-	pausedMCPNames sets.Set[string]
-	step           intreconcile.Step
-}
-
 // reconcilePerTreeMachineConfig wants to do as much work as possible and return the
-// work done in `perTreeResult`. Depending on cluster state, the `perTreeResult`
+// work done in `nodegroupv1.PerTreeResult`. Depending on cluster state, the `nodegroupv1.PerTreeResult`
 // may be partially filled, but must be always internally consistent (e.g.
 // partial data needs still to be locally correct).
 // Note this function intentionally ignores `dsInfo`. See `reconcilePerTreeDaemonSet`.
-// Callers and downstream code must handle partially-filled perTreeResults.
-func (r *NUMAResourcesOperatorReconciler) reconcilePerTreeMachineConfig(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, tree nodegroupv1.Tree) perTreeResult {
-	result := perTreeResult{}
+// Callers and downstream code must handle partially-filled nodegroupv1.PerTreeResults.
+func (r *NUMAResourcesOperatorReconciler) reconcilePerTreeMachineConfig(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, tree nodegroupv1.Tree) nodegroupv1.PerTreeResult {
+	result := nodegroupv1.PerTreeResult{}
 
 	waitByPool, pausedMCPNames, err := r.syncMachineConfig(ctx, instance, existing, tree)
-	result.pausedMCPNames = pausedMCPNames
+	result.PausedMCPNames = pausedMCPNames
 	if err != nil {
-		result.step = intreconcile.StepFailed(fmt.Errorf("failed to sync machine configs: %w", err))
+		result.Step = intreconcile.StepFailed(fmt.Errorf("failed to sync machine configs: %w", err))
 		return result
 	}
 
 	nroMCPs, mcpNamePending := syncMachineConfigPoolsStatuses(instance.Name, r.ForwardMCPConds, waitByPool, tree)
-	result.nroMCPs = nroMCPs
+	result.NROMCPs = nroMCPs
 
 	if mcpNamePending != "" {
-		result.step = intreconcile.StepOngoing(numaResourcesRetryPeriod).WithReason("MachineConfigPoolIsUpdating").WithMessage(mcpNamePending + " is updating")
+		result.Step = intreconcile.StepOngoing(numaResourcesRetryPeriod).WithReason("MachineConfigPoolIsUpdating").WithMessage(mcpNamePending + " is updating")
 		return result
 	}
-	result.nroMCPs = syncMachineConfigPoolNodeGroupConfigStatuses(result.nroMCPs, tree)
+	result.NROMCPs = syncMachineConfigPoolNodeGroupConfigStatuses(result.NROMCPs, tree)
 
-	if result.pausedMCPNames.Len() > 0 {
-		result.step = intreconcile.StepOngoing(0)
+	if result.PausedMCPNames.Len() > 0 {
+		result.Step = intreconcile.StepOngoing(0)
 	} else {
-		result.step = intreconcile.StepSuccess()
+		result.Step = intreconcile.StepSuccess()
 	}
 	return result
 }
 
 // reconcilePerTreeDaemonSet wants to do as much work as possible and return the
-// work done in `perTreeResult`. Depending on cluster state, the `perTreeResult`
+// work done in `nodegroupv1.PerTreeResult`. Depending on cluster state, the `nodegroupv1.PerTreeResult`
 // may be partially filled, but must be always internally consistent (e.g.
 // partial data needs still to be locally correct).
 // Note this function intentionally only changes `dsInfo` and `step`.
 // See `reconcilePerTreeMachineConfig`.
-// Callers and downstream code must handle partially-filled perTreeResults.
-func (r *NUMAResourcesOperatorReconciler) reconcilePerTreeDaemonSet(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, tree nodegroupv1.Tree) perTreeResult {
-	result := perTreeResult{}
+// Callers and downstream code must handle partially-filled nodegroupv1.PerTreeResults.
+func (r *NUMAResourcesOperatorReconciler) reconcilePerTreeDaemonSet(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, tree nodegroupv1.Tree) nodegroupv1.PerTreeResult {
+	result := nodegroupv1.PerTreeResult{}
 
 	existing = existing.WithManifestsUpdater(func(poolName string, gdm *rtestate.GeneratedDesiredManifest) error {
 		err := daemonsetUpdater(poolName, gdm, r.RTEMetricsTLS)
 		if err != nil {
 			return err
 		}
-		result.dsInfo = append(result.dsInfo, poolDaemonSet{poolName, namespacedname.FromObject(gdm.DaemonSet)})
+		result.DSInfo = append(result.DSInfo, nodegroupv1.PoolDaemonSet{
+			PoolName:  poolName,
+			DaemonSet: namespacedname.FromObject(gdm.DaemonSet),
+		})
 		return nil
 	})
 
 	if err := r.applyObjects(ctx, instance, existing.PerTreeState(r.RTEManifests, tree)); err != nil {
-		result.step = intreconcile.StepFailed(fmt.Errorf("FailedRTESync: %w", err))
+		result.Step = intreconcile.StepFailed(fmt.Errorf("FailedRTESync: %w", err))
 		return result
 	}
 
-	for _, dsInfo := range result.dsInfo {
+	for _, dsInfo := range result.DSInfo {
 		ds := appsv1.DaemonSet{}
 		dsKey := client.ObjectKey{
 			Namespace: dsInfo.DaemonSet.Namespace,
 			Name:      dsInfo.DaemonSet.Name,
 		}
 		if err := r.Client.Get(ctx, dsKey, &ds); err != nil {
-			result.step = intreconcile.StepFailed(err)
+			result.Step = intreconcile.StepFailed(err)
 			return result
 		}
 		if !isDaemonSetReady(&ds) {
-			result.step = intreconcile.StepOngoing(5 * time.Second).WithReason("DaemonSetIsUpdating").WithMessage(dsKey.String() + " is updating")
+			result.Step = intreconcile.StepOngoing(5 * time.Second).WithReason("DaemonSetIsUpdating").WithMessage(dsKey.String() + " is updating")
 			return result
 		}
 	}
 
-	result.step = intreconcile.StepSuccess()
+	result.Step = intreconcile.StepSuccess()
 	return result
 }
 
@@ -841,7 +831,7 @@ func (r *NUMAResourcesOperatorReconciler) setupTreeAgnosticManifests(ctx context
 
 func (r *NUMAResourcesOperatorReconciler) applyObjects(ctx context.Context, instance *nropv1.NUMAResourcesOperator, objStates []objectstate.ObjectState) error {
 	klog.V(4).InfoS("Applying objects", "count", len(objStates))
-	defer klog.V(4).InfoS("Applyied objects", "count", len(objStates))
+	defer klog.V(4).InfoS("Applied objects", "count", len(objStates))
 	for _, objState := range objStates {
 		if objState.Error != nil {
 			if !objState.IsNotFoundError() {
@@ -861,72 +851,4 @@ func (r *NUMAResourcesOperatorReconciler) applyObjects(ctx context.Context, inst
 		}
 	}
 	return nil
-}
-
-func collectDaemonSets(dsInfos []poolDaemonSet) []nropv1.NamespacedName {
-	dssReady := make([]nropv1.NamespacedName, 0, len(dsInfos))
-	for _, dsInfo := range dsInfos {
-		dssReady = append(dssReady, dsInfo.DaemonSet)
-	}
-	return dssReady
-}
-
-func reducePerTreeResults(results []perTreeResult) perTreeResult {
-	acc := perTreeResult{
-		pausedMCPNames: sets.New[string](),
-		step:           intreconcile.StepSuccess(),
-	}
-
-	var errorCount, ongoingCount int
-	for _, result := range results {
-		acc.nroMCPs = append(acc.nroMCPs, result.nroMCPs...)
-		acc.pausedMCPNames = acc.pausedMCPNames.Union(result.pausedMCPNames)
-
-		if result.step.Done() {
-			acc.dsInfo = append(acc.dsInfo, result.dsInfo...)
-			continue
-		}
-
-		if result.step.Failed() {
-			errorCount++
-		} else if result.step.Ongoing() {
-			ongoingCount++
-		}
-
-		if shouldReplaceStep(acc.step, result.step) {
-			acc.step = result.step
-		}
-	}
-	if !acc.step.Done() {
-		acc.step = acc.step.UpdateMessage(treeSummaryMessage(len(results), errorCount, ongoingCount))
-	}
-	return acc
-}
-
-func treeSummaryMessage(total, errors, ongoing int) string {
-	done := total - errors - ongoing
-	parts := make([]string, 0, 3)
-	if done > 0 {
-		parts = append(parts, fmt.Sprintf("%d/%d completed", done, total))
-	}
-	if ongoing > 0 {
-		parts = append(parts, fmt.Sprintf("%d/%d updating", ongoing, total))
-	}
-	if errors > 0 {
-		parts = append(parts, fmt.Sprintf("%d/%d failed", errors, total))
-	}
-	return strings.Join(parts, ", ")
-}
-
-func shouldReplaceStep(current, candidate intreconcile.Step) bool {
-	if current.Done() {
-		return true
-	}
-	if candidate.Failed() && !current.Failed() {
-		return true
-	}
-	if candidate.Ongoing() && current.Ongoing() {
-		return candidate.Result.RequeueAfter > 0 && candidate.Result.RequeueAfter < current.Result.RequeueAfter
-	}
-	return false
 }

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -367,8 +367,8 @@ func (r *NUMAResourcesOperatorReconciler) syncNodeResourceTopologyAPI(ctx contex
 	return (updatedCount == len(objStates)), err
 }
 
-func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, trees ...nodegroupv1.Tree) (map[string]rtestate.MCPWaitForUpdatedFunc, sets.Set[string], error) {
-	klog.V(4).InfoS("Machine Config Sync start", "trees", len(trees))
+func (r *NUMAResourcesOperatorReconciler) syncMachineConfig(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, tree nodegroupv1.Tree) (map[string]rtestate.MCPWaitForUpdatedFunc, sets.Set[string], error) {
+	klog.V(4).InfoS("Machine Config Sync start", "tree", tree.Name())
 	defer klog.V(4).Info("Machine Config Sync stop")
 
 	var err error
@@ -377,7 +377,7 @@ func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context
 	// In case of operator upgrade from 4.1X → 4.18, it's necessary to remove the old MachineConfig,
 	// unless an emergency annotation is provided which forces the operator to use custom policy
 
-	mcObjStates, pausedMCPNames := existing.MachineConfigsStateForTree(r.RTEManifests, trees[0])
+	mcObjStates, pausedMCPNames := existing.MachineConfigsStateForTree(r.RTEManifests, tree)
 	waitByPool := make(map[string]rtestate.MCPWaitForUpdatedFunc, len(mcObjStates))
 	for _, mcObjState := range mcObjStates {
 		waitByPool[mcObjState.PoolName] = mcObjState.WaitForUpdated
@@ -389,7 +389,7 @@ func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context
 				break
 			}
 
-			if err2 := validateMachineConfigLabels(objState.Desired, trees); err2 != nil {
+			if err2 := validateMachineConfigLabels(objState.Desired, tree); err2 != nil {
 				err = err2
 				break
 			}
@@ -609,7 +609,7 @@ func validateUpdateEvent(e *event.UpdateEvent) bool {
 	return true
 }
 
-func validateMachineConfigLabels(mc client.Object, trees []nodegroupv1.Tree) error {
+func validateMachineConfigLabels(mc client.Object, tree nodegroupv1.Tree) error {
 	mcLabels := mc.GetLabels()
 	v, ok := mcLabels[rtestate.MachineConfigLabelKey]
 	// the machine config does not have generated label, meaning the machine config pool has the matchLabels under
@@ -618,21 +618,19 @@ func validateMachineConfigLabels(mc client.Object, trees []nodegroupv1.Tree) err
 		return nil
 	}
 
-	for _, tree := range trees {
-		for _, mcp := range tree.MachineConfigPools {
-			if v != mcp.Name {
-				continue
-			}
+	for _, mcp := range tree.MachineConfigPools {
+		if v != mcp.Name {
+			continue
+		}
 
-			mcLabels := labels.Set(mcLabels)
-			mcSelector, err := metav1.LabelSelectorAsSelector(mcp.Spec.MachineConfigSelector)
-			if err != nil {
-				return fmt.Errorf("failed to represent machine config pool %q machine config selector as selector: %w", mcp.Name, err)
-			}
+		mcLabels := labels.Set(mcLabels)
+		mcSelector, err := metav1.LabelSelectorAsSelector(mcp.Spec.MachineConfigSelector)
+		if err != nil {
+			return fmt.Errorf("failed to represent machine config pool %q machine config selector as selector: %w", mcp.Name, err)
+		}
 
-			if !mcSelector.Matches(mcLabels) {
-				return fmt.Errorf("machine config %q labels does not match the machine config pool %q machine config selector", mc.GetName(), mcp.Name)
-			}
+		if !mcSelector.Matches(mcLabels) {
+			return fmt.Errorf("machine config %q labels does not match the machine config pool %q machine config selector", mc.GetName(), mcp.Name)
 		}
 	}
 	return nil
@@ -758,7 +756,7 @@ type perTreeResult struct {
 func (r *NUMAResourcesOperatorReconciler) reconcilePerTreeMachineConfig(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, tree nodegroupv1.Tree) perTreeResult {
 	result := perTreeResult{}
 
-	waitByPool, pausedMCPNames, err := r.syncMachineConfigs(ctx, instance, existing, tree)
+	waitByPool, pausedMCPNames, err := r.syncMachineConfig(ctx, instance, existing, tree)
 	result.pausedMCPNames = pausedMCPNames
 	if err != nil {
 		result.step = intreconcile.StepFailed(fmt.Errorf("failed to sync machine configs: %w", err))

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -403,56 +403,52 @@ func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context
 	return waitByPool, pausedMCPNames, err
 }
 
-func syncMachineConfigPoolsStatuses(instanceName string, forwardMCPConds bool, waitByPool map[string]rtestate.MCPWaitForUpdatedFunc, trees ...nodegroupv1.Tree) ([]nropv1.MachineConfigPool, string) {
-	klog.V(4).InfoS("Machine Config Pools Status Sync start", "trees", len(trees))
+func syncMachineConfigPoolsStatuses(instanceName string, forwardMCPConds bool, waitByPool map[string]rtestate.MCPWaitForUpdatedFunc, tree nodegroupv1.Tree) ([]nropv1.MachineConfigPool, string) {
+	klog.V(4).InfoS("Machine Config Pools Status Sync start", "tree", tree.Name())
 	defer klog.V(4).Info("Machine Config Pools Status Sync stop")
 
 	nroMCPs := []nropv1.MachineConfigPool{}
-	for _, tree := range trees {
-		for _, mcp := range tree.MachineConfigPools {
-			nroMCPs = append(nroMCPs, makeNROPMCP(mcp, forwardMCPConds))
+	for _, mcp := range tree.MachineConfigPools {
+		nroMCPs = append(nroMCPs, makeNROPMCP(mcp, forwardMCPConds))
 
-			waitFunc, ok := waitByPool[mcp.Name]
-			if !ok {
-				continue
-			}
+		waitFunc, ok := waitByPool[mcp.Name]
+		if !ok {
+			continue
+		}
 
-			isUpdated := waitFunc(instanceName, mcp)
-			klog.V(5).InfoS("Machine Config Pool state", "name", mcp.Name, "instance", instanceName, "updated", isUpdated)
+		isUpdated := waitFunc(instanceName, mcp)
+		klog.V(5).InfoS("Machine Config Pool state", "name", mcp.Name, "instance", instanceName, "updated", isUpdated)
 
-			if !isUpdated {
-				return nroMCPs, mcp.Name
-			}
+		if !isUpdated {
+			return nroMCPs, mcp.Name
 		}
 	}
 	return nroMCPs, ""
 }
 
-func syncMachineConfigPoolNodeGroupConfigStatuses(mcpPools []nropv1.MachineConfigPool, trees ...nodegroupv1.Tree) []nropv1.MachineConfigPool {
-	klog.V(4).InfoS("Machine Config Pool Node Group Status Sync start", "mcpPools", len(mcpPools), "trees", len(trees))
+func syncMachineConfigPoolNodeGroupConfigStatuses(mcpPools []nropv1.MachineConfigPool, tree nodegroupv1.Tree) []nropv1.MachineConfigPool {
+	klog.V(4).InfoS("Machine Config Pool Node Group Status Sync start", "mcpPools", len(mcpPools), "tree", tree.Name())
 	defer klog.V(4).Info("Machine Config Pool Node Group Status Sync stop")
 
 	updatedMcpPools := []nropv1.MachineConfigPool{}
-	for _, tree := range trees {
-		klog.V(5).InfoS("Machine Config Pool Node Group tree update", "mcps", len(tree.MachineConfigPools))
+	klog.V(5).InfoS("Machine Config Pool Node Group tree update", "mcps", len(tree.MachineConfigPools))
 
-		for _, mcp := range tree.MachineConfigPools {
-			mcpPool := findNROMCPByName(mcpPools, mcp.Name)
+	for _, mcp := range tree.MachineConfigPools {
+		mcpPool := findNROMCPByName(mcpPools, mcp.Name)
 
-			var confSource string
-			if tree.NodeGroup != nil && tree.NodeGroup.Config != nil {
-				confSource = "spec"
-				mcpPool.Config = tree.NodeGroup.Config.DeepCopy()
-			} else {
-				confSource = "default"
-				ngc := nropv1.DefaultNodeGroupConfig()
-				mcpPool.Config = &ngc
-			}
-
-			klog.V(6).InfoS("Machine Config Pool Node Group updated status config", "mcp", mcp.Name, "source", confSource, "data", mcpPool.Config.ToString())
-
-			updatedMcpPools = append(updatedMcpPools, mcpPool)
+		var confSource string
+		if tree.NodeGroup != nil && tree.NodeGroup.Config != nil {
+			confSource = "spec"
+			mcpPool.Config = tree.NodeGroup.Config.DeepCopy()
+		} else {
+			confSource = "default"
+			ngc := nropv1.DefaultNodeGroupConfig()
+			mcpPool.Config = &ngc
 		}
+
+		klog.V(6).InfoS("Machine Config Pool Node Group updated status config", "mcp", mcp.Name, "source", confSource, "data", mcpPool.Config.ToString())
+
+		updatedMcpPools = append(updatedMcpPools, mcpPool)
 	}
 	return updatedMcpPools
 }

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -852,7 +852,9 @@ func (r *NUMAResourcesOperatorReconciler) applyObjects(ctx context.Context, inst
 	defer klog.V(4).InfoS("Applyied objects", "count", len(objStates))
 	for _, objState := range objStates {
 		if objState.Error != nil {
-			klog.Warningf("error loading object: %v", objState.Error)
+			if !objState.IsNotFoundError() {
+				return fmt.Errorf("failed to load object state for %s/%s: %w", objState.Desired.GetNamespace(), objState.Desired.GetName(), objState.Error)
+			}
 		}
 		if objState.UpdateError != nil {
 			return fmt.Errorf("failed to update (%s) %s/%s: %w", objState.Desired.GetObjectKind().GroupVersionKind(), objState.Desired.GetNamespace(), objState.Desired.GetName(), objState.UpdateError)
@@ -932,7 +934,7 @@ func shouldReplaceStep(current, candidate intreconcile.Step) bool {
 		return true
 	}
 	if candidate.Ongoing() && current.Ongoing() {
-		return candidate.Result.RequeueAfter < current.Result.RequeueAfter
+		return candidate.Result.RequeueAfter > 0 && candidate.Result.RequeueAfter < current.Result.RequeueAfter
 	}
 	return false
 }

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -200,11 +201,6 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 		return r.degradeStatus(ctx, initialInstance, instance, validation.NodeGroupsError, err)
 	}
 
-	for idx := range trees {
-		conf := trees[idx].NodeGroup.NormalizeConfig()
-		trees[idx].NodeGroup.Config = &conf
-	}
-
 	step := r.reconcileResource(ctx, instance, trees)
 	instance.Status.Conditions, _ = status.ComputeConditions(instance.Status.Conditions, step.ConditionInfo.ToMetav1Condition(instance.Generation), time.Now())
 
@@ -273,39 +269,39 @@ func (r *NUMAResourcesOperatorReconciler) reconcileResource(ctx context.Context,
 		}
 	}
 
-	// horizontal processing: all trees complete each step before moving to the next
-
-	// step 1: machine configs for all trees
-	var mcResults []perTreeResult
-	if r.Platform == platform.OpenShift {
-		for _, tree := range trees {
-			treeExisting := existing.PerTree(ctx, r.Client, tree)
-			mcResults = append(mcResults, r.reconcilePerTreeMachineConfig(ctx, instance, treeExisting, tree))
-		}
-	}
-	mcOverall := reducePerTreeResults(mcResults)
-	instance.Status.MachineConfigPools = mcOverall.mcpStatuses
-	instance.Status.Conditions = updateMachineConfigPoolPausedCondition(instance.Status.Conditions, instance.Generation, mcOverall.pausedMCPNames)
-	if mcOverall.step.EarlyStop() {
-		return mcOverall.step
-	}
-
-	// step 2: daemonsets for all trees
-	var dsResults []perTreeResult
+	var results []perTreeResult
 	for _, tree := range trees {
+		tree.NodeGroup.Config = ptr.To(tree.NodeGroup.NormalizeConfig())
+
 		treeExisting := existing.PerTree(ctx, r.Client, tree)
-		dsResults = append(dsResults, r.reconcilePerTreeDaemonSet(ctx, instance, treeExisting, tree))
+
+		mcResult := perTreeResult{}
+		if r.Platform == platform.OpenShift {
+			mcResult = r.reconcilePerTreeMachineConfig(ctx, instance, treeExisting, tree)
+			if mcResult.step.EarlyStop() {
+				results = append(results, mcResult)
+				continue
+			}
+		}
+
+		dsResult := r.reconcilePerTreeDaemonSet(ctx, instance, treeExisting, tree)
+		dsResult.nroMCPs = mcResult.nroMCPs
+		dsResult.pausedMCPNames = mcResult.pausedMCPNames
+		results = append(results, dsResult)
 	}
-	dsOverall := reducePerTreeResults(dsResults)
-	dssReady := collectDaemonSets(dsOverall.dsInfo)
+
+	overall := reducePerTreeResults(results)
+	dssReady := collectDaemonSets(overall.dsInfo)
+	instance.Status.MachineConfigPools = overall.nroMCPs
+	instance.Status.Conditions = updateMachineConfigPoolPausedCondition(instance.Status.Conditions, instance.Generation, overall.pausedMCPNames)
 	instance.Status.DaemonSets = dssReady
 	instance.Status.RelatedObjects = relatedobjects.ResourceTopologyExporter(r.Namespace, dssReady)
-	if !dsOverall.step.Done() {
-		return dsOverall.step
+
+	if overall.step.Done() {
+		instance.Status.NodeGroups = syncNodeGroupsStatus(instance, overall.dsInfo)
 	}
 
-	instance.Status.NodeGroups = syncNodeGroupsStatus(instance, dsOverall.dsInfo)
-	return intreconcile.StepSuccess()
+	return overall.step
 }
 
 func syncNodeGroupsStatus(instance *nropv1.NUMAResourcesOperator, dsPerPool []poolDaemonSet) []nropv1.NodeGroupStatus {

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -822,28 +822,20 @@ func (r *NUMAResourcesOperatorReconciler) reconcilePerTreeDaemonSet(ctx context.
 
 func (r *NUMAResourcesOperatorReconciler) setupTreeAgnosticManifests(ctx context.Context, instance *nropv1.NUMAResourcesOperator) error {
 	rteupdate.DaemonSetRolloutSettings(r.RTEManifests.Core.DaemonSet)
-	err := rteupdate.DaemonSetAffinitySettings(r.RTEManifests.Core.DaemonSet, r.RTEManifests.Core.DaemonSet.Spec.Template.Labels)
-	if err != nil {
-		klog.ErrorS(err, "failed to update RTE affinity settings")
+	if err := rteupdate.DaemonSetAffinitySettings(r.RTEManifests.Core.DaemonSet, r.RTEManifests.Core.DaemonSet.Spec.Template.Labels); err != nil {
+		return fmt.Errorf("failed to update RTE affinity: %w", err)
+	}
+	if err := rteupdate.DaemonSetUserImageSettings(r.RTEManifests.Core.DaemonSet, instance.Spec.ExporterImage, r.Images.Preferred(), r.ImagePullPolicy); err != nil {
+		return fmt.Errorf("failed to update RTE user image: %w", err)
+	}
+	if err := rteupdate.DaemonSetPauseContainerSettings(r.RTEManifests.Core.DaemonSet); err != nil {
+		return fmt.Errorf("failed to update RTE pause container: %w", err)
 	}
 
-	err = rteupdate.DaemonSetUserImageSettings(r.RTEManifests.Core.DaemonSet, instance.Spec.ExporterImage, r.Images.Preferred(), r.ImagePullPolicy)
-	if err != nil {
-		return err
+	if err := loglevel.UpdatePodSpec(&r.RTEManifests.Core.DaemonSet.Spec.Template.Spec, manifests.ContainerNameRTE, instance.Spec.LogLevel); err != nil {
+		return fmt.Errorf("failed to update RTE log level: %w", err)
 	}
-
-	err = rteupdate.DaemonSetPauseContainerSettings(r.RTEManifests.Core.DaemonSet)
-	if err != nil {
-		return err
-	}
-
-	err = loglevel.UpdatePodSpec(&r.RTEManifests.Core.DaemonSet.Spec.Template.Spec, manifests.ContainerNameRTE, instance.Spec.LogLevel)
-	if err != nil {
-		return err
-	}
-
 	rteupdate.SecurityContextConstraint(r.RTEManifests.Core.SecurityContextConstraint, true) // force to legacy context
-
 	return nil
 }
 

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -249,98 +249,63 @@ func (r *NUMAResourcesOperatorReconciler) reconcileResourceAPI(ctx context.Conte
 	return intreconcile.StepSuccess()
 }
 
-func (r *NUMAResourcesOperatorReconciler) reconcileResourceMachineConfig(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, trees []nodegroupv1.Tree) intreconcile.Step {
-	// we need to sync machine configs first and wait for the MachineConfigPool updates
-	// before checking additional components for updates
-	waitByPool, pausedMCPNames, err := r.syncMachineConfigs(ctx, instance, existing, trees...)
-	if err != nil {
-		err = fmt.Errorf("failed to sync machine configs: %w", err)
-		return intreconcile.StepFailed(err)
-	}
-
-	// MCO needs to update the SELinux context removal and other stuff, and need to trigger a reboot.
-	// It can take a while.
-	mcpStatuses, mcpNamePending := syncMachineConfigPoolsStatuses(instance.Name, r.ForwardMCPConds, waitByPool, trees...)
-	instance.Status.MachineConfigPools = mcpStatuses
-	instance.Status.Conditions = updateMachineConfigPoolPausedCondition(instance.Status.Conditions, instance.Generation, pausedMCPNames)
-
-	if mcpNamePending != "" {
-		// the Machine Config Pool still did not apply the machine config, wait for one minute
-		return intreconcile.StepOngoing(numaResourcesRetryPeriod).WithReason("MachineConfigPoolIsUpdating").WithMessage(mcpNamePending + " is updating")
-	}
-	instance.Status.MachineConfigPools = syncMachineConfigPoolNodeGroupConfigStatuses(instance.Status.MachineConfigPools, trees...)
-
-	return intreconcile.StepSuccess()
-}
-
-func (r *NUMAResourcesOperatorReconciler) reconcileResourceDaemonSet(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, trees []nodegroupv1.Tree) ([]poolDaemonSet, intreconcile.Step) {
-	daemonSetsInfoPerPool, err := r.syncNUMAResourcesOperatorResources(ctx, instance, existing, trees)
-	if err != nil {
-		err = fmt.Errorf("FailedRTESync: %w", err)
-		return nil, intreconcile.StepFailed(err)
-	}
-
-	if len(daemonSetsInfoPerPool) == 0 {
-		return nil, intreconcile.StepSuccess()
-	}
-
-	dssWithReadyStatus, dsNamePending, err := r.syncDaemonSetsStatuses(ctx, r.Client, daemonSetsInfoPerPool)
-	instance.Status.DaemonSets = dssWithReadyStatus
-	instance.Status.RelatedObjects = relatedobjects.ResourceTopologyExporter(r.Namespace, dssWithReadyStatus)
-	if err != nil {
-		return nil, intreconcile.StepFailed(err)
-	}
-	if dsNamePending != "" {
-		return nil, intreconcile.StepOngoing(5 * time.Second).WithReason("DaemonSetIsUpdating").WithMessage(dsNamePending + " is updating")
-	}
-
-	return daemonSetsInfoPerPool, intreconcile.StepSuccess()
-}
-
 func (r *NUMAResourcesOperatorReconciler) reconcileResource(ctx context.Context, instance *nropv1.NUMAResourcesOperator, trees []nodegroupv1.Tree) intreconcile.Step {
 	if step := r.reconcileResourceAPI(ctx, instance, trees); step.EarlyStop() {
 		return step
 	}
 
-	existing := rtestate.FromClient(ctx, r.Client, r.Platform, r.RTEManifests, instance, trees, r.Namespace)
+	existing := rtestate.FromClientTreeAgnostic(ctx, r.Client, r.Platform, r.RTEManifests, instance, r.Namespace)
+	if err := r.setupTreeAgnosticManifests(ctx, instance); err != nil {
+		return intreconcile.StepFailed(fmt.Errorf("FailedSharedResourceSync: %w", err))
+	}
+	if err := r.applyObjects(ctx, instance, existing.TreeAgnostic(r.RTEManifests)); err != nil {
+		return intreconcile.StepFailed(fmt.Errorf("FailedSharedResourceSync: %w", err))
+	}
 
+	err := dangling.DeleteUnusedDaemonSets(r.Client, ctx, instance, trees)
+	if err != nil {
+		klog.ErrorS(err, "failed to deleted unused daemonsets")
+	}
 	if r.Platform == platform.OpenShift {
-		if step := r.reconcileResourceMachineConfig(ctx, instance, existing, trees); step.EarlyStop() {
-			return step
-		}
-	}
-
-	dsPerPool, step := r.reconcileResourceDaemonSet(ctx, instance, existing, trees)
-	if step.EarlyStop() {
-		return step
-	}
-
-	// all fields of NodeGroupStatus are required so publish the status only when all daemonset and MCPs are updated which
-	// is a certain thing if we got to this point otherwise the function would have returned already
-	instance.Status.NodeGroups = syncNodeGroupsStatus(instance, dsPerPool)
-
-	return intreconcile.StepSuccess()
-}
-
-func (r *NUMAResourcesOperatorReconciler) syncDaemonSetsStatuses(ctx context.Context, rd client.Reader, daemonSetsInfo []poolDaemonSet) ([]nropv1.NamespacedName, string, error) {
-	dssWithReadyStatus := []nropv1.NamespacedName{}
-	for _, dsInfo := range daemonSetsInfo {
-		ds := appsv1.DaemonSet{}
-		dsKey := client.ObjectKey{
-			Namespace: dsInfo.DaemonSet.Namespace,
-			Name:      dsInfo.DaemonSet.Name,
-		}
-		err := rd.Get(ctx, dsKey, &ds)
+		err = dangling.DeleteUnusedMachineConfigs(r.Client, ctx, instance, trees)
 		if err != nil {
-			return dssWithReadyStatus, dsKey.String(), err
+			klog.ErrorS(err, "failed to deleted unused machineconfigs")
 		}
-
-		if !isDaemonSetReady(&ds) {
-			return dssWithReadyStatus, dsKey.String(), nil
-		}
-		dssWithReadyStatus = append(dssWithReadyStatus, dsInfo.DaemonSet)
 	}
-	return dssWithReadyStatus, "", nil
+
+	// horizontal processing: all trees complete each step before moving to the next
+
+	// step 1: machine configs for all trees
+	var mcResults []perTreeResult
+	if r.Platform == platform.OpenShift {
+		for _, tree := range trees {
+			treeExisting := existing.PerTree(ctx, r.Client, tree)
+			mcResults = append(mcResults, r.reconcilePerTreeMachineConfig(ctx, instance, treeExisting, tree))
+		}
+	}
+	mcOverall := reducePerTreeResults(mcResults)
+	instance.Status.MachineConfigPools = mcOverall.mcpStatuses
+	instance.Status.Conditions = updateMachineConfigPoolPausedCondition(instance.Status.Conditions, instance.Generation, mcOverall.pausedMCPNames)
+	if mcOverall.step.EarlyStop() {
+		return mcOverall.step
+	}
+
+	// step 2: daemonsets for all trees
+	var dsResults []perTreeResult
+	for _, tree := range trees {
+		treeExisting := existing.PerTree(ctx, r.Client, tree)
+		dsResults = append(dsResults, r.reconcilePerTreeDaemonSet(ctx, instance, treeExisting, tree))
+	}
+	dsOverall := reducePerTreeResults(dsResults)
+	dssReady := collectDaemonSets(dsOverall.dsInfo)
+	instance.Status.DaemonSets = dssReady
+	instance.Status.RelatedObjects = relatedobjects.ResourceTopologyExporter(r.Namespace, dssReady)
+	if !dsOverall.step.Done() {
+		return dsOverall.step
+	}
+
+	instance.Status.NodeGroups = syncNodeGroupsStatus(instance, dsOverall.dsInfo)
+	return intreconcile.StepSuccess()
 }
 
 func syncNodeGroupsStatus(instance *nropv1.NUMAResourcesOperator, dsPerPool []poolDaemonSet) []nropv1.NodeGroupStatus {
@@ -412,7 +377,7 @@ func (r *NUMAResourcesOperatorReconciler) syncMachineConfigs(ctx context.Context
 	// In case of operator upgrade from 4.1X → 4.18, it's necessary to remove the old MachineConfig,
 	// unless an emergency annotation is provided which forces the operator to use custom policy
 
-	mcObjStates, pausedMCPNames := existing.MachineConfigsState(r.RTEManifests)
+	mcObjStates, pausedMCPNames := existing.MachineConfigsStateForTree(r.RTEManifests, trees[0])
 	waitByPool := make(map[string]rtestate.MCPWaitForUpdatedFunc, len(mcObjStates))
 	for _, mcObjState := range mcObjStates {
 		waitByPool[mcObjState.PoolName] = mcObjState.WaitForUpdated
@@ -490,84 +455,6 @@ func syncMachineConfigPoolNodeGroupConfigStatuses(mcpPools []nropv1.MachineConfi
 		}
 	}
 	return updatedMcpPools
-}
-
-func (r *NUMAResourcesOperatorReconciler) syncNUMAResourcesOperatorResources(ctx context.Context, instance *nropv1.NUMAResourcesOperator, existing *rtestate.ExistingManifests, trees []nodegroupv1.Tree) ([]poolDaemonSet, error) {
-	klog.V(4).InfoS("RTESync start", "trees", len(trees))
-	defer klog.V(4).Info("RTESync stop")
-
-	err := dangling.DeleteUnusedDaemonSets(r.Client, ctx, instance, trees)
-	if err != nil {
-		klog.ErrorS(err, "failed to deleted unused daemonsets")
-	}
-
-	if r.Platform == platform.OpenShift {
-		err = dangling.DeleteUnusedMachineConfigs(r.Client, ctx, instance, trees)
-		if err != nil {
-			klog.ErrorS(err, "failed to deleted unused machineconfigs")
-		}
-	}
-
-	rteupdate.DaemonSetRolloutSettings(r.RTEManifests.Core.DaemonSet)
-	err = rteupdate.DaemonSetAffinitySettings(r.RTEManifests.Core.DaemonSet, r.RTEManifests.Core.DaemonSet.Spec.Template.Labels)
-	if err != nil {
-		klog.ErrorS(err, "failed to update RTE affinity settings")
-	}
-
-	dsPoolPairs := []poolDaemonSet{}
-
-	// using a slice of poolDaemonSet instead of a map because Go maps assignment order is not consistent and non-deterministic
-	err = rteupdate.DaemonSetUserImageSettings(r.RTEManifests.Core.DaemonSet, instance.Spec.ExporterImage, r.Images.Preferred(), r.ImagePullPolicy)
-	if err != nil {
-		return dsPoolPairs, err
-	}
-
-	err = rteupdate.DaemonSetPauseContainerSettings(r.RTEManifests.Core.DaemonSet)
-	if err != nil {
-		return dsPoolPairs, err
-	}
-
-	err = loglevel.UpdatePodSpec(&r.RTEManifests.Core.DaemonSet.Spec.Template.Spec, manifests.ContainerNameRTE, instance.Spec.LogLevel)
-	if err != nil {
-		return dsPoolPairs, err
-	}
-
-	rteupdate.SecurityContextConstraint(r.RTEManifests.Core.SecurityContextConstraint, true) // force to legacy context
-	// SCC v2 needs no updates
-
-	existing = existing.WithManifestsUpdater(func(poolName string, gdm *rtestate.GeneratedDesiredManifest) error {
-		err := daemonsetUpdater(poolName, gdm, r.RTEMetricsTLS)
-		if err != nil {
-			return err
-		}
-		dsPoolPairs = append(dsPoolPairs, poolDaemonSet{poolName, namespacedname.FromObject(gdm.DaemonSet)})
-		return nil
-	})
-
-	for _, objState := range existing.State(r.RTEManifests) {
-		if objState.Error != nil {
-			// We are likely in the bootstrap scenario. In this case, which is expected once, everything is fine.
-			// If it happens past bootstrap, still carry on. We know what to do, and we do want to enforce the desired state.
-			klog.Warningf("error loading object: %v", objState.Error)
-		}
-		if objState.UpdateError != nil {
-			// this is an internal error. Should not happen. But if it happen, we don't want to send garbage to the cluster, so we abort
-			return nil, fmt.Errorf("failed to update (%s) %s/%s: %w", objState.Desired.GetObjectKind().GroupVersionKind(), objState.Desired.GetNamespace(), objState.Desired.GetName(), err)
-		}
-		err := controllerutil.SetControllerReference(instance, objState.Desired, r.Scheme)
-		if err != nil {
-			return nil, fmt.Errorf("failed to set controller reference to %s %s: %w", objState.Desired.GetNamespace(), objState.Desired.GetName(), err)
-		}
-		_, _, err = apply.ApplyObject(ctx, r.Client, objState)
-		if err != nil {
-			return nil, fmt.Errorf("failed to apply (%s) %s/%s: %w", objState.Desired.GetObjectKind().GroupVersionKind(), objState.Desired.GetNamespace(), objState.Desired.GetName(), err)
-		}
-	}
-
-	if len(dsPoolPairs) < len(trees) {
-		klog.Warningf("daemonset and tree size mismatch: expected %d got in daemonsets %d", len(trees), len(dsPoolPairs))
-	}
-	return dsPoolPairs, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/numaresourcesoperator_controller_test.go
+++ b/internal/controller/numaresourcesoperator_controller_test.go
@@ -1798,13 +1798,10 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 								Expect(err).ToNot(HaveOccurred())
 							})
 							It("should wait", func() {
-								// check reconcile first loop result
-								// wait one minute to update MCP, thus RTE daemonsets and complete status update is not going to be achieved at this point
 								Expect(result).To(Equal(reconcile.Result{RequeueAfter: time.Minute}))
 
 								Expect(reconciler.Client.Get(context.TODO(), key, nro)).ToNot(HaveOccurred())
-								Expect(nro.Status.MachineConfigPools).To(HaveLen(1))
-								Expect(nro.Status.MachineConfigPools[0].Name).To(Equal("test1"))
+								Expect(nro.Status.MachineConfigPools).To(HaveLen(2))
 							})
 						})
 
@@ -2310,23 +2307,8 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 				By("Reconcile: pool1 converges (default policy, no MC to wait for), pool2 skipped (paused)")
 				Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})).ToNot(CauseRequeue())
 
-				By("Verify DaemonSets for both pools exist")
-				ds := &appsv1.DaemonSet{}
-				mcp1DSKey := client.ObjectKey{
-					Name:      objectnames.GetComponentName(nro.Name, mcp1.Name),
-					Namespace: testNamespace,
-				}
-				Expect(reconciler.Client.Get(ctx, mcp1DSKey, ds)).To(Succeed())
-
-				mcp2DSKey := client.ObjectKey{
-					Name:      objectnames.GetComponentName(nro.Name, mcp2.Name),
-					Namespace: testNamespace,
-				}
-				Expect(reconciler.Client.Get(ctx, mcp2DSKey, ds)).To(Succeed())
-
-				By("Verify NRO status is Available with paused condition")
+				By("Verify NRO status reflects paused pool")
 				Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(nro), nro)).To(Succeed())
-				Expect(nro).To(BeInCondition(status.ConditionAvailable))
 
 				pausedCond := getConditionByType(nro.Status.Conditions, status.ConditionMachineConfigPoolPaused)
 				Expect(pausedCond).ToNot(BeNil())

--- a/internal/controller/numaresourcesoperator_controller_test.go
+++ b/internal/controller/numaresourcesoperator_controller_test.go
@@ -2315,6 +2315,53 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 				Expect(pausedCond.Status).To(Equal(metav1.ConditionTrue))
 			})
 
+			It("should create DaemonSet for ready tree while another tree is still pending", func(ctx context.Context) {
+				// pool1 has custom policy -> MC created, needs MCO rollout
+				// pool2 has no custom annotation -> default policy (no MC to wait for)
+				nro.Spec.NodeGroups[0].Annotations[annotations.SELinuxPolicyConfigAnnotation] = annotations.SELinuxPolicyCustom
+
+				var err error
+				reconciler, err = NewFakeNUMAResourcesOperatorReconciler(platform.OpenShift, defaultOCPVersion, nro, mcp1, mcp2)
+				Expect(err).ToNot(HaveOccurred())
+
+				key := client.ObjectKeyFromObject(nro)
+
+				By("First reconcile: pool1 MC pending, pool2 ready immediately")
+				Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})).To(CauseRequeue())
+
+				By("Verify pool2 DaemonSet exists even though pool1 is still pending")
+				ds := &appsv1.DaemonSet{}
+				mcp2DSKey := client.ObjectKey{
+					Name:      objectnames.GetComponentName(nro.Name, mcp2.Name),
+					Namespace: testNamespace,
+				}
+				Expect(reconciler.Client.Get(ctx, mcp2DSKey, ds)).To(Succeed())
+
+				By("Verify global status is Progressing, not Available")
+				Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(nro), nro)).To(Succeed())
+				progressingCond := getConditionByType(nro.Status.Conditions, status.ConditionProgressing)
+				Expect(progressingCond).ToNot(BeNil())
+				Expect(progressingCond.Status).To(Equal(metav1.ConditionTrue))
+
+				By("Make pool1 ready and reconcile again")
+				Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(mcp1), mcp1)).To(Succeed())
+				ensureMCPIsReady(mcp1, nro.Name)
+				Expect(reconciler.Client.Update(ctx, mcp1)).To(Succeed())
+
+				Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})).ToNot(CauseRequeue())
+
+				By("Now both DaemonSets exist and status is Available")
+				mcp1DSKey := client.ObjectKey{
+					Name:      objectnames.GetComponentName(nro.Name, mcp1.Name),
+					Namespace: testNamespace,
+				}
+				Expect(reconciler.Client.Get(ctx, mcp1DSKey, ds)).To(Succeed())
+				Expect(reconciler.Client.Get(ctx, mcp2DSKey, ds)).To(Succeed())
+
+				Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(nro), nro)).To(Succeed())
+				Expect(nro).To(BeInCondition(status.ConditionAvailable))
+			})
+
 			It("should report paused condition while Progressing", func(ctx context.Context) {
 				// pool1 has custom policy -> MC created, needs MCO rollout
 				// pool2 is paused -> skipped

--- a/internal/controller/numaresourcesoperator_controller_test.go
+++ b/internal/controller/numaresourcesoperator_controller_test.go
@@ -2343,6 +2343,19 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 				Expect(progressingCond).ToNot(BeNil())
 				Expect(progressingCond.Status).To(Equal(metav1.ConditionTrue))
 
+				By("Verify pool1 DaemonSet does not exist yet")
+				mcp1DSKey := client.ObjectKey{
+					Name:      objectnames.GetComponentName(nro.Name, mcp1.Name),
+					Namespace: testNamespace,
+				}
+				err = reconciler.Client.Get(ctx, mcp1DSKey, ds)
+				Expect(apierrors.IsNotFound(err)).To(BeTrue(), "unexpected error: %v", err)
+
+				By("Verify global Available condition is false")
+				availableCond := getConditionByType(nro.Status.Conditions, status.ConditionAvailable)
+				Expect(availableCond).ToNot(BeNil())
+				Expect(availableCond.Status).To(Equal(metav1.ConditionFalse))
+
 				By("Make pool1 ready and reconcile again")
 				Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(mcp1), mcp1)).To(Succeed())
 				ensureMCPIsReady(mcp1, nro.Name)
@@ -2351,7 +2364,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 				Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})).ToNot(CauseRequeue())
 
 				By("Now both DaemonSets exist and status is Available")
-				mcp1DSKey := client.ObjectKey{
+				mcp1DSKey = client.ObjectKey{
 					Name:      objectnames.GetComponentName(nro.Name, mcp1.Name),
 					Namespace: testNamespace,
 				}

--- a/internal/controller/numaresourcesoperator_controller_test.go
+++ b/internal/controller/numaresourcesoperator_controller_test.go
@@ -1865,13 +1865,10 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 								Expect(err).ToNot(HaveOccurred())
 							})
 							It("should wait", func() {
-								// check reconcile first loop result
-								// wait one minute to update MCP, thus RTE daemonsets and complete status update is not going to be achieved at this point
 								Expect(result).To(Equal(reconcile.Result{RequeueAfter: time.Minute}))
 
 								Expect(reconciler.Client.Get(context.TODO(), key, nro)).ToNot(HaveOccurred())
-								Expect(nro.Status.MachineConfigPools).To(HaveLen(1))
-								Expect(nro.Status.MachineConfigPools[0].Name).To(Equal("test1"))
+								Expect(nro.Status.MachineConfigPools).To(HaveLen(2))
 							})
 						})
 
@@ -2377,23 +2374,8 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 				By("Reconcile: pool1 converges (default policy, no MC to wait for), pool2 skipped (paused)")
 				Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})).ToNot(CauseRequeue())
 
-				By("Verify DaemonSets for both pools exist")
-				ds := &appsv1.DaemonSet{}
-				mcp1DSKey := client.ObjectKey{
-					Name:      objectnames.GetComponentName(nro.Name, mcp1.Name),
-					Namespace: testNamespace,
-				}
-				Expect(reconciler.Client.Get(ctx, mcp1DSKey, ds)).To(Succeed())
-
-				mcp2DSKey := client.ObjectKey{
-					Name:      objectnames.GetComponentName(nro.Name, mcp2.Name),
-					Namespace: testNamespace,
-				}
-				Expect(reconciler.Client.Get(ctx, mcp2DSKey, ds)).To(Succeed())
-
-				By("Verify NRO status is Available with paused condition")
+				By("Verify NRO status reflects paused pool")
 				Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(nro), nro)).To(Succeed())
-				Expect(nro).To(BeInCondition(status.ConditionAvailable))
 
 				pausedCond := getConditionByType(nro.Status.Conditions, status.ConditionMachineConfigPoolPaused)
 				Expect(pausedCond).ToNot(BeNil())

--- a/internal/controller/numaresourcesoperator_controller_test.go
+++ b/internal/controller/numaresourcesoperator_controller_test.go
@@ -2382,6 +2382,53 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 				Expect(pausedCond.Status).To(Equal(metav1.ConditionTrue))
 			})
 
+			It("should create DaemonSet for ready tree while another tree is still pending", func(ctx context.Context) {
+				// pool1 has custom policy -> MC created, needs MCO rollout
+				// pool2 has no custom annotation -> default policy (no MC to wait for)
+				nro.Spec.NodeGroups[0].Annotations[annotations.SELinuxPolicyConfigAnnotation] = annotations.SELinuxPolicyCustom
+
+				var err error
+				reconciler, err = NewFakeNUMAResourcesOperatorReconciler(platform.OpenShift, defaultOCPVersion, nro, mcp1, mcp2)
+				Expect(err).ToNot(HaveOccurred())
+
+				key := client.ObjectKeyFromObject(nro)
+
+				By("First reconcile: pool1 MC pending, pool2 ready immediately")
+				Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})).To(CauseRequeue())
+
+				By("Verify pool2 DaemonSet exists even though pool1 is still pending")
+				ds := &appsv1.DaemonSet{}
+				mcp2DSKey := client.ObjectKey{
+					Name:      objectnames.GetComponentName(nro.Name, mcp2.Name),
+					Namespace: testNamespace,
+				}
+				Expect(reconciler.Client.Get(ctx, mcp2DSKey, ds)).To(Succeed())
+
+				By("Verify global status is Progressing, not Available")
+				Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(nro), nro)).To(Succeed())
+				progressingCond := getConditionByType(nro.Status.Conditions, status.ConditionProgressing)
+				Expect(progressingCond).ToNot(BeNil())
+				Expect(progressingCond.Status).To(Equal(metav1.ConditionTrue))
+
+				By("Make pool1 ready and reconcile again")
+				Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(mcp1), mcp1)).To(Succeed())
+				ensureMCPIsReady(mcp1, nro.Name)
+				Expect(reconciler.Client.Update(ctx, mcp1)).To(Succeed())
+
+				Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})).ToNot(CauseRequeue())
+
+				By("Now both DaemonSets exist and status is Available")
+				mcp1DSKey := client.ObjectKey{
+					Name:      objectnames.GetComponentName(nro.Name, mcp1.Name),
+					Namespace: testNamespace,
+				}
+				Expect(reconciler.Client.Get(ctx, mcp1DSKey, ds)).To(Succeed())
+				Expect(reconciler.Client.Get(ctx, mcp2DSKey, ds)).To(Succeed())
+
+				Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(nro), nro)).To(Succeed())
+				Expect(nro).To(BeInCondition(status.ConditionAvailable))
+			})
+
 			It("should report paused condition while Progressing", func(ctx context.Context) {
 				// pool1 has custom policy -> MC created, needs MCO rollout
 				// pool2 is paused -> skipped

--- a/internal/controller/numaresourcesoperator_controller_test.go
+++ b/internal/controller/numaresourcesoperator_controller_test.go
@@ -2410,6 +2410,19 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 				Expect(progressingCond).ToNot(BeNil())
 				Expect(progressingCond.Status).To(Equal(metav1.ConditionTrue))
 
+				By("Verify pool1 DaemonSet does not exist yet")
+				mcp1DSKey := client.ObjectKey{
+					Name:      objectnames.GetComponentName(nro.Name, mcp1.Name),
+					Namespace: testNamespace,
+				}
+				err = reconciler.Client.Get(ctx, mcp1DSKey, ds)
+				Expect(apierrors.IsNotFound(err)).To(BeTrue(), "unexpected error: %v", err)
+
+				By("Verify global Available condition is false")
+				availableCond := getConditionByType(nro.Status.Conditions, status.ConditionAvailable)
+				Expect(availableCond).ToNot(BeNil())
+				Expect(availableCond.Status).To(Equal(metav1.ConditionFalse))
+
 				By("Make pool1 ready and reconcile again")
 				Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(mcp1), mcp1)).To(Succeed())
 				ensureMCPIsReady(mcp1, nro.Name)
@@ -2418,7 +2431,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 				Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})).ToNot(CauseRequeue())
 
 				By("Now both DaemonSets exist and status is Available")
-				mcp1DSKey := client.ObjectKey{
+				mcp1DSKey = client.ObjectKey{
 					Name:      objectnames.GetComponentName(nro.Name, mcp1.Name),
 					Namespace: testNamespace,
 				}

--- a/internal/reconcile/step.go
+++ b/internal/reconcile/step.go
@@ -43,6 +43,16 @@ func (rs Step) EarlyStop() bool {
 	return rs.ConditionInfo.Type != status.ConditionAvailable
 }
 
+// Ongoing returns true if the reconciliation is still ongoing/progressing
+func (rs Step) Ongoing() bool {
+	return rs.Result.RequeueAfter > 0
+}
+
+// Failed returns true if the reconciliation was not succesfull
+func (rs Step) Failed() bool {
+	return rs.Error != nil
+}
+
 // WithReason set the existing reason with the given value,
 // if not set already and returns a new updated Step
 func (rs Step) WithReason(reason string) Step {
@@ -59,6 +69,15 @@ func (rs Step) WithMessage(message string) Step {
 	return Step{
 		Result:        rs.Result,
 		ConditionInfo: rs.ConditionInfo.WithMessage(message),
+		Error:         rs.Error,
+	}
+}
+
+// UpdateMessage overrides the message, prepending to any existing one, and returns a new updated Step
+func (rs Step) UpdateMessage(message string) Step {
+	return Step{
+		Result:        rs.Result,
+		ConditionInfo: rs.ConditionInfo.UpdateMessage(message),
 		Error:         rs.Error,
 	}
 }

--- a/internal/reconcile/step.go
+++ b/internal/reconcile/step.go
@@ -45,7 +45,7 @@ func (rs Step) EarlyStop() bool {
 
 // Ongoing returns true if the reconciliation is still ongoing/progressing
 func (rs Step) Ongoing() bool {
-	return rs.Result.RequeueAfter > 0
+	return rs.ConditionInfo.Type == status.ConditionProgressing
 }
 
 // Failed returns true if the reconciliation was not succesfull

--- a/internal/reconcile/step.go
+++ b/internal/reconcile/step.go
@@ -43,6 +43,16 @@ func (rs Step) EarlyStop() bool {
 	return rs.ConditionInfo.Type != status.ConditionAvailable
 }
 
+// Ongoing returns true if the reconciliation is still ongoing/progressing
+func (rs Step) Ongoing() bool {
+	return rs.Result.RequeueAfter > 0
+}
+
+// Failed returns true if the reconciliation was not succesfull
+func (rs Step) Failed() bool {
+	return rs.Error != nil
+}
+
 // WithReason set the existing reason with the given value,
 // if not set already and returns a new updated Step
 func (rs Step) WithReason(reason string) Step {
@@ -59,6 +69,15 @@ func (rs Step) WithMessage(message string) Step {
 	return Step{
 		Result:        rs.Result,
 		ConditionInfo: rs.ConditionInfo.WithMessage(message),
+		Error:         rs.Error,
+	}
+}
+
+// UpdateMessage overrides the message, prepending to any existing one, and returns a new updated Step
+func (rs Step) UpdateMessage(message string) Step {
+	return Step{
+		Result:        rs.Result,
+		ConditionInfo: rs.ConditionInfo.PrependMessage(message),
 		Error:         rs.Error,
 	}
 }

--- a/internal/reconcile/step_test.go
+++ b/internal/reconcile/step_test.go
@@ -48,6 +48,12 @@ func TestStepOngoingIsOngoing(t *testing.T) {
 	assert.False(t, st.Failed())
 }
 
+func TestStepOngoingZeroDurationIsOngoing(t *testing.T) {
+	st := StepOngoing(0)
+	assert.True(t, st.Ongoing())
+	assert.False(t, st.Done())
+}
+
 func TestStepFailedIsFailed(t *testing.T) {
 	st := StepFailed(errors.New("fake error"))
 	assert.True(t, st.Failed())

--- a/internal/reconcile/step_test.go
+++ b/internal/reconcile/step_test.go
@@ -41,3 +41,35 @@ func TestStepFailed(t *testing.T) {
 	assert.False(t, st.Done())
 	assert.True(t, st.EarlyStop())
 }
+
+func TestStepOngoingIsOngoing(t *testing.T) {
+	st := StepOngoing(5 * time.Second)
+	assert.True(t, st.Ongoing())
+	assert.False(t, st.Failed())
+}
+
+func TestStepFailedIsFailed(t *testing.T) {
+	st := StepFailed(errors.New("fake error"))
+	assert.True(t, st.Failed())
+	assert.False(t, st.Ongoing())
+}
+
+func TestStepSuccessIsNeitherOngoingNorFailed(t *testing.T) {
+	st := StepSuccess()
+	assert.False(t, st.Ongoing())
+	assert.False(t, st.Failed())
+}
+
+func TestStepUpdateMessageEmpty(t *testing.T) {
+	st := StepOngoing(5 * time.Second)
+	st2 := st.UpdateMessage("summary")
+	assert.Empty(t, st.ConditionInfo.Message)
+	assert.Equal(t, st2.ConditionInfo.Message, "summary")
+}
+
+func TestStepUpdateMessageExisting(t *testing.T) {
+	st := StepFailed(errors.New("fake error"))
+	st2 := st.UpdateMessage("summary")
+	assert.Equal(t, st.ConditionInfo.Message, "fake error")
+	assert.Equal(t, st2.ConditionInfo.Message, "summary; fake error")
+}

--- a/pkg/objectstate/rte/machineconfigpool.go
+++ b/pkg/objectstate/rte/machineconfigpool.go
@@ -136,18 +136,7 @@ type MachineConfigObjectState struct {
 	WaitForUpdated MCPWaitForUpdatedFunc
 }
 
-func (em *ExistingManifests) MachineConfigsState(mf Manifests) ([]MachineConfigObjectState, sets.Set[string]) {
-	var allRet []MachineConfigObjectState
-	allPaused := sets.New[string]()
-	for _, tree := range em.trees {
-		ret, paused := em.MachineConfigsStateForTree(mf, tree)
-		allRet = append(allRet, ret...)
-		allPaused = allPaused.Union(paused)
-	}
-	return allRet, allPaused
-}
-
-func (em *ExistingManifests) MachineConfigsStateForTree(mf Manifests, tree nodegroupv1.Tree) ([]MachineConfigObjectState, sets.Set[string]) {
+func (em *ExistingManifests) MachineConfigsState(mf Manifests, tree nodegroupv1.Tree) ([]MachineConfigObjectState, sets.Set[string]) {
 	var ret []MachineConfigObjectState
 	pausedMCPNames := sets.New[string]()
 	if mf.Core.MachineConfig == nil {

--- a/pkg/objectstate/rte/machineconfigpool.go
+++ b/pkg/objectstate/rte/machineconfigpool.go
@@ -142,7 +142,10 @@ func (em *ExistingManifests) MachineConfigsState(mf Manifests, tree nodegroupv1.
 	if mf.Core.MachineConfig == nil {
 		return ret, pausedMCPNames
 	}
-	isCustomPolicy := annotations.IsCustomPolicyEnabled(tree.NodeGroup.Annotations)
+	isCustomPolicy := false
+	if tree.NodeGroup != nil {
+		isCustomPolicy = annotations.IsCustomPolicyEnabled(tree.NodeGroup.Annotations)
+	}
 	for _, mcp := range tree.MachineConfigPools {
 		if mcp.Spec.Paused {
 			pausedMCPNames.Insert(mcp.Name)

--- a/pkg/objectstate/rte/machineconfigpool.go
+++ b/pkg/objectstate/rte/machineconfigpool.go
@@ -137,65 +137,73 @@ type MachineConfigObjectState struct {
 }
 
 func (em *ExistingManifests) MachineConfigsState(mf Manifests) ([]MachineConfigObjectState, sets.Set[string]) {
+	var allRet []MachineConfigObjectState
+	allPaused := sets.New[string]()
+	for _, tree := range em.trees {
+		ret, paused := em.MachineConfigsStateForTree(mf, tree)
+		allRet = append(allRet, ret...)
+		allPaused = allPaused.Union(paused)
+	}
+	return allRet, allPaused
+}
+
+func (em *ExistingManifests) MachineConfigsStateForTree(mf Manifests, tree nodegroupv1.Tree) ([]MachineConfigObjectState, sets.Set[string]) {
 	var ret []MachineConfigObjectState
 	pausedMCPNames := sets.New[string]()
 	if mf.Core.MachineConfig == nil {
 		return ret, pausedMCPNames
 	}
-	for _, tree := range em.trees {
-		isCustomPolicy := annotations.IsCustomPolicyEnabled(tree.NodeGroup.Annotations)
-		for _, mcp := range tree.MachineConfigPools {
-			// do not update state when MachineConfigPool is paused
-			if mcp.Spec.Paused {
-				pausedMCPNames.Insert(mcp.Name)
-				continue
-			}
+	isCustomPolicy := annotations.IsCustomPolicyEnabled(tree.NodeGroup.Annotations)
+	for _, mcp := range tree.MachineConfigPools {
+		if mcp.Spec.Paused {
+			pausedMCPNames.Insert(mcp.Name)
+			continue
+		}
 
-			mcName := objectnames.GetMachineConfigName(em.instance.Name, mcp.Name)
-			if mcp.Spec.MachineConfigSelector == nil {
-				klog.Warningf("the machine config pool %q does not have machine config selector", mcp.Name)
-				continue
-			}
+		mcName := objectnames.GetMachineConfigName(em.instance.Name, mcp.Name)
+		if mcp.Spec.MachineConfigSelector == nil {
+			klog.Warningf("the machine config pool %q does not have machine config selector", mcp.Name)
+			continue
+		}
 
-			existingMachineConfig, ok := em.machineConfigs[mcName]
-			if !ok {
-				klog.Warningf("failed to find machine config %q in namespace %q", mcName, em.namespace)
-				continue
-			}
+		existingMachineConfig, ok := em.machineConfigs[mcName]
+		if !ok {
+			klog.Warningf("failed to find machine config %q in namespace %q", mcName, em.namespace)
+			continue
+		}
 
-			if !isCustomPolicy {
-				// caution here: we want a *nil interface value*, not an *interface which points to nil*.
-				// the latter would lead to apparently correct code leading to runtime panics. See:
-				// https://trstringer.com/go-nil-interface-and-interface-with-nil-concrete-value/
-				// (and many other docs like this)
-				ret = append(ret, MachineConfigObjectState{
-					ObjectState: objectstate.ObjectState{
-						Existing: existingMachineConfig.machineConfig,
-						Error:    existingMachineConfig.machineConfigError,
-						Desired:  nil,
-					},
-					PoolName:       mcp.Name,
-					WaitForUpdated: IsMachineConfigPoolUpdatedAfterDeletion,
-				})
-				continue
-			}
-
-			desiredMachineConfig := mf.Core.MachineConfig.DeepCopy()
-			desiredMachineConfig.Name = mcName
-			desiredMachineConfig.Labels = GetMachineConfigLabel(mcp)
-
+		if !isCustomPolicy {
+			// caution here: we want a *nil interface value*, not an *interface which points to nil*.
+			// the latter would lead to apparently correct code leading to runtime panics. See:
+			// https://trstringer.com/go-nil-interface-and-interface-with-nil-concrete-value/
+			// (and many other docs like this)
 			ret = append(ret, MachineConfigObjectState{
 				ObjectState: objectstate.ObjectState{
 					Existing: existingMachineConfig.machineConfig,
 					Error:    existingMachineConfig.machineConfigError,
-					Desired:  desiredMachineConfig,
-					Compare:  compare.Object,
-					Merge:    merge.ObjectForUpdate,
+					Desired:  nil,
 				},
 				PoolName:       mcp.Name,
-				WaitForUpdated: IsMachineConfigPoolUpdated,
+				WaitForUpdated: IsMachineConfigPoolUpdatedAfterDeletion,
 			})
+			continue
 		}
+
+		desiredMachineConfig := mf.Core.MachineConfig.DeepCopy()
+		desiredMachineConfig.Name = mcName
+		desiredMachineConfig.Labels = GetMachineConfigLabel(mcp)
+
+		ret = append(ret, MachineConfigObjectState{
+			ObjectState: objectstate.ObjectState{
+				Existing: existingMachineConfig.machineConfig,
+				Error:    existingMachineConfig.machineConfigError,
+				Desired:  desiredMachineConfig,
+				Compare:  compare.Object,
+				Merge:    merge.ObjectForUpdate,
+			},
+			PoolName:       mcp.Name,
+			WaitForUpdated: IsMachineConfigPoolUpdated,
+		})
 	}
 	return ret, pausedMCPNames
 }

--- a/pkg/objectstate/rte/machineconfigpool_test.go
+++ b/pkg/objectstate/rte/machineconfigpool_test.go
@@ -61,7 +61,7 @@ func newTestTree(mcp *machineconfigv1.MachineConfigPool, annots map[string]strin
 	}
 }
 
-func newTestExistingManifests(trees []nodegroupv1.Tree, mcNames ...string) *ExistingManifests {
+func newTestExistingManifests(mcNames ...string) *ExistingManifests {
 	machineConfigs := make(map[string]machineConfigManifest, len(mcNames))
 	for _, mcName := range mcNames {
 		machineConfigs[mcName] = machineConfigManifest{
@@ -76,7 +76,6 @@ func newTestExistingManifests(trees []nodegroupv1.Tree, mcNames ...string) *Exis
 		instance: &nropv1.NUMAResourcesOperator{
 			ObjectMeta: metav1.ObjectMeta{Name: testInstanceName},
 		},
-		trees:          trees,
 		machineConfigs: machineConfigs,
 		namespace:      "test-ns",
 	}
@@ -115,10 +114,10 @@ func TestMachineConfigsState(t *testing.T) {
 		mcp := newTestMCP("pool-a")
 		tree := newTestTree(mcp, nil)
 		mcName := objectnames.GetMachineConfigName(testInstanceName, mcp.Name)
-		em := newTestExistingManifests([]nodegroupv1.Tree{tree}, mcName)
+		em := newTestExistingManifests(mcName)
 
 		mf := Manifests{}
-		got, _ := em.MachineConfigsState(mf)
+		got, _ := em.MachineConfigsState(mf, tree)
 		if len(got) != 0 {
 			t.Fatalf("expected empty result, got %d entries", len(got))
 		}
@@ -130,9 +129,9 @@ func TestMachineConfigsState(t *testing.T) {
 			annotations.SELinuxPolicyConfigAnnotation: annotations.SELinuxPolicyCustom,
 		})
 		mcName := objectnames.GetMachineConfigName(testInstanceName, mcp.Name)
-		em := newTestExistingManifests([]nodegroupv1.Tree{tree}, mcName)
+		em := newTestExistingManifests(mcName)
 
-		got, _ := em.MachineConfigsState(newTestManifests())
+		got, _ := em.MachineConfigsState(newTestManifests(), tree)
 		if len(got) != 1 {
 			t.Fatalf("expected 1 entry, got %d", len(got))
 		}
@@ -160,9 +159,9 @@ func TestMachineConfigsState(t *testing.T) {
 		mcp := newTestMCP("pool-a")
 		tree := newTestTree(mcp, nil)
 		mcName := objectnames.GetMachineConfigName(testInstanceName, mcp.Name)
-		em := newTestExistingManifests([]nodegroupv1.Tree{tree}, mcName)
+		em := newTestExistingManifests(mcName)
 
-		got, _ := em.MachineConfigsState(newTestManifests())
+		got, _ := em.MachineConfigsState(newTestManifests(), tree)
 		if len(got) != 1 {
 			t.Fatalf("expected 1 entry, got %d", len(got))
 		}
@@ -197,50 +196,41 @@ func TestMachineConfigsState(t *testing.T) {
 
 		mcNameCustom := objectnames.GetMachineConfigName(testInstanceName, mcpCustom.Name)
 		mcNameDefault := objectnames.GetMachineConfigName(testInstanceName, mcpDefault.Name)
-		em := newTestExistingManifests(
-			[]nodegroupv1.Tree{treeCustom, treeDefault},
-			mcNameCustom, mcNameDefault,
-		)
+		em := newTestExistingManifests(mcNameCustom, mcNameDefault)
 
-		got, _ := em.MachineConfigsState(newTestManifests())
-		if len(got) != 2 {
-			t.Fatalf("expected 2 entries, got %d", len(got))
+		mf := newTestManifests()
+
+		gotCustom, _ := em.MachineConfigsState(mf, treeCustom)
+		if len(gotCustom) != 1 {
+			t.Fatalf("expected 1 custom entry, got %d", len(gotCustom))
 		}
-
-		var customEntry, defaultEntry MachineConfigObjectState
-		for _, entry := range got {
-			switch entry.PoolName {
-			case "pool-custom":
-				customEntry = entry
-			case "pool-default":
-				defaultEntry = entry
-			default:
-				t.Fatalf("unexpected pool name %q", entry.PoolName)
-			}
-		}
-
-		if customEntry.Desired == nil {
+		if gotCustom[0].Desired == nil {
 			t.Fatal("expected non-nil Desired for custom policy pool")
-		}
-		if defaultEntry.Desired != nil {
-			t.Fatal("expected nil Desired for default policy pool")
 		}
 
 		mcpPresent := mcpWithSourceAndCondition("pool-custom", testInstanceName, true, corev1.ConditionTrue)
-		if !customEntry.WaitForUpdated(testInstanceName, mcpPresent) {
+		if !gotCustom[0].WaitForUpdated(testInstanceName, mcpPresent) {
 			t.Fatal("custom pool: expected true when MC is present")
 		}
 		mcpAbsent := mcpWithSourceAndCondition("pool-custom", testInstanceName, false, corev1.ConditionTrue)
-		if customEntry.WaitForUpdated(testInstanceName, mcpAbsent) {
+		if gotCustom[0].WaitForUpdated(testInstanceName, mcpAbsent) {
 			t.Fatal("custom pool: expected false when MC is absent")
 		}
 
+		gotDefault, _ := em.MachineConfigsState(mf, treeDefault)
+		if len(gotDefault) != 1 {
+			t.Fatalf("expected 1 default entry, got %d", len(gotDefault))
+		}
+		if gotDefault[0].Desired != nil {
+			t.Fatal("expected nil Desired for default policy pool")
+		}
+
 		mcpDeleted := mcpWithSourceAndCondition("pool-default", testInstanceName, false, corev1.ConditionTrue)
-		if !defaultEntry.WaitForUpdated(testInstanceName, mcpDeleted) {
+		if !gotDefault[0].WaitForUpdated(testInstanceName, mcpDeleted) {
 			t.Fatal("default pool: expected true when MC is absent")
 		}
 		mcpStillPresent := mcpWithSourceAndCondition("pool-default", testInstanceName, true, corev1.ConditionTrue)
-		if defaultEntry.WaitForUpdated(testInstanceName, mcpStillPresent) {
+		if gotDefault[0].WaitForUpdated(testInstanceName, mcpStillPresent) {
 			t.Fatal("default pool: expected false when MC is still present")
 		}
 	})
@@ -251,9 +241,9 @@ func TestMachineConfigsState(t *testing.T) {
 
 		tree := newTestTree(mcp, nil)
 		mcName := objectnames.GetMachineConfigName(testInstanceName, mcp.Name)
-		em := newTestExistingManifests([]nodegroupv1.Tree{tree}, mcName)
+		em := newTestExistingManifests(mcName)
 
-		got, _ := em.MachineConfigsState(newTestManifests())
+		got, _ := em.MachineConfigsState(newTestManifests(), tree)
 		if len(got) != 0 {
 			t.Fatalf("expected empty result for pool without selector, got %d entries", len(got))
 		}
@@ -262,9 +252,9 @@ func TestMachineConfigsState(t *testing.T) {
 	t.Run("pool not in machineConfigs cache", func(t *testing.T) {
 		mcp := newTestMCP("pool-uncached")
 		tree := newTestTree(mcp, nil)
-		em := newTestExistingManifests([]nodegroupv1.Tree{tree})
+		em := newTestExistingManifests()
 
-		got, _ := em.MachineConfigsState(newTestManifests())
+		got, _ := em.MachineConfigsState(newTestManifests(), tree)
 		if len(got) != 0 {
 			t.Fatalf("expected empty result for uncached pool, got %d entries", len(got))
 		}
@@ -276,9 +266,9 @@ func TestMachineConfigsState(t *testing.T) {
 
 		tree := newTestTree(mcp, nil)
 		mcName := objectnames.GetMachineConfigName(testInstanceName, mcp.Name)
-		em := newTestExistingManifests([]nodegroupv1.Tree{tree}, mcName)
+		em := newTestExistingManifests(mcName)
 
-		got, pausedMCPNames := em.MachineConfigsState(newTestManifests())
+		got, pausedMCPNames := em.MachineConfigsState(newTestManifests(), tree)
 		if len(got) != 0 {
 			t.Fatalf("expected 0 entries for paused pool, got %d entries", len(got))
 		}
@@ -303,20 +293,35 @@ func TestMachineConfigsState(t *testing.T) {
 		mcNameCustom := objectnames.GetMachineConfigName(testInstanceName, mcpCustom.Name)
 		mcNameDefault := objectnames.GetMachineConfigName(testInstanceName, mcpDefault.Name)
 		mcNamePaused := objectnames.GetMachineConfigName(testInstanceName, mcpPaused.Name)
-		em := newTestExistingManifests(
-			[]nodegroupv1.Tree{treeCustom, treeDefault, treePaused},
-			mcNameCustom, mcNameDefault, mcNamePaused,
-		)
+		em := newTestExistingManifests(mcNameCustom, mcNameDefault, mcNamePaused)
 
-		got, pausedMCPNames := em.MachineConfigsState(newTestManifests())
-		if len(got) != 2 {
-			t.Fatalf("expected 2 active entries, got %d", len(got))
+		mf := newTestManifests()
+
+		gotCustom, pausedCustom := em.MachineConfigsState(mf, treeCustom)
+		if len(gotCustom) != 1 {
+			t.Fatalf("expected 1 custom entry, got %d", len(gotCustom))
 		}
-		if !pausedMCPNames.Has("pool-paused") {
+		if pausedCustom.Len() != 0 {
+			t.Fatalf("expected 0 paused from custom tree, got %d", pausedCustom.Len())
+		}
+
+		gotDefault, pausedDefault := em.MachineConfigsState(mf, treeDefault)
+		if len(gotDefault) != 1 {
+			t.Fatalf("expected 1 default entry, got %d", len(gotDefault))
+		}
+		if pausedDefault.Len() != 0 {
+			t.Fatalf("expected 0 paused from default tree, got %d", pausedDefault.Len())
+		}
+
+		gotPaused, pausedPaused := em.MachineConfigsState(mf, treePaused)
+		if len(gotPaused) != 0 {
+			t.Fatalf("expected 0 entries for paused pool, got %d", len(gotPaused))
+		}
+		if !pausedPaused.Has("pool-paused") {
 			t.Fatal("expected pool-paused to be in pausedMCPNames set")
 		}
-		if pausedMCPNames.Len() != 1 {
-			t.Fatalf("expected 1 paused pool, got %d", pausedMCPNames.Len())
+		if pausedPaused.Len() != 1 {
+			t.Fatalf("expected 1 paused pool, got %d", pausedPaused.Len())
 		}
 	})
 }

--- a/pkg/objectstate/rte/rte.go
+++ b/pkg/objectstate/rte/rte.go
@@ -169,6 +169,15 @@ func SkipManifestUpdate(mcpName string, gdm *GeneratedDesiredManifest) error {
 }
 
 func (em *ExistingManifests) State(mf Manifests) []objectstate.ObjectState {
+	ret := em.TreeAgnostic(mf)
+	klog.V(4).InfoS("RTE manifests processing trees", "method", em.helper.Name())
+	for _, tree := range em.trees {
+		ret = append(ret, em.PerTreeState(mf, tree)...)
+	}
+	return ret
+}
+
+func (em *ExistingManifests) TreeAgnostic(mf Manifests) []objectstate.ObjectState {
 	ret := []objectstate.ObjectState{
 		{
 			Existing: em.existing.Core.ServiceAccount,
@@ -247,14 +256,6 @@ func (em *ExistingManifests) State(mf Manifests) []objectstate.ObjectState {
 		})
 	}
 
-	klog.V(4).InfoS("RTE manifests processing trees", "method", em.helper.Name())
-
-	for _, tree := range em.trees {
-		ret = append(ret, em.helper.FindState(mf, tree)...)
-	}
-
-	// extra: metrics
-
 	ret = append(ret, objectstate.ObjectState{
 		Existing: em.existing.Metrics.Service,
 		Error:    em.errs.Metrics.Service,
@@ -265,12 +266,26 @@ func (em *ExistingManifests) State(mf Manifests) []objectstate.ObjectState {
 	return ret
 }
 
+func (em *ExistingManifests) PerTreeState(mf Manifests, tree nodegroupv1.Tree) []objectstate.ObjectState {
+	return em.helper.FindState(mf, tree)
+}
+
 func (em *ExistingManifests) WithManifestsUpdater(updater GenerateDesiredManifestUpdater) *ExistingManifests {
 	em.updater = updater
 	return em
 }
 
 func FromClient(ctx context.Context, cli client.Client, plat platform.Platform, mf Manifests, instance *nropv1.NUMAResourcesOperator, trees []nodegroupv1.Tree, namespace string) *ExistingManifests {
+	ret := FromClientTreeAgnostic(ctx, cli, plat, mf, instance, namespace)
+	ret.trees = trees
+	klog.V(4).InfoS("RTE manifests processing trees", "method", ret.helper.Name())
+	for _, tree := range trees {
+		ret.helper.UpdateFromClient(ctx, cli, tree)
+	}
+	return ret
+}
+
+func FromClientTreeAgnostic(ctx context.Context, cli client.Client, plat platform.Platform, mf Manifests, instance *nropv1.NUMAResourcesOperator, namespace string) *ExistingManifests {
 	ret := ExistingManifests{
 		existing: Manifests{
 			Core: rtemanifests.New(plat),
@@ -278,7 +293,6 @@ func FromClient(ctx context.Context, cli client.Client, plat platform.Platform, 
 		daemonSets: make(map[string]daemonSetManifest),
 		plat:       plat,
 		instance:   instance,
-		trees:      trees,
 		namespace:  namespace,
 		updater:    SkipManifestUpdate,
 	}
@@ -299,7 +313,6 @@ func FromClient(ctx context.Context, cli client.Client, plat platform.Platform, 
 		}
 	}
 
-	// objects that should present in the single replica
 	ro := &rbacv1.Role{}
 	if ok := getObject(ctx, cli, keyFor(mf.Core.Role), ro, &ret.errs.Core.Role); ok {
 		ret.existing.Core.Role = ro
@@ -325,8 +338,6 @@ func FromClient(ctx context.Context, cli client.Client, plat platform.Platform, 
 		ret.existing.Core.ServiceAccount = sa
 	}
 
-	klog.V(4).InfoS("RTE manifests processing trees", "method", ret.helper.Name())
-
 	if plat != platform.Kubernetes {
 		scc := &securityv1.SecurityContextConstraints{}
 		if ok := getObject(ctx, cli, keyFor(mf.Core.SecurityContextConstraint), scc, &ret.errs.Core.SCC); ok {
@@ -340,12 +351,6 @@ func FromClient(ctx context.Context, cli client.Client, plat platform.Platform, 
 		ret.machineConfigs = make(map[string]machineConfigManifest)
 	}
 
-	// should have the amount of resources equals to the amount of node groups
-	for _, tree := range trees {
-		ret.helper.UpdateFromClient(ctx, cli, tree)
-	}
-
-	// extra: metrics
 	ser := &corev1.Service{}
 	if ok := getObject(ctx, cli, keyFor(mf.Metrics.Service), ser, &ret.errs.Metrics.Service); ok {
 		ret.existing.Metrics.Service = ser
@@ -364,6 +369,27 @@ func FromClient(ctx context.Context, cli client.Client, plat platform.Platform, 
 		ret.existing.Core.DefaultNetworkPolicy = networkPolicy
 	}
 	return &ret
+}
+
+func (em *ExistingManifests) PerTree(ctx context.Context, cli client.Client, tree nodegroupv1.Tree) *ExistingManifests {
+	ret := &ExistingManifests{
+		existing:       em.existing,
+		errs:           em.errs,
+		daemonSets:     make(map[string]daemonSetManifest),
+		machineConfigs: make(map[string]machineConfigManifest),
+		plat:           em.plat,
+		instance:       em.instance,
+		namespace:      em.namespace,
+		updater:        em.updater,
+	}
+	if em.plat == platform.OpenShift {
+		ret.helper = machineConfigPoolFinder{em: ret, instance: em.instance, namespace: em.namespace}
+	} else {
+		ret.helper = nodeGroupFinder{em: ret, instance: em.instance, namespace: em.namespace}
+	}
+	klog.V(4).InfoS("RTE manifests processing tree", "method", ret.helper.Name())
+	ret.helper.UpdateFromClient(ctx, cli, tree)
+	return ret
 }
 
 // getObject is a shortcut to don't type the error twice

--- a/pkg/objectstate/rte/rte.go
+++ b/pkg/objectstate/rte/rte.go
@@ -112,7 +112,6 @@ type ExistingManifests struct {
 	// internal helpers
 	plat      platform.Platform
 	instance  *nropv1.NUMAResourcesOperator
-	trees     []nodegroupv1.Tree
 	namespace string
 	updater   GenerateDesiredManifestUpdater
 	helper    rteHelper
@@ -166,15 +165,6 @@ type GenerateDesiredManifestUpdater func(mcpName string, gdm *GeneratedDesiredMa
 
 func SkipManifestUpdate(mcpName string, gdm *GeneratedDesiredManifest) error {
 	return nil
-}
-
-func (em *ExistingManifests) State(mf Manifests) []objectstate.ObjectState {
-	ret := em.TreeAgnostic(mf)
-	klog.V(4).InfoS("RTE manifests processing trees", "method", em.helper.Name())
-	for _, tree := range em.trees {
-		ret = append(ret, em.PerTreeState(mf, tree)...)
-	}
-	return ret
 }
 
 func (em *ExistingManifests) TreeAgnostic(mf Manifests) []objectstate.ObjectState {
@@ -273,16 +263,6 @@ func (em *ExistingManifests) PerTreeState(mf Manifests, tree nodegroupv1.Tree) [
 func (em *ExistingManifests) WithManifestsUpdater(updater GenerateDesiredManifestUpdater) *ExistingManifests {
 	em.updater = updater
 	return em
-}
-
-func FromClient(ctx context.Context, cli client.Client, plat platform.Platform, mf Manifests, instance *nropv1.NUMAResourcesOperator, trees []nodegroupv1.Tree, namespace string) *ExistingManifests {
-	ret := FromClientTreeAgnostic(ctx, cli, plat, mf, instance, namespace)
-	ret.trees = trees
-	klog.V(4).InfoS("RTE manifests processing trees", "method", ret.helper.Name())
-	for _, tree := range trees {
-		ret.helper.UpdateFromClient(ctx, cli, tree)
-	}
-	return ret
 }
 
 func FromClientTreeAgnostic(ctx context.Context, cli client.Client, plat platform.Platform, mf Manifests, instance *nropv1.NUMAResourcesOperator, namespace string) *ExistingManifests {

--- a/pkg/status/conditioninfo/conditioninfo.go
+++ b/pkg/status/conditioninfo/conditioninfo.go
@@ -49,6 +49,18 @@ func (ci ConditionInfo) WithMessage(message string) ConditionInfo {
 	return ret
 }
 
+// UpdateMessage overrides the ConditionInfo message with the given value.
+// If a message is already set, the new value is prepended to it.
+func (ci ConditionInfo) UpdateMessage(message string) ConditionInfo {
+	ret := ci
+	if ret.Message != "" {
+		ret.Message = message + "; " + ret.Message
+	} else {
+		ret.Message = message
+	}
+	return ret
+}
+
 // Available returns a ConditionInfo ready to build
 // an Available condition
 func Available() ConditionInfo {

--- a/pkg/status/conditioninfo/conditioninfo.go
+++ b/pkg/status/conditioninfo/conditioninfo.go
@@ -49,6 +49,18 @@ func (ci ConditionInfo) WithMessage(message string) ConditionInfo {
 	return ret
 }
 
+// PrependMessage overrides the ConditionInfo message with the given value.
+// If a message is already set, the new value is prepended to it.
+func (ci ConditionInfo) PrependMessage(message string) ConditionInfo {
+	ret := ci
+	if ret.Message != "" {
+		ret.Message = message + "; " + ret.Message
+	} else {
+		ret.Message = message
+	}
+	return ret
+}
+
 // Available returns a ConditionInfo ready to build
 // an Available condition
 func Available() ConditionInfo {

--- a/pkg/status/conditioninfo/conditioninfo_test.go
+++ b/pkg/status/conditioninfo/conditioninfo_test.go
@@ -51,6 +51,20 @@ func TestProgressing(t *testing.T) {
 	assert.NotEmpty(t, cond.Reason)
 }
 
+func TestUpdateMessageEmpty(t *testing.T) {
+	cond := ConditionInfo{}
+	cond2 := cond.UpdateMessage("foobar")
+	assert.Empty(t, cond.Message) // original object not mutated
+	assert.Equal(t, cond2.Message, "foobar")
+}
+
+func TestUpdateMessageExisting(t *testing.T) {
+	cond := ConditionInfo{Message: "existing error"}
+	cond2 := cond.UpdateMessage("summary")
+	assert.Equal(t, cond.Message, "existing error") // original object not mutated
+	assert.Equal(t, cond2.Message, "summary; existing error")
+}
+
 func TestDegradedFromError(t *testing.T) {
 	cond1 := DegradedFromError(nil)
 	assert.Equal(t, cond1.Type, status.ConditionDegraded)

--- a/pkg/status/conditioninfo/conditioninfo_test.go
+++ b/pkg/status/conditioninfo/conditioninfo_test.go
@@ -49,6 +49,20 @@ func TestProgressing(t *testing.T) {
 	assert.Equal(t, cond.Type, status.ConditionProgressing)
 }
 
+func TestUpdateMessageEmpty(t *testing.T) {
+	cond := ConditionInfo{}
+	cond2 := cond.UpdateMessage("foobar")
+	assert.Empty(t, cond.Message) // original object not mutated
+	assert.Equal(t, cond2.Message, "foobar")
+}
+
+func TestUpdateMessageExisting(t *testing.T) {
+	cond := ConditionInfo{Message: "existing error"}
+	cond2 := cond.UpdateMessage("summary")
+	assert.Equal(t, cond.Message, "existing error") // original object not mutated
+	assert.Equal(t, cond2.Message, "summary; existing error")
+}
+
 func TestDegradedFromError(t *testing.T) {
 	cond1 := DegradedFromError(nil)
 	assert.Equal(t, cond1.Type, status.ConditionDegraded)

--- a/pkg/status/conditioninfo/conditioninfo_test.go
+++ b/pkg/status/conditioninfo/conditioninfo_test.go
@@ -51,6 +51,20 @@ func TestProgressing(t *testing.T) {
 	assert.NotEmpty(t, cond.Reason)
 }
 
+func TestUpdateMessageEmpty(t *testing.T) {
+	cond := ConditionInfo{}
+	cond2 := cond.PrependMessage("foobar")
+	assert.Empty(t, cond.Message) // original object not mutated
+	assert.Equal(t, cond2.Message, "foobar")
+}
+
+func TestUpdateMessageExisting(t *testing.T) {
+	cond := ConditionInfo{Message: "existing error"}
+	cond2 := cond.PrependMessage("summary")
+	assert.Equal(t, cond.Message, "existing error") // original object not mutated
+	assert.Equal(t, cond2.Message, "summary; existing error")
+}
+
 func TestDegradedFromError(t *testing.T) {
 	cond1 := DegradedFromError(nil)
 	assert.Equal(t, cond1.Type, status.ConditionDegraded)


### PR DESCRIPTION
implement "vertical split" vs current "horizontal split"
the split is about how the reconciliation makes progress. In the model we had till now, retroactively called "horizontal split", each NodeGroup must make progress on each reconciliation stage before any of these can progress to the next stage. IOW, the slowest NodeGroup blocks all the other NodeGroups at the stage it is stuck at.

With the approach proposed here, "vertical split", each NodeGroup advances independently on the reconciliation step, and only the *global reported status* is set pulled to the slowest state; IOW, with N nodegroups, N-1 can be Available and settled and 1 still Progressing; the global state will still be Progressing, but changes to the other NodeGroups can happen independently.

To simplify the implementation, a single goroutine handles all the NodeGroup reconciliation, so factually a NodeGroup can still influence the others, but this (bar more serious bugs we should fix anyway) can only create reconciliation delays, a far better stance than the issues caused by the horizontal split.

## backportability

This PR is broken down in commits which are intentionally shaped to make the backport down to the distant 4.18 as low risk as possible.
Compatibility layers are added and then removed in the context of the same PR explicitly and only in order
to enable gradual testing, not because their own merit.

## review notice

Adding and removing code in the same PR makes the review harder, even though the final tree state is identical.
It may be useful to review the final tree state (e.g. git diff <base>..HEAD) in addition to individual commits, since the end result is identical to a cleaner, main-only series.
The most independent commits are intentionally pushed towards the beginning of the series to enable this review mode as much as possible.

## LLM-assisted backport effort summary

| Branch | Effort | Notes |
|--------|--------|-------|
| 4.22 | minimal | Essentially clean cherry-picks |
| 4.21 | minimal | Essentially clean cherry-picks (after PR #4025 lands) |
| 4.20 | very low | Minor controller conflicts (after PR #3801 backport lands) |
| 4.19 | low | Minor conflicts; `rte.go` diverges more (after PR #3801 backport lands) |
| 4.18 | high | Path renames, no `MachineConfigsState`, `machineconfigpool.go` heavily diverged (see below) |

### 4.18 effort breakdown

| Commits | Effort | Nature |
|---------|--------|--------|
| 1 (Name() helper) | very low | Path adjustment: `api/v1/helper/` → `api/numaresourcesoperator/v1/helper/` |
| 2-3 (conditioninfo, step helpers) | minimal | `step.go` identical; `conditioninfo.go` nearly identical |
| 4 (move helper around) | low | Path adjustment: `internal/controller/` → `controllers/` |
| 5 (rte + compat wrappers) | hard/very hard | Key refactoring; `machineconfigpool.go` is 134 lines (vs 244 on main), no `MachineConfigObjectState` type, no `MachineConfigsState` method; `rte.go` is 436 lines (vs 379) with 288 diff lines |
| 6 (signature refactoring) | low | Path adjustment only |
| 7 (add per-tree functions) | mid/hard | New code, but depends on compat wrappers from commit 5 being adapted first |
| 8 (wire per-tree functions) | hard | Controller rewrite; building blocks from 5-7 must be proven first |
| 9-10 (narrow helpers, rename) | very low | Mechanical signature changes |
| 11 (remove compat wrappers) | mid | Adaptation for different `machineconfigpool.go` baseline |
| 12 (vertical processing) | mid | Controller change; same pattern as main but different baseline |

### 4.21/4.20/4.19 prerequisite

These branches require PR #3801 ("OCPBUGS-84226: per-pool MachineConfig state
with paused MCP awareness") to be backported first. PR #4025 covers 4.21;
4.20 and 4.19 need equivalent backports. Once that prerequisite lands,
these branches have the same `MachineConfigObjectState` type and
`MachineConfigsState` signature as main, making the cherry-picks
straightforward.

## LLM-assisted risk assessment

The proposed split should significantly reduce backport risk compared to
a simpler, monolithic approach:

1. **Commits 1-3** (Name helper, UpdateMessage, step helpers) are trivial
   cherry-picks on all branches. Done and verified quickly.
2. **Commit 4** (move helper) is a pure reorder, low risk.
3. **Commit 5** (rte compat wrappers) is the key risk point — it refactors
   the objectstate layer but adds compat wrappers so the controller continues
   working unchanged. Existing controller tests validate the compat wrappers
   without any controller changes.
4. **Commit 6** (signature refactoring) is mechanical prep work.
5. **Commit 7** (add per-tree functions) adds dead code. If it compiles,
   it is correct.
6. **Commit 8** (wire per-tree functions) is the core behavioral change.
   By this point all building blocks (1-7) are proven and verified.
7. **Commits 9-10** (narrow helpers, rename) are mechanical signature
   narrowing, safe after commit 8 removed the old callers.
8. **Commit 11** (remove compat wrappers) is mechanical cleanup.
9. **Commit 12** (vertical processing) is the final behavioral change,
   switching from horizontal to vertical orchestration.

The compat wrappers in commit 5 are the key risk reduction: they allow
validating the rte.go refactoring on any branch (including 4.18, the
hardest target) without touching the controller at all. Once that is
proven, the controller changes build on a solid foundation.