### PR TITLE
AA: e2e: wire TLS suite into runner and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,11 +272,15 @@ binary-e2e-tools: generate-source ## Build tools e2e test binary.
 binary-e2e-must-gather: generate-source ## Build must-gather e2e test binary.
 	go test -c -v -o bin/e2e-nrop-must-gather.test ./test/e2e/must-gather
 
+.PHONY: binary-e2e-tls
+binary-e2e-tls: generate-source ## Build TLS e2e test binary.
+	go test -c -v -o bin/e2e-nrop-tls.test ./test/e2e/tls
+
 # backward compatibility
 binary-must-gather-e2e: binary-e2e-must-gather
 
 .PHONY: binary-e2e-all
-binary-e2e-all: goversion binary-e2e-install binary-e2e-upgrade binary-e2e-rte binary-e2e-sched binary-e2e-uninstall binary-e2e-serial binary-e2e-tools binary-e2e-must-gather runner-e2e-serial build-pause introspect-data ## Build all e2e test binaries.
+binary-e2e-all: goversion binary-e2e-install binary-e2e-upgrade binary-e2e-rte binary-e2e-sched binary-e2e-uninstall binary-e2e-serial binary-e2e-tools binary-e2e-must-gather binary-e2e-tls runner-e2e-serial build-pause introspect-data ## Build all e2e test binaries.
 
 .PHONY: runner-e2e-serial
 runner-e2e-serial: bin/envsubst ## Render and validate the serial e2e runner script.
@@ -326,6 +330,9 @@ build-e2e-all: generate-source fmt vet binary-e2e-all ## Build all e2e tests.
 
 .PHONY: build-e2e-must-gather
 build-e2e-must-gather: fmt vet binary-e2e-must-gather ## Build must-gather e2e tests.
+
+.PHONY: build-e2e-tls
+build-e2e-tls: fmt vet binary-e2e-tls ## Build TLS e2e tests.
 
 # backward compatibility
 build-must-gather-e2e: build-e2e-must-gather

--- a/hack/run-test-e2e.sh
+++ b/hack/run-test-e2e.sh
@@ -43,6 +43,9 @@ if [ "$ENABLE_SCHED_TESTS" = true ]; then
   echo "Running NROScheduler install test suite"
   ${BIN_DIR}/e2e-nrop-sched-install.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.fail-fast --ginkgo.junit-report=${REPORT_DIR}/sched-install.xml
 
+  echo "Running TLS e2e suite"
+  ${BIN_DIR}/e2e-nrop-tls.test ${NO_COLOR} --ginkgo.v --ginkgo.junit-report=${REPORT_DIR}/e2e-tls.xml
+
   echo "Running Functional Tests: ${GINKGO_SUITS}"
   # -v: print out the text and location for each spec before running it and flush output to stdout in realtime
   # -timeout: exit the suite after the specified time


### PR DESCRIPTION
Add binary-e2e-tls and build-e2e-tls targets, include the TLS test binary in binary-e2e-all, and run e2e-nrop-tls.test after the scheduler install suite in hack/run-test-e2e.sh. Skip the TLS suite in BeforeSuite when the OpenShift APIServer API is unavailable so kind-based CI is not broken.

Assisted-by: Cursor 3.1.7
AI-attribution: AIA PAI Hin R cursor 3.1.7 v1