### PR TITLE
CNF-23603: Upstream catalog-template update — NUMA Resources Operator 4.18.3

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-18@sha256:5724a0af01dae3aed54ae36dd820858fd39abf4a089e93dc461b28e8ee972268
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-18@sha256:9a7aaa76332d160b9096461618063e4e3cfa6d7e071a599f20f49a1882ed5cdd

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -21,6 +21,10 @@ entries:
       - name: numaresources-operator.v4.18.3
         replaces: numaresources-operator.v4.18.2
         skipRange: '>=4.16.0 <4.18.3'
+      # v4.18.4
+      - name: numaresources-operator.v4.18.4
+        replaces: numaresources-operator.v4.18.3
+        skipRange: '>=4.16.0 <4.18.4'
     name: "4.18"
     package: numaresources-operator
     schema: olm.channel
@@ -34,6 +38,9 @@ entries:
   - image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:9a48e096d245b499aa201cc35fb99cc10e636b8ae1a5bee6d18cd01a17614de6
     schema: olm.bundle
     # v4.18.3 bundle
+  - image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:5724a0af01dae3aed54ae36dd820858fd39abf4a089e93dc461b28e8ee972268
+    schema: olm.bundle
+    # v4.18.4 bundle
     # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for NUMA Resources Operator 4.18.3 → 4.18.4.

Generated by release-automator-konflux.