### PR TITLE
OCPBUGS-79418: ctrl: sched: add PodAntiAffinity to deployment

### DIFF
--- a/internal/controller/numaresourcesscheduler_controller.go
+++ b/internal/controller/numaresourcesscheduler_controller.go
@@ -360,6 +360,10 @@ func (r *NUMAResourcesSchedulerReconciler) syncNUMASchedulerResources(ctx contex
 		return nropv1.NUMAResourcesSchedulerStatus{}, err
 	}
 
+	if err := schedupdate.DeploymentAffinityWithStrategy(r.SchedulerManifests.Deployment, instance.Spec); err != nil {
+		return nropv1.NUMAResourcesSchedulerStatus{}, err
+	}
+
 	k8swgrbacupdate.RoleForLeaderElection(r.SchedulerManifests.Role, r.Namespace, nrosched.LeaderElectionResourceName)
 	k8swgrbacupdate.RoleBinding(r.SchedulerManifests.RoleBinding, r.SchedulerManifests.ServiceAccount.Name, r.Namespace)
 

--- a/internal/controller/numaresourcesscheduler_controller_test.go
+++ b/internal/controller/numaresourcesscheduler_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -1029,6 +1030,193 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 			Expect(reconciler.Client.Get(context.TODO(), client.ObjectKey{Namespace: testNamespace, Name: "secondary-scheduler"}, dp)).To(Succeed())
 			Expect(dp.Spec.Template.Spec.Containers[0].Args).To(ContainElement("--tls-min-version=" + updatedSettings.MinVersion))
 			Expect(dp.Spec.Template.Spec.Containers[0].Args).To(ContainElement("--tls-cipher-suites=" + updatedSettings.CipherSuites))
+		})
+	})
+
+	Context("when setting the scheduler PodAntiAffinity", func() {
+		var (
+			expectedPodAntiAff *corev1.PodAntiAffinity
+			expectedStrategy   appsv1.DeploymentStrategy
+		)
+
+		BeforeEach(func() {
+			expectedPodAntiAff = &corev1.PodAntiAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"app": "secondary-scheduler",
+							},
+						},
+						TopologyKey: "kubernetes.io/hostname",
+					},
+				},
+			}
+			expectedStrategy = appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxUnavailable: ptr.To(intstr.FromInt(1)),
+					MaxSurge:       ptr.To(intstr.FromInt(0)),
+				},
+			}
+		})
+
+		Context("set different replicas counts", func() {
+			type testCase struct {
+				replicasCount         *int32
+				expectPodAntiAffinity bool
+			}
+
+			DescribeTable("should set PodAntiAffinity for scheduler Deployment according to replicas count", func(ctx context.Context, tc testCase) {
+				nrs := testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 11*time.Second)
+				nrs.Spec.Replicas = tc.replicasCount
+				initObjects := []runtime.Object{nrs}
+				initObjects = append(initObjects, fakeNodes(3, 0)...)
+				reconciler, err := NewFakeNUMAResourcesSchedulerReconciler(initObjects...)
+				Expect(err).ToNot(HaveOccurred())
+				// Baseline node affinity comes from the scheduler deployment manifest; reconcile must preserve it.
+				Expect(reconciler.SchedulerManifests.Deployment.Spec.Template.Spec.Affinity).ToNot(BeNil())
+				expectedNodeAff := reconciler.SchedulerManifests.Deployment.Spec.Template.Spec.Affinity.NodeAffinity.DeepCopy()
+
+				key := client.ObjectKeyFromObject(nrs)
+				_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+				Expect(err).ToNot(HaveOccurred())
+
+				dp := &appsv1.Deployment{}
+				dpKey := client.ObjectKey{Namespace: testNamespace, Name: "secondary-scheduler"}
+				Expect(reconciler.Client.Get(ctx, dpKey, dp)).To(Succeed())
+				affinity := dp.Spec.Template.Spec.Affinity
+				Expect(affinity).ToNot(BeNil())
+				Expect(affinity.NodeAffinity).To(Equal(expectedNodeAff))
+
+				if !tc.expectPodAntiAffinity {
+					Expect(affinity.PodAntiAffinity).To(BeNil())
+					Expect(dp.Spec.Strategy).To(Equal(appsv1.DeploymentStrategy{}))
+
+					// no changes expected on second reconcile with same input
+					_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(reconciler.Client.Get(ctx, dpKey, dp)).To(Succeed())
+					affinity = dp.Spec.Template.Spec.Affinity
+					Expect(affinity).ToNot(BeNil())
+					Expect(affinity.NodeAffinity).To(Equal(expectedNodeAff))
+					Expect(affinity.PodAntiAffinity).To(BeNil())
+					Expect(dp.Spec.Strategy).To(Equal(appsv1.DeploymentStrategy{}))
+					return
+				}
+
+				Expect(affinity.PodAntiAffinity).ToNot(BeNil())
+				Expect(affinity.PodAntiAffinity).To(Equal(expectedPodAntiAff))
+				Expect(dp.Spec.Strategy).To(Equal(expectedStrategy))
+
+				// no changes expected on second reconcile with same input
+				_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(reconciler.Client.Get(ctx, dpKey, dp)).To(Succeed())
+				affinity = dp.Spec.Template.Spec.Affinity
+				Expect(affinity).ToNot(BeNil())
+				Expect(affinity.NodeAffinity).To(Equal(expectedNodeAff))
+				Expect(affinity.PodAntiAffinity).ToNot(BeNil())
+				Expect(affinity.PodAntiAffinity).To(Equal(expectedPodAntiAff))
+				Expect(dp.Spec.Strategy).To(Equal(expectedStrategy))
+			},
+				Entry("when replicas are not set, expected podAntiAffinity", testCase{expectPodAntiAffinity: true}),
+				Entry("when replicas are set and zero, no podAntiAffinity is set", testCase{replicasCount: ptr.To(int32(0)), expectPodAntiAffinity: false}),
+				Entry("when replicas are set and non-zero, no podAntiAffinity is set", testCase{replicasCount: ptr.To(int32(1)), expectPodAntiAffinity: false}),
+			)
+		})
+
+		Context("switch between replicas counts", func() {
+			It("should reset podAntiAffinity and strategy - transition from autodetect to explicit replicas count", func(ctx context.Context) {
+				nrs := testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 11*time.Second)
+				nrs.Spec.Replicas = nil // autodetect
+				initObjects := []runtime.Object{nrs}
+				initObjects = append(initObjects, fakeNodes(3, 0)...)
+				reconciler, err := NewFakeNUMAResourcesSchedulerReconciler(initObjects...)
+				Expect(err).ToNot(HaveOccurred())
+
+				key := client.ObjectKeyFromObject(nrs)
+				_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+				Expect(err).ToNot(HaveOccurred())
+
+				dp := &appsv1.Deployment{}
+				dpKey := client.ObjectKey{Namespace: testNamespace, Name: "secondary-scheduler"}
+
+				Expect(reconciler.Client.Get(ctx, dpKey, dp)).To(Succeed())
+				affinity := dp.Spec.Template.Spec.Affinity
+				Expect(affinity).ToNot(BeNil())
+				Expect(affinity.PodAntiAffinity).To(Equal(expectedPodAntiAff))
+				Expect(dp.Spec.Strategy).To(Equal(expectedStrategy))
+
+				// reconcile with non-nil replicas count
+				Eventually(func(g Gomega) {
+					g.Expect(reconciler.Client.Get(ctx, key, nrs)).ToNot(HaveOccurred())
+					nrs.Spec.Replicas = ptr.To(int32(2))
+					g.Expect(reconciler.Client.Update(ctx, nrs)).ToNot(HaveOccurred())
+				}).WithPolling(5 * time.Second).WithTimeout(30 * time.Second).Should(Succeed())
+
+				_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(reconciler.Client.Get(ctx, dpKey, dp)).To(Succeed())
+				affinity = dp.Spec.Template.Spec.Affinity
+				Expect(affinity).ToNot(BeNil())
+				Expect(affinity.PodAntiAffinity).To(BeNil())
+				Expect(dp.Spec.Strategy).To(Equal(appsv1.DeploymentStrategy{}))
+
+				// reconcile with a different non-nil replicas count should keep the same result
+				Eventually(func(g Gomega) {
+					g.Expect(reconciler.Client.Get(ctx, key, nrs)).ToNot(HaveOccurred())
+					nrs.Spec.Replicas = ptr.To(int32(0))
+					g.Expect(reconciler.Client.Update(ctx, nrs)).ToNot(HaveOccurred())
+				}).WithPolling(5 * time.Second).WithTimeout(30 * time.Second).Should(Succeed())
+
+				_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(reconciler.Client.Get(ctx, dpKey, dp)).To(Succeed())
+				affinity = dp.Spec.Template.Spec.Affinity
+				Expect(affinity).ToNot(BeNil())
+				Expect(affinity.PodAntiAffinity).To(BeNil())
+				Expect(dp.Spec.Strategy).To(Equal(appsv1.DeploymentStrategy{}))
+
+			})
+
+			It("should reset podAntiAffinity and strategy - transition from explicit replicas count to autodetect", func(ctx context.Context) {
+				nrs := testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 11*time.Second)
+				nrs.Spec.Replicas = ptr.To(int32(3))
+				initObjects := []runtime.Object{nrs}
+				initObjects = append(initObjects, fakeNodes(3, 0)...)
+				reconciler, err := NewFakeNUMAResourcesSchedulerReconciler(initObjects...)
+				Expect(err).ToNot(HaveOccurred())
+
+				key := client.ObjectKeyFromObject(nrs)
+				_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+				Expect(err).ToNot(HaveOccurred())
+
+				dp := &appsv1.Deployment{}
+				dpKey := client.ObjectKey{Namespace: testNamespace, Name: "secondary-scheduler"}
+				Expect(reconciler.Client.Get(ctx, dpKey, dp)).To(Succeed())
+				affinity := dp.Spec.Template.Spec.Affinity
+				Expect(affinity).ToNot(BeNil())
+				Expect(affinity.PodAntiAffinity).To(BeNil())
+				Expect(dp.Spec.Strategy).To(Equal(appsv1.DeploymentStrategy{}))
+
+				Eventually(func(g Gomega) {
+					g.Expect(reconciler.Client.Get(ctx, key, nrs)).ToNot(HaveOccurred())
+					nrs.Spec.Replicas = nil // autodetect
+					g.Expect(reconciler.Client.Update(ctx, nrs)).ToNot(HaveOccurred())
+				}).WithPolling(5 * time.Second).WithTimeout(30 * time.Second).Should(Succeed())
+
+				_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(reconciler.Client.Get(ctx, dpKey, dp)).To(Succeed())
+				affinity = dp.Spec.Template.Spec.Affinity
+				Expect(affinity).ToNot(BeNil())
+				Expect(affinity.PodAntiAffinity).To(Equal(expectedPodAntiAff))
+				Expect(dp.Spec.Strategy).To(Equal(expectedStrategy))
+			})
 		})
 	})
 })

--- a/pkg/objectupdate/sched/sched.go
+++ b/pkg/objectupdate/sched/sched.go
@@ -17,12 +17,16 @@
 package sched
 
 import (
+	"errors"
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/flagcodec"
 	k8swgmanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
@@ -99,6 +103,52 @@ func DeploymentTLSSettings(dp *appsv1.Deployment, tlsSettings objtls.Settings) e
 	cnt.Args = flags.Argv()
 
 	klog.V(3).InfoS("Scheduler TLS settings", "minVersion", tlsSettings.MinVersion, "cipherSuites", tlsSettings.CipherSuites)
+	return nil
+}
+
+// DeploymentAffinityWithStrategy configures required pod anti-affinity on the scheduler
+// deployment only when the CR leaves replica count to autodetection (Replicas unset).
+// An explicit non-nil Replicas value means the user chose a replica count and keeps
+// full control (no required pod anti-affinity).
+func DeploymentAffinityWithStrategy(dp *appsv1.Deployment, spec nropv1.NUMAResourcesSchedulerSpec) error {
+	if spec.Replicas != nil {
+		if dp.Spec.Template.Spec.Affinity != nil {
+			dp.Spec.Template.Spec.Affinity.PodAntiAffinity = nil
+		}
+		dp.Spec.Strategy = appsv1.DeploymentStrategy{}
+		return nil
+	}
+
+	labels := dp.Spec.Template.Labels
+	if len(labels) == 0 {
+		return errors.New("no labels provided for PodAntiAffinity")
+	}
+
+	if dp.Spec.Template.Spec.Affinity == nil {
+		dp.Spec.Template.Spec.Affinity = &corev1.Affinity{}
+	}
+
+	dp.Spec.Template.Spec.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+			{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				TopologyKey: "kubernetes.io/hostname",
+			},
+		},
+	}
+	klog.V(3).InfoS("Scheduler Deployment affinity", "podAntiAffinity", dp.Spec.Template.Spec.Affinity.PodAntiAffinity.String())
+	// NOTE: With replicas=1 and no PodAntiAffinity, the default strategy (surge 1, then remove old)
+	// works as expected — the new pod can schedule anywhere, no constraints block it.
+	dp.Spec.Strategy = appsv1.DeploymentStrategy{
+		Type: appsv1.RollingUpdateDeploymentStrategyType,
+		RollingUpdate: &appsv1.RollingUpdateDeployment{
+			MaxUnavailable: ptr.To(intstr.FromInt(1)),
+			MaxSurge:       ptr.To(intstr.FromInt(0)),
+		},
+	}
+	klog.V(3).InfoS("Scheduler Deployment Rollout Strategy", "rolloutStrategy", dp.Spec.Strategy.String())
 	return nil
 }
 

--- a/pkg/objectupdate/sched/sched_test.go
+++ b/pkg/objectupdate/sched/sched_test.go
@@ -24,10 +24,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 
 	k8swgmanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
 
@@ -628,6 +632,125 @@ func TestDeploymentTLSSettingsRepeated(t *testing.T) {
 
 	if !reflect.DeepEqual(firstArgs, secondArgs) {
 		t.Errorf("duplicates found in TLS args\nfirst:  %v\nsecond: %v", firstArgs, secondArgs)
+	}
+}
+
+func TestDeploymentAffinityWithStrategyNoLabels(t *testing.T) {
+	dp := dpMinimal.DeepCopy()
+	err := DeploymentAffinityWithStrategy(dp, nropv1.NUMAResourcesSchedulerSpec{})
+	if err == nil {
+		t.Fatalf("expected error but received nil")
+	}
+}
+
+func TestDeploymentAffinityWithStrategyExplicitNonNilReplicasCount(t *testing.T) {
+	testcases := []struct {
+		name                string
+		nonNilReplicasCount *int32
+	}{
+		{
+			name:                "replicas count is positive int",
+			nonNilReplicasCount: ptr.To(int32(2)),
+		},
+		{
+			name:                "replicas count is zero",
+			nonNilReplicasCount: ptr.To(int32(0)),
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			dp := dpMinimal.DeepCopy()
+			dp.Spec.Template.ObjectMeta.Labels = map[string]string{"app": "scheduler"}
+			initialNodeAffinity := &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{
+									Key:      "node-role.kubernetes.io/worker",
+									Operator: corev1.NodeSelectorOpExists,
+									Values:   []string{""},
+								},
+							},
+						},
+					},
+				},
+			}
+			dp.Spec.Template.Spec.Affinity = &corev1.Affinity{
+				NodeAffinity: initialNodeAffinity,
+				PodAntiAffinity: &corev1.PodAntiAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+						{
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "scheduler"},
+							},
+						},
+					},
+				},
+			}
+			err := DeploymentAffinityWithStrategy(dp, nropv1.NUMAResourcesSchedulerSpec{Replicas: tc.nonNilReplicasCount})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			// check that the node affinity is preserved
+			if diff := cmp.Diff(initialNodeAffinity, dp.Spec.Template.Spec.Affinity.NodeAffinity); diff != "" {
+				t.Errorf("should preserve existing NodeAffinity: affinity mismatch (-expected +got):\n%s", diff)
+			}
+			if dp.Spec.Template.Spec.Affinity.PodAntiAffinity != nil {
+				t.Fatalf("expected podAntiAffinity to be reset but got %v", dp.Spec.Template.Spec.Affinity.PodAntiAffinity)
+			}
+			if dp.Spec.Strategy != (appsv1.DeploymentStrategy{}) {
+				t.Fatalf("expected strategy to be reset but got %v", dp.Spec.Strategy)
+			}
+		})
+	}
+}
+
+func TestDeploymentAffinityWithStrategyWithOverride(t *testing.T) {
+	labels := map[string]string{"app": "scheduler"}
+	expectedStrategy := appsv1.DeploymentStrategy{
+		Type: appsv1.RollingUpdateDeploymentStrategyType,
+		RollingUpdate: &appsv1.RollingUpdateDeployment{
+			MaxUnavailable: ptr.To(intstr.FromInt(1)),
+			MaxSurge:       ptr.To(intstr.FromInt(0)),
+		},
+	}
+	expectedPodAntiAffinity := &corev1.PodAntiAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+			{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				TopologyKey: "kubernetes.io/hostname",
+			},
+		},
+	}
+	dp := dpMinimal.DeepCopy()
+	dp.Spec.Template.ObjectMeta.Labels = labels
+
+	err := DeploymentAffinityWithStrategy(dp, nropv1.NUMAResourcesSchedulerSpec{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if diff := cmp.Diff(expectedPodAntiAffinity, dp.Spec.Template.Spec.Affinity.PodAntiAffinity); diff != "" {
+		t.Errorf("affinity mismatch (-expected +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(expectedStrategy, dp.Spec.Strategy); diff != "" {
+		t.Errorf("strategy mismatch (-expected +got):\n%s", diff)
+	}
+
+	// check reset works
+	err = DeploymentAffinityWithStrategy(dp, nropv1.NUMAResourcesSchedulerSpec{Replicas: ptr.To(int32(2))})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if dp.Spec.Template.Spec.Affinity != nil && dp.Spec.Template.Spec.Affinity.PodAntiAffinity != nil {
+		t.Fatalf("Override failed: expected no podAntiAffinity but got %v", dp.Spec.Template.Spec.Affinity.PodAntiAffinity)
+	}
+	if dp.Spec.Strategy != (appsv1.DeploymentStrategy{}) {
+		t.Fatalf("expected strategy to be reset but got %v", dp.Spec.Strategy)
 	}
 }
 


### PR DESCRIPTION
The default functionality of the scheduler HA feature is to create scheduler
pod per node (control-plane in Hypershift and worker in Openshift).
This will create the pods regardless of the readiness of the nodes, and
doesn't necessarily place one pod on each node and this specially rises
when some of the hosting nodes are down. The scheduler pod that was
meant to be scheduled on that node will be running on another node which
already has the scheduler pod. The duplicate pod does not add much value while
 still consume node resources.

This commit adjusts the scheduler deployment to use PodAntiAffinity to
avoid creating the same app pod on the same host; IOW each possible host
will host only one scheduler pod.This applies only when the autodetection
of scheduler replicas is requested, meaning only when spec.replicas is
nil (unset).

However, having PodAntiAffinity is not enough specially for deployments running
on compact OpenShift clusters (control-plane nodes only, typically three) with high
availability and preferred NodeAffinity tied to control-plane nodes.
n such a case, the default RollingUpdate surge tries to add a new pod before terminating
an old one. With every node already hosting a scheduler pod, the extra pod
cannot schedule and the rollout stalls (new pods Pending).

To fix this, we need to adjust the rollout strategy on the deployment to first delete a pod then
create a new updated one,that's done useing RollingUpdate strategy with maxSurge 0 and maxUnavailable
1 so nodes free a slot before the replacement pod is scheduled.
