### PR TITLE
e2e: sched: verify PodAntiAffinity and Rollout Strategy settings

### DIFF
--- a/internal/controller/numaresourcesscheduler_controller.go
+++ b/internal/controller/numaresourcesscheduler_controller.go
@@ -360,7 +360,9 @@ func (r *NUMAResourcesSchedulerReconciler) syncNUMASchedulerResources(ctx contex
 		return nropv1.NUMAResourcesSchedulerStatus{}, err
 	}
 
-	if err := schedupdate.DeploymentAffinityWithStrategy(r.SchedulerManifests.Deployment, instance.Spec); err != nil {
+	schedupdate.DeploymentRolloutStrategy(r.SchedulerManifests.Deployment)
+
+	if err := schedupdate.DeploymentAffinity(r.SchedulerManifests.Deployment, instance.Spec); err != nil {
 		return nropv1.NUMAResourcesSchedulerStatus{}, err
 	}
 

--- a/internal/controller/numaresourcesscheduler_controller_test.go
+++ b/internal/controller/numaresourcesscheduler_controller_test.go
@@ -1033,10 +1033,75 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 		})
 	})
 
-	Context("when setting the scheduler PodAntiAffinity", func() {
+	When("setting the scheduler rollout strategy", func() {
+		var (
+			expectedStrategy appsv1.DeploymentStrategy
+			dpKey            client.ObjectKey
+		)
+
+		BeforeEach(func() {
+			expectedStrategy = appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxUnavailable: ptr.To(intstr.FromInt(1)),
+					MaxSurge:       ptr.To(intstr.FromInt(0)),
+				},
+			}
+			dpKey = client.ObjectKey{Namespace: testNamespace, Name: "secondary-scheduler"}
+
+		})
+
+		It("should set the rollout strategy with maxSurge set to 0 by default", func(ctx context.Context) {
+			nrs := testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 11*time.Second)
+			initObjects := []runtime.Object{nrs}
+			initObjects = append(initObjects, fakeNodes(3, 0)...)
+			reconciler, err := NewFakeNUMAResourcesSchedulerReconciler(initObjects...)
+			Expect(err).ToNot(HaveOccurred())
+			key := client.ObjectKeyFromObject(nrs)
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).ToNot(HaveOccurred())
+
+			dp := &appsv1.Deployment{}
+			Expect(reconciler.Client.Get(ctx, dpKey, dp)).To(Succeed())
+			Expect(dp.Spec.Strategy).To(Equal(expectedStrategy))
+		})
+
+		It("should still set the rollout strategy with maxSurge set to 0 even if the replicas are set to non-zero", func(ctx context.Context) {
+			nrs := testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 11*time.Second)
+			nrs.Spec.Replicas = ptr.To(int32(3))
+			initObjects := []runtime.Object{nrs}
+			initObjects = append(initObjects, fakeNodes(3, 0)...)
+			reconciler, err := NewFakeNUMAResourcesSchedulerReconciler(initObjects...)
+			Expect(err).ToNot(HaveOccurred())
+			key := client.ObjectKeyFromObject(nrs)
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).ToNot(HaveOccurred())
+
+			dp := &appsv1.Deployment{}
+			Expect(reconciler.Client.Get(ctx, dpKey, dp)).To(Succeed())
+			Expect(dp.Spec.Strategy).To(Equal(expectedStrategy))
+		})
+
+		It("should still set the rollout strategy with maxSurge set to 0 even if the replicas are set to zero", func(ctx context.Context) {
+			nrs := testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 11*time.Second)
+			nrs.Spec.Replicas = ptr.To(int32(0))
+			initObjects := []runtime.Object{nrs}
+			initObjects = append(initObjects, fakeNodes(3, 0)...)
+			reconciler, err := NewFakeNUMAResourcesSchedulerReconciler(initObjects...)
+			Expect(err).ToNot(HaveOccurred())
+			key := client.ObjectKeyFromObject(nrs)
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).ToNot(HaveOccurred())
+
+			dp := &appsv1.Deployment{}
+			Expect(reconciler.Client.Get(ctx, dpKey, dp)).To(Succeed())
+			Expect(dp.Spec.Strategy).To(Equal(expectedStrategy))
+		})
+	})
+
+	When("setting the scheduler PodAntiAffinity", func() {
 		var (
 			expectedPodAntiAff *corev1.PodAntiAffinity
-			expectedStrategy   appsv1.DeploymentStrategy
 		)
 
 		BeforeEach(func() {
@@ -1050,13 +1115,6 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 						},
 						TopologyKey: "kubernetes.io/hostname",
 					},
-				},
-			}
-			expectedStrategy = appsv1.DeploymentStrategy{
-				Type: appsv1.RollingUpdateDeploymentStrategyType,
-				RollingUpdate: &appsv1.RollingUpdateDeployment{
-					MaxUnavailable: ptr.To(intstr.FromInt(1)),
-					MaxSurge:       ptr.To(intstr.FromInt(0)),
 				},
 			}
 		})
@@ -1091,7 +1149,6 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 
 				if !tc.expectPodAntiAffinity {
 					Expect(affinity.PodAntiAffinity).To(BeNil())
-					Expect(dp.Spec.Strategy).To(Equal(appsv1.DeploymentStrategy{}))
 
 					// no changes expected on second reconcile with same input
 					_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
@@ -1101,13 +1158,11 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 					Expect(affinity).ToNot(BeNil())
 					Expect(affinity.NodeAffinity).To(Equal(expectedNodeAff))
 					Expect(affinity.PodAntiAffinity).To(BeNil())
-					Expect(dp.Spec.Strategy).To(Equal(appsv1.DeploymentStrategy{}))
 					return
 				}
 
 				Expect(affinity.PodAntiAffinity).ToNot(BeNil())
 				Expect(affinity.PodAntiAffinity).To(Equal(expectedPodAntiAff))
-				Expect(dp.Spec.Strategy).To(Equal(expectedStrategy))
 
 				// no changes expected on second reconcile with same input
 				_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
@@ -1118,7 +1173,6 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 				Expect(affinity.NodeAffinity).To(Equal(expectedNodeAff))
 				Expect(affinity.PodAntiAffinity).ToNot(BeNil())
 				Expect(affinity.PodAntiAffinity).To(Equal(expectedPodAntiAff))
-				Expect(dp.Spec.Strategy).To(Equal(expectedStrategy))
 			},
 				Entry("when replicas are not set, expected podAntiAffinity", testCase{expectPodAntiAffinity: true}),
 				Entry("when replicas are set and zero, no podAntiAffinity is set", testCase{replicasCount: ptr.To(int32(0)), expectPodAntiAffinity: false}),
@@ -1127,7 +1181,7 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 		})
 
 		Context("switch between replicas counts", func() {
-			It("should reset podAntiAffinity and strategy - transition from autodetect to explicit replicas count", func(ctx context.Context) {
+			It("should reset podAntiAffinity - transition from autodetect to explicit replicas count", func(ctx context.Context) {
 				nrs := testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 11*time.Second)
 				nrs.Spec.Replicas = nil // autodetect
 				initObjects := []runtime.Object{nrs}
@@ -1146,7 +1200,6 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 				affinity := dp.Spec.Template.Spec.Affinity
 				Expect(affinity).ToNot(BeNil())
 				Expect(affinity.PodAntiAffinity).To(Equal(expectedPodAntiAff))
-				Expect(dp.Spec.Strategy).To(Equal(expectedStrategy))
 
 				// reconcile with non-nil replicas count
 				Eventually(func(g Gomega) {
@@ -1162,7 +1215,6 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 				affinity = dp.Spec.Template.Spec.Affinity
 				Expect(affinity).ToNot(BeNil())
 				Expect(affinity.PodAntiAffinity).To(BeNil())
-				Expect(dp.Spec.Strategy).To(Equal(appsv1.DeploymentStrategy{}))
 
 				// reconcile with a different non-nil replicas count should keep the same result
 				Eventually(func(g Gomega) {
@@ -1178,11 +1230,9 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 				affinity = dp.Spec.Template.Spec.Affinity
 				Expect(affinity).ToNot(BeNil())
 				Expect(affinity.PodAntiAffinity).To(BeNil())
-				Expect(dp.Spec.Strategy).To(Equal(appsv1.DeploymentStrategy{}))
-
 			})
 
-			It("should reset podAntiAffinity and strategy - transition from explicit replicas count to autodetect", func(ctx context.Context) {
+			It("should reset podAntiAffinity - transition from explicit replicas count to autodetect", func(ctx context.Context) {
 				nrs := testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 11*time.Second)
 				nrs.Spec.Replicas = ptr.To(int32(3))
 				initObjects := []runtime.Object{nrs}
@@ -1200,7 +1250,6 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 				affinity := dp.Spec.Template.Spec.Affinity
 				Expect(affinity).ToNot(BeNil())
 				Expect(affinity.PodAntiAffinity).To(BeNil())
-				Expect(dp.Spec.Strategy).To(Equal(appsv1.DeploymentStrategy{}))
 
 				Eventually(func(g Gomega) {
 					g.Expect(reconciler.Client.Get(ctx, key, nrs)).ToNot(HaveOccurred())
@@ -1215,7 +1264,6 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 				affinity = dp.Spec.Template.Spec.Affinity
 				Expect(affinity).ToNot(BeNil())
 				Expect(affinity.PodAntiAffinity).To(Equal(expectedPodAntiAff))
-				Expect(dp.Spec.Strategy).To(Equal(expectedStrategy))
 			})
 		})
 	})

--- a/internal/wait/deployment.go
+++ b/internal/wait/deployment.go
@@ -20,15 +20,20 @@ import (
 	"context"
 
 	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8swait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const deploymentRevisionAnnotation = "deployment.kubernetes.io/revision"
+
 func (wt Waiter) ForDeploymentComplete(ctx context.Context, dp *appsv1.Deployment) (*appsv1.Deployment, error) {
-	// This function waits for the readiness of the pods under the deployment. The best use of this check is for
-	// completely new deployments. If the deployment exists on the cluster and simply updated, this check is
-	// not enough to guarantee that the deployment is ready with the NEW replica, thus need to cover that by
-	// additional checks as the context requires
+	return wt.ForDeploymentCompleteWithReplicas(ctx, dp, dp.Spec.Replicas)
+}
+
+func (wt Waiter) ForDeploymentCompleteWithReplicas(ctx context.Context, dp *appsv1.Deployment, expectedReplicas *int32) (*appsv1.Deployment, error) {
 	key := ObjectKeyFromObject(dp)
 	updatedDp := &appsv1.Deployment{}
 	immediate := true
@@ -39,8 +44,17 @@ func (wt Waiter) ForDeploymentComplete(ctx context.Context, dp *appsv1.Deploymen
 			return false, err
 		}
 
-		if !IsDeploymentComplete(dp, &updatedDp.Status) {
+		if !IsDeploymentComplete(dp.Generation, expectedReplicas, &updatedDp.Status) {
 			klog.Warningf("deployment %s not yet complete", key.String())
+			return false, nil
+		}
+
+		rolloutComplete, err := wt.isDeploymentRolloutComplete(aContext, updatedDp, expectedReplicas)
+		if err != nil {
+			return false, err
+		}
+		if !rolloutComplete {
+			klog.Warningf("deployment %s rollout not yet complete", key.String())
 			return false, nil
 		}
 
@@ -50,15 +64,90 @@ func (wt Waiter) ForDeploymentComplete(ctx context.Context, dp *appsv1.Deploymen
 	return updatedDp, err
 }
 
+func (wt Waiter) isDeploymentRolloutComplete(ctx context.Context, dp *appsv1.Deployment, expectedReplicas *int32) (bool, error) {
+	revision, ok := dp.Annotations[deploymentRevisionAnnotation]
+	if !ok || revision == "" {
+		return true, nil
+	}
+
+	sel, err := metav1.LabelSelectorAsSelector(dp.Spec.Selector)
+	if err != nil {
+		return false, err
+	}
+
+	rsList := &appsv1.ReplicaSetList{}
+	if err := wt.Cli.List(ctx, rsList, &client.ListOptions{
+		Namespace:     dp.Namespace,
+		LabelSelector: sel,
+	}); err != nil {
+		return false, err
+	}
+
+	want := deploymentExpectedReplicaCount(expectedReplicas, dp.Status.Replicas)
+	var currentRS *appsv1.ReplicaSet
+	for i := range rsList.Items {
+		rs := &rsList.Items[i]
+		if !metav1.IsControlledBy(rs, dp) {
+			continue
+		}
+		if rs.Annotations[deploymentRevisionAnnotation] != revision {
+			continue
+		}
+		currentRS = rs
+		break
+	}
+	if currentRS == nil {
+		klog.V(4).InfoS("deployment rollout waiting for current revision replicaset",
+			"deployment", ObjectKeyFromObject(dp).String(), "revision", revision)
+		return false, nil
+	}
+	if !isReplicasetStatusComplete(currentRS.Generation, want, &currentRS.Status) {
+		klog.V(4).InfoS("deployment rollout waiting for current revision replicaset to become ready",
+			"deployment", ObjectKeyFromObject(dp).String(),
+			"replicaset", currentRS.Name,
+			"want", want,
+			"ready", currentRS.Status.ReadyReplicas,
+			"replicas", currentRS.Status.Replicas,
+			"available", currentRS.Status.AvailableReplicas)
+		return false, nil
+	}
+
+	for i := range rsList.Items {
+		rs := &rsList.Items[i]
+		if !metav1.IsControlledBy(rs, dp) {
+			continue
+		}
+		if rs.UID == currentRS.UID {
+			continue
+		}
+		if rs.Status.Replicas != 0 {
+			klog.V(4).InfoS("deployment rollout waiting for old replicaset to drain",
+				"deployment", ObjectKeyFromObject(dp).String(),
+				"replicaset", rs.Name,
+				"replicas", rs.Status.Replicas)
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func deploymentExpectedReplicaCount(expectedReplicas *int32, statusReplicas int32) int32 {
+	if expectedReplicas != nil {
+		return *expectedReplicas
+	}
+	return statusReplicas
+}
+
 func areDeploymentReplicasAvailable(newStatus *appsv1.DeploymentStatus, replicas int32) bool {
 	return newStatus.UpdatedReplicas == replicas &&
 		newStatus.Replicas == replicas &&
 		newStatus.AvailableReplicas == replicas
 }
 
-func IsDeploymentComplete(dp *appsv1.Deployment, newStatus *appsv1.DeploymentStatus) bool {
-	return areDeploymentReplicasAvailable(newStatus, *(dp.Spec.Replicas)) &&
-		newStatus.ObservedGeneration >= dp.Generation
+func IsDeploymentComplete(oldGeneration int64, replicas *int32, newStatus *appsv1.DeploymentStatus) bool {
+	expectedReplicas := deploymentExpectedReplicaCount(replicas, newStatus.Replicas)
+	return areDeploymentReplicasAvailable(newStatus, expectedReplicas) &&
+		newStatus.ObservedGeneration >= oldGeneration
 }
 
 func (wt Waiter) ForDeploymentReplicasCreation(ctx context.Context, dp *appsv1.Deployment, expectedReplicas int32) (*appsv1.Deployment, error) {

--- a/internal/wait/deployment_test.go
+++ b/internal/wait/deployment_test.go
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wait
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestDeploymentExpectedReplicaCount(t *testing.T) {
+	want := int32(3)
+	got := deploymentExpectedReplicaCount(&want, 1)
+	if got != want {
+		t.Fatalf("expected %d, got %d", want, got)
+	}
+
+	got = deploymentExpectedReplicaCount(nil, 2)
+	if got != 2 {
+		t.Fatalf("expected 2, got %d", got)
+	}
+}
+
+func TestIsDeploymentComplete(t *testing.T) {
+	status := appsv1.DeploymentStatus{
+		Replicas:           3,
+		UpdatedReplicas:    3,
+		AvailableReplicas:  3,
+		ObservedGeneration: 5,
+	}
+	if !IsDeploymentComplete(5, ptr.To(int32(3)), &status) {
+		t.Fatal("expected deployment to be complete")
+	}
+	if IsDeploymentComplete(6, ptr.To(int32(3)), &status) {
+		t.Fatal("expected deployment to be incomplete when generation not observed")
+	}
+	if IsDeploymentComplete(5, ptr.To(int32(2)), &status) {
+		t.Fatal("expected deployment to be incomplete when replica count mismatches")
+	}
+}
+
+func TestIsDeploymentRolloutComplete(t *testing.T) {
+	const (
+		ns       = "test-ns"
+		depName  = "scheduler"
+		revision = "2"
+		replicas = int32(3)
+	)
+
+	labelSel := map[string]string{"app": depName}
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      depName,
+			Namespace: ns,
+			UID:       "dep-uid",
+			Annotations: map[string]string{
+				deploymentRevisionAnnotation: revision,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: labelSel},
+			Replicas: ptr.To(replicas),
+		},
+		Status: appsv1.DeploymentStatus{Replicas: replicas},
+	}
+
+	currentRS := newControlledReplicaSet(dep, "scheduler-2", revision, replicas, replicas)
+	currentRS.UID = "rs-current-uid"
+	oldRSWithPods := newControlledReplicaSet(dep, "scheduler-1", "1", replicas, replicas)
+	oldRSWithPods.UID = "rs-old-uid"
+	oldRSWithPods.Status.Replicas = 1
+	oldRSWithPods.Status.ReadyReplicas = 1
+	oldRSWithPods.Status.AvailableReplicas = 1
+
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		want    bool
+	}{
+		{
+			name:    "current revision replicaset ready",
+			objects: []runtime.Object{dep, currentRS},
+			want:    true,
+		},
+		{
+			name:    "old replicaset still has replicas",
+			objects: []runtime.Object{dep, currentRS, oldRSWithPods},
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(tt.objects...).Build()
+			wt := Waiter{Cli: cli}
+
+			got, err := wt.isDeploymentRolloutComplete(context.TODO(), dep, dep.Spec.Replicas)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("isDeploymentRolloutComplete() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func newControlledReplicaSet(dep *appsv1.Deployment, name, revision string, ready, total int32) *appsv1.ReplicaSet {
+	controller := true
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  dep.Namespace,
+			Labels:     dep.Spec.Selector.MatchLabels,
+			Generation: 1,
+			Annotations: map[string]string{
+				deploymentRevisionAnnotation: revision,
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: appsv1.SchemeGroupVersion.String(),
+				Kind:       "Deployment",
+				Name:       dep.Name,
+				UID:        dep.UID,
+				Controller: &controller,
+			}},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Selector: dep.Spec.Selector,
+			Replicas: ptr.To(total),
+		},
+		Status: appsv1.ReplicaSetStatus{
+			Replicas:           total,
+			ReadyReplicas:      ready,
+			AvailableReplicas:  ready,
+			ObservedGeneration: 1,
+		},
+	}
+	return rs
+}

--- a/internal/wait/replicaset.go
+++ b/internal/wait/replicaset.go
@@ -35,7 +35,7 @@ func (wt Waiter) ForReplicasetComplete(ctx context.Context, rs *appsv1.ReplicaSe
 			return false, err
 		}
 
-		if !isReplicasetComplete(rs, &updatedRs.Status) {
+		if !isReplicasetComplete(updatedRs, &updatedRs.Status) {
 			klog.Warningf("replicaset %s not yet complete", key.String())
 			return false, nil
 		}
@@ -47,9 +47,16 @@ func (wt Waiter) ForReplicasetComplete(ctx context.Context, rs *appsv1.ReplicaSe
 }
 
 func isReplicasetComplete(rs *appsv1.ReplicaSet, newStatus *appsv1.ReplicaSetStatus) bool {
-	replicas := *(rs.Spec.Replicas)
-	areReplicasAvailable := newStatus.ReadyReplicas == replicas &&
+	replicas := int32(1)
+	if rs.Spec.Replicas != nil {
+		replicas = *rs.Spec.Replicas
+	}
+	return isReplicasetStatusComplete(rs.Generation, replicas, newStatus)
+}
+
+func isReplicasetStatusComplete(generation int64, replicas int32, newStatus *appsv1.ReplicaSetStatus) bool {
+	return newStatus.ReadyReplicas == replicas &&
 		newStatus.Replicas == replicas &&
-		newStatus.AvailableReplicas == replicas
-	return areReplicasAvailable && newStatus.ObservedGeneration >= rs.Generation
+		newStatus.AvailableReplicas == replicas &&
+		newStatus.ObservedGeneration >= generation
 }

--- a/internal/wait/waiter.go
+++ b/internal/wait/waiter.go
@@ -31,7 +31,7 @@ const (
 	// DefaultPollTimeout was computed by trial and error, not scientifically,
 	// so it may adjusted in the future any time.
 	// Roughly match the time it takes for pods to go running in CI.
-	DefaultPollTimeout = 3 * time.Minute
+	DefaultPollTimeout = 5 * time.Minute
 )
 
 type ObjectKey struct {

--- a/pkg/objectupdate/sched/sched.go
+++ b/pkg/objectupdate/sched/sched.go
@@ -106,16 +106,15 @@ func DeploymentTLSSettings(dp *appsv1.Deployment, tlsSettings objtls.Settings) e
 	return nil
 }
 
-// DeploymentAffinityWithStrategy configures required pod anti-affinity on the scheduler
+// DeploymentAffinity configures required pod anti-affinity on the scheduler
 // deployment only when the CR leaves replica count to autodetection (Replicas unset).
 // An explicit non-nil Replicas value means the user chose a replica count and keeps
 // full control (no required pod anti-affinity).
-func DeploymentAffinityWithStrategy(dp *appsv1.Deployment, spec nropv1.NUMAResourcesSchedulerSpec) error {
+func DeploymentAffinity(dp *appsv1.Deployment, spec nropv1.NUMAResourcesSchedulerSpec) error {
 	if spec.Replicas != nil {
 		if dp.Spec.Template.Spec.Affinity != nil {
 			dp.Spec.Template.Spec.Affinity.PodAntiAffinity = nil
 		}
-		dp.Spec.Strategy = appsv1.DeploymentStrategy{}
 		return nil
 	}
 
@@ -139,8 +138,13 @@ func DeploymentAffinityWithStrategy(dp *appsv1.Deployment, spec nropv1.NUMAResou
 		},
 	}
 	klog.V(3).InfoS("Scheduler Deployment affinity", "podAntiAffinity", dp.Spec.Template.Spec.Affinity.PodAntiAffinity.String())
-	// NOTE: With replicas=1 and no PodAntiAffinity, the default strategy (surge 1, then remove old)
-	// works as expected — the new pod can schedule anywhere, no constraints block it.
+	return nil
+}
+
+// DeploymentRolloutStrategy configures the rollout strategy for the scheduler deployment
+// with maxSurge set to 0 to enforce terminating an old pod first. This is important to align
+// as much as possible scheduling the scheduler pods with the expected affinities.
+func DeploymentRolloutStrategy(dp *appsv1.Deployment) {
 	dp.Spec.Strategy = appsv1.DeploymentStrategy{
 		Type: appsv1.RollingUpdateDeploymentStrategyType,
 		RollingUpdate: &appsv1.RollingUpdateDeployment{
@@ -149,7 +153,6 @@ func DeploymentAffinityWithStrategy(dp *appsv1.Deployment, spec nropv1.NUMAResou
 		},
 	}
 	klog.V(3).InfoS("Scheduler Deployment Rollout Strategy", "rolloutStrategy", dp.Spec.Strategy.String())
-	return nil
 }
 
 func SchedulerConfig(cm *corev1.ConfigMap, name string, params *k8swgmanifests.ConfigParams) error {

--- a/pkg/objectupdate/sched/sched_test.go
+++ b/pkg/objectupdate/sched/sched_test.go
@@ -635,15 +635,15 @@ func TestDeploymentTLSSettingsRepeated(t *testing.T) {
 	}
 }
 
-func TestDeploymentAffinityWithStrategyNoLabels(t *testing.T) {
+func TestDeploymentAffinityNoLabels(t *testing.T) {
 	dp := dpMinimal.DeepCopy()
-	err := DeploymentAffinityWithStrategy(dp, nropv1.NUMAResourcesSchedulerSpec{})
+	err := DeploymentAffinity(dp, nropv1.NUMAResourcesSchedulerSpec{})
 	if err == nil {
 		t.Fatalf("expected error but received nil")
 	}
 }
 
-func TestDeploymentAffinityWithStrategyExplicitNonNilReplicasCount(t *testing.T) {
+func TestDeploymentAffinityExplicitNonNilReplicasCount(t *testing.T) {
 	testcases := []struct {
 		name                string
 		nonNilReplicasCount *int32
@@ -688,7 +688,7 @@ func TestDeploymentAffinityWithStrategyExplicitNonNilReplicasCount(t *testing.T)
 					},
 				},
 			}
-			err := DeploymentAffinityWithStrategy(dp, nropv1.NUMAResourcesSchedulerSpec{Replicas: tc.nonNilReplicasCount})
+			err := DeploymentAffinity(dp, nropv1.NUMAResourcesSchedulerSpec{Replicas: tc.nonNilReplicasCount})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -699,22 +699,12 @@ func TestDeploymentAffinityWithStrategyExplicitNonNilReplicasCount(t *testing.T)
 			if dp.Spec.Template.Spec.Affinity.PodAntiAffinity != nil {
 				t.Fatalf("expected podAntiAffinity to be reset but got %v", dp.Spec.Template.Spec.Affinity.PodAntiAffinity)
 			}
-			if dp.Spec.Strategy != (appsv1.DeploymentStrategy{}) {
-				t.Fatalf("expected strategy to be reset but got %v", dp.Spec.Strategy)
-			}
 		})
 	}
 }
 
-func TestDeploymentAffinityWithStrategyWithOverride(t *testing.T) {
+func TestDeploymentAffinityWithOverride(t *testing.T) {
 	labels := map[string]string{"app": "scheduler"}
-	expectedStrategy := appsv1.DeploymentStrategy{
-		Type: appsv1.RollingUpdateDeploymentStrategyType,
-		RollingUpdate: &appsv1.RollingUpdateDeployment{
-			MaxUnavailable: ptr.To(intstr.FromInt(1)),
-			MaxSurge:       ptr.To(intstr.FromInt(0)),
-		},
-	}
 	expectedPodAntiAffinity := &corev1.PodAntiAffinity{
 		RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 			{
@@ -728,7 +718,7 @@ func TestDeploymentAffinityWithStrategyWithOverride(t *testing.T) {
 	dp := dpMinimal.DeepCopy()
 	dp.Spec.Template.ObjectMeta.Labels = labels
 
-	err := DeploymentAffinityWithStrategy(dp, nropv1.NUMAResourcesSchedulerSpec{})
+	err := DeploymentAffinity(dp, nropv1.NUMAResourcesSchedulerSpec{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -736,12 +726,9 @@ func TestDeploymentAffinityWithStrategyWithOverride(t *testing.T) {
 	if diff := cmp.Diff(expectedPodAntiAffinity, dp.Spec.Template.Spec.Affinity.PodAntiAffinity); diff != "" {
 		t.Errorf("affinity mismatch (-expected +got):\n%s", diff)
 	}
-	if diff := cmp.Diff(expectedStrategy, dp.Spec.Strategy); diff != "" {
-		t.Errorf("strategy mismatch (-expected +got):\n%s", diff)
-	}
 
 	// check reset works
-	err = DeploymentAffinityWithStrategy(dp, nropv1.NUMAResourcesSchedulerSpec{Replicas: ptr.To(int32(2))})
+	err = DeploymentAffinity(dp, nropv1.NUMAResourcesSchedulerSpec{Replicas: ptr.To(int32(2))})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -749,8 +736,22 @@ func TestDeploymentAffinityWithStrategyWithOverride(t *testing.T) {
 	if dp.Spec.Template.Spec.Affinity != nil && dp.Spec.Template.Spec.Affinity.PodAntiAffinity != nil {
 		t.Fatalf("Override failed: expected no podAntiAffinity but got %v", dp.Spec.Template.Spec.Affinity.PodAntiAffinity)
 	}
-	if dp.Spec.Strategy != (appsv1.DeploymentStrategy{}) {
-		t.Fatalf("expected strategy to be reset but got %v", dp.Spec.Strategy)
+}
+
+func TestDeploymentRolloutStrategy(t *testing.T) {
+	dp := dpMinimal.DeepCopy()
+
+	DeploymentRolloutStrategy(dp)
+
+	expected := appsv1.DeploymentStrategy{
+		Type: appsv1.RollingUpdateDeploymentStrategyType,
+		RollingUpdate: &appsv1.RollingUpdateDeployment{
+			MaxUnavailable: ptr.To(intstr.FromInt(1)),
+			MaxSurge:       ptr.To(intstr.FromInt(0)),
+		},
+	}
+	if diff := cmp.Diff(expected, dp.Spec.Strategy); diff != "" {
+		t.Errorf("strategy mismatch (-expected +got):\n%s", diff)
 	}
 }
 

--- a/test/e2e/sched/sched_test.go
+++ b/test/e2e/sched/sched_test.go
@@ -27,6 +27,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -44,7 +46,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("[Scheduler] imageReplacement", func() {
+var _ = Describe("[Scheduler] Scheduler CR modifications", func() {
 	var initialized bool
 	nroSchedObj := &nropv1.NUMAResourcesScheduler{}
 	BeforeEach(func() {
@@ -272,5 +274,147 @@ var _ = Describe("[Scheduler] imageReplacement", func() {
 				Expect(pod.UID).ToNot(Equal(uid), "new scheduler pod has not been created")
 			}
 		})
+	})
+
+	When("testing deployment PodAntiAffinity and rollout strategy", func() {
+		var (
+			expectedPodAntiAffinity   corev1.PodAntiAffinity
+			expectedStrategy          appsv1.DeploymentStrategy
+			nroSchedKey               client.ObjectKey
+			autoDetectedReplicasCount *int32
+			podsUIDsInitial           []types.UID
+			schedDp                   *appsv1.Deployment
+		)
+
+		BeforeEach(func(ctx context.Context) {
+			nroSchedKey = client.ObjectKeyFromObject(nroSchedObj)
+			Expect(e2eclient.Client.Get(ctx, nroSchedKey, nroSchedObj)).To(Succeed())
+			currentReplicas := nroSchedObj.Spec.Replicas
+			var err error
+			schedDp, err = podlist.With(e2eclient.Client).DeploymentByOwnerReference(ctx, nroSchedObj.UID)
+			Expect(err).ToNot(HaveOccurred())
+
+			if currentReplicas != nil {
+				By(fmt.Sprintf("configure NRS replicas for autodetection: current=%d desired=nil", *currentReplicas))
+				Eventually(func(g Gomega) {
+					g.Expect(e2eclient.Client.Get(ctx, nroSchedKey, nroSchedObj)).To(Succeed())
+					nroSchedObj.Spec.Replicas = nil
+					g.Expect(e2eclient.Client.Update(ctx, nroSchedObj)).To(Succeed())
+				}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).Should(Succeed(), "failed to update NRS with autodetection mode for replicas")
+
+				schedDp, err = wait.With(e2eclient.Client).Timeout(5*time.Minute).Interval(10*time.Second).ForDeploymentCompleteWithReplicas(ctx, schedDp, nil)
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			expectedPodAntiAffinity = corev1.PodAntiAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: schedDp.Spec.Template.Labels,
+						},
+						TopologyKey: "kubernetes.io/hostname",
+					},
+				},
+			}
+			expectedStrategy = appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxUnavailable: ptr.To(intstr.FromInt(1)),
+					MaxSurge:       ptr.To(intstr.FromInt(0)),
+				},
+			}
+
+			By("checking PodAntiAffinity and strategy are set when autodetection mode is enabled - default mode")
+			affinity := schedDp.Spec.Template.Spec.Affinity
+			Expect(affinity).ToNot(BeNil(), "affinity is nil")
+			Expect(affinity.PodAntiAffinity).ToNot(BeNil(), "podAntiAffinity is nil")
+			Expect(affinity.PodAntiAffinity).To(Equal(&expectedPodAntiAffinity), "podAntiAffinity mismatch")
+			Expect(schedDp.Spec.Strategy).To(Equal(expectedStrategy), "strategy mismatch")
+
+			autoDetectedReplicasCount = schedDp.Spec.Replicas
+			Expect(autoDetectedReplicasCount).ToNot(BeNil()) // must never happen
+			podListInitial, err := podlist.With(e2eclient.Client).ByDeployment(ctx, *schedDp)
+			Expect(err).NotTo(HaveOccurred())
+			By("verifying new pods are created")
+			podsUIDsInitial = make([]types.UID, 0, len(podListInitial))
+			for _, pod := range podListInitial {
+				if pod.Status.Phase != corev1.PodRunning || pod.DeletionTimestamp != nil {
+					continue
+				}
+				podsUIDsInitial = append(podsUIDsInitial, pod.UID)
+			}
+			Expect(podsUIDsInitial).To(HaveLen(int(*autoDetectedReplicasCount)), "expected %d initial pods, got %d", *autoDetectedReplicasCount, len(podsUIDsInitial))
+		})
+
+		DescribeTable("should set PodAntiAffinity on replicas autodetection (high-availability) and update it when replicas are set explicitly", func(ctx context.Context, replicasCount int) {
+			By("checking PodAntiAffinity is removed when replicas are set explicitly")
+			newCount := int32(replicasCount)
+			if replicasCount == -1 {
+				// intentionally challenge the condition by setting the replicas count to the autodetected count;
+				// this isolates the podAffinity/strategy check from the old deployment replica count (which results
+				//  the same number of pods on autodetection mode)
+				newCount = *autoDetectedReplicasCount
+			}
+			By(fmt.Sprintf("update NRS to use explicit %d replicas", newCount))
+			Eventually(func(g Gomega) {
+				g.Expect(e2eclient.Client.Get(ctx, nroSchedKey, nroSchedObj)).To(Succeed())
+				nroSchedObj.Spec.Replicas = &newCount
+				g.Expect(e2eclient.Client.Update(ctx, nroSchedObj)).To(Succeed())
+			}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).Should(Succeed(), "failed to update NRS with explicit replicas count")
+
+			// allow enough time for the rollout to complete; 10 mins were proved to be enough for 3 target nodes
+			schedDp, err := wait.With(e2eclient.Client).Timeout(10*time.Minute).Interval(10*time.Second).ForDeploymentCompleteWithReplicas(ctx, schedDp, &newCount)
+			Expect(err).ToNot(HaveOccurred())
+			affinity := schedDp.Spec.Template.Spec.Affinity
+			if affinity != nil {
+				Expect(affinity.PodAntiAffinity).To(BeNil(), "podAntiAffinity mismatch")
+			}
+
+			Expect(schedDp.Spec.Strategy).To(Equal(expectedStrategy), "strategy mismatch")
+			updatedPodListExplicit, err := podlist.With(e2eclient.Client).ByDeployment(ctx, *schedDp)
+			Expect(err).NotTo(HaveOccurred())
+			By("verifying new pods are created")
+			newUIDsExplicit := make([]types.UID, 0, len(updatedPodListExplicit))
+			for _, pod := range updatedPodListExplicit {
+				if pod.Status.Phase != corev1.PodRunning || pod.DeletionTimestamp != nil {
+					continue
+				}
+				newUIDsExplicit = append(newUIDsExplicit, pod.UID)
+			}
+			Expect(newUIDsExplicit).To(HaveLen(int(newCount)), "expected %d new pods, got %d", newCount, len(newUIDsExplicit))
+			Expect(newUIDsExplicit).ToNot(ContainElements(podsUIDsInitial), "scheduler pods should be replaced after explicit replica rollout")
+
+			By("switch back to autodetection mode and verify PodAntiAffinity and strategy are set properly and deployment is running")
+			Eventually(func(g Gomega) {
+				g.Expect(e2eclient.Client.Get(ctx, nroSchedKey, nroSchedObj)).To(Succeed())
+				nroSchedObj.Spec.Replicas = nil
+				g.Expect(e2eclient.Client.Update(ctx, nroSchedObj)).To(Succeed())
+			}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).Should(Succeed(), "failed to update NRS with autodetection mode for replicas")
+
+			// allow enough time for the rollout to complete; 10 mins were proved to be enough for 3 target nodes
+			schedDp, err = wait.With(e2eclient.Client).Timeout(10*time.Minute).Interval(10*time.Second).ForDeploymentCompleteWithReplicas(ctx, schedDp, autoDetectedReplicasCount)
+			Expect(err).ToNot(HaveOccurred())
+			affinity = schedDp.Spec.Template.Spec.Affinity
+			Expect(affinity).ToNot(BeNil(), "affinity is nil")
+			Expect(affinity.PodAntiAffinity).ToNot(BeNil(), "podAntiAffinity is nil")
+			Expect(affinity.PodAntiAffinity).To(Equal(&expectedPodAntiAffinity), "podAntiAffinity mismatch")
+			Expect(schedDp.Spec.Strategy).To(Equal(expectedStrategy), "strategy mismatch")
+
+			By("verifying new pods are created and running")
+			updatedPodListAutodetection, err := podlist.With(e2eclient.Client).ByDeployment(ctx, *schedDp)
+			Expect(err).NotTo(HaveOccurred())
+			newUIDsAutodetection := make([]types.UID, 0, len(updatedPodListAutodetection))
+			for _, pod := range updatedPodListAutodetection {
+				if pod.Status.Phase != corev1.PodRunning || pod.DeletionTimestamp != nil {
+					continue
+				}
+				newUIDsAutodetection = append(newUIDsAutodetection, pod.UID)
+			}
+			Expect(newUIDsAutodetection).To(HaveLen(int(*autoDetectedReplicasCount)), "expected %d new pods, got %d", *autoDetectedReplicasCount, len(newUIDsAutodetection))
+			Expect(newUIDsExplicit).ToNot(ContainElements(newUIDsAutodetection), "scheduler pods should be replaced after explicit replica rollout")
+		},
+			Entry("with 0 replicas count", 0),
+			Entry("with explicit replicas count equal to autodetected count", -1),
+		)
 	})
 })

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -1000,7 +1000,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 				e2efixture.By("ensuring the deployment %q keep being pending %d/%d", deployment.Name, step+1, maxStep)
 				err = fxt.Client.Get(ctx, client.ObjectKeyFromObject(deployment), &updatedDeployment)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(wait.IsDeploymentComplete(deployment, &updatedDeployment.Status)).To(BeFalse(), "deployment %q become ready", deployment.Name)
+				Expect(wait.IsDeploymentComplete(deployment.Generation, deployment.Spec.Replicas, &updatedDeployment.Status)).To(BeFalse(), "deployment %q become ready", deployment.Name)
 			}
 
 			By("checking the deployment pod has failed scheduling and its at the pending status")

--- a/test/e2e/serial/tests/scheduler_removal.go
+++ b/test/e2e/serial/tests/scheduler_removal.go
@@ -95,7 +95,7 @@ var _ = Describe("[serial][disruptive][scheduler][schedrst] numaresources schedu
 				err = fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(dp), updatedDp)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(wait.IsDeploymentComplete(dp, &updatedDp.Status)).To(BeTrue(), "deployment %q become unready", dp.Name)
+				Expect(wait.IsDeploymentComplete(dp.Generation, dp.Spec.Replicas, &updatedDp.Status)).To(BeTrue(), "deployment %q become unready", dp.Name)
 			}
 		})
 
@@ -122,7 +122,7 @@ var _ = Describe("[serial][disruptive][scheduler][schedrst] numaresources schedu
 				err = fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(dp), updatedDp)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(wait.IsDeploymentComplete(dp, &updatedDp.Status)).To(BeFalse(), "deployment %q become ready", dp.Name)
+				Expect(wait.IsDeploymentComplete(dp.Generation, dp.Spec.Replicas, &updatedDp.Status)).To(BeFalse(), "deployment %q become ready", dp.Name)
 			}
 		})
 	})
@@ -153,7 +153,7 @@ var _ = Describe("[serial][disruptive][scheduler][schedrst] numaresources schedu
 				err = fxt.Client.Get(ctx, client.ObjectKeyFromObject(dp), updatedDp)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(wait.IsDeploymentComplete(dp, &updatedDp.Status)).To(BeFalse(), "deployment %q become ready", dp.Name)
+				Expect(wait.IsDeploymentComplete(dp.Generation, dp.Spec.Replicas, &updatedDp.Status)).To(BeFalse(), "deployment %q become ready", dp.Name)
 			}
 
 			restoreScheduler(fxt, nroSchedObj)

--- a/test/e2e/serial/tests/workload_placement_nodelabel.go
+++ b/test/e2e/serial/tests/workload_placement_nodelabel.go
@@ -347,7 +347,7 @@ var _ = Describe("[serial][disruptive][scheduler] numaresources workload placeme
 						updatedDp := &appsv1.Deployment{}
 						err := fxt.Client.Get(context.TODO(), client.ObjectKeyFromObject(deployment), updatedDp)
 						Expect(err).ToNot(HaveOccurred())
-						return wait.IsDeploymentComplete(deployment, &updatedDp.Status)
+						return wait.IsDeploymentComplete(deployment.Generation, deployment.Spec.Replicas, &updatedDp.Status)
 					}).WithTimeout(time.Second*30).WithPolling(time.Second*5).Should(BeTrue(), "deployment %q became unready", deployment.Name)
 				},
 				Entry("[test_id:47597] should be able to schedule pod with affinity property requiredDuringSchedulingIgnoredDuringExecution on the available node with feasible numa zone", createNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution),


### PR DESCRIPTION
With https://github.com/openshift-kni/numaresources-operator/pull/4021
introducing the deployment PodAntiAffinity and the update to rollout
strategy to allow terminating a pod first before creating a new one,
a new condition was noticed on especially compact clusters (can be
reproduced on an MNO as well by marking worker-nodes as unschedulable)
that revealed that on a specific scenario of switching between
autodetection replicas mode to an explicit replicas count that's equal to
the autodetected count, the new version of the deployment will have the
default strategy which is 25% maxSurge and 25%maxUnavailable. The pods
of the new replicas will keep pending due to a stall rollout because of
the combination of the default strategy and PodAntiAffinityone.
By example it will be like this on a 3 control-plane cluster:
1. autodetect mode: deployment complete with 3 pods running
2. switch to explicit 3 replicas: because maxSurge allows one pod more
   it gets created, but because of the podAntiaffinity it keeps pending,
already using the maxUnavailable limit.
3. the result is a deadlock: that the deployment has 4 replicas (4 pods), 1 pending
   (new one part of the rollout); and the old 3 are running.

The solution is to allow at least to delete an old pod first then
continue deploying the new ones. That was the behavior set only when
podAntiAffinity is set. This commit extends that to be the default
behavior (set during the reconcile).

The PR includes implemented e2e that covers the podantiaffinity and the strategy's new expectations, plus an enhancement in the way the tests wait for an updated deployment to be complete.