### PR TITLE
add gzip to must-gather konflux image

### DIFF
--- a/.konflux/must-gather/must-gather.konflux.Dockerfile
+++ b/.konflux/must-gather/must-gather.konflux.Dockerfile
@@ -20,7 +20,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:12db9874bd753eb98
 
 ARG OPENSHIFT_VERSION
 
-RUN microdnf install -y procps-ng tar rsync ; microdnf clean all
+RUN microdnf install -y procps-ng tar rsync gzip ; microdnf clean all
 
 # Copy must-gather required binaries
 COPY --from=mgbuilder /usr/bin/openshift-must-gather /usr/bin/openshift-must-gather

--- a/.konflux/must-gather/rpms.in.yaml
+++ b/.konflux/must-gather/rpms.in.yaml
@@ -17,6 +17,7 @@ packages:
   - procps-ng
   - rsync
   - tar
+  - gzip
 
 arches:
   - x86_64

--- a/.konflux/must-gather/rpms.lock.yaml
+++ b/.konflux/must-gather/rpms.lock.yaml
@@ -4,6 +4,13 @@ lockfileVendor: redhat
 arches:
 - arch: x86_64
   packages:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gzip-1.12-1.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 171206
+    checksum: sha256:c8b3e0414d55b1eedb0185a564ac6cb2368bee2fd5f995447d045f6a714488ac
+    name: gzip
+    evr: 1.12-1.el9
+    sourcerpm: gzip-1.12-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/procps-ng-3.3.17-14.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 361526


### PR DESCRIPTION
Install gzip in the must-gather runtime image and update the must-gather RPM lock data so SELinux data gathering (tar czf | tar xzf) works.