### PR TITLE
[release-4.18] status: set ObservedGeneration in all status conds

### DIFF
--- a/controllers/numaresourcesoperator_controller.go
+++ b/controllers/numaresourcesoperator_controller.go
@@ -211,7 +211,12 @@ func updateStatusConditionsIfNeeded(instance *nropv1.NUMAResourcesOperator, cond
 		return
 	}
 	klog.InfoS("updateStatus", "condition", cond.Type, "reason", cond.Reason, "message", cond.Message)
-	conditions, ok := status.UpdateConditions(instance.Status.Conditions, cond.Type, cond.Reason, cond.Message)
+	conditions, ok := status.UpdateConditions(instance.Status.Conditions, metav1.Condition{
+		Type:               cond.Type,
+		Reason:             cond.Reason,
+		Message:            cond.Message,
+		ObservedGeneration: instance.Generation,
+	}, time.Now())
 	if ok {
 		// UpdateConditions replaces with base conditions only; preserve extras
 		for _, c := range instance.Status.Conditions {

--- a/internal/api/features/_topics.json
+++ b/internal/api/features/_topics.json
@@ -20,6 +20,7 @@
     "ngpoolname",
     "nganns",
     "metrics",
-    "nrtcrdanns"
+    "nrtcrdanns",
+    "operobsgen"
   ]
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -94,8 +94,8 @@ func EqualConditions(current, updated []metav1.Condition) bool {
 // UpdateConditions compute new conditions based on arguments, and then compare with given current conditions.
 // Returns the conditions to use, either current or newly computed, and a boolean flag which is `true` if conditions need
 // update - so if they are updated since the current conditions.
-func UpdateConditions(currentConditions []metav1.Condition, condition string, reason string, message string) ([]metav1.Condition, bool) {
-	conditions := NewConditions(condition, reason, message)
+func UpdateConditions(currentConditions []metav1.Condition, cond metav1.Condition, now time.Time) ([]metav1.Condition, bool) {
+	conditions := NewConditions(cond, now)
 
 	if EqualConditions(currentConditions, conditions) {
 		return currentConditions, false
@@ -113,26 +113,29 @@ func FindCondition(conditions []metav1.Condition, condition string) *metav1.Cond
 	return nil
 }
 
-func NewConditions(condition string, reason string, message string) []metav1.Condition {
-	conditions := newBaseConditions()
-	switch condition {
+func NewConditions(cond metav1.Condition, now time.Time) []metav1.Condition {
+	conditions := newBaseConditions(now)
+	switch cond.Type {
 	case ConditionAvailable:
 		conditions[0].Status = metav1.ConditionTrue
+		conditions[0].ObservedGeneration = cond.ObservedGeneration
 		conditions[1].Status = metav1.ConditionTrue
+		conditions[1].ObservedGeneration = cond.ObservedGeneration
 	case ConditionProgressing:
 		conditions[2].Status = metav1.ConditionTrue
-		conditions[2].Reason = reason
-		conditions[2].Message = message
+		conditions[2].Reason = cond.Reason
+		conditions[2].Message = cond.Message
+		conditions[2].ObservedGeneration = cond.ObservedGeneration
 	case ConditionDegraded:
 		conditions[3].Status = metav1.ConditionTrue
-		conditions[3].Reason = reason
-		conditions[3].Message = message
+		conditions[3].Reason = cond.Reason
+		conditions[3].Message = cond.Message
+		conditions[3].ObservedGeneration = cond.ObservedGeneration
 	}
 	return conditions
 }
 
-func newBaseConditions() []metav1.Condition {
-	now := time.Now()
+func newBaseConditions(now time.Time) []metav1.Condition {
 	return []metav1.Condition{
 		{
 			Type:               ConditionAvailable,
@@ -164,7 +167,7 @@ func newBaseConditions() []metav1.Condition {
 // NewNUMAResourcesOperatorConditions creates specific operator conditions on
 // top of newBaseConditions.
 func NewNUMAResourcesOperatorConditions() []metav1.Condition {
-	return append(newBaseConditions(), operatorExtraConditions()...)
+	return append(newBaseConditions(time.Now()), operatorExtraConditions()...)
 }
 
 // EnsureNUMAResourcesOperatorConditions backfills operator-specific conditions

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -44,6 +44,7 @@ func TestFindCondition(t *testing.T) {
 		expectedFound bool
 	}
 
+	now := time.Now()
 	testCases := []testCase{
 		{
 			name:          "nil conditions",
@@ -53,13 +54,13 @@ func TestFindCondition(t *testing.T) {
 		{
 			name:          "missing condition",
 			desired:       "foobar",
-			conds:         newBaseConditions(),
+			conds:         newBaseConditions(now),
 			expectedFound: false,
 		},
 		{
 			name:          "found condition",
 			desired:       ConditionProgressing,
-			conds:         newBaseConditions(),
+			conds:         newBaseConditions(now),
 			expectedFound: true,
 		},
 	}
@@ -84,7 +85,12 @@ func TestUpdate(t *testing.T) {
 	nro := testobjs.NewNUMAResourcesOperator("test-nro")
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(nro).Build()
 
-	nro.Status.Conditions, _ = UpdateConditions(nro.Status.Conditions, ConditionProgressing, "testReason", "test message")
+	nro.Status.Conditions, _ = UpdateConditions(nro.Status.Conditions, metav1.Condition{
+		Type:               ConditionProgressing,
+		Reason:             "testReason",
+		Message:            "test message",
+		ObservedGeneration: 8181,
+	}, time.Time{})
 	err = fakeClient.Update(context.TODO(), nro)
 	if err != nil {
 		t.Errorf("Update() failed with: %v", err)
@@ -112,13 +118,17 @@ func TestUpdateIfNeeded(t *testing.T) {
 	nro := testobjs.NewNUMAResourcesOperator("test-nro")
 
 	var ok bool
-	nro.Status.Conditions, ok = UpdateConditions(nro.Status.Conditions, ConditionAvailable, "", "")
+	nro.Status.Conditions, ok = UpdateConditions(nro.Status.Conditions, metav1.Condition{
+		Type: ConditionAvailable,
+	}, time.Time{})
 	if !ok {
 		t.Errorf("Update did not change status, but it should")
 	}
 
 	// same status twice in a row. We should not overwrite identical status to save transactions.
-	_, ok = UpdateConditions(nro.Status.Conditions, ConditionAvailable, "", "")
+	_, ok = UpdateConditions(nro.Status.Conditions, metav1.Condition{
+		Type: ConditionAvailable,
+	}, time.Time{})
 	if ok {
 		t.Errorf("Update did change status, but it should not")
 	}
@@ -141,22 +151,38 @@ func TestIsUpdatedNUMAResourcesOperator(t *testing.T) {
 		{
 			name: "status, conditions, updated only time",
 			oldStatus: &nropv1.NUMAResourcesOperatorStatus{
-				Conditions: NewConditions(ConditionAvailable, "test all good", "testing info"),
+				Conditions: NewConditions(metav1.Condition{
+					Type:    ConditionAvailable,
+					Reason:  "test all good",
+					Message: "testing info",
+				}, time.Now()),
 			},
 			updaterFunc: func(st *nropv1.NUMAResourcesOperatorStatus) {
 				time.Sleep(42 * time.Millisecond) // make sure the timestamp changed
-				st.Conditions = NewConditions(ConditionAvailable, "test all good", "testing info")
+				st.Conditions = NewConditions(metav1.Condition{
+					Type:    ConditionAvailable,
+					Reason:  "test all good",
+					Message: "testing info",
+				}, time.Now())
 			},
 			expectedUpdated: false,
 		},
 		{
 			name: "status, conditions, updated only time, other fields changed",
 			oldStatus: &nropv1.NUMAResourcesOperatorStatus{
-				Conditions: NewConditions(ConditionAvailable, "test all good", "testing info"),
+				Conditions: NewConditions(metav1.Condition{
+					Type:    ConditionAvailable,
+					Reason:  "test all good",
+					Message: "testing info",
+				}, time.Now()),
 			},
 			updaterFunc: func(st *nropv1.NUMAResourcesOperatorStatus) {
 				time.Sleep(42 * time.Millisecond) // make sure the timestamp changed
-				st.Conditions = NewConditions(ConditionAvailable, "test all good", "testing info")
+				st.Conditions = NewConditions(metav1.Condition{
+					Type:    ConditionAvailable,
+					Reason:  "test all good",
+					Message: "testing info",
+				}, time.Now())
 				st.DaemonSets = []nropv1.NamespacedName{
 					{
 						Namespace: "foo",
@@ -169,7 +195,11 @@ func TestIsUpdatedNUMAResourcesOperator(t *testing.T) {
 		{
 			name: "status, conditions, updated only time, other fields mutated",
 			oldStatus: &nropv1.NUMAResourcesOperatorStatus{
-				Conditions: NewConditions(ConditionAvailable, "test all good", "testing info"),
+				Conditions: NewConditions(metav1.Condition{
+					Type:    ConditionAvailable,
+					Reason:  "test all good",
+					Message: "testing info",
+				}, time.Now()),
 				DaemonSets: []nropv1.NamespacedName{
 					{
 						Namespace: "foo",
@@ -179,7 +209,11 @@ func TestIsUpdatedNUMAResourcesOperator(t *testing.T) {
 			},
 			updaterFunc: func(st *nropv1.NUMAResourcesOperatorStatus) {
 				time.Sleep(42 * time.Millisecond) // make sure the timestamp changed
-				st.Conditions = NewConditions(ConditionAvailable, "test all good", "testing info")
+				st.Conditions = NewConditions(metav1.Condition{
+					Type:    ConditionAvailable,
+					Reason:  "test all good",
+					Message: "testing info",
+				}, time.Now())
 				st.DaemonSets = []nropv1.NamespacedName{
 					{
 						Namespace: "foo",
@@ -221,22 +255,38 @@ func TestNUMAResourcesSchedulerNeedsUpdate(t *testing.T) {
 		{
 			name: "status, conditions, updated only time",
 			oldStatus: nropv1.NUMAResourcesSchedulerStatus{
-				Conditions: NewConditions(ConditionAvailable, "test all good", "testing info"),
+				Conditions: NewConditions(metav1.Condition{
+					Type:    ConditionAvailable,
+					Reason:  "test all good",
+					Message: "testing info",
+				}, time.Now()),
 			},
 			updaterFunc: func(st *nropv1.NUMAResourcesSchedulerStatus) {
 				time.Sleep(42 * time.Millisecond) // make sure the timestamp changed
-				st.Conditions = NewConditions(ConditionAvailable, "test all good", "testing info")
+				st.Conditions = NewConditions(metav1.Condition{
+					Type:    ConditionAvailable,
+					Reason:  "test all good",
+					Message: "testing info",
+				}, time.Now())
 			},
 			expectedUpdated: false,
 		},
 		{
 			name: "status, conditions, updated only time, other fields changed",
 			oldStatus: nropv1.NUMAResourcesSchedulerStatus{
-				Conditions: NewConditions(ConditionAvailable, "test all good", "testing info"),
+				Conditions: NewConditions(metav1.Condition{
+					Type:    ConditionAvailable,
+					Reason:  "test all good",
+					Message: "testing info",
+				}, time.Now()),
 			},
 			updaterFunc: func(st *nropv1.NUMAResourcesSchedulerStatus) {
 				time.Sleep(42 * time.Millisecond) // make sure the timestamp changed
-				st.Conditions = NewConditions(ConditionAvailable, "test all good", "testing info")
+				st.Conditions = NewConditions(metav1.Condition{
+					Type:    ConditionAvailable,
+					Reason:  "test all good",
+					Message: "testing info",
+				}, time.Now())
 				st.CacheResyncPeriod = ptr.To(metav1.Duration{Duration: 42 * time.Second})
 			},
 			expectedUpdated: true,


### PR DESCRIPTION
Manual cherry-pick of #https://github.com/openshift-kni/numaresources-operator/pull/4029