### PR TITLE
[release-4.22] add feature introspection topic for supported versions

### DIFF
--- a/internal/api/features/_topics.json
+++ b/internal/api/features/_topics.json
@@ -22,6 +22,7 @@
     "metrics",
     "nrtcrdanns",
     "netpols",
+    "introspection",
     "mgselinuxcollect"
   ]
 }


### PR DESCRIPTION
Register the introspection feature in the active topics list so that the skip list mechanism can gate the introspection tests on operator versions that predate the feature (< 4.21). So we need to backport this til 4.21 where it was first introduced.


(cherry picked from commit 32eb1f94578e775b38ac4f0037b1cc27f06b0043)