### PR TITLE
[release-4.21] add feature introspection topic for supported versions

### DIFF
--- a/internal/api/features/_topics.json
+++ b/internal/api/features/_topics.json
@@ -21,6 +21,7 @@
     "nganns",
     "metrics",
     "nrtcrdanns",
-    "netpols"
+    "netpols",
+    "introspection"
   ]
 }


### PR DESCRIPTION
Register the introspection feature in the active topics list so that the skip list mechanism can gate the introspection tests on operator versions that predate the feature (< 4.21). So we need to backport this til 4.21 where it was first introduced.

(cherry picked from commit 32eb1f94578e775b38ac4f0037b1cc27f06b0043) 
(cherry picked from commit 5f29e62975a22f140f39319af492eaf325a84e77)