### PR TITLE
controllers: rework status writes

### DIFF
--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -192,6 +192,7 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 
 	if err := r.Client.Status().Patch(ctx, instance, client.MergeFrom(initialInstance)); err != nil {
 		klog.InfoS("Failed to update numaresources-operator status", "error", err)
+		return ctrl.Result{}, err
 	}
 
 	return step.Result, step.Error

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -146,8 +146,8 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 
-	initialStatus := *instance.Status.DeepCopy()
-	if len(initialStatus.Conditions) == 0 {
+	initialInstance := instance.DeepCopy()
+	if len(initialInstance.Status.Conditions) == 0 {
 		instance.Status.Conditions = status.NewNUMAResourcesOperatorConditions()
 	} else {
 		// on upgrade, backfill conditions added in newer versions
@@ -156,7 +156,7 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 
 	if req.Name != objectnames.DefaultNUMAResourcesOperatorCrName {
 		err := fmt.Errorf("incorrect NUMAResourcesOperator resource name: %s", instance.Name)
-		return r.degradeStatus(ctx, initialStatus, instance, status.ConditionTypeIncorrectNUMAResourcesOperatorResourceName, err)
+		return r.degradeStatus(ctx, initialInstance, instance, status.ConditionTypeIncorrectNUMAResourcesOperatorResourceName, err)
 	}
 
 	if annotations.IsPauseReconciliationEnabled(instance.Annotations) {
@@ -165,17 +165,17 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	if err := validation.NodeGroups(instance.Spec.NodeGroups, r.Platform); err != nil {
-		return r.degradeStatus(ctx, initialStatus, instance, validation.NodeGroupsError, err)
+		return r.degradeStatus(ctx, initialInstance, instance, validation.NodeGroupsError, err)
 	}
 
 	trees, err := getTreesByNodeGroup(ctx, r.Client, instance.Spec.NodeGroups, r.Platform)
 	if err != nil {
-		return r.degradeStatus(ctx, initialStatus, instance, validation.NodeGroupsError, err)
+		return r.degradeStatus(ctx, initialInstance, instance, validation.NodeGroupsError, err)
 	}
 
 	tolerable, err := validation.NodeGroupsTree(instance, trees, r.Platform)
 	if err != nil {
-		return r.degradeStatus(ctx, initialStatus, instance, validation.NodeGroupsError, err)
+		return r.degradeStatus(ctx, initialInstance, instance, validation.NodeGroupsError, err)
 	}
 
 	for idx := range trees {
@@ -187,29 +187,17 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 	instance.Status.Conditions, _ = status.ComputeConditions(instance.Status.Conditions, step.ConditionInfo.ToMetav1Condition(instance.Generation), time.Now())
 
 	if step.Done() && tolerable != nil {
-		return r.degradeStatus(ctx, initialStatus, instance, tolerable.Reason, tolerable.Error)
+		return r.degradeStatus(ctx, initialInstance, instance, tolerable.Reason, tolerable.Error)
 	}
 
-	if err := r.updateStatus(ctx, initialStatus, instance); err != nil {
+	if err := r.Client.Status().Patch(ctx, instance, client.MergeFrom(initialInstance)); err != nil {
 		klog.InfoS("Failed to update numaresources-operator status", "error", err)
 	}
 
 	return step.Result, step.Error
 }
 
-func (r *NUMAResourcesOperatorReconciler) updateStatus(ctx context.Context, initialStatus nropv1.NUMAResourcesOperatorStatus, instance *nropv1.NUMAResourcesOperator) error {
-	if !status.NUMAResourceOperatorNeedsUpdate(initialStatus, instance.Status) {
-		return nil
-	}
-
-	updErr := r.Client.Status().Update(ctx, instance)
-	if updErr != nil {
-		return fmt.Errorf("could not update status for object %s: %w", client.ObjectKeyFromObject(instance), updErr)
-	}
-	return nil
-}
-
-func (r *NUMAResourcesOperatorReconciler) degradeStatus(ctx context.Context, initialStatus nropv1.NUMAResourcesOperatorStatus, instance *nropv1.NUMAResourcesOperator, reason string, stErr error) (ctrl.Result, error) {
+func (r *NUMAResourcesOperatorReconciler) degradeStatus(ctx context.Context, initialInstance, instance *nropv1.NUMAResourcesOperator, reason string, stErr error) (ctrl.Result, error) {
 	info := conditioninfo.DegradedFromError(stErr)
 	if reason != "" { // intentionally overwrite
 		info.Reason = reason
@@ -217,7 +205,7 @@ func (r *NUMAResourcesOperatorReconciler) degradeStatus(ctx context.Context, ini
 
 	instance.Status.Conditions, _ = status.ComputeConditions(instance.Status.Conditions, info.ToMetav1Condition(instance.Generation), time.Now())
 
-	err := r.updateStatus(ctx, initialStatus, instance)
+	err := r.Client.Status().Patch(ctx, instance, client.MergeFrom(initialInstance))
 	if err != nil {
 		klog.InfoS("Failed to update numaresourcesoperator status", "error", err)
 	}

--- a/internal/controller/numaresourcesscheduler_controller.go
+++ b/internal/controller/numaresourcesscheduler_controller.go
@@ -124,7 +124,7 @@ func (r *NUMAResourcesSchedulerReconciler) Reconcile(ctx context.Context, req ct
 
 	if req.Name != objectnames.DefaultNUMAResourcesSchedulerCrName {
 		message := fmt.Sprintf("incorrect NUMAResourcesScheduler resource name: %s", instance.Name)
-		return ctrl.Result{}, r.degradeStatus(ctx, initialInstance, instance, status.ConditionTypeIncorrectNUMAResourcesSchedulerResourceName, message)
+		return r.degradeStatus(ctx, initialInstance, instance, status.ConditionTypeIncorrectNUMAResourcesSchedulerResourceName, message)
 	}
 
 	if annotations.IsPauseReconciliationEnabled(instance.Annotations) {
@@ -136,12 +136,13 @@ func (r *NUMAResourcesSchedulerReconciler) Reconcile(ctx context.Context, req ct
 	instance.Status.Conditions, _ = status.ComputeConditions(instance.Status.Conditions, step.ConditionInfo.ToMetav1Condition(instance.Generation), time.Now())
 	if err := r.Client.Status().Patch(ctx, instance, client.MergeFrom(initialInstance)); err != nil {
 		klog.InfoS("Failed to update numaresourcesscheduler status", "error", err)
+		return ctrl.Result{}, err
 	}
 
 	return step.Result, step.Error
 }
 
-func (r *NUMAResourcesSchedulerReconciler) degradeStatus(ctx context.Context, initialInstance, instance *nropv1.NUMAResourcesScheduler, reason string, message string) error {
+func (r *NUMAResourcesSchedulerReconciler) degradeStatus(ctx context.Context, initialInstance, instance *nropv1.NUMAResourcesScheduler, reason string, message string) (ctrl.Result, error) {
 	condition := metav1.Condition{
 		Type:               status.ConditionDegraded,
 		Status:             metav1.ConditionTrue,
@@ -154,9 +155,9 @@ func (r *NUMAResourcesSchedulerReconciler) degradeStatus(ctx context.Context, in
 
 	err := r.Client.Status().Patch(ctx, instance, client.MergeFrom(initialInstance))
 	if err != nil {
-		klog.InfoS("Failed to update numaresourcesoperator status", "error", err)
+		klog.InfoS("Failed to update numaresourcesscheduler status", "error", err)
 	}
-	return err
+	return ctrl.Result{}, err
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/numaresourcesscheduler_controller.go
+++ b/internal/controller/numaresourcesscheduler_controller.go
@@ -117,14 +117,14 @@ func (r *NUMAResourcesSchedulerReconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, err
 	}
 
-	initialStatus := *instance.Status.DeepCopy()
-	if len(initialStatus.Conditions) == 0 {
+	initialInstance := instance.DeepCopy()
+	if len(initialInstance.Status.Conditions) == 0 {
 		instance.Status.Conditions = status.NewNUMAResourcesSchedulerBaseConditions()
 	}
 
 	if req.Name != objectnames.DefaultNUMAResourcesSchedulerCrName {
 		message := fmt.Sprintf("incorrect NUMAResourcesScheduler resource name: %s", instance.Name)
-		return ctrl.Result{}, r.degradeStatus(ctx, initialStatus, instance, status.ConditionTypeIncorrectNUMAResourcesSchedulerResourceName, message)
+		return ctrl.Result{}, r.degradeStatus(ctx, initialInstance, instance, status.ConditionTypeIncorrectNUMAResourcesSchedulerResourceName, message)
 	}
 
 	if annotations.IsPauseReconciliationEnabled(instance.Annotations) {
@@ -134,14 +134,14 @@ func (r *NUMAResourcesSchedulerReconciler) Reconcile(ctx context.Context, req ct
 
 	step := r.reconcileResource(ctx, instance)
 	instance.Status.Conditions, _ = status.ComputeConditions(instance.Status.Conditions, step.ConditionInfo.ToMetav1Condition(instance.Generation), time.Now())
-	if err := r.updateStatus(ctx, initialStatus, instance); err != nil {
+	if err := r.Client.Status().Patch(ctx, instance, client.MergeFrom(initialInstance)); err != nil {
 		klog.InfoS("Failed to update numaresourcesscheduler status", "error", err)
 	}
 
 	return step.Result, step.Error
 }
 
-func (r *NUMAResourcesSchedulerReconciler) degradeStatus(ctx context.Context, initialStatus nropv1.NUMAResourcesSchedulerStatus, instance *nropv1.NUMAResourcesScheduler, reason string, message string) error {
+func (r *NUMAResourcesSchedulerReconciler) degradeStatus(ctx context.Context, initialInstance, instance *nropv1.NUMAResourcesScheduler, reason string, message string) error {
 	condition := metav1.Condition{
 		Type:               status.ConditionDegraded,
 		Status:             metav1.ConditionTrue,
@@ -152,7 +152,7 @@ func (r *NUMAResourcesSchedulerReconciler) degradeStatus(ctx context.Context, in
 
 	instance.Status.Conditions, _ = status.ComputeConditions(instance.Status.Conditions, condition, time.Now())
 
-	err := r.updateStatus(ctx, initialStatus, instance)
+	err := r.Client.Status().Patch(ctx, instance, client.MergeFrom(initialInstance))
 	if err != nil {
 		klog.InfoS("Failed to update numaresourcesoperator status", "error", err)
 	}
@@ -420,17 +420,6 @@ func updateDedicatedInformerCondition(conds []metav1.Condition, instanceGenerati
 
 	conds, _ = status.ComputeConditions(conds, informerCondition, time.Time{})
 	return conds
-}
-
-func (r *NUMAResourcesSchedulerReconciler) updateStatus(ctx context.Context, initialStatus nropv1.NUMAResourcesSchedulerStatus, sched *nropv1.NUMAResourcesScheduler) error {
-	if !status.NUMAResourcesSchedulerNeedsUpdate(initialStatus, sched.Status) {
-		return nil
-	}
-
-	if err := r.Client.Status().Update(ctx, sched); err != nil {
-		return fmt.Errorf("could not update status for object %s: %w", client.ObjectKeyFromObject(sched), err)
-	}
-	return nil
 }
 
 func unpackAPIResyncPeriod(reconcilePeriod *metav1.Duration) time.Duration {


### PR DESCRIPTION
we bundle two changes about how controllers write back their status to the apiserver:
- switch from Update() to Patch(): we can reuse more controller-runtime/client-go primitives and shed some equivalent but worse application code
- make sure to not lose status updates: if we fail to update the status subresource, we need to requeue the operation. Supercedes #3992 