### PR TITLE
CNF-22981: add allow-automatic-merge label for rpm-lockfile manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,14 @@
             "addLabels": [
                 "allow-automatic-merge"
             ],
+            "matchManagers": [
+                "rpm-lockfile"
+            ]
+        },
+        {
+            "addLabels": [
+                "allow-automatic-merge"
+            ],
             "enabled": true,
             "ignoreTests": false,
             "matchDatasources": [


### PR DESCRIPTION
## Summary

- Add a `packageRule` to label PRs generated by the `rpm-lockfile` manager with `allow-automatic-merge`
- This enables auto-merge of `rpms.lock.yaml` refresh PRs created by the mintmaker preset (`github>konflux-ci/mintmaker-presets:refresh-rpm-lockfiles`)

## Motivation

PRs that refresh RPM lock files are generated automatically by `red-hat-konflux[bot]` and only update RPM lock file checksums/versions. They should be auto-merged without manual intervention.


Made with [Cursor](https://cursor.com)