### PR TITLE
OCPBUGS-12988: force degraded status if ExporterImage is set

### DIFF
--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -189,6 +189,10 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 		return r.degradeStatus(ctx, initialInstance, instance, tolerable.Reason, tolerable.Error)
 	}
 
+	if step.Done() && instance.Spec.ExporterImage != "" {
+		return r.degradeStatusf(ctx, initialInstance, instance, status.ConditionTypeCustomUserImage, "custom operand image set: %s", instance.Spec.ExporterImage)
+	}
+
 	if err := r.Client.Status().Patch(ctx, instance, client.MergeFrom(initialInstance)); err != nil {
 		klog.InfoS("Failed to update numaresources-operator status", "error", err)
 		return ctrl.Result{}, err

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -155,8 +155,7 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	if req.Name != objectnames.DefaultNUMAResourcesOperatorCrName {
-		err := fmt.Errorf("incorrect NUMAResourcesOperator resource name: %s", instance.Name)
-		return r.degradeStatus(ctx, initialInstance, instance, status.ConditionTypeIncorrectNUMAResourcesOperatorResourceName, err)
+		return r.degradeStatusf(ctx, initialInstance, instance, status.ConditionTypeIncorrectNUMAResourcesOperatorResourceName, "incorrect NUMAResourcesOperator resource name: %s", instance.Name)
 	}
 
 	if annotations.IsPauseReconciliationEnabled(instance.Annotations) {
@@ -198,19 +197,28 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 	return step.Result, step.Error
 }
 
+func (r *NUMAResourcesOperatorReconciler) degradeStatusf(ctx context.Context, initialInstance, instance *nropv1.NUMAResourcesOperator, reason string, format string, args ...any) (ctrl.Result, error) {
+	return r.degradeStatusWithInfo(ctx, initialInstance, instance, conditioninfo.ConditionInfo{
+		Type:    status.ConditionDegraded,
+		Message: fmt.Sprintf(format, args...),
+		Reason:  reason,
+	})
+}
+
 func (r *NUMAResourcesOperatorReconciler) degradeStatus(ctx context.Context, initialInstance, instance *nropv1.NUMAResourcesOperator, reason string, stErr error) (ctrl.Result, error) {
-	info := conditioninfo.DegradedFromError(stErr)
-	if reason != "" { // intentionally overwrite
-		info.Reason = reason
-	}
+	return r.degradeStatusWithInfo(ctx, initialInstance, instance, conditioninfo.ConditionInfo{
+		Type:    status.ConditionDegraded,
+		Message: status.MessageFromError(stErr),
+		Reason:  reason,
+	})
+}
 
+func (r *NUMAResourcesOperatorReconciler) degradeStatusWithInfo(ctx context.Context, initialInstance, instance *nropv1.NUMAResourcesOperator, info conditioninfo.ConditionInfo) (ctrl.Result, error) {
 	instance.Status.Conditions, _ = status.ComputeConditions(instance.Status.Conditions, info.ToMetav1Condition(instance.Generation), time.Now())
-
 	err := r.Client.Status().Patch(ctx, instance, client.MergeFrom(initialInstance))
 	if err != nil {
 		klog.InfoS("Failed to update numaresourcesoperator status", "error", err)
 	}
-
 	return ctrl.Result{}, err
 }
 

--- a/internal/controller/numaresourcesoperator_controller_test.go
+++ b/internal/controller/numaresourcesoperator_controller_test.go
@@ -192,6 +192,31 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 			})
 		})
 
+		Context("with custom ExporterImage set", func() {
+			It("should update the CR condition to degraded", func(ctx context.Context) {
+				pn := "test"
+				ng := nropv1.NodeGroup{
+					PoolName: &pn,
+				}
+				nro := testobjs.NewNUMAResourcesOperator(objectnames.DefaultNUMAResourcesOperatorCrName, ng)
+				nro.Spec.ExporterImage = "quay.io/custom/image:latest"
+
+				labSel := &metav1.LabelSelector{
+					MatchLabels: map[string]string{pn: pn},
+				}
+				mcp := testobjs.NewMachineConfigPool(pn, labSel.MatchLabels, labSel, labSel)
+
+				reconciler, err := NewFakeNUMAResourcesOperatorReconciler(platf, defaultOCPVersion, nro, mcp)
+				Expect(err).ToNot(HaveOccurred())
+
+				key := client.ObjectKeyFromObject(nro)
+				Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})).ToNot(CauseRequeue())
+
+				Expect(reconciler.Client.Get(ctx, key, nro)).ToNot(HaveOccurred())
+				Expect(nro).To(BeDegradedWithReason(status.ConditionTypeCustomUserImage))
+			})
+		})
+
 		Context("with default RTE SELinux and PoolName set", func() {
 			Context("with correct NRO and more than one NodeGroup", func() {
 				var nro *nropv1.NUMAResourcesOperator

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -54,6 +54,7 @@ const (
 
 const (
 	ConditionTypeIncorrectNUMAResourcesOperatorResourceName = "IncorrectNUMAResourcesOperatorResourceName"
+	ConditionTypeCustomUserImage                            = "CustomUserImage"
 )
 
 const (


### PR DESCRIPTION
ExporterImage is an escape hatch we had from day0 but which we never really leveraged. It made on the stable API and we can't deprecate it anytime soon, but we can at least narrow down the perimeter and make it obvious and loud it should not be used.
Force the status to Degraded if the ExporterImage is set by the user.