### PR TITLE
fix(deps): remove .git suffix from telco5g-konflux package URL

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
                 ],
                 "additionalBranchPrefix": "telco5g-konflux-",
                 "matchPackageNames": [
-                    "https://github.com/openshift-kni/telco5g-konflux.git"
+                    "https://github.com/openshift-kni/telco5g-konflux"
                 ],
                 "schedule": [
                     "at any time"


### PR DESCRIPTION
The .git extension in the matchPackageNames URL is unnecessary and may cause renovate to fail matching the submodule updates.