### PR TITLE
E2E:  verify RTE metrics endpoint TLS compliance

### DIFF
--- a/test/e2e/tls/tls_test.go
+++ b/test/e2e/tls/tls_test.go
@@ -23,14 +23,21 @@ import (
 	"fmt"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1 "github.com/openshift/api/config/v1"
 	libgocrypto "github.com/openshift/library-go/pkg/crypto"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
+	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
 	"github.com/openshift-kni/numaresources-operator/test/e2e/label"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/internal/clients"
+	e2efixture "github.com/openshift-kni/numaresources-operator/test/internal/fixture"
 	"github.com/openshift-kni/numaresources-operator/test/internal/objects"
 	intls "github.com/openshift-kni/numaresources-operator/test/internal/tls"
 
@@ -136,5 +143,99 @@ var _ = Describe("TLS", func() {
 				return intls.CheckRTEDaemonSetTLSFlagsMatchClusterProfile(ctx, e2eclient.Client)
 			}).WithTimeout(rteDaemonSetCheckTimeout).WithPolling(rteDaemonSetCheckInterval).Should(Succeed())
 		})
+
+		Context("RTE Metrics end point TLS Compliance", Ordered, func() {
+			const rteMetricsPort = "2112"
+			var (
+				minVersion       uint16
+				profileSpec      configv1.TLSProfileSpec
+				rtePods          []corev1.Pod
+				disallowedCipher string
+			)
+			BeforeAll(func(ctx context.Context) {
+				var err error
+				minVersion, profileSpec, err = intls.GetClusterTLSProfile(ctx, e2eclient.Client)
+				Expect(err).ToNot(HaveOccurred())
+				rtePods = getRTEPodsFromNRO(ctx)
+				disallowedCipher = intls.FindDisallowedCipher(profileSpec.Ciphers)
+				if disallowedCipher != "" {
+					e2efixture.By("selected disallowed cipher for negative tests: %s", disallowedCipher)
+				}
+			})
+
+			It("[test_id:88381] should service metrics over TLS adhering to cluster profile", func(ctx context.Context) {
+				for _, rtePod := range rtePods {
+					By("Verifying TLS Handshake succeeds and negotiated version meets the cluster profile")
+					// fetch TLS Version and the cipher supported by TLS version
+					gotVersion, gotCipherId, err := intls.ProbeTLSSettings(e2eclient.K8sClient, &rtePod, rteMetricsPort)
+
+					Expect(err).ToNot(HaveOccurred(), "TLS Handshake failed on pod %q", rtePod.Name)
+					klog.InfoS("negotiated TLS settings",
+						"version", tls.VersionName(gotVersion),
+						"cipher", tls.CipherSuiteName(gotCipherId))
+
+					Expect(gotVersion).To(BeNumerically(">=", minVersion),
+						"negotiated version %s below minimum %s",
+						tls.VersionName(gotVersion), tls.VersionName(minVersion))
+
+					By("Fetching /metrics over TLS via port-fortward")
+					body, err := intls.FetchMetrics(e2eclient.K8sClient, &rtePod, rteMetricsPort)
+					Expect(err).ToNot(HaveOccurred(), "failed to fetch metrics from pod %q", rtePod.Name)
+
+					Expect(body).ToNot(BeEmpty(), "metrics response body should not be empty")
+					Expect(string(body)).To(ContainSubstring("rte_noderesourcetopology_writes_total"))
+				}
+			})
+
+			It("[test_id:88382] should reject TLS connections incompatible with the cluster profile", func() {
+				belowMinVersion, err := intls.TLSVersionBelow(minVersion)
+				Expect(err).ToNot(HaveOccurred(), "cannot determine version below %s", tls.VersionName(minVersion))
+				e2efixture.By("verifying TLS %s is rejected on each RTE pod", tls.VersionName(belowMinVersion))
+				for _, rtePod := range rtePods {
+					err = intls.ProbeMaxTLSVersion(e2eclient.K8sClient, &rtePod, rteMetricsPort, belowMinVersion)
+					Expect(err).To(HaveOccurred(), "pod %q should reject TLS %s", rtePod.Name, tls.VersionName(belowMinVersion))
+					Expect(errors.Is(err, intls.ErrTLSHandshakeRejected)).To(BeTrue(), "pod %q: got: %v", rtePod.Name, err)
+				}
+				if minVersion == tls.VersionTLS13 {
+					Skip("TLS 1.3 ciphers are not individually configurable, skipping cipher rejection test")
+				}
+
+				if disallowedCipher == "" {
+					Skip("all known TLS 1.2 ciphers are in the allowed set, nothing to test")
+				}
+				e2efixture.By("verifying disallowed cipher %s is rejected on each RTE pod", disallowedCipher)
+				for _, rtePod := range rtePods {
+					e2efixture.By("probing pod %s/%s with disallowed cipher %s", rtePod.Namespace, rtePod.Name, disallowedCipher)
+					err = intls.ProbeTLSCipher(e2eclient.K8sClient, &rtePod, rteMetricsPort, disallowedCipher)
+					Expect(err).To(HaveOccurred(), "pod %q should reject cipher %s", rtePod.Name, disallowedCipher)
+					Expect(errors.Is(err, intls.ErrTLSHandshakeRejected)).To(BeTrue(),
+						"pod %q cipher %s: expected TLS handshake rejection, got: %v", rtePod.Name, disallowedCipher, err)
+					klog.InfoS("disallowed cipher rejected as expected", "pod", rtePod.Name, "cipher", disallowedCipher)
+				}
+			})
+		})
 	})
 })
+
+func getRTEPodsFromNRO(ctx context.Context) []corev1.Pod {
+	GinkgoHelper()
+	nropObj := &nropv1.NUMAResourcesOperator{}
+	nropKey := client.ObjectKey{Name: objectnames.DefaultNUMAResourcesOperatorCrName}
+	Expect(e2eclient.Client.Get(ctx, nropKey, nropObj)).To(Succeed(), "failed to get NRO %q in the cluster", nropKey.Name)
+	Expect(nropObj.Status.NodeGroups).ToNot(BeEmpty(), "NRO %q must have at least one NodeGroup", nropKey.Name)
+	var rtePods []corev1.Pod
+	for _, nodeGroup := range nropObj.Status.NodeGroups {
+		daemonSet := &appsv1.DaemonSet{}
+		dsKey := client.ObjectKey{
+			Namespace: nodeGroup.DaemonSet.Namespace,
+			Name:      nodeGroup.DaemonSet.Name,
+		}
+		Expect(e2eclient.Client.Get(ctx, dsKey, daemonSet)).To(Succeed(), "failed to get RTE DaemonSet %s/%s", dsKey.Namespace, dsKey.Name)
+		pods, err := podlist.With(e2eclient.Client).ByDaemonset(ctx, *daemonSet)
+		Expect(err).ToNot(HaveOccurred(), "failed to list pods for RTE DaemonSet %s/%s", dsKey.Namespace, dsKey.Name)
+		Expect(pods).ToNot(BeEmpty(), "expected at least one RTE pod from Daemonset %s/%s", dsKey.Namespace, dsKey.Name)
+		rtePods = append(rtePods, pods...)
+	}
+	Expect(rtePods).ToNot(BeEmpty(), "expected at least one RTE Pod from NRO managed Daemonsets")
+	return rtePods
+}

--- a/test/e2e/tls/tls_test.go
+++ b/test/e2e/tls/tls_test.go
@@ -25,12 +25,10 @@ import (
 
 	"k8s.io/klog/v2"
 
-	ctrltls "github.com/openshift/controller-runtime-common/pkg/tls"
 	libgocrypto "github.com/openshift/library-go/pkg/crypto"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
-	objtls "github.com/openshift-kni/numaresources-operator/pkg/objectupdate/tls"
 	"github.com/openshift-kni/numaresources-operator/test/e2e/label"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/internal/clients"
 	"github.com/openshift-kni/numaresources-operator/test/internal/objects"
@@ -45,13 +43,8 @@ const schedulerSecurePort = "10259"
 var _ = Describe("TLS", func() {
 	It("should reject TLS connections that are not compatible with the profile - negative test", func(ctx context.Context) {
 		By("getting the current OCP TLS profile")
-		tlsProfileSpec, err := ctrltls.FetchAPIServerTLSProfile(ctx, e2eclient.Client)
+		minVersion, tlsProfileSpec, err := intls.GetClusterTLSProfile(ctx, e2eclient.Client)
 		Expect(err).ToNot(HaveOccurred(), "unable to get TLS profile from APIServer")
-
-		tlsConfigFn, _ := ctrltls.NewTLSConfigFromProfile(tlsProfileSpec)
-		tlsCfg := &tls.Config{}
-		tlsConfigFn(tlsCfg)
-		minVersion := tlsCfg.MinVersion
 		klog.InfoS("current TLS minimum version", "version", libgocrypto.TLSVersionToNameOrDie(minVersion))
 
 		belowMinVersion, err := intls.TLSVersionBelow(minVersion)
@@ -77,9 +70,8 @@ var _ = Describe("TLS", func() {
 		Expect(err).To(HaveOccurred(), "scheduler server should reject TLS connections capped at %s", tls.VersionName(belowMinVersion))
 		Expect(errors.Is(err, intls.ErrTLSHandshakeRejected)).To(BeTrue(),
 			"expected TLS handshake rejection, got: %v", err)
-		By("verifying that TLS connections with unsupported ciphers are rejected by the server")
 		if minVersion == tls.VersionTLS13 {
-			klog.InfoS("TLS 1.3 is not configurable, so we cannot test unsupported ciphers")
+			By("skipping disallowed-cipher probe: TLS 1.3 ciphers are not individually configurable")
 			return
 		}
 
@@ -87,7 +79,7 @@ var _ = Describe("TLS", func() {
 		if disallowedCipher == "" {
 			Skip("all known TLS 1.2 ciphers are in the allowed set, nothing to test")
 		}
-		klog.InfoS("testing with disallowed cipher", "cipher", disallowedCipher)
+		By(fmt.Sprintf("verifying that TLS connections with disallowed cipher %s are rejected by pod %s", disallowedCipher, schedulerPod.Name))
 		err = intls.ProbeTLSCipher(e2eclient.K8sClient, schedulerPod, schedulerSecurePort, disallowedCipher)
 		Expect(err).To(HaveOccurred(), "scheduler server should reject connections with disallowed cipher %s", disallowedCipher)
 		Expect(errors.Is(err, intls.ErrTLSHandshakeRejected)).To(BeTrue(), "expected TLS handshake rejection for cipher %s, got: %v", disallowedCipher, err)
@@ -95,13 +87,8 @@ var _ = Describe("TLS", func() {
 
 	It("should adhere to openshift TLS profile - positive test", func(ctx context.Context) {
 		By("getting the current OCP TLS profile")
-		tlsProfileSpec, err := ctrltls.FetchAPIServerTLSProfile(ctx, e2eclient.Client)
+		minVersion, tlsProfileSpec, err := intls.GetClusterTLSProfile(ctx, e2eclient.Client)
 		Expect(err).ToNot(HaveOccurred(), "unable to get TLS profile from APIServer")
-
-		tlsConfigFn, _ := ctrltls.NewTLSConfigFromProfile(tlsProfileSpec)
-		tlsCfg := &tls.Config{}
-		tlsConfigFn(tlsCfg)
-		minVersion := tlsCfg.MinVersion
 		klog.InfoS("current TLS minimum version", "version", libgocrypto.TLSVersionToNameOrDie(minVersion))
 
 		By("getting the scheduler deployment and pods")
@@ -144,17 +131,9 @@ var _ = Describe("TLS", func() {
 			rteDaemonSetCheckInterval = 5 * time.Second
 		)
 		It("[test_id:88380] should have RTE DaemonSet args aligned with the cluster TLS profile", func(ctx context.Context) {
-			By("Getting initial OCP TLS profile")
-			tlsProfileSpec, err := ctrltls.FetchAPIServerTLSProfile(ctx, e2eclient.Client)
-			Expect(err).ToNot(HaveOccurred(), "Unable to get TLS Profile from APIServer")
-			tlsConfig, _ := ctrltls.NewTLSConfigFromProfile(tlsProfileSpec)
-			tlsCfg := &tls.Config{}
-			tlsConfig(tlsCfg)
-			tlsSettings := objtls.NewSettings(tlsCfg)
-			klog.InfoS("Initial TLS Settings", "tlsSettings", tlsSettings)
 			By("Verifying RTE DaemonSet TLS flags match the cluster TLS profile")
 			Eventually(func() error {
-				return intls.CheckRTEDaemonSetTLSFlags(ctx, e2eclient.Client, tlsSettings)
+				return intls.CheckRTEDaemonSetTLSFlagsMatchClusterProfile(ctx, e2eclient.Client)
 			}).WithTimeout(rteDaemonSetCheckTimeout).WithPolling(rteDaemonSetCheckInterval).Should(Succeed())
 		})
 	})

--- a/test/internal/tls/tls.go
+++ b/test/internal/tls/tls.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1 "github.com/openshift/api/config/v1"
+	ctrltls "github.com/openshift/controller-runtime-common/pkg/tls"
 	libgocrypto "github.com/openshift/library-go/pkg/crypto"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/flagcodec"
@@ -188,6 +189,35 @@ func FindDisallowedCipher(allowed []string) string {
 	return ""
 }
 
+// GetClusterTLSProfile returns the cluster APIServer TLS profile spec and its minimum TLS version.
+func GetClusterTLSProfile(ctx context.Context, cli client.Client) (minVersion uint16, profileSpec configv1.TLSProfileSpec, err error) {
+	profileSpec, err = ctrltls.FetchAPIServerTLSProfile(ctx, cli)
+	if err != nil {
+		return 0, configv1.TLSProfileSpec{}, fmt.Errorf("unable to fetch TLS profile from API Server: %w", err)
+	}
+	cfg := tlsConfigFromProfileSpec(profileSpec)
+	klog.InfoS("cluster TLS minimum version", "version", tls.VersionName(cfg.MinVersion))
+	return cfg.MinVersion, profileSpec, nil
+}
+
+// RTESettingsFromClusterProfile returns expected RTE metrics TLS flags for the cluster APIServer profile.
+func RTESettingsFromClusterProfile(ctx context.Context, cli client.Client) (objtls.Settings, error) {
+	_, profileSpec, err := GetClusterTLSProfile(ctx, cli)
+	if err != nil {
+		return objtls.Settings{}, err
+	}
+	return objtls.NewSettings(tlsConfigFromProfileSpec(profileSpec)), nil
+}
+
+// CheckRTEDaemonSetTLSFlagsMatchClusterProfile verifies RTE DaemonSet TLS flags against the cluster APIServer profile.
+func CheckRTEDaemonSetTLSFlagsMatchClusterProfile(ctx context.Context, cli client.Client) error {
+	settings, err := RTESettingsFromClusterProfile(ctx, cli)
+	if err != nil {
+		return err
+	}
+	return CheckRTEDaemonSetTLSFlags(ctx, cli, settings)
+}
+
 func TLSVersionBelow(v uint16) (uint16, error) {
 	switch v {
 	case tls.VersionTLS13:
@@ -247,4 +277,14 @@ func matchTLSFlag(rteFlags *flagcodec.Flags, flagName, expected, dsName string) 
 		return fmt.Errorf("%s mismatch daemonsetName=%q expected=%q got=%q", flagName, dsName, expected, got)
 	}
 	return nil
+}
+
+func tlsConfigFromProfileSpec(profileSpec configv1.TLSProfileSpec) *tls.Config {
+	tlsConfigFn, unsupportedCiphers := ctrltls.NewTLSConfigFromProfile(profileSpec)
+	if len(unsupportedCiphers) > 0 {
+		klog.InfoS("TLS profile has unsupported ciphers", "ciphers", unsupportedCiphers)
+	}
+	cfg := &tls.Config{}
+	tlsConfigFn(cfg)
+	return cfg
 }

--- a/test/internal/tls/tls.go
+++ b/test/internal/tls/tls.go
@@ -21,7 +21,9 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -259,6 +261,76 @@ func CheckRTEDaemonSetTLSFlags(ctx context.Context, cli client.Client, expected 
 		}
 	}
 	return nil
+}
+
+// FetchMetrics performs TLS handshake to rte pods metrics port and issues an HTTP Get /metrics request,
+// returning the response body
+func FetchMetrics(cli kubernetes.Interface, pod *corev1.Pod, podPort string) ([]byte, error) {
+	var body []byte
+	err := remoteexec.PortForwardToPod(cli, pod, podPort, func(conn net.Conn) error {
+		var reqErr error
+		body, reqErr = doMetricsRequestOverConnection(conn, podPort)
+		return reqErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func doMetricsRequestOverConnection(conn net.Conn, podPort string) ([]byte, error) {
+	httpCli := buildMetricsHTTPClient(conn)
+	defer httpCli.CloseIdleConnections()
+	return executeMetricsRequest(httpCli, podPort)
+}
+func buildMetricsHTTPClient(conn net.Conn) *http.Client {
+	usedConn := false
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+		// The port-forward callback provides a single live stream connection
+		// we allow exactly one dial so HTTP/TLS uses this stream and fails fast
+		// if a retry/exta dial is attempted
+		DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+			if usedConn {
+				return nil, fmt.Errorf("unexpected extra dial attempt while fetching metrics")
+			}
+			usedConn = true
+			return conn, nil
+		},
+		DisableKeepAlives: true,
+	}
+	return &http.Client{Transport: tr}
+}
+
+func executeMetricsRequest(httpCli *http.Client, podPort string) ([]byte, error) {
+	const url = "https://127.0.0.1/metrics"
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build HTTP request: %w", err)
+	}
+	req.Host = "127.0.0.1:" + podPort
+
+	resp, err := httpCli.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed HTTPS Get /metrics: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			klog.ErrorS(err, "failed to close /metrics response body")
+		}
+	}()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read /metrics response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected /metrics status code %d: %q", resp.StatusCode, strings.TrimSpace(string(responseBody)))
+	}
+	return responseBody, nil
 }
 
 func matchTLSFlag(rteFlags *flagcodec.Flags, flagName, expected, dsName string) error {


### PR DESCRIPTION
Add e2e tests that probe each RTE pod's metrics port directly over port-forward to confirm:
- the TLS handshake succeeds and the negotiated version meets the cluster TLS profile minimum
- the /metrics endpoint returns a valid response body
- connections using a version or cipher incompatible with the cluster profile are rejected

Add FetchMetrics helper in test/internal/tls to perform an HTTPS GET /metrics over a port-forwarded connection, reusing the existing port-forward and TLS probing infrastructure.

AI Attribution: AIA Human-AI blend, New content, Human-initiated, Reviewed, Cursor 3.0.16 v1.0