### PR TITLE
CNF-24207: Upstream release-config version bump — NUMA Resources Operator 4.14.11

### DIFF
--- a/.konflux/bundle/overlay/release.in.yaml
+++ b/.konflux/bundle/overlay/release.in.yaml
@@ -6,9 +6,9 @@ variables:
 
       You can find additional guidance in the upstream repository: https://github.com/openshift-kni/numaresources-operator
   display_name: "NUMA Resources Operator"
-  manager_version: "numaresources-operator.v4.14.11"
+  manager_version: "numaresources-operator.v4.14.12"
   # min_kube_version should match ocp
   # https://access.redhat.com/solutions/4870701
   min_kube_version: "1.23.0"
-  version: "4.14.11"
+  version: "4.14.12"
 


### PR DESCRIPTION
Automated post-release update for NUMA Resources Operator 4.14.11 → 4.14.12.

Generated by release-automator-konflux.