### PR TITLE
ci: fix kubelet api crd path

### DIFF
--- a/hack/deploy-mco-crds.sh
+++ b/hack/deploy-mco-crds.sh
@@ -5,7 +5,7 @@ source hack/common.sh
 # Specify the URL link to the machine config pool CRD
 CRD_MACHINE_CONFIG_POOL_URL="https://raw.githubusercontent.com/openshift/api/refs/heads/master/payload-manifests/crds/0000_80_machine-config_01_machineconfigpools-Default.crd.yaml"
 # Specify the URL link to the kubeletconfig CRD
-CRD_KUBELET_CONFIG_URL="https://raw.githubusercontent.com/openshift/api/refs/heads/master/payload-manifests/crds/0000_80_machine-config_01_kubeletconfigs.crd.yaml"
+CRD_KUBELET_CONFIG_URL="https://raw.githubusercontent.com/openshift/api/refs/heads/master/payload-manifests/crds/0000_80_machine-config_01_kubeletconfigs-Default.crd.yaml"
 
 [ ! -x ${REPO_DIR}/bin/lsplatform ] && exit 1
 


### PR DESCRIPTION
after https://github.com/openshift/api/pull/2583 the path for kubeletconfig CRD has changed.

this commit fixes the url to point to the right source.