### PR TITLE
CNF-24207: Upstream catalog-template update — NUMA Resources Operator 4.14.11

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-14@sha256:04cd9ca3e21d1ab9b0eb9cae8882d3830f83fbf33f172446bfd1eaa321c8abb1
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-14@sha256:093ff90eb6a9a0340e8ad962e37f5b2fd1f7b4e8f0869296437f201f766ae072

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -42,6 +42,10 @@ entries:
       - name: numaresources-operator.v4.14.11
         replaces: numaresources-operator.v4.14.10
         skipRange: '>=4.12.0 <4.14.11'
+      # v4.14.12
+      - name: numaresources-operator.v4.14.12
+        replaces: numaresources-operator.v4.14.11
+        skipRange: '>=4.12.0 <4.14.12'
     name: "4.14"
     package: numaresources-operator
     schema: olm.channel
@@ -76,6 +80,9 @@ entries:
   - image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:142eaf04c58205568c82b861e6ee9edf098cf5262f59d5825a059d1553efa3fb
     schema: olm.bundle
   # v4.14.11 bundle  
+  - image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:04cd9ca3e21d1ab9b0eb9cae8882d3830f83fbf33f172446bfd1eaa321c8abb1
+    schema: olm.bundle
+    # v4.14.12 bundle
     # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for NUMA Resources Operator 4.14.11 → 4.14.12.

Generated by release-automator-konflux.