### PR TITLE
govulcheck: use aligned go versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 env:
-  GOLANG_VERSION: 1.25.8
+  GOLANG_VERSION: 1.25.11
 
 defaults:
   run:

--- a/.github/workflows/e2e-local.yaml
+++ b/.github/workflows/e2e-local.yaml
@@ -33,7 +33,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v5
       with:
-        go-version: 1.25.8
+        go-version: 1.25.11
 
     - name: Verify modules
       run: go mod verify

--- a/.github/workflows/e2e-tools.yaml
+++ b/.github/workflows/e2e-tools.yaml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v5
       with:
-        go-version: 1.25.8
+        go-version: 1.25.11
 
     - name: Verify modules
       run: go mod verify

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,7 +35,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v5
       with:
-        go-version: 1.25.8
+        go-version: 1.25.11
 
     - name: Verify modules
       run: go mod verify

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -14,7 +14,7 @@ on:
       - main
 
 env:
-  GOLANG_VERSION: 1.25.8
+  GOLANG_VERSION: 1.25.11
 
 defaults:
   run:

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -13,6 +13,9 @@ on:
     branches:
       - main
 
+env:
+  GOLANG_VERSION: 1.25.8
+
 defaults:
   run:
     shell: bash
@@ -27,7 +30,7 @@ jobs:
       - name: Set up golang
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.8
+          go-version: ${{ env.GOLANG_VERSION }}
 
       - name: Show current working directory
         run: pwd
@@ -36,3 +39,4 @@ jobs:
         uses: golang/govulncheck-action@v1
         with:
           go-package: "./..."
+          go-version-input: ${{ env.GOLANG_VERSION }}

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-go@v5
         id: go
         with:
-          go-version: 1.25.8
+          go-version: 1.25.11
 
       - name: Set release version env var
         run: |

--- a/.github/workflows/support-tools.yaml
+++ b/.github/workflows/support-tools.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-go@v5
         id: go
         with:
-          go-version: 1.25.8
+          go-version: 1.25.11
 
   build:
     needs: [setup]

--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi
 
 ENV HOME=/home/ci
 ENV GOROOT=/usr/local/go
-ENV GOVERSION=1.25.8
+ENV GOVERSION=1.25.11
 ENV GOPATH=/go
 ENV GOBIN=${GOPATH}/bin
 ENV PATH=${PATH}:${GOROOT}/bin:${GOBIN}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/openshift-kni/numaresources-operator
 
 go 1.25.0
 
+toolchain go1.25.11
+
 require (
 	github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492
 	github.com/coreos/ignition/v2 v2.18.0


### PR DESCRIPTION
Use aligned go version in setup and vulnerability check. ref:
https://github.com/golang/govulncheck-action/blob/master/action.yml