### PR TITLE
chore: mco: fix CRD path

### DIFF
--- a/.github/workflows/e2e-tools.yaml
+++ b/.github/workflows/e2e-tools.yaml
@@ -55,7 +55,7 @@ jobs:
       run: |
         # kind is part of 20.04 image, see relevant READMEs in https://github.com/actions/virtual-environments/tree/main/images/linux
         kind version
-        kind create cluster --config=hack/kind-config-e2e-no-registry.yaml --image kindest/node:v1.30.4@sha256:976ea815844d5fa93be213437e3ff5754cd599b040946b5cca43ca45c2047114
+        kind create cluster --config=hack/kind-config-e2e-no-registry.yaml --image kindest/node:v1.35.5@sha256:ce977ae6d65918d0b58a5f8b5e940429c2ce42fa3a5619ec2bbc60b949c0ac95
         kubectl label node kind-worker node-role.kubernetes.io/worker=''
 
     - name: Deploy NUMA Resources Operator

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -57,7 +57,7 @@ jobs:
       run: |
         # kind is part of 20.04 image, see relevant READMEs in https://github.com/actions/virtual-environments/tree/main/images/linux
         kind version
-        kind create cluster --config=hack/kind-config-e2e-no-registry.yaml --image kindest/node:v1.30.4@sha256:976ea815844d5fa93be213437e3ff5754cd599b040946b5cca43ca45c2047114 
+        kind create cluster --config=hack/kind-config-e2e-no-registry.yaml --image kindest/node:v1.35.5@sha256:ce977ae6d65918d0b58a5f8b5e940429c2ce42fa3a5619ec2bbc60b949c0ac95
         kubectl label node kind-worker node-role.kubernetes.io/worker=''
         kind load docker-image ${built_image}
 

--- a/hack/deploy-mco-crds.sh
+++ b/hack/deploy-mco-crds.sh
@@ -3,7 +3,7 @@
 source hack/common.sh
 
 # Specify the URL link to the machine config pool CRD
-CRD_MACHINE_CONFIG_POOL_URL="https://raw.githubusercontent.com/openshift/api/refs/heads/master/payload-manifests/crds/0000_80_machine-config_01_machineconfigpools-Default.crd.yaml"
+CRD_MACHINE_CONFIG_POOL_URL="https://raw.githubusercontent.com/openshift/api/refs/heads/master/payload-manifests/crds/0000_80_machine-config_01_machineconfigpools-SelfManagedHA.crd.yaml"
 # Specify the URL link to the kubeletconfig CRD
 CRD_KUBELET_CONFIG_URL="https://raw.githubusercontent.com/openshift/api/refs/heads/master/payload-manifests/crds/0000_80_machine-config_01_kubeletconfigs-Default.crd.yaml"
 


### PR DESCRIPTION
the MCO CRD we depended on was moved in openshift/api@b479107f81ea

Use the replacement accordingly.