### PR TITLE
CNF-24916: Upstream catalog-template update — NUMA Resources Operator 4.20.2

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,3 +1,3 @@
 ---
 # When we are ready to ship the first Konflux release, replace this with the nudge to the quay build
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-20@sha256:2b8d27b6afc36aa4300e75c6df4efb99840401109d4843be00b9307f9d92f5e9
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-20@sha256:deac623ea8920625a9d01f2711392489ab75e3daa826fd643bba4074e477d546

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -18,6 +18,10 @@ entries:
       - name: numaresources-operator.v4.20.2
         replaces: numaresources-operator.v4.20.1
         skipRange: '>=4.18.0 <4.20.2'
+      # v4.20.3
+      - name: numaresources-operator.v4.20.3
+        replaces: numaresources-operator.v4.20.2
+        skipRange: '>=4.18.0 <4.20.3'
     name: "4.20"
     package: numaresources-operator
     schema: olm.channel
@@ -30,6 +34,10 @@ entries:
       - name: numaresources-operator.v4.20.2
         replaces: numaresources-operator.v4.20.1
         skipRange: '>=4.18.0 <4.20.2'
+      # v4.20.3
+      - name: numaresources-operator.v4.20.3
+        replaces: numaresources-operator.v4.20.2
+        skipRange: '>=4.18.0 <4.20.3'
     name: stable
     package: numaresources-operator
     schema: olm.channel
@@ -40,6 +48,9 @@ entries:
   - image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:afc381b798ca279319eb6cb0791514ce77f212682bd1498120e9f9ef0c3d5fe0
     schema: olm.bundle
     # v4.20.2 bundle
+  - image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:2b8d27b6afc36aa4300e75c6df4efb99840401109d4843be00b9307f9d92f5e9
+    schema: olm.bundle
+    # v4.20.3 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for NUMA Resources Operator 4.20.2 → 4.20.3.

Generated by release-automator-konflux.