### PR TITLE
CNF-25138: Upstream catalog-template update — NUMA Resources Operator 4.19.3

### DIFF
--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -21,6 +21,10 @@ entries:
       - name: numaresources-operator.v4.19.3
         replaces: numaresources-operator.v4.19.2
         skipRange: '>=4.18.0 <4.19.3'
+      # v4.19.4
+      - name: numaresources-operator.v4.19.4
+        replaces: numaresources-operator.v4.19.3
+        skipRange: '>=4.18.0 <4.19.4'
     name: "4.19"
     package: numaresources-operator
     schema: olm.channel
@@ -36,6 +40,10 @@ entries:
       - name: numaresources-operator.v4.19.3
         replaces: numaresources-operator.v4.19.2
         skipRange: '>=4.18.0 <4.19.3'
+      # v4.19.4
+      - name: numaresources-operator.v4.19.4
+        replaces: numaresources-operator.v4.19.3
+        skipRange: '>=4.18.0 <4.19.4'
     name: stable
     package: numaresources-operator
     schema: olm.channel
@@ -49,6 +57,9 @@ entries:
   - image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:6046f629533275ab97c7cf1e4ba43e31b57afe98d1d1e76af921f2d1f478c623
     schema: olm.bundle
     # v4.19.3 bundle
+  - image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:37d9fabfd1ba93b91dfe0cd5bd2f0fb179af11177a336d6c42fb1efef0f8d885
+    schema: olm.bundle
+    # v4.19.4 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for NUMA Resources Operator 4.19.3 → 4.19.4.

Generated by release-automator-konflux.