### PR TITLE
CNF-25198: Upstream catalog-template update — NUMA Resources Operator 4.21.2

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,3 +1,3 @@
 ---
 # When we are ready to ship the first Konflux release, replace this with the nudge to the quay build
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-21@sha256:6ec43fbbe3118150854f16900d009745a79c4e50ca6d0edd31423e71b45d1dcd
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-21@sha256:6df3a6fe36c02af2ddb84e7dd263c0917fad43818c1e54d71f8434bf30c5cc63

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -21,6 +21,10 @@ entries:
       - name: numaresources-operator.v4.21.2
         replaces: numaresources-operator.v4.21.1
         skipRange: '>=4.20.0 <4.21.2'
+      # v4.21.3
+      - name: numaresources-operator.v4.21.3
+        replaces: numaresources-operator.v4.21.2
+        skipRange: '>=4.20.0 <4.21.3'
     name: "4.21"
     package: numaresources-operator
     schema: olm.channel
@@ -36,6 +40,10 @@ entries:
       - name: numaresources-operator.v4.21.2
         replaces: numaresources-operator.v4.21.1
         skipRange: '>=4.20.0 <4.21.2'
+      # v4.21.3
+      - name: numaresources-operator.v4.21.3
+        replaces: numaresources-operator.v4.21.2
+        skipRange: '>=4.20.0 <4.21.3'
     name: stable
     package: numaresources-operator
     schema: olm.channel
@@ -46,6 +54,9 @@ entries:
   - image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:28aa1282b20393e5b6aa45fd8ba0018b272364b4232818beb6e9d10082b9183d
     schema: olm.bundle
   # v4.21.2 bundle
+  - image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:6ec43fbbe3118150854f16900d009745a79c4e50ca6d0edd31423e71b45d1dcd
+    schema: olm.bundle
+    # v4.21.3 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for NUMA Resources Operator 4.21.2 → 4.21.3.

Generated by release-automator-konflux.