### PR TITLE
[release-4.22] hack: use release-4.22 openshift/api branch for MCO CRD URLs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - "release-4.22"
       - "release-4.21"
       - "release-4.20"
       - "release-4.19"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
         run: echo ${{ env.BRANCH_NAME }}
 
       - name: Verify commits
-        run: TRIGGER_BRANCH=${{ env.BRANCH_NAME }} ./hack/verify-commits.sh
+        run: UPSTREAM_COMMIT=origin/${{ github.base_ref }} TRIGGER_BRANCH=${{ env.BRANCH_NAME }} ./hack/verify-commits.sh
 
   test-units:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-local.yaml
+++ b/.github/workflows/e2e-local.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - "release-4.22"
       - "release-4.21"
       - "release-4.20"
       - "release-4.19"

--- a/.github/workflows/e2e-tools.yaml
+++ b/.github/workflows/e2e-tools.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - "release-4.22"
       - "release-4.21"
       - "release-4.20"
       - "release-4.19"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - "release-4.22"
       - "release-4.21"
       - "release-4.20"
       - "release-4.19"

--- a/hack/deploy-mco-crds.sh
+++ b/hack/deploy-mco-crds.sh
@@ -3,9 +3,9 @@
 source hack/common.sh
 
 # Specify the URL link to the machine config pool CRD
-CRD_MACHINE_CONFIG_POOL_URL="https://raw.githubusercontent.com/openshift/api/refs/heads/master/payload-manifests/crds/0000_80_machine-config_01_machineconfigpools-Default.crd.yaml"
+CRD_MACHINE_CONFIG_POOL_URL="https://raw.githubusercontent.com/openshift/api/refs/heads/release-4.22/payload-manifests/crds/0000_80_machine-config_01_machineconfigpools-Default.crd.yaml"
 # Specify the URL link to the kubeletconfig CRD
-CRD_KUBELET_CONFIG_URL="https://raw.githubusercontent.com/openshift/api/refs/heads/master/payload-manifests/crds/0000_80_machine-config_01_kubeletconfigs.crd.yaml"
+CRD_KUBELET_CONFIG_URL="https://raw.githubusercontent.com/openshift/api/refs/heads/release-4.22/payload-manifests/crds/0000_80_machine-config_01_kubeletconfigs.crd.yaml"
 
 [ ! -x ${REPO_DIR}/bin/lsplatform ] && exit 1
 


### PR DESCRIPTION
The CRD URLs were hardcoded to fetch from the master branch of openshift/api which may have incompatible schema changes. Point to the matching release-4.22 branch instead.

It is possible to detect the branch from within the script, but I found it fragile.

Another option is passing the branch as an argument, but that involves with many changes around the callers in the code base and it does NOT guaranteed that the URL structure will not change again in the future.

AIA: Primarily AI, New content, Human-initiated, Reviewed, Claude Opus 4.6 v1.0
Signed-off-by: Talor Itzhak <titzhak@redhat.com>
