### PR TITLE
hack: add local-run workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,11 +212,17 @@ build-installer: manifests generate kustomize ## Generate a consolidated YAML wi
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default > dist/install.yaml
 
+OPERATOR_LDFLAGS := -X github.com/openshift-kni/numaresources-operator/pkg/images.tag=$(VERSION)
+ifneq ($(OPERATOR_IMAGE_REPO),)
+OPERATOR_LDFLAGS += -X github.com/openshift-kni/numaresources-operator/pkg/images.repo=$(OPERATOR_IMAGE_REPO)
+endif
+ifneq ($(OPERATOR_IMAGE_NAME),)
+OPERATOR_LDFLAGS += -X github.com/openshift-kni/numaresources-operator/pkg/images.name=$(OPERATOR_IMAGE_NAME)
+endif
+
 .PHONY: binary
 binary: build-tools ## Build the manager binary.
-	LDFLAGS="-s -w"; \
-	LDFLAGS+=" -X github.com/openshift-kni/numaresources-operator/pkg/images.tag=$(VERSION)"; \
-	go build -mod=vendor -o bin/manager -ldflags "$$LDFLAGS" -tags "$$GOTAGS" cmd/main.go
+	go build -mod=vendor -o bin/manager -ldflags "-s -w $(OPERATOR_LDFLAGS)" -tags "$$GOTAGS" cmd/main.go
 
 .PHONY: binary-rte
 binary-rte: build-tools ## Build the RTE exporter binary.

--- a/Makefile
+++ b/Makefile
@@ -487,6 +487,19 @@ deploy: manifests kustomize deploy-mco-crds ## Deploy controller to the K8s clus
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
+.PHONY: deploy-local
+deploy-local: manifests kustomize deploy-mco-crds ## Install CRDs + RBAC + Namespace for local operator development (no Deployment).
+	hack/run-local.sh --prepare
+
+.PHONY: undeploy-local
+undeploy-local: kustomize ## Remove CRDs + RBAC + Namespace installed by deploy-local.
+	hack/run-local.sh --cleanup
+
+OPERATOR_ARGS ?=
+.PHONY: run-local
+run-local: binary manifests kustomize deploy-mco-crds ## Run the operator locally as its ServiceAccount (no container image needed).
+	hack/run-local.sh $(OPERATOR_ARGS)
+
 ##@ Dependencies
 
 ## Location to install dependencies to

--- a/config/local-run/kustomization.yaml
+++ b/config/local-run/kustomization.yaml
@@ -1,0 +1,12 @@
+# Kustomize overlay for local operator development.
+# Installs CRDs, RBAC and namespace - but NOT the manager Deployment.
+# Use with hack/run-local.sh to run the operator as its ServiceAccount.
+
+namespace: numaresources
+
+namePrefix: numaresources-
+
+resources:
+- ../crd
+- ../rbac
+- namespace.yaml

--- a/config/local-run/namespace.yaml
+++ b/config/local-run/namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    workload.openshift.io/allowed: management
+  labels:
+    openshift.io/cluster-monitoring: "true"
+    control-plane: controller-manager
+  name: system

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -2,6 +2,7 @@
 
 REPO_DIR=$(dirname "${BASH_SOURCE[0]}")/..
 BIN_DIR="${REPO_DIR}/bin"
+DRY_RUN="${DRY_RUN:-false}"
 
 function runcmd() {
 	echo "Running: $@"

--- a/hack/run-local.sh
+++ b/hack/run-local.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# Run the numaresources-operator locally as its own ServiceAccount.
+#
+# Default flow: setup -> run -> teardown (no cluster leftovers).
+#
+# All positional arguments are passed through to bin/manager:
+#   hack/run-local.sh --enable-metrics=false --leader-elect=false -v=6
+#
+# Standalone modes (run one stage and exit):
+#   hack/run-local.sh --prepare    install CRDs + RBAC + Namespace, then exit
+#   hack/run-local.sh --cleanup    remove  CRDs + RBAC + Namespace, then exit
+# or manually:
+#   bin/kustomize build config/local-run | kubectl apply -f -
+#   bin/kustomize build config/local-run | kubectl delete --ignore-not-found -f -
+#
+# Script behavior is configured via environment variables only:
+#   NAMESPACE       operator namespace            (default: numaresources)
+#   SA_NAME         ServiceAccount name           (default: numaresources-controller-manager)
+#   TOKEN_DURATION  SA token lifetime             (default: 3600s)
+#   SKIP_SETUP      skip kustomize apply if true  (default: false)
+#   SKIP_TEARDOWN   skip kustomize delete on exit (default: false)
+#   BARE            skip both setup and teardown  (default: false)
+#   KUSTOMIZE       path to kustomize             (default: bin/kustomize)
+#   KUBECTL         path to kubectl               (default: kubectl)
+#   OPERATOR_BIN    path to operator binary       (default: bin/manager)
+#   OPERATOR_DEFAULT_ARGS  default args matching the Deployment (default: -v=4)
+#   DRY_RUN         print commands without running (from hack/common.sh)
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+NAMESPACE="${NAMESPACE:-numaresources}"
+SA_NAME="${SA_NAME:-numaresources-controller-manager}"
+TOKEN_DURATION="${TOKEN_DURATION:-14400s}" # the serial suite is slow
+
+KUSTOMIZE="${KUSTOMIZE:-${BIN_DIR}/kustomize}"
+KUBECTL="${KUBECTL:-kubectl}"
+OPERATOR_BIN="${OPERATOR_BIN:-${BIN_DIR}/manager}"
+OPERATOR_DEFAULT_ARGS="${OPERATOR_DEFAULT_ARGS:-v=4}"
+
+if [[ "${BARE:-false}" == "true" ]]; then
+	SKIP_SETUP=true
+	SKIP_TEARDOWN=true
+fi
+SKIP_SETUP="${SKIP_SETUP:-false}"
+SKIP_TEARDOWN="${SKIP_TEARDOWN:-false}"
+
+if [[ "${1:-}" == "--prepare" ]]; then
+	echo "Installing CRDs + RBAC + Namespace..."
+	runcmd "${KUSTOMIZE} build ${REPO_DIR}/config/local-run | ${KUBECTL} apply -f -"
+	exit 0
+fi
+
+if [[ "${1:-}" == "--cleanup" ]]; then
+	echo "Removing CRDs + RBAC + Namespace..."
+	runcmd "${KUSTOMIZE} build ${REPO_DIR}/config/local-run | ${KUBECTL} delete --ignore-not-found -f -"
+	exit 0
+fi
+
+SA_KUBECONFIG=""
+CA_TMPFILE=""
+
+cleanup() {
+	local exit_code=$?
+	if [[ -n "${CA_TMPFILE}" && -f "${CA_TMPFILE}" ]]; then
+		rm -f "${CA_TMPFILE}"
+	fi
+	if [[ -n "${SA_KUBECONFIG}" && -f "${SA_KUBECONFIG}" ]]; then
+		rm -f "${SA_KUBECONFIG}"
+	fi
+	if [[ "${SKIP_TEARDOWN}" != "true" ]]; then
+		echo ""
+		echo "Tearing down CRDs + RBAC + Namespace..."
+		runcmd "${KUSTOMIZE} build ${REPO_DIR}/config/local-run | ${KUBECTL} delete --ignore-not-found -f -" || true
+	fi
+	exit "${exit_code}"
+}
+trap cleanup EXIT INT TERM
+
+if [[ "${SKIP_SETUP}" != "true" ]]; then
+	echo "Installing CRDs + RBAC + Namespace..."
+	runcmd "${KUSTOMIZE} build ${REPO_DIR}/config/local-run | ${KUBECTL} apply -f -"
+fi
+
+# Create a short-lived SA token
+if [[ "${DRY_RUN}" == "true" ]]; then
+	echo "DRY_RUN: would create SA token (duration: ${TOKEN_DURATION})"
+	SA_TOKEN="dry-run-token"
+else
+	echo "Creating SA token (duration: ${TOKEN_DURATION})..."
+	SA_TOKEN=$(${KUBECTL} create token "${SA_NAME}" \
+		--namespace "${NAMESPACE}" \
+		--duration "${TOKEN_DURATION}")
+fi
+
+# Build SA kubeconfig
+CLUSTER_SERVER=$(${KUBECTL} config view --minify -o jsonpath='{.clusters[0].cluster.server}')
+CLUSTER_CA_DATA=$(${KUBECTL} config view --minify --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
+CLUSTER_NAME=$(${KUBECTL} config view --minify -o jsonpath='{.clusters[0].name}')
+
+if [[ -z "${CLUSTER_CA_DATA}" ]]; then
+	CA_FILE=$(${KUBECTL} config view --minify -o jsonpath='{.clusters[0].cluster.certificate-authority}')
+	if [[ -n "${CA_FILE}" && -f "${CA_FILE}" ]]; then
+		CLUSTER_CA_DATA=$(base64 -w0 < "${CA_FILE}")
+	else
+		echo "WARNING: could not extract cluster CA certificate"
+	fi
+fi
+
+SA_KUBECONFIG=$(mktemp "${BIN_DIR}/.sa-kubeconfig.XXXXXX")
+
+if [[ -n "${CLUSTER_CA_DATA}" ]]; then
+	CA_TMPFILE=$(mktemp "${BIN_DIR}/.ca-cert.XXXXXX")
+	echo "${CLUSTER_CA_DATA}" | base64 -d > "${CA_TMPFILE}"
+	KUBECONFIG="${SA_KUBECONFIG}" ${KUBECTL} config set-cluster "${CLUSTER_NAME}" \
+		--server="${CLUSTER_SERVER}" \
+		--certificate-authority="${CA_TMPFILE}" \
+		--embed-certs=true > /dev/null
+else
+	KUBECONFIG="${SA_KUBECONFIG}" ${KUBECTL} config set-cluster "${CLUSTER_NAME}" \
+		--server="${CLUSTER_SERVER}" \
+		--embed-certs=false > /dev/null
+fi
+KUBECONFIG="${SA_KUBECONFIG}" ${KUBECTL} config set-credentials "sa-${SA_NAME}" \
+	--token="${SA_TOKEN}" > /dev/null
+KUBECONFIG="${SA_KUBECONFIG}" ${KUBECTL} config set-context "local-run" \
+	--cluster="${CLUSTER_NAME}" \
+	--user="sa-${SA_NAME}" \
+	--namespace="${NAMESPACE}" > /dev/null
+KUBECONFIG="${SA_KUBECONFIG}" ${KUBECTL} config use-context "local-run" > /dev/null
+
+echo "Verifying SA authentication..."
+if ${KUBECTL} --kubeconfig="${SA_KUBECONFIG}" auth can-i get numaresourcesoperators.nodetopology.openshift.io 2>/dev/null; then
+	echo "SA authentication verified"
+else
+	echo "WARNING: SA may not have expected permissions yet"
+fi
+
+echo ""
+echo "Running operator as SA ${SA_NAME} (token expires in ${TOKEN_DURATION})"
+echo "  namespace: ${NAMESPACE}"
+echo "  args:      ${OPERATOR_DEFAULT_ARGS} $*"
+echo ""
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+	echo "DRY_RUN: would execute ${OPERATOR_BIN} ${OPERATOR_DEFAULT_ARGS} $*"
+else
+	KUBECONFIG="${SA_KUBECONFIG}" \
+	NAMESPACE="${NAMESPACE}" \
+		"${OPERATOR_BIN}" ${OPERATOR_DEFAULT_ARGS} "$@"
+fi

--- a/pkg/images/version.go
+++ b/pkg/images/version.go
@@ -22,8 +22,12 @@ const (
 	defaultTag  string = "devel"
 )
 
-// tag Must not be const, supposed to be set using ldflags at build time
-var tag = defaultTag
+// Must not be const, supposed to be set using ldflags at build time
+var (
+	repo = defaultRepo
+	name = defaultName
+	tag  = defaultTag
+)
 
 // Tag returns the image tag as a string
 func Tag() string {
@@ -32,12 +36,12 @@ func Tag() string {
 
 // Name returns the image name as a string
 func Name() string {
-	return defaultName
+	return name
 }
 
 // Repo returns the image repo as a string
 func Repo() string {
-	return defaultRepo
+	return repo
 }
 
 // SpecPath() returns the image full image spec path as a string

--- a/test/e2e/serial/README.md
+++ b/test/e2e/serial/README.md
@@ -53,6 +53,9 @@ they found it before they run.
   the cluster and will be used as a resource of type `device-type-2` in the tests.
 - `E2E_NROP_DEVICE_TYPE_3` (accepts string, e.g `example.com/deviceC`) declares name of a device type that exists on
   the cluster and will be used as a resource of type `device-type-3` in the tests.
+- `E2E_NROP_BUILDINFO` (accepts string, e.g `/path/to/buildinfo.json`) instructs the suite to read the operator
+  build information from the given local file path instead of discovering the operator pod in the cluster and
+  reading it via remote exec. Useful when running the operator locally via `hack/run-local.sh`.
 - `E2E_RTE_CI_IMAGE` (accepts string, e.g `quay.io/openshift-kni/resource-topology-exporter:test-ci`) sets the 
   RTE image to be used for testing purposes particularly for modifying the operator object.
   

--- a/test/e2e/serial/tests/version.go
+++ b/test/e2e/serial/tests/version.go
@@ -19,6 +19,8 @@ package tests
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"os"
 	"path/filepath"
 
 	"k8s.io/klog/v2"
@@ -28,6 +30,7 @@ import (
 	"github.com/openshift-kni/numaresources-operator/internal/remoteexec"
 	"github.com/openshift-kni/numaresources-operator/pkg/version"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/internal/clients"
+	"github.com/openshift-kni/numaresources-operator/test/internal/configuration"
 	"github.com/openshift-kni/numaresources-operator/test/internal/deploy"
 	"github.com/openshift-kni/numaresources-operator/test/internal/objects"
 
@@ -49,13 +52,20 @@ var _ = Describe("[serial] numaresources version", Serial, Label("feature:config
 			}
 			By("running against cluster " + discoveredCluster.Platform.String() + " " + discoveredCluster.LongVersion.String())
 
-			nropKey := objects.NROObjectKey()
-			nropObj := nropv1.NUMAResourcesOperator{}
-			Expect(e2eclient.Client.Get(ctx, nropKey, &nropObj)).To(Succeed(), "failed to get the NRO resource: %v", nropKey)
+			var stdout []byte
+			if biPath := configuration.GetBuildInfoPath(); biPath != "" {
+				By(fmt.Sprintf("using buildinfo from local path: %s", biPath))
+				stdout, err = os.ReadFile(biPath)
+			} else {
+				nropKey := objects.NROObjectKey()
+				nropObj := nropv1.NUMAResourcesOperator{}
+				Expect(e2eclient.Client.Get(ctx, nropKey, &nropObj)).To(Succeed(), "failed to get the NRO resource: %v", nropKey)
 
-			pod, err := deploy.FindNUMAResourcesOperatorPod(ctx, e2eclient.Client, &nropObj)
-			Expect(err).ToNot(HaveOccurred())
-			stdout, _, err := remoteexec.CommandOnPod(ctx, e2eclient.K8sClient, pod, "/bin/cat", filepath.Join("/usr/local/share/", "buildinfo.json"))
+				pod, err2 := deploy.FindNUMAResourcesOperatorPod(ctx, e2eclient.Client, &nropObj)
+				Expect(err2).ToNot(HaveOccurred())
+				By(fmt.Sprintf("using buildinfo from operator pod: %s/%s", pod.Namespace, pod.Name))
+				stdout, _, err = remoteexec.CommandOnPod(ctx, e2eclient.K8sClient, pod, "/bin/cat", filepath.Join("/usr/local/share/", "buildinfo.json"))
+			}
 
 			// older version may miss the buildinfo.json, and that's fine
 			if err != nil {
@@ -66,7 +76,7 @@ var _ = Describe("[serial] numaresources version", Serial, Label("feature:config
 			// this should not happen, but since we are sneaking in, not worth to fail
 			nropBi := buildinfo.BuildInfo{}
 			if err := json.Unmarshal(stdout, &nropBi); err != nil {
-				klog.ErrorS(err, "buildinfo unmarshal failure", "nropNamespace", pod.Namespace, "nropName", pod.Name)
+				klog.ErrorS(err, "buildinfo unmarshal failure")
 				By("running against NUMAResources UNKNOWN UNKNOWN")
 				return
 			}

--- a/test/internal/configuration/configuration.go
+++ b/test/internal/configuration/configuration.go
@@ -41,6 +41,7 @@ const (
 	envVarMCPUpdateInterval = "E2E_NROP_MCP_UPDATE_INTERVAL"
 	envVarPlatform          = "E2E_NROP_PLATFORM"
 	envVarPlatformVersion   = "E2E_NROP_PLATFORM_VERSION"
+	envVarBuildInfoPath     = "E2E_NROP_BUILDINFO"
 )
 
 const (
@@ -81,6 +82,10 @@ func init() {
 	discoveredCluster, _ := version.DiscoverCluster(ctx, os.Getenv(envVarPlatform), os.Getenv(envVarPlatformVersion))
 	Plat = discoveredCluster.Platform
 	PlatVersion = discoveredCluster.ShortVersion
+}
+
+func GetBuildInfoPath() string {
+	return os.Getenv(envVarBuildInfoPath)
 }
 
 func getMachineConfigPoolUpdateValueFromEnv(envVar string, fallback time.Duration) (time.Duration, error) {


### PR DESCRIPTION
local-run enables **developers** to run the operator from their machine but with all the manifests but the deployment applied. IOW, it is like the `make deploy` workflow but without the need of creating and uploading an operator image, which saves time, is more convenient and saves registry bandwidth.