### PR TITLE
status: streamline reporting

### DIFF
--- a/pkg/status/conditioninfo/conditioninfo.go
+++ b/pkg/status/conditioninfo/conditioninfo.go
@@ -62,7 +62,8 @@ func Available() ConditionInfo {
 // an Progressing condition
 func Progressing() ConditionInfo {
 	return ConditionInfo{
-		Type: status.ConditionProgressing,
+		Type:   status.ConditionProgressing,
+		Reason: status.ConditionProgressing,
 	}
 }
 

--- a/pkg/status/conditioninfo/conditioninfo_test.go
+++ b/pkg/status/conditioninfo/conditioninfo_test.go
@@ -42,11 +42,13 @@ func TestWithMessage(t *testing.T) {
 func TestAvailable(t *testing.T) {
 	cond := Available()
 	assert.Equal(t, cond.Type, status.ConditionAvailable)
+	assert.NotEmpty(t, cond.Reason)
 }
 
 func TestProgressing(t *testing.T) {
 	cond := Progressing()
 	assert.Equal(t, cond.Type, status.ConditionProgressing)
+	assert.NotEmpty(t, cond.Reason)
 }
 
 func TestDegradedFromError(t *testing.T) {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -113,7 +113,7 @@ func ComputeConditions(conds []metav1.Condition, condition metav1.Condition, ts 
 	}
 
 	if !updated {
-		klog.InfoS("Failed to update status condition", "condition", condition.Type, "conditions", newConds)
+		klog.V(6).InfoS("Status condition unchanged", "condition", condition.Type, "conditions", newConds)
 	}
 
 	return newConds, updated


### PR DESCRIPTION
our status update logic may determine there's no need to do a status update. This is totally expected and benign,
but wasn't conveyed properly in the log which sound unnecessarily scary. Fix the log to reflect reality, and make it visible only at debug log levels.

In addition, fix `Reason` on `Progressing` conditions. Failing to report reason will cause an apiserver reject on status update.