### PR TITLE
e2e: skip HyperShift install test until OCPBUGS-88738

### DIFF
--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"time"
 
+	ginkgotypes "github.com/onsi/ginkgo/v2/types"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -37,6 +39,7 @@ import (
 	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/assets/selinux"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte"
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 
@@ -64,6 +67,10 @@ import (
 
 const (
 	containerNameRTE = "resource-topology-exporter"
+
+	// skipHyperShiftKCDetachReason documents why HyperShift durability specs are skipped.
+	// Remove once hypershift#8890 (OCPBUGS-88738) is in CI payloads and teardown passes.
+	skipHyperShiftKCDetachReason = "Skipped until OCPBUGS-88738 (hypershift#8890): HCCO does not delete mirrored kubelet ConfigMap on guest cluster after KC detach"
 )
 
 var _ = Describe("[Install] continuousIntegration", Serial, func() {
@@ -170,11 +177,17 @@ var _ = Describe("[Install] durability", Serial, func() {
 		var nroObj *nropv1.NUMAResourcesOperator
 
 		BeforeEach(func() {
+			if configuration.Plat == platform.HyperShift {
+				Skip(skipHyperShiftKCDetachReason)
+			}
 			deployer = deploy.NewForPlatform(configuration.Plat)
 			nroObj = deployer.Deploy(context.TODO(), configuration.MachineConfigPoolUpdateTimeout)
 		})
 
 		AfterEach(func() {
+			if CurrentSpecReport().State.Is(ginkgotypes.SpecStateSkipped) {
+				return
+			}
 			deployer.Teardown(context.TODO(), 5*time.Minute)
 		})
 


### PR DESCRIPTION
After openshift/hypershift#8672 (OCPBUGS-86949), HCCO no longer deletes mirrored kubelet ConfigMaps when they are detached from a NodePool. As a result, the operator retains the derived RTE ConfigMap, causing the install test cleanup assertion to fail.

This PR therefore skips all `[Install] durability` specs on HyperShift until the platform fix lands in [hypershift#8890](https://github.com/openshift/hypershift/pull/8890) (OCPBUGS-88738).
