### PR TITLE
CNF-25500: Upstream release-config version bump — NUMA Resources Operator 4.22.1

### DIFF
--- a/.konflux/bundle/overlay/release.in.yaml
+++ b/.konflux/bundle/overlay/release.in.yaml
@@ -6,8 +6,8 @@ variables:
 
       You can find additional guidance in the upstream repository: https://github.com/openshift-kni/numaresources-operator
   display_name: "NUMA Resources Operator"
-  manager_version: "numaresources-operator.v4.22.1"
+  manager_version: "numaresources-operator.v4.22.2"
   # min_kube_version should match ocp
   # https://access.redhat.com/solutions/4870701
   min_kube_version: "1.32.0"
-  version: "4.22.1"
+  version: "4.22.2"


### PR DESCRIPTION
Post z stream release version bump to 4.22.1

Replaces https://github.com/openshift-kni/numaresources-operator/pull/4567/ for the short term until we add an exception for ocp-telco-ci-gitlab-ci account in the verify-commits CI job