### PR TITLE
OCPBUGS-94181: fix: disallow custom exporter image by default

### DIFF
--- a/api/v1/numaresourcesoperator_types.go
+++ b/api/v1/numaresourcesoperator_types.go
@@ -35,7 +35,10 @@ type NUMAResourcesOperatorSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Group of nodes to enable RTE on"
 	NodeGroups []NodeGroup `json:"nodeGroups,omitempty"`
 	// Optional Resource Topology Exporter image URL
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Optional RTE image URL",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	//
+	// Deprecated: custom operand image override is restricted by default;
+	// set EXPORTER_IMAGE_RESTRICTION=false in the operator environment to re-enable.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="DEPRECATED: Optional RTE image URL restricted by default",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	ExporterImage string `json:"imageSpec,omitempty"`
 	// Valid values are: "Normal", "Debug", "Trace", "TraceAll".
 	// Defaults to "Normal".

--- a/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -43,7 +43,11 @@ spec:
             description: NUMAResourcesOperatorSpec defines the desired state of NUMAResourcesOperator
             properties:
               imageSpec:
-                description: Optional Resource Topology Exporter image URL
+                description: |-
+                  Optional Resource Topology Exporter image URL
+
+                  Deprecated: custom operand image override is restricted by default;
+                  set EXPORTER_IMAGE_RESTRICTION=false in the operator environment to re-enable.
                 type: string
               logLevel:
                 default: Normal

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -66,7 +66,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-05-13T12:16:00Z"
+    createdAt: "2026-07-06T08:55:09Z"
     features.operators.openshift.io/cnf: "true"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -103,8 +103,12 @@ spec:
         name: ""
         version: v1
       specDescriptors:
-      - description: Optional Resource Topology Exporter image URL
-        displayName: Optional RTE image URL
+      - description: |-
+          Optional Resource Topology Exporter image URL
+
+          Deprecated: custom operand image override is restricted by default;
+          set EXPORTER_IMAGE_RESTRICTION=false in the operator environment to re-enable.
+        displayName: 'DEPRECATED: Optional RTE image URL restricted by default'
         path: imageSpec
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -399,12 +399,13 @@ func main() {
 			Core:    rteManifestsRendered,
 			Metrics: rteMetricsManifests,
 		},
-		Platform:        discoveredCluster.Platform,
-		Images:          imgs,
-		ImagePullPolicy: pullPolicy,
-		Namespace:       namespace,
-		ForwardMCPConds: params.enableMCPCondsForward,
-		RTEMetricsTLS:   tlsSettings,
+		Platform:            discoveredCluster.Platform,
+		Images:              imgs,
+		ImagePullPolicy:     pullPolicy,
+		Namespace:           namespace,
+		ForwardMCPConds:     params.enableMCPCondsForward,
+		RTEMetricsTLS:       tlsSettings,
+		OverridableRTEImage: controller.IsRTEImageOverridable(),
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create controller", "controller", "NUMAResourcesOperator")
 		exitWithCancel(cancel, 1)

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -43,7 +43,11 @@ spec:
             description: NUMAResourcesOperatorSpec defines the desired state of NUMAResourcesOperator
             properties:
               imageSpec:
-                description: Optional Resource Topology Exporter image URL
+                description: |-
+                  Optional Resource Topology Exporter image URL
+
+                  Deprecated: custom operand image override is restricted by default;
+                  set EXPORTER_IMAGE_RESTRICTION=false in the operator environment to re-enable.
                 type: string
               logLevel:
                 default: Normal

--- a/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
@@ -38,8 +38,12 @@ spec:
         name: ""
         version: v1
       specDescriptors:
-      - description: Optional Resource Topology Exporter image URL
-        displayName: Optional RTE image URL
+      - description: |-
+          Optional Resource Topology Exporter image URL
+
+          Deprecated: custom operand image override is restricted by default;
+          set EXPORTER_IMAGE_RESTRICTION=false in the operator environment to re-enable.
+        displayName: 'DEPRECATED: Optional RTE image URL restricted by default'
         path: imageSpec
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -74,6 +75,13 @@ import (
 	"github.com/openshift-kni/numaresources-operator/rte/pkg/config"
 )
 
+const (
+	// ExporterImageRestrictionEnvVar is the environment variable that controls whether the exporter image restriction is enabled.
+	// If it is set to "false", the exporter image restriction is disabled; any other value is considered as enabled.
+	// Remove at after 5.4, preferably at 5.2.
+	ExporterImageRestrictionEnvVar = "EXPORTER_IMAGE_RESTRICTION"
+)
+
 const numaResourcesRetryPeriod = 1 * time.Minute
 
 // poolDaemonSet a struct to hold the target MCP of a configured node group and its created respective RTE daemonset
@@ -85,15 +93,16 @@ type poolDaemonSet struct {
 // NUMAResourcesOperatorReconciler reconciles a NUMAResourcesOperator object
 type NUMAResourcesOperatorReconciler struct {
 	client.Client
-	Scheme          *runtime.Scheme
-	Platform        platform.Platform
-	APIManifests    apimanifests.Manifests
-	RTEManifests    rtestate.Manifests
-	Namespace       string
-	Images          images.Data
-	ImagePullPolicy corev1.PullPolicy
-	Recorder        record.EventRecorder
-	ForwardMCPConds bool
+	Scheme              *runtime.Scheme
+	Platform            platform.Platform
+	APIManifests        apimanifests.Manifests
+	RTEManifests        rtestate.Manifests
+	Namespace           string
+	Images              images.Data
+	ImagePullPolicy     corev1.PullPolicy
+	Recorder            record.EventRecorder
+	ForwardMCPConds     bool
+	OverridableRTEImage bool
 	// RTEMetricsTLS is derived from apiserver.config.openshift.io/cluster TLS profile at operator
 	// startup (same source as the operator metrics server and scheduler).
 	RTEMetricsTLS objtls.Settings
@@ -162,6 +171,13 @@ func (r *NUMAResourcesOperatorReconciler) Reconcile(ctx context.Context, req ctr
 	if annotations.IsPauseReconciliationEnabled(instance.Annotations) {
 		klog.V(2).InfoS("Pause reconciliation enabled", "object", req.NamespacedName)
 		return ctrl.Result{}, nil
+	}
+
+	if !r.OverridableRTEImage && instance.Spec.ExporterImage != "" {
+		// intentionally mention the env var override only in the logs
+		klog.V(4).InfoS("custom operand image is not supported use env var to override", "image", instance.Spec.ExporterImage, "envVar", ExporterImageRestrictionEnvVar, "shouldHaveValue", "false")
+		err := fmt.Errorf("custom operand image is not supported: %s", instance.Spec.ExporterImage)
+		return r.degradeStatus(ctx, initialInstance, instance, status.ReasonCustomUserImage, err)
 	}
 
 	if err := validation.NodeGroups(instance.Spec.NodeGroups, r.Platform); err != nil {
@@ -836,4 +852,13 @@ func getTreesByNodeGroup(ctx context.Context, cli client.Client, nodeGroups []nr
 	default:
 		return nil, fmt.Errorf("unsupported platform")
 	}
+}
+
+func IsRTEImageOverridable() bool {
+	var overridable bool
+	if val, ok := os.LookupEnv(ExporterImageRestrictionEnvVar); ok && val == "false" {
+		overridable = true
+	}
+	klog.InfoS("Exporter image", "overridable", overridable)
+	return overridable
 }

--- a/internal/controller/numaresourcesoperator_controller_test.go
+++ b/internal/controller/numaresourcesoperator_controller_test.go
@@ -192,6 +192,57 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 			})
 		})
 
+		Context("with custom ExporterImage set", func() {
+			It("should reject and set the CR condition to degraded when image restriction is enabled", func(ctx context.Context) {
+				pn := "test"
+				ng := nropv1.NodeGroup{
+					PoolName: &pn,
+				}
+				nro := testobjs.NewNUMAResourcesOperator(objectnames.DefaultNUMAResourcesOperatorCrName, ng)
+				nro.Spec.ExporterImage = "quay.io/custom/image:latest"
+
+				reconciler, err := NewFakeNUMAResourcesOperatorReconciler(platf, defaultOCPVersion, nro)
+				Expect(err).ToNot(HaveOccurred())
+
+				key := client.ObjectKeyFromObject(nro)
+				Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})).ToNot(CauseRequeue())
+
+				Expect(reconciler.Client.Get(ctx, key, nro)).ToNot(HaveOccurred())
+				Expect(nro).To(BeDegradedWithReason(status.ReasonCustomUserImage))
+			})
+
+			It("should allow custom image and not degrade when image restriction is disabled", func(ctx context.Context) {
+				pn := "test"
+				ng := nropv1.NodeGroup{
+					PoolName: &pn,
+				}
+				nro := testobjs.NewNUMAResourcesOperator(objectnames.DefaultNUMAResourcesOperatorCrName, ng)
+				nro.Spec.ExporterImage = "quay.io/custom/image:latest"
+
+				mcpSelector := &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						pn: pn,
+					},
+				}
+				mcp := testobjs.NewMachineConfigPool(pn, mcpSelector.MatchLabels, mcpSelector, mcpSelector)
+
+				reconciler, err := NewFakeNUMAResourcesOperatorReconciler(platf, defaultOCPVersion, nro, mcp)
+				Expect(err).ToNot(HaveOccurred())
+				reconciler.OverridableRTEImage = true
+
+				key := client.ObjectKeyFromObject(nro)
+				Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})).ToNot(CauseRequeue())
+
+				Expect(reconciler.Client.Get(ctx, key, nro)).ToNot(HaveOccurred())
+				degradedCondition := getConditionByType(nro.Status.Conditions, status.ConditionDegraded)
+				Expect(degradedCondition.Status).To(Equal(metav1.ConditionFalse), "should not be degraded when image restriction is disabled")
+
+				availableCondition := getConditionByType(nro.Status.Conditions, status.ConditionAvailable)
+				Expect(availableCondition).ToNot(BeNil())
+				Expect(availableCondition.Status).To(Equal(metav1.ConditionTrue), "should be available when image restriction is disabled")
+			})
+		})
+
 		Context("with default RTE SELinux and PoolName set", func() {
 			Context("with correct NRO and more than one NodeGroup", func() {
 				var nro *nropv1.NUMAResourcesOperator

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -48,8 +48,9 @@ const (
 
 // TODO: are we duping these?
 const (
-	ReasonAsExpected    = "AsExpected"
-	ReasonInternalError = "InternalError"
+	ReasonAsExpected      = "AsExpected"
+	ReasonInternalError   = "InternalError"
+	ReasonCustomUserImage = "CustomUserImage"
 )
 
 const (

--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -192,13 +192,13 @@ var _ = Describe("[Install] durability", Serial, func() {
 			deployer.Teardown(context.TODO(), 5*time.Minute)
 		})
 
-		It("[test_id:47587] should restart RTE DaemonSet when image is updated in NUMAResourcesOperator", Label(label.Tier1), func() {
+		It("should reject custom ExporterImage and go Degraded without changing the DaemonSet", Label(label.Tier1), func(ctx context.Context) {
 			By("getting up-to-date NRO object")
 			nroKey := objects.NROObjectKey()
 
 			immediate := true
-			err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 10*time.Minute, immediate, func(ctx context.Context) (bool, error) {
-				err := e2eclient.Client.Get(ctx, nroKey, nroObj)
+			err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 10*time.Minute, immediate, func(fCtx context.Context) (bool, error) {
+				err := e2eclient.Client.Get(fCtx, nroKey, nroObj)
 				if err != nil {
 					return false, err
 				}
@@ -209,7 +209,7 @@ var _ = Describe("[Install] durability", Serial, func() {
 				return true, nil
 			})
 			if err != nil {
-				logRTEPodsLogs(e2eclient.Client, e2eclient.K8sClient, context.TODO(), nroObj, "NRO not available")
+				logRTEPodsLogs(e2eclient.Client, e2eclient.K8sClient, ctx, nroObj, "NRO not available")
 			}
 			Expect(err).NotTo(HaveOccurred(), "inconsistent NRO instance:\n%s", objects.ToYAML(nroObj))
 
@@ -219,23 +219,161 @@ var _ = Describe("[Install] durability", Serial, func() {
 			}
 
 			By("waiting for DaemonSet to be ready")
-			ds, err := nrowait.With(e2eclient.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(context.TODO(), dsKey)
+			ds, err := nrowait.With(e2eclient.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
 			Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
+			dsUID := ds.GetUID()
 
-			By("Update RTE image in NRO")
+			By("setting a custom ExporterImage in NRO")
 			Eventually(func() error {
-				err := e2eclient.Client.Get(context.TODO(), nroKey, nroObj)
+				err := e2eclient.Client.Get(ctx, nroKey, nroObj)
 				if err != nil {
 					return err
 				}
 				nroObj.Spec.ExporterImage = e2eimages.RTETestImageCI
-				return e2eclient.Client.Update(context.TODO(), nroObj)
+				return e2eclient.Client.Update(ctx, nroObj)
 			}).WithTimeout(3 * time.Minute).WithPolling(10 * time.Second).ShouldNot(HaveOccurred())
 
-			By("waiting for the daemonset to be ready again")
+			defer func() {
+				By("reverting ExporterImage to restore healthy state")
+				Eventually(func() error {
+					err := e2eclient.Client.Get(ctx, nroKey, nroObj)
+					if err != nil {
+						return err
+					}
+					nroObj.Spec.ExporterImage = ""
+					return e2eclient.Client.Update(ctx, nroObj)
+				}).WithTimeout(3 * time.Minute).WithPolling(10 * time.Second).ShouldNot(HaveOccurred())
+
+				Eventually(func() error {
+					updatedNroObj := &nropv1.NUMAResourcesOperator{}
+					if err := e2eclient.Client.Get(ctx, nroKey, updatedNroObj); err != nil {
+						return err
+					}
+					cond := metahelper.FindStatusCondition(updatedNroObj.Status.Conditions, status.ConditionAvailable)
+					if cond == nil {
+						return fmt.Errorf("missing Available condition")
+					}
+					if cond.Status != metav1.ConditionTrue {
+						return fmt.Errorf("NRO did not recover after reverting ExporterImage: status %q", cond.Status)
+					}
+					return nil
+				}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+			}()
+
+			By("waiting for the operator to report Degraded")
+			Eventually(func() error {
+				updatedNroObj := &nropv1.NUMAResourcesOperator{}
+				if err := e2eclient.Client.Get(ctx, nroKey, updatedNroObj); err != nil {
+					return err
+				}
+
+				cond := metahelper.FindStatusCondition(updatedNroObj.Status.Conditions, status.ConditionDegraded)
+				if cond == nil {
+					return fmt.Errorf("missing Degraded condition")
+				}
+				if cond.Status != metav1.ConditionTrue {
+					return fmt.Errorf("operator not yet Degraded: status %q", cond.Status)
+				}
+				if cond.Reason != status.ReasonCustomUserImage {
+					return fmt.Errorf("Degraded reason mismatch: got %q expected %q", cond.Reason, status.ReasonCustomUserImage)
+				}
+				return nil
+			}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+
+			By("verifying the DaemonSet was not changed")
+			Consistently(func() error {
+				updatedDs := &appsv1.DaemonSet{}
+				if err := e2eclient.Client.Get(ctx, dsKey.AsKey(), updatedDs); err != nil {
+					return err
+				}
+				if updatedDs.GetUID() != dsUID {
+					return fmt.Errorf("DaemonSet was recreated unexpectedly: got UID %q expected %q", updatedDs.GetUID(), dsUID)
+				}
+
+				rteContainer, err := findContainerByName(*updatedDs, containerNameRTE)
+				if err != nil {
+					return err
+				}
+				if rteContainer.Image == e2eimages.RTETestImageCI {
+					return fmt.Errorf("DaemonSet image should not have changed to the custom image: %q", rteContainer.Image)
+				}
+				return nil
+			}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(Succeed())
+		})
+
+		It("[test_id:47587] should restart RTE DaemonSet when image is updated in NUMAResourcesOperator and the ExporterImage restriction is disabled", Label(label.Tier1), func(ctx context.Context) {
+			By("getting up-to-date NRO object")
+			nroKey := objects.NROObjectKey()
+
+			immediate := true
+			err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 10*time.Minute, immediate, func(fCtx context.Context) (bool, error) {
+				err := e2eclient.Client.Get(fCtx, nroKey, nroObj)
+				if err != nil {
+					return false, err
+				}
+				if len(nroObj.Status.DaemonSets) != 1 {
+					klog.InfoS("unsupported daemonsets (/MCP)", "count", len(nroObj.Status.DaemonSets))
+					return false, nil
+				}
+				return true, nil
+			})
+			if err != nil {
+				logRTEPodsLogs(e2eclient.Client, e2eclient.K8sClient, ctx, nroObj, "NRO not available")
+			}
+			Expect(err).NotTo(HaveOccurred(), "inconsistent NRO instance:\n%s", objects.ToYAML(nroObj))
+
+			By("checking if ExporterImage restriction is disabled in the operator pod")
+			nropPod, err := deploy.FindNUMAResourcesOperatorPod(ctx, e2eclient.Client, nroObj)
+			Expect(err).ToNot(HaveOccurred())
+
+			unrestricted := false
+			for _, cnt := range nropPod.Spec.Containers {
+				for _, env := range cnt.Env {
+					if env.Name == "EXPORTER_IMAGE_RESTRICTION" && env.Value == "false" {
+						unrestricted = true
+						break
+					}
+				}
+			}
+			if !unrestricted {
+				Skip("EXPORTER_IMAGE_RESTRICTION is not set to false, skipping unrestricted ExporterImage test")
+			}
+
+			dsKey := nrowait.ObjectKey{
+				Namespace: nroObj.Status.DaemonSets[0].Namespace,
+				Name:      nroObj.Status.DaemonSets[0].Name,
+			}
+
+			By("waiting for DaemonSet to be ready")
+			ds, err := nrowait.With(e2eclient.Client).Interval(10*time.Second).Timeout(3*time.Minute).ForDaemonSetReadyByKey(ctx, dsKey)
+			Expect(err).ToNot(HaveOccurred(), "failed to get the daemonset %s: %v", dsKey.String(), err)
+
+			By("setting a custom ExporterImage in NRO")
+			Eventually(func() error {
+				err := e2eclient.Client.Get(ctx, nroKey, nroObj)
+				if err != nil {
+					return err
+				}
+				nroObj.Spec.ExporterImage = e2eimages.RTETestImageCI
+				return e2eclient.Client.Update(ctx, nroObj)
+			}).WithTimeout(3 * time.Minute).WithPolling(10 * time.Second).ShouldNot(HaveOccurred())
+
+			defer func() {
+				By("reverting ExporterImage")
+				Eventually(func() error {
+					err := e2eclient.Client.Get(ctx, nroKey, nroObj)
+					if err != nil {
+						return err
+					}
+					nroObj.Spec.ExporterImage = ""
+					return e2eclient.Client.Update(ctx, nroObj)
+				}).WithTimeout(3 * time.Minute).WithPolling(10 * time.Second).ShouldNot(HaveOccurred())
+			}()
+
+			By("waiting for the daemonset to be updated with the new image")
 			Eventually(func() bool {
 				updatedDs := &appsv1.DaemonSet{}
-				err := e2eclient.Client.Get(context.TODO(), dsKey.AsKey(), updatedDs)
+				err := e2eclient.Client.Get(ctx, dsKey.AsKey(), updatedDs)
 				if err != nil {
 					klog.ErrorS(err, "failed to get the daemonset", "key", dsKey.String())
 					return false
@@ -351,6 +489,7 @@ var _ = Describe("[Install] durability", Serial, func() {
 				return nil
 			}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 		})
+
 		It("should have the desired topology manager configuration under the NRT object", func() {
 			rteConfigMap := &corev1.ConfigMap{}
 			Eventually(func() bool {

--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	ginkgotypes "github.com/onsi/ginkgo/v2/types"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -185,7 +183,7 @@ var _ = Describe("[Install] durability", Serial, func() {
 		})
 
 		AfterEach(func() {
-			if CurrentSpecReport().State.Is(ginkgotypes.SpecStateSkipped) {
+			if deployer == nil {
 				return
 			}
 			deployer.Teardown(context.TODO(), 5*time.Minute)

--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -35,9 +35,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/assets/selinux"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/flagcodec"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte"
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 
@@ -46,6 +48,7 @@ import (
 	nropmcp "github.com/openshift-kni/numaresources-operator/internal/machineconfigpools"
 	"github.com/openshift-kni/numaresources-operator/internal/podlogs"
 	nrowait "github.com/openshift-kni/numaresources-operator/internal/wait"
+	"github.com/openshift-kni/numaresources-operator/pkg/loglevel"
 	"github.com/openshift-kni/numaresources-operator/pkg/status"
 	rteconfig "github.com/openshift-kni/numaresources-operator/rte/pkg/config"
 	"github.com/openshift-kni/numaresources-operator/test/e2e/label"
@@ -260,11 +263,11 @@ var _ = Describe("[Install] durability", Serial, func() {
 			Expect(rteContainer.Image).To(BeIdenticalTo(e2eimages.RTETestImageCI))
 		})
 
-		It("should be able to delete NUMAResourceOperator CR and redeploy without polluting cluster state", func() {
+		It("should be able to delete NUMAResourceOperator CR and redeploy without polluting cluster state", func(ctx context.Context) {
 			nname := client.ObjectKeyFromObject(nroObj)
 			Expect(nname.Name).NotTo(BeEmpty())
 
-			err := e2eclient.Client.Get(context.TODO(), objects.NROObjectKey(), nroObj)
+			err := e2eclient.Client.Get(ctx, objects.NROObjectKey(), nroObj)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("waiting for the DaemonSet to be created..")
@@ -290,7 +293,7 @@ var _ = Describe("[Install] durability", Serial, func() {
 				objs := mf.ToObjects()
 				for _, obj := range objs {
 					key := client.ObjectKeyFromObject(obj)
-					if err := e2eclient.Client.Get(context.TODO(), key, obj); !errors.IsNotFound(err) {
+					if err := e2eclient.Client.Get(ctx, key, obj); !errors.IsNotFound(err) {
 						if err == nil {
 							klog.InfoS("obj still exists", "key", key.String())
 						} else {
@@ -302,40 +305,51 @@ var _ = Describe("[Install] durability", Serial, func() {
 				return true
 			}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(BeTrue())
 
-			By("redeploy with other parameters")
+			By("redeploy with a different parameter to verify it's not a stale cached redeploy")
 			nroObjRedep := objects.TestNRO(objects.NROWithMCPSelector(objects.EmptyMatchLabels()))
 			nroObjRedep.Spec = *nroObj.Spec.DeepCopy()
-			// TODO change to an image which is test dedicated
-			nroObjRedep.Spec.ExporterImage = e2eimages.RTETestImageCI
+			nroObjRedep.Spec.LogLevel = operatorv1.Trace
 
 			var mcps []*machineconfigv1.MachineConfigPool
 			if inthelper.IsCustomPolicyEnabled(nroObj) {
 				// need to get MCPs before the mutation
-				mcps, err = nropmcp.GetListByNodeGroupsV1(context.TODO(), e2eclient.Client, nroObj.Spec.NodeGroups)
+				mcps, err = nropmcp.GetListByNodeGroupsV1(ctx, e2eclient.Client, nroObj.Spec.NodeGroups)
 				Expect(err).NotTo(HaveOccurred())
 			}
 
-			err = e2eclient.Client.Create(context.TODO(), nroObjRedep)
+			err = e2eclient.Client.Create(ctx, nroObjRedep)
 			Expect(err).ToNot(HaveOccurred())
 
 			if inthelper.IsCustomPolicyEnabled(nroObj) {
-				Expect(deploy.WaitForMCPsCondition(e2eclient.Client, context.TODO(), machineconfigv1.MachineConfigPoolUpdated, mcps...)).To(Succeed())
+				Expect(deploy.WaitForMCPsCondition(e2eclient.Client, ctx, machineconfigv1.MachineConfigPoolUpdated, mcps...)).To(Succeed())
 			}
 
-			Eventually(func() bool {
+			Eventually(func() error {
 				updatedNroObj := &nropv1.NUMAResourcesOperator{}
-				err := e2eclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(nroObj), updatedNroObj)
-				Expect(err).ToNot(HaveOccurred())
-
-				ds, err := getDaemonSetByOwnerReference(updatedNroObj.GetUID())
-				if err != nil {
-					// TODO: multi-line value in structured log
-					klog.ErrorS(err, "failed to get the RTE DaemonSet", "nroYAML", objects.ToYAML(updatedNroObj))
-					return false
+				if err := e2eclient.Client.Get(ctx, client.ObjectKeyFromObject(nroObj), updatedNroObj); err != nil {
+					return err
 				}
 
-				return ds.Spec.Template.Spec.Containers[0].Image == e2eimages.RTETestImageCI
-			}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(BeTrue())
+				redepDs, err := getDaemonSetByOwnerReference(updatedNroObj.GetUID())
+				if err != nil {
+					return fmt.Errorf("failed to get the RTE DaemonSet: %w", err)
+				}
+				if !nrowait.AreDaemonSetPodsReady(&redepDs.Status) {
+					return fmt.Errorf("DaemonSet not ready after redeploy")
+				}
+
+				cnt := redepDs.Spec.Template.Spec.Containers[0]
+				rteFlags := flagcodec.ParseArgvKeyValue(cnt.Args, flagcodec.WithFlagNormalization)
+				kLvl := loglevel.ToKlog(operatorv1.Trace)
+				val, found := rteFlags.GetFlag("-v")
+				if !found {
+					return fmt.Errorf("-v flag not found in container %q args", cnt.Name)
+				}
+				if val.Data != kLvl.String() {
+					return fmt.Errorf("LogLevel not reflected in -v flag of container %q: got %q expected %q", cnt.Name, val.Data, kLvl.String())
+				}
+				return nil
+			}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 		})
 		It("should have the desired topology manager configuration under the NRT object", func() {
 			rteConfigMap := &corev1.ConfigMap{}

--- a/test/e2e/serial/tests/configuration.go
+++ b/test/e2e/serial/tests/configuration.go
@@ -210,7 +210,6 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 
 				newNGs := append(nroOperObj.Spec.NodeGroups, testNG)
 				nroOperObj.Spec.NodeGroups = newNGs
-				nroOperObj.Spec.ExporterImage = serialconfig.GetRteCiImage()
 
 				if nroOperObj.Spec.LogLevel == operatorv1.Trace {
 					newLogLevel = operatorv1.Debug
@@ -250,9 +249,7 @@ var _ = Describe("[serial][disruptive] numaresources configuration management", 
 					By("check the correct match labels for the new RTE daemonset")
 					Expect(ds.Spec.Template.Spec.NodeSelector).To(Equal(testMCP.Spec.NodeSelector.MatchLabels))
 				}
-				By("check the correct image")
 				cnt := ds.Spec.Template.Spec.Containers[0] // shortcut
-				Expect(cnt.Image).To(Equal(serialconfig.GetRteCiImage()))
 
 				By("checking the correct LogLevel")
 				found, match := matchLogLevelToKlog(&cnt, newLogLevel)


### PR DESCRIPTION
Stronger version of https://github.com/openshift-kni/numaresources-operator/pull/4227, which supercedes it.

ExporterImage is an escape hatch we had from day0 but which we never really leveraged. It made on the stable API, but still we can at narrow down the perimeter and make it obvious and loud it should not be used.
Force the status to Degraded if the ExporterImage is set by the user, and refuse to reconcile.

Cluster admins can temporarily restore the old behavior by setting the env var `EXPORTER_IMAGE_RESTRICTION` to `false`.