### PR TITLE
e2e: drop workload partitioning resources in DropHostLevelResources

### DIFF
--- a/test/internal/noderesourcetopologies/nrts.go
+++ b/test/internal/noderesourcetopologies/nrts.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 	"time"
@@ -43,6 +44,8 @@ import (
 
 // ErrNotEnoughResources means a NUMA zone or a node has not enough resouces to reserve
 var ErrNotEnoughResources = errors.New("nrt: Not enough resources")
+
+const WorkloadPartitioningResourcePrefix = "management.workload.openshift.io/"
 
 func GetZoneIDFromName(zoneName string) (int, error) {
 	for _, prefix := range []string{
@@ -257,6 +260,11 @@ func DropHostLevelResources(res corev1.ResourceList) corev1.ResourceList {
 	newList := res.DeepCopy() // since res is a map, updating it directly would mutate its instance in all places
 	klog.Info("drop host-level resources")
 	delete(newList, corev1.ResourceEphemeralStorage)
+	// workload partitioning resources (e.g. management.workload.openshift.io/cores) are
+	// reported in node allocatable but not in NRT zone data, so we must drop them.
+	maps.DeleteFunc(newList, func(resName corev1.ResourceName, _ resource.Quantity) bool {
+		return strings.HasPrefix(string(resName), WorkloadPartitioningResourcePrefix)
+	})
 	return newList
 }
 


### PR DESCRIPTION
On clusters with workload partitioning enabled, node allocatable includes `management.workload.openshift.io/cores` which gets picked up by the baseload computation.
However, NRT zone data does not report this resource, causing `SaturateZoneUntilLeft` to fail with "resource not found in zone" during padding pod creation.

Strip all `management.workload.openshift.io/*` resources alongside `ephemeral-storage` so padding works on workload-partitioned clusters.

AIA: Primarily AI, New content, Human-initiated, Reviewed, Claude Opus 4.6 v1.0
Signed-off-by: Talor Itzhak <titzhak@redhat.com>
