### PR TITLE
OCPBUGS-94176: sched: validate scheduler image 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,11 @@ binary-numacell: build-tools ## Build the numacell test device plugin binary.
 	LDFLAGS="-s -w" \
 	CGO_ENABLED=0 go build -mod=vendor -o bin/numacell -ldflags "$$LDFLAGS" test/deviceplugin/cmd/numacell/main.go
 
+.PHONY: binary-getdigests
+binary-getdigests: 
+	LDFLAGS="-s -w"; \
+	go build -mod=vendor -o bin/getdigests -ldflags "$$LDFLAGS" tools/getdigests/getdigests.go
+
 .PHONY: binary-all
 binary-all: goversion binary binary-rte binary-nrovalidate introspect-data ## Build all component binaries.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,31 @@ Note that installing the operator using this method requires adding the openshif
 
 For further details, please refer to the [operator-sdk documentation](https://sdk.operatorframework.io/docs/olm-integration/tutorial-bundle/)
 
+## deploying with a scheduler
+
+The controller validates the scheduler image set in `numaresourcesscheduler.spec.image` against an embedded set of valid images by their digests. This set is fetched from the production registry. To pass the image validation, the following must be true:
+1. The image is pinned by SHA digest.
+2. The digest belongs to an image that's available in the production registry `registry.redhat.io` and is of the same minor operator version or is the latest of the previous minor version. 
+
+If a privileged user wants to extend the allow list to include other digests, that is possible by providing a comma-separated list of SHA digests as an environment variable `SCHEDULER_IMAGE_DIGESTS` under `subscription.spec.config.env`.
+A privileged user can completely disable the image validation by setting `SCHEDULER_IMAGE_VALIDATION` to `false` under `subscription.spec.config.env`, any other value is ignored and keeps the validation `ON`.
+
+
+On locally installed operators (no OLM), one can directly set the environment variables through the manager deployment using this command:
+
+```
+kubectl -n numaresources set env deployment/numaresources-controller-manager \
+  SCHEDULER_IMAGE_DIGESTS='sha256:abc...'
+```
+
+or completely disable the validation:
+```
+kubectl -n numaresources set env deployment/numaresources-controller-manager \
+  SCHEDULER_IMAGE_VALIDATION=false
+```
+
+IMPORTANT: the cluster admin should ensure that only other cluster admins (e.g. not namespace users) can set these variables.
+
 ## roadmap
 
 The NUMA Resources operator is meant to have a limited lifetime, because all the operands it manages have a path towards

--- a/api/v1/numaresourcesscheduler_types.go
+++ b/api/v1/numaresourcesscheduler_types.go
@@ -82,7 +82,7 @@ const (
 
 // NUMAResourcesSchedulerSpec defines the desired state of NUMAResourcesScheduler
 type NUMAResourcesSchedulerSpec struct {
-	// Scheduler container image URL
+	// Scheduler container image URL, must be referenced by SHA256 digest, not by tag
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Scheduler container image URL",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	SchedulerImage string `json:"imageSpec"`
 	// Scheduler name to be used in pod templates

--- a/bundle/manifests/nodetopology.openshift.io_numaresourcesschedulers.yaml
+++ b/bundle/manifests/nodetopology.openshift.io_numaresourcesschedulers.yaml
@@ -60,7 +60,8 @@ spec:
                 description: Set the cache resync period. Use explicit 0 to disable.
                 type: string
               imageSpec:
-                description: Scheduler container image URL
+                description: Scheduler container image URL, must be referenced by
+                  SHA256 digest, not by tag
                 type: string
               logLevel:
                 default: Normal

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -284,7 +284,8 @@ spec:
         path: cacheResyncPeriod
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Scheduler container image URL
+      - description: Scheduler container image URL, must be referenced by SHA256 digest,
+          not by tag
         displayName: Scheduler container image URL
         path: imageSpec
         x-descriptors:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -64,6 +64,7 @@ import (
 	intkloglevel "github.com/openshift-kni/numaresources-operator/internal/kloglevel"
 	"github.com/openshift-kni/numaresources-operator/internal/platforminfo"
 
+	schedulerapi "github.com/openshift-kni/numaresources-operator/internal/api/scheduler"
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	"github.com/openshift-kni/numaresources-operator/pkg/images"
 	rtemetricsmanifests "github.com/openshift-kni/numaresources-operator/pkg/metrics/manifests/monitor"
@@ -446,6 +447,11 @@ func main() {
 		}
 		klog.InfoS("manifests loaded", "component", "Scheduler")
 
+		iv := schedulerapi.GetImageValidationData()
+		if !iv.Enabled {
+			klog.InfoS("scheduler image validation is disabled. To enable it unset the environment variable", "controller", "NUMAResourcesScheduler", "envvar", schedulerapi.SchedulerImageValidationEnvVar)
+		}
+
 		if err = (&controller.NUMAResourcesSchedulerReconciler{
 			Client:             mgr.GetClient(),
 			Scheme:             mgr.GetScheme(),
@@ -453,6 +459,7 @@ func main() {
 			Namespace:          namespace,
 			PlatformInfo:       platforminfo.New(discoveredCluster.Platform, discoveredCluster.LongVersion),
 			TLSSettings:        tlsSettings,
+			ImageValidation:    iv,
 		}).SetupWithManager(mgr); err != nil {
 			klog.ErrorS(err, "unable to create controller", "controller", "NUMAResourcesScheduler")
 			exitWithCancel(cancel, 1)

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesschedulers.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesschedulers.yaml
@@ -60,7 +60,8 @@ spec:
                 description: Set the cache resync period. Use explicit 0 to disable.
                 type: string
               imageSpec:
-                description: Scheduler container image URL
+                description: Scheduler container image URL, must be referenced by
+                  SHA256 digest, not by tag
                 type: string
               logLevel:
                 default: Normal

--- a/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
@@ -219,7 +219,8 @@ spec:
         path: cacheResyncPeriod
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Scheduler container image URL
+      - description: Scheduler container image URL, must be referenced by SHA256 digest,
+          not by tag
         displayName: Scheduler container image URL
         path: imageSpec
         x-descriptors:

--- a/internal/api/scheduler/_digests.json
+++ b/internal/api/scheduler/_digests.json
@@ -1,0 +1,6 @@
+{
+    "current_channel": [
+        "sha256:55d3fe347f35c257b6f828ec0da1aeef057f723bbcec1576d4d0f9018fb74fe7"
+    ],
+    "prev_channel_last": "sha256:fe33777a6227cfc85949982b9b01c56abc03eab6fad7104132b54d7c940feb8c"
+}

--- a/internal/api/scheduler/digests.go
+++ b/internal/api/scheduler/digests.go
@@ -20,16 +20,22 @@ import (
 	"encoding/json"
 	"os"
 	"regexp"
+	"strings"
 
 	_ "embed"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 )
 
 const (
 	// SchedulerImageValidationEnvVar is the environment variable that controls whether the scheduler image validation is enabled.
 	// If it is set to "false", the scheduler image validation is disabled; any other value is considered as enabled.
 	SchedulerImageValidationEnvVar = "SCHEDULER_IMAGE_VALIDATION"
+
+	// CustomSchedulerDigestsEnvVar is the environment variable that contains a user-provided comma-separated list of SHA256
+	// digests of the scheduler images. It is used to extend the embedded digests.
+	CustomSchedulerDigestsEnvVar = "SCHEDULER_IMAGE_DIGESTS"
 )
 
 var (
@@ -65,9 +71,44 @@ func loadDigests() sets.Set[string] {
 
 	digests := sets.New(d.CurrentChannel...)
 	digests.Insert(d.PreviousChannelLast)
+
+	userDigests := getUserImageDigests()
+	digests.Insert(userDigests...)
+
+	klog.V(4).InfoS("trusted set of scheduler images",
+		"fromCurrentChannel", d.CurrentChannel,
+		"latestFromPreviousChannel", d.PreviousChannelLast,
+		"customDigests", userDigests)
+
 	return digests
 }
 
 func IsValidDigest(digest string) bool {
 	return sha256DigestRE.MatchString(digest)
+}
+
+func getUserImageDigests() []string {
+	val, ok := os.LookupEnv(CustomSchedulerDigestsEnvVar)
+	if !ok {
+		return []string{}
+	}
+	return parseCustomSchedulerDigests(val)
+}
+
+func parseCustomSchedulerDigests(customList string) []string {
+	ret := []string{}
+	digests := strings.Split(strings.TrimSpace(customList), ",")
+	for _, d := range digests {
+		d = strings.TrimSpace(d)
+		if d == "" {
+			continue
+		}
+		if !sha256DigestRE.MatchString(d) {
+			klog.Warningf("custom scheduler image digest %q is malformed: expected sha256:<64 hex chars>", d)
+			continue
+		}
+		ret = append(ret, d)
+	}
+
+	return ret
 }

--- a/internal/api/scheduler/digests.go
+++ b/internal/api/scheduler/digests.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scheduler
+
+import (
+	"encoding/json"
+	"os"
+	"regexp"
+
+	_ "embed"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	// SchedulerImageValidationEnvVar is the environment variable that controls whether the scheduler image validation is enabled.
+	// If it is set to "false", the scheduler image validation is disabled; any other value is considered as enabled.
+	SchedulerImageValidationEnvVar = "SCHEDULER_IMAGE_VALIDATION"
+)
+
+var (
+	//go:embed _digests.json
+	digestsData string
+
+	// sha256DigestRE is a regular expression to match a sha256 digest at the end of a string as
+	// per the OCI and docker registry specifications, e.g. it matches strings of exactly this shape:
+	// sha256:a3f1b2c4d5e6...  (64 hex characters)
+	sha256DigestRE = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
+)
+
+func GetImageValidationData() ImageValidation {
+	val, ok := os.LookupEnv(SchedulerImageValidationEnvVar)
+	if ok && val == "false" {
+		return ImageValidation{
+			Enabled: false,
+			Digests: sets.New[string](),
+		}
+	}
+
+	return ImageValidation{
+		Enabled: true,
+		Digests: loadDigests(),
+	}
+}
+
+func loadDigests() sets.Set[string] {
+	var d Digests
+	if err := json.Unmarshal([]byte(digestsData), &d); err != nil {
+		panic(err)
+	}
+
+	digests := sets.New(d.CurrentChannel...)
+	digests.Insert(d.PreviousChannelLast)
+	return digests
+}
+
+func IsValidDigest(digest string) bool {
+	return sha256DigestRE.MatchString(digest)
+}

--- a/internal/api/scheduler/digests_test.go
+++ b/internal/api/scheduler/digests_test.go
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scheduler
+
+import (
+	"encoding/json"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func loadEmbeddedDigests() sets.Set[string] {
+	var d Digests
+	if err := json.Unmarshal([]byte(digestsData), &d); err != nil {
+		panic(err)
+	}
+	digests := sets.New(d.CurrentChannel...)
+	digests.Insert(d.PreviousChannelLast)
+	return digests
+}
+
+func TestGetImageValidation(t *testing.T) {
+	embeddedDigests := loadEmbeddedDigests()
+	type testCase struct {
+		name      string
+		setEnvVar bool
+		envValue  string
+		expected  ImageValidation
+	}
+
+	testCases := []testCase{
+		{
+			name:      "validation enabled when env is unset",
+			setEnvVar: false,
+			expected: ImageValidation{
+				Enabled: true,
+				Digests: embeddedDigests,
+			},
+		},
+		{
+			name:      "validation disabled when env is false",
+			setEnvVar: true,
+			envValue:  "false",
+			expected: ImageValidation{
+				Enabled: false,
+				Digests: sets.New[string](),
+			},
+		},
+		{
+			name:      "validation enabled when env is true",
+			setEnvVar: true,
+			envValue:  "true",
+			expected: ImageValidation{
+				Enabled: true,
+				Digests: embeddedDigests,
+			},
+		},
+		{
+			name:      "validation enabled for any value other than false",
+			setEnvVar: true,
+			envValue:  "anything",
+			expected: ImageValidation{
+				Enabled: true,
+				Digests: embeddedDigests,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setEnvVar {
+				t.Setenv(SchedulerImageValidationEnvVar, tc.envValue)
+			}
+
+			got := GetImageValidationData()
+
+			if got.Enabled != tc.expected.Enabled {
+				t.Errorf("Enabled: got=%v want=%v", got.Enabled, tc.expected.Enabled)
+			}
+			if !got.Digests.Equal(tc.expected.Digests) {
+				t.Errorf("Digests: got=%v want=%v", sets.List(got.Digests), sets.List(tc.expected.Digests))
+			}
+		})
+	}
+}

--- a/internal/api/scheduler/digests_test.go
+++ b/internal/api/scheduler/digests_test.go
@@ -33,6 +33,12 @@ func loadEmbeddedDigests() sets.Set[string] {
 	return digests
 }
 
+func embeddedDigestsWith(extra ...string) sets.Set[string] {
+	d := loadEmbeddedDigests().Clone()
+	d.Insert(extra...)
+	return d
+}
+
 func TestGetImageValidation(t *testing.T) {
 	embeddedDigests := loadEmbeddedDigests()
 	type testCase struct {
@@ -93,6 +99,123 @@ func TestGetImageValidation(t *testing.T) {
 			}
 			if !got.Digests.Equal(tc.expected.Digests) {
 				t.Errorf("Digests: got=%v want=%v", sets.List(got.Digests), sets.List(tc.expected.Digests))
+			}
+		})
+	}
+}
+
+func TestGetImageValidationWithCustomDigests(t *testing.T) {
+	const (
+		customDigest1 = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+		customDigest2 = "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	)
+
+	type testCase struct {
+		name             string
+		customDigests    string
+		validationEnv    string
+		setValidationEnv bool
+		expected         ImageValidation
+	}
+
+	testCases := []testCase{
+		{
+			name:          "extends embedded digests with a valid custom digest",
+			customDigests: customDigest1,
+			expected: ImageValidation{
+				Enabled: true,
+				Digests: embeddedDigestsWith(customDigest1),
+			},
+		},
+		{
+			name:          "accepts multiple comma-separated custom digests",
+			customDigests: customDigest1 + ", " + customDigest2,
+			expected: ImageValidation{
+				Enabled: true,
+				Digests: embeddedDigestsWith(customDigest1, customDigest2),
+			},
+		},
+		{
+			name:          "skips malformed custom digests",
+			customDigests: "not-a-digest, sha256:short, " + customDigest1,
+			expected: ImageValidation{
+				Enabled: true,
+				Digests: embeddedDigestsWith(customDigest1),
+			},
+		},
+		{
+			name:             "validation disabled ignores custom digests",
+			customDigests:    customDigest1,
+			setValidationEnv: true,
+			validationEnv:    "false",
+			expected: ImageValidation{
+				Enabled: false,
+				Digests: sets.New[string](),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setValidationEnv {
+				t.Setenv(SchedulerImageValidationEnvVar, tc.validationEnv)
+			}
+			t.Setenv(CustomSchedulerDigestsEnvVar, tc.customDigests)
+
+			got := GetImageValidationData()
+
+			if got.Enabled != tc.expected.Enabled {
+				t.Errorf("Enabled: got=%v want=%v", got.Enabled, tc.expected.Enabled)
+			}
+			if !got.Digests.Equal(tc.expected.Digests) {
+				t.Errorf("Digests: got=%v want=%v", sets.List(got.Digests), sets.List(tc.expected.Digests))
+			}
+		})
+	}
+}
+
+func TestParseCustomSchedulerDigests(t *testing.T) {
+	const validDigest = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+
+	type testCase struct {
+		name     string
+		input    string
+		expected []string
+	}
+
+	testCases := []testCase{
+		{
+			name:     "empty input",
+			input:    "",
+			expected: []string{},
+		},
+		{
+			name:     "single valid digest",
+			input:    validDigest,
+			expected: []string{validDigest},
+		},
+		{
+			name:     "trims whitespace and skips empty entries",
+			input:    "  " + validDigest + " , , ",
+			expected: []string{validDigest},
+		},
+		{
+			name:     "skips malformed digests",
+			input:    "not-a-digest, sha256:short",
+			expected: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseCustomSchedulerDigests(tc.input)
+			if len(got) != len(tc.expected) {
+				t.Fatalf("got=%v want=%v", got, tc.expected)
+			}
+			for i := range got {
+				if got[i] != tc.expected[i] {
+					t.Errorf("index %d: got=%q want=%q", i, got[i], tc.expected[i])
+				}
 			}
 		})
 	}

--- a/internal/api/scheduler/types.go
+++ b/internal/api/scheduler/types.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scheduler
+
+import "k8s.io/apimachinery/pkg/util/sets"
+
+type ImageValidation struct {
+	Enabled bool
+	Digests sets.Set[string]
+}
+
+type Digests struct {
+	CurrentChannel      []string `json:"current_channel"`
+	PreviousChannelLast string   `json:"prev_channel_last"`
+}
+
+func (ti *Digests) AddCurrentChannel(digest string) {
+	ti.CurrentChannel = append(ti.CurrentChannel, digest)
+}

--- a/internal/api/scheduler/types_test.go
+++ b/internal/api/scheduler/types_test.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scheduler
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDigests_AddCurrentChannel(t *testing.T) {
+	const (
+		digest1 = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+		digest2 = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	)
+
+	d := Digests{}
+	d.AddCurrentChannel(digest1)
+
+	if !reflect.DeepEqual(d.CurrentChannel, []string{digest1}) {
+		t.Fatalf("after first add: got=%v want=%v", d.CurrentChannel, []string{digest1})
+	}
+
+	d.AddCurrentChannel(digest2)
+
+	want := []string{digest1, digest2}
+	if !reflect.DeepEqual(d.CurrentChannel, want) {
+		t.Fatalf("after second add: got=%v want=%v", d.CurrentChannel, want)
+	}
+}

--- a/internal/controller/numaresourcesscheduler_controller.go
+++ b/internal/controller/numaresourcesscheduler_controller.go
@@ -47,6 +47,7 @@ import (
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
 	"github.com/openshift-kni/numaresources-operator/internal/api/annotations"
+	schedulerapi "github.com/openshift-kni/numaresources-operator/internal/api/scheduler"
 	"github.com/openshift-kni/numaresources-operator/internal/platforminfo"
 	intreconcile "github.com/openshift-kni/numaresources-operator/internal/reconcile"
 	"github.com/openshift-kni/numaresources-operator/internal/relatedobjects"
@@ -60,6 +61,7 @@ import (
 	schedupdate "github.com/openshift-kni/numaresources-operator/pkg/objectupdate/sched"
 	objtls "github.com/openshift-kni/numaresources-operator/pkg/objectupdate/tls"
 	"github.com/openshift-kni/numaresources-operator/pkg/status"
+	"github.com/openshift-kni/numaresources-operator/pkg/validation"
 )
 
 const (
@@ -75,6 +77,7 @@ type NUMAResourcesSchedulerReconciler struct {
 	Namespace          string
 	PlatformInfo       platforminfo.PlatformInfo
 	TLSSettings        objtls.Settings
+	ImageValidation    schedulerapi.ImageValidation
 }
 
 // Namespace Scoped
@@ -139,6 +142,14 @@ func (r *NUMAResourcesSchedulerReconciler) Reconcile(ctx context.Context, req ct
 	if annotations.IsPauseReconciliationEnabled(instance.Annotations) {
 		klog.InfoS("Pause reconciliation enabled", "object", req.NamespacedName)
 		return ctrl.Result{}, nil
+	}
+
+	if r.ImageValidation.Enabled {
+		if err := validation.SchedulerImage(instance.Spec.SchedulerImage, r.ImageValidation.Digests); err != nil {
+			return r.degradeStatus(ctx, initialInstance, instance, status.ReasonInvalidSchedulerImage, err.Error())
+		}
+	} else {
+		klog.V(4).InfoS("Skipping scheduler image validation. To enable it unset the environment variable", "object", req.NamespacedName, "envvar", schedulerapi.SchedulerImageValidationEnvVar)
 	}
 
 	step := r.reconcileResource(ctx, instance)

--- a/internal/controller/numaresourcesscheduler_controller_test.go
+++ b/internal/controller/numaresourcesscheduler_controller_test.go
@@ -49,6 +49,7 @@ import (
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
 	"github.com/openshift-kni/numaresources-operator/internal/api/annotations"
+	schedulerapi "github.com/openshift-kni/numaresources-operator/internal/api/scheduler"
 	testobjs "github.com/openshift-kni/numaresources-operator/internal/objects"
 	"github.com/openshift-kni/numaresources-operator/internal/platforminfo"
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
@@ -66,6 +67,11 @@ import (
 
 const testSchedulerName = "testSchedulerName"
 
+func getSchedulerTestImage() string {
+	iv := schedulerapi.GetImageValidationData()
+	return "some/url@" + iv.Digests.UnsortedList()[0]
+}
+
 func NewFakeNUMAResourcesSchedulerReconciler(initObjects ...runtime.Object) (*NUMAResourcesSchedulerReconciler, error) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithStatusSubresource(&nropv1.NUMAResourcesScheduler{}).WithRuntimeObjects(initObjects...).Build()
 	schedMf, err := schedmanifests.GetManifests(testNamespace)
@@ -82,13 +88,14 @@ func NewFakeNUMAResourcesSchedulerReconciler(initObjects ...runtime.Object) (*NU
 			MinVersion:   tls.VersionTLS13,
 			CipherSuites: []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
 		}),
+		ImageValidation: schedulerapi.GetImageValidationData(),
 	}, nil
 }
 
 var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 	Context("with unexpected NRS CR name", func() {
 		It("should reject creating the CR", func() {
-			nrs := testobjs.NewNUMAResourcesScheduler("test", "some/url:latest", testSchedulerName, 9*time.Second)
+			nrs := testobjs.NewNUMAResourcesScheduler("test", getSchedulerTestImage(), testSchedulerName, 9*time.Second)
 			err := k8sClient.Create(context.TODO(), nrs)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("the object name must be 'numaresourcesscheduler'."))
@@ -97,7 +104,7 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 
 	Context("with status conditions updates", func() {
 		It("should fix degraded condition on progressing scheduler", func() {
-			nrs := testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 9*time.Second)
+			nrs := testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", getSchedulerTestImage(), testSchedulerName, 9*time.Second)
 			reconciler, err := NewFakeNUMAResourcesSchedulerReconciler(nrs)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -132,6 +139,61 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 			Expect(degradedCondition.Reason).To(Equal(status.ConditionDegraded))
 			Expect(degradedCondition.Message).To(BeEmpty())
 		})
+
+		When("scheduler image validation is enabled - default case", func() {
+			It("should degrade status when image is not pinned by SHA256 digest", func(ctx context.Context) {
+				image := "some/url:v4.22.0"
+				nrs := testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", image, testSchedulerName, 9*time.Second)
+				reconciler, err := NewFakeNUMAResourcesSchedulerReconciler(nrs)
+				Expect(err).ToNot(HaveOccurred())
+				key := client.ObjectKeyFromObject(nrs)
+				_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(reconciler.Client.Get(ctx, key, nrs)).To(Succeed())
+				degradedCondition := getConditionByType(nrs.Status.Conditions, status.ConditionDegraded)
+				Expect(degradedCondition.Status).To(Equal(metav1.ConditionTrue))
+				Expect(degradedCondition.Reason).To(Equal(status.ReasonInvalidSchedulerImage))
+				Expect(degradedCondition.Message).To(ContainSubstring("image %q must be referenced by digest, not by tag", image))
+			})
+
+			It("should degrade status when image is pinned by untrusted SHA256 digest", func(ctx context.Context) {
+				image := "some/url@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+				nrs := testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", image, testSchedulerName, 9*time.Second)
+				reconciler, err := NewFakeNUMAResourcesSchedulerReconciler(nrs)
+				Expect(err).ToNot(HaveOccurred())
+				key := client.ObjectKeyFromObject(nrs)
+				_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(reconciler.Client.Get(ctx, key, nrs)).To(Succeed())
+				degradedCondition := getConditionByType(nrs.Status.Conditions, status.ConditionDegraded)
+				Expect(degradedCondition.Status).To(Equal(metav1.ConditionTrue))
+				Expect(degradedCondition.Reason).To(Equal(status.ReasonInvalidSchedulerImage))
+				Expect(degradedCondition.Message).To(ContainSubstring("is not in the trusted list"))
+			})
+		})
+
+		When("scheduler image validation is OFF", func() {
+			It("should NOT degrade status when image digest is not found among trusted digests", func(ctx context.Context) {
+				testSHA := "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+				nrs := testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url@"+testSHA, testSchedulerName, 9*time.Second)
+				initObjects := []runtime.Object{nrs}
+				initObjects = append(initObjects, fakeNodes(3, 3)...)
+				reconciler, err := NewFakeNUMAResourcesSchedulerReconciler(initObjects...)
+				Expect(err).ToNot(HaveOccurred())
+
+				reconciler.ImageValidation.Enabled = false
+
+				key := client.ObjectKeyFromObject(nrs)
+				_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(reconciler.Client.Get(ctx, key, nrs)).To(Succeed())
+				degradedCondition := getConditionByType(nrs.Status.Conditions, status.ConditionDegraded)
+				Expect(degradedCondition.Status).To(Equal(metav1.ConditionFalse))
+			})
+		})
 	})
 
 	Context("with correct NRS CR", func() {
@@ -141,7 +203,7 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 
 		BeforeEach(func() {
 			var err error
-			nrs = testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 11*time.Second)
+			nrs = testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", getSchedulerTestImage(), testSchedulerName, 11*time.Second)
 			initObjects := []runtime.Object{nrs}
 			initObjects = append(initObjects, fakeNodes(numOfMasters, 3)...)
 			reconciler, err = NewFakeNUMAResourcesSchedulerReconciler(initObjects...)
@@ -796,7 +858,7 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 
 		BeforeEach(func() {
 			var err error
-			nrs = testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 11*time.Second)
+			nrs = testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", getSchedulerTestImage(), testSchedulerName, 11*time.Second)
 			initObjects := []runtime.Object{nrs}
 			initObjects = append(initObjects, fakeNodes(numOfMasters, 3)...)
 			reconciler, err = NewFakeNUMAResourcesSchedulerReconciler(initObjects...)
@@ -884,7 +946,7 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 
 			DescribeTable("should configure by default the informerMode to the expected when field is not set", func(reconcilerPlatInfo platforminfo.PlatformInfo, expectedInformer string) {
 				var err error
-				nrs = testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 11*time.Second)
+				nrs = testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", getSchedulerTestImage(), testSchedulerName, 11*time.Second)
 				initObjects := []runtime.Object{nrs}
 				initObjects = append(initObjects, fakeNodes(numOfMasters, 3)...)
 				reconciler, err = NewFakeNUMAResourcesSchedulerReconciler(initObjects...)
@@ -922,7 +984,7 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 
 			DescribeTable("should preserve informerMode value if set", func(reconcilerPlatInfo platforminfo.PlatformInfo) {
 				var err error
-				nrs = testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 11*time.Second)
+				nrs = testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", getSchedulerTestImage(), testSchedulerName, 11*time.Second)
 				infMode := nropv1.SchedulerInformerDedicated
 				nrs.Spec.SchedulerInformer = &infMode
 				initObjects := []runtime.Object{nrs}
@@ -949,7 +1011,7 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 
 			DescribeTable("should allow to update the informerMode to be Dedicated after an overridden default", func(reconcilerPlatInfo platforminfo.PlatformInfo) {
 				var err error
-				nrs = testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 11*time.Second)
+				nrs = testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", getSchedulerTestImage(), testSchedulerName, 11*time.Second)
 				initObjects := []runtime.Object{nrs}
 				initObjects = append(initObjects, fakeNodes(numOfMasters, 3)...)
 				reconciler, err = NewFakeNUMAResourcesSchedulerReconciler(initObjects...)
@@ -999,7 +1061,7 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 		var reconciler *NUMAResourcesSchedulerReconciler
 
 		BeforeEach(func() {
-			nrs = testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 5*time.Second)
+			nrs = testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", getSchedulerTestImage(), testSchedulerName, 5*time.Second)
 			nrsKey = client.ObjectKeyFromObject(nrs)
 			initObjects := []runtime.Object{nrs}
 			initObjects = append(initObjects, fakeNodes(3, 3)...)
@@ -1138,7 +1200,7 @@ var _ = Describe("Test computeSchedulerReplicas", func() {
 		}
 		DescribeTable(
 			"should not allow more replicas than the number of nodes", func(ctx context.Context, tc testCase) {
-				nrs := testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 11*time.Second)
+				nrs := testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", getSchedulerTestImage(), testSchedulerName, 11*time.Second)
 				nrs.Spec.Replicas = tc.explicitReplicas
 				initObjects := []runtime.Object{nrs}
 				initObjects = append(initObjects, fakeNodes(tc.numControlPlane, tc.numWorker)...)
@@ -1227,7 +1289,7 @@ var _ = Describe("Test computeSchedulerReplicas", func() {
 		)
 
 		It("should degrade when nodes are scaled down with higher number of explicit replicas", func(ctx context.Context) {
-			nrs := testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", "some/url:latest", testSchedulerName, 11*time.Second)
+			nrs := testobjs.NewNUMAResourcesScheduler("numaresourcesscheduler", getSchedulerTestImage(), testSchedulerName, 11*time.Second)
 			initialReplicas := int32(3)
 			nrs.Spec.Replicas = ptr.To(initialReplicas)
 			initObjects := []runtime.Object{nrs}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -48,9 +48,10 @@ const (
 
 // TODO: are we duping these?
 const (
-	ReasonAsExpected      = "AsExpected"
-	ReasonInternalError   = "InternalError"
-	ReasonCustomUserImage = "CustomUserImage"
+	ReasonAsExpected            = "AsExpected"
+	ReasonInternalError         = "InternalError"
+	ReasonCustomUserImage       = "CustomUserImage"
+	ReasonInvalidSchedulerImage = "InvalidSchedulerImage"
 )
 
 const (

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -255,7 +255,7 @@ func SchedulerImage(image string, digests sets.Set[string]) error {
 	}
 
 	if !digests.Has(digest) {
-		return fmt.Errorf("image %q digest %q is not in the trusted list", image, digest)
+		return fmt.Errorf("image %q digest %q is not in the trusted list. To extend the list, update the environment variable %q with comma separated list of digests", image, digest, schedulerapi.CustomSchedulerDigestsEnvVar)
 	}
 	return nil
 }

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -19,14 +19,17 @@ package validation
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
 	nodegroupv1 "github.com/openshift-kni/numaresources-operator/api/v1/helper/nodegroup"
 	"github.com/openshift-kni/numaresources-operator/internal/api/annotations"
+	schedulerapi "github.com/openshift-kni/numaresources-operator/internal/api/scheduler"
 )
 
 const (
@@ -236,4 +239,23 @@ func nodeGroupsAnnotations(nodeGroups []nropv1.NodeGroup) error {
 		err = errors.Join(err, fmt.Errorf("pool #%d has too many annotations %d max %d", idx, len(nodeGroup.Annotations), nropv1.NodeGroupMaxAnnotations))
 	}
 	return err
+}
+
+// SchedulerImage checks if the scheduler image is pinned by a valid sha256 digest and is
+// found in the trusted digests list
+func SchedulerImage(image string, digests sets.Set[string]) error {
+	idx := strings.Index(image, "@")
+	if idx == -1 {
+		return fmt.Errorf("image %q must be referenced by digest, not by tag", image)
+	}
+
+	digest := image[idx+1:]
+	if !schedulerapi.IsValidDigest(digest) {
+		return fmt.Errorf("image %q has malformed digest %q: expected sha256:<64 hex chars>", image, digest)
+	}
+
+	if !digests.Has(digest) {
+		return fmt.Errorf("image %q digest %q is not in the trusted list", image, digest)
+	}
+	return nil
 }

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
 
@@ -352,6 +353,75 @@ func TestMultipleMCPsPerTree(t *testing.T) {
 			}
 			if err != nil && !tc.expectedError {
 				t.Errorf("expected success, but failed instead: %v", err)
+			}
+		})
+	}
+}
+
+func TestSchedulerImage(t *testing.T) {
+	const (
+		trustedDigest   = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		untrustedDigest = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	)
+
+	trustedDigests := sets.New(trustedDigest)
+
+	type testCase struct {
+		name                 string
+		image                string
+		digests              sets.Set[string]
+		expectedError        bool
+		expectedErrorMessage string
+	}
+
+	testCases := []testCase{
+		{
+			name:    "accepts trusted digest-pinned image",
+			image:   "registry.example/numaresources/scheduler@" + trustedDigest,
+			digests: trustedDigests,
+		},
+		{
+			name:                 "rejects tag-pinned image",
+			image:                "registry.example/numaresources/scheduler:v4.20.0",
+			digests:              trustedDigests,
+			expectedError:        true,
+			expectedErrorMessage: "must be referenced by digest, not by tag",
+		},
+		{
+			name:                 "rejects malformed digest",
+			image:                "registry.example/numaresources/scheduler@sha256:short",
+			digests:              trustedDigests,
+			expectedError:        true,
+			expectedErrorMessage: "has malformed digest",
+		},
+		{
+			name:                 "rejects digest not in trusted list",
+			image:                "registry.example/numaresources/scheduler@" + untrustedDigest,
+			digests:              trustedDigests,
+			expectedError:        true,
+			expectedErrorMessage: "is not in the trusted list",
+		},
+		{
+			name:          "trusted digest without image name",
+			image:         "@" + trustedDigest,
+			digests:       trustedDigests,
+			expectedError: false, // would fail later on pulling the image
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := SchedulerImage(tc.image, tc.digests)
+			if err == nil && tc.expectedError {
+				t.Errorf("expected error but succeeded instead")
+			}
+			if err != nil && !tc.expectedError {
+				t.Errorf("expected success but failed instead: %v", err)
+			}
+			if tc.expectedErrorMessage != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.expectedErrorMessage) {
+					t.Errorf("unexpected error: %v (expected %q)", err, tc.expectedErrorMessage)
+				}
 			}
 		})
 	}

--- a/test/e2e/must-gather/must_gather_suite_test.go
+++ b/test/e2e/must-gather/must_gather_suite_test.go
@@ -24,9 +24,12 @@ import (
 	"time"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
+	intsched "github.com/openshift-kni/numaresources-operator/internal/api/scheduler"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/internal/clients"
 	"github.com/openshift-kni/numaresources-operator/test/internal/configuration"
 	"github.com/openshift-kni/numaresources-operator/test/internal/deploy"
+	e2eenvvar "github.com/openshift-kni/numaresources-operator/test/internal/envvar"
+	e2esched "github.com/openshift-kni/numaresources-operator/test/internal/nrosched"
 	"github.com/openshift-kni/numaresources-operator/test/internal/objects"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -81,7 +84,23 @@ var _ = BeforeSuite(func() {
 
 	deployment = deploy.NewForPlatform(configuration.Plat)
 	_ = deployment.Deploy(ctx, configuration.MachineConfigPoolUpdateTimeout) // we don't care about the nrop instance
+
+	if !e2esched.IsSchedulerImageValidationEnabled() {
+		// for e2e verification we disable the image validation because handling pulling images in the CI from the
+		// production registry is troublesome, and so is handling changing the digests on each branch. Testing e2e
+		// for the image validation will be handled in a separate test.
+		By("identify the source of operator installation and disable scheduler image validation")
+		var err error
+		restoreFunc, err := e2eenvvar.SetOperatorEnvVar(ctx, e2eclient.Client, intsched.SchedulerImageValidationEnvVar, "false")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func(cleanupCtx context.Context) {
+			By("restoring scheduler image validation settings")
+			Expect(restoreFunc(cleanupCtx)).To(Succeed())
+		})
+	}
+
 	nroSchedObj = deploy.DeployNROScheduler(ctx, nroSchedTimeout)
+
 })
 
 var _ = AfterSuite(func() {

--- a/test/e2e/must-gather/must_gather_test.go
+++ b/test/e2e/must-gather/must_gather_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/internal/clients"
 	"github.com/openshift-kni/numaresources-operator/test/internal/configuration"
+	testconsts "github.com/openshift-kni/numaresources-operator/test/internal/consts"
 	"github.com/openshift-kni/numaresources-operator/test/internal/objects"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -184,7 +185,7 @@ var _ = Describe("[must-gather] NRO data collected", func() {
 					}
 					podFolderNames = append(podFolderNames, podFolder.Name())
 				}
-				Expect(podFolderNames).To(ContainElement(MatchRegexp("^numaresources-controller-manager*")))
+				Expect(podFolderNames).To(ContainElement(MatchRegexp("^" + testconsts.OperatorDeploymentName + "*")))
 				Expect(podFolderNames).To(ContainElement(MatchRegexp("^secondary-scheduler*")))
 			}
 		})

--- a/test/e2e/sched/install/test_suite_install_test.go
+++ b/test/e2e/sched/install/test_suite_install_test.go
@@ -17,9 +17,13 @@
 package install
 
 import (
+	"context"
 	"testing"
 
+	intsched "github.com/openshift-kni/numaresources-operator/internal/api/scheduler"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/internal/clients"
+	e2eenvvar "github.com/openshift-kni/numaresources-operator/test/internal/envvar"
+	e2esched "github.com/openshift-kni/numaresources-operator/test/internal/nrosched"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -30,7 +34,21 @@ func TestInstall(t *testing.T) {
 	RunSpecs(t, "Install")
 }
 
-var _ = BeforeSuite(func() {
+var _ = BeforeSuite(func(ctx context.Context) {
 	By("Creating all test resources")
 	Expect(e2eclient.ClientsEnabled).To(BeTrue(), "failed to create runtime-controller client")
+
+	if !e2esched.IsSchedulerImageValidationEnabled() {
+		// for e2e verification we disable the image validation because handling pulling images in the CI from the
+		// production registry is troublesome, and so is handling changing the digests on each branch. Testing e2e
+		// for the image validation will be handled in a separate test.
+		By("identify the source of operator installation and disable scheduler image validation")
+		var err error
+		restoreFunc, err := e2eenvvar.SetOperatorEnvVar(ctx, e2eclient.Client, intsched.SchedulerImageValidationEnvVar, "false")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func(cleanupCtx context.Context) {
+			By("restoring scheduler image validation settings")
+			Expect(restoreFunc(cleanupCtx)).To(Succeed())
+		})
+	}
 })

--- a/test/e2e/sched/test_suite_sched_test.go
+++ b/test/e2e/sched/test_suite_sched_test.go
@@ -17,7 +17,13 @@
 package sched
 
 import (
+	"context"
 	"testing"
+
+	intsched "github.com/openshift-kni/numaresources-operator/internal/api/scheduler"
+	e2eclient "github.com/openshift-kni/numaresources-operator/test/internal/clients"
+	e2eenvvar "github.com/openshift-kni/numaresources-operator/test/internal/envvar"
+	e2esched "github.com/openshift-kni/numaresources-operator/test/internal/nrosched"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -27,3 +33,19 @@ func TestScheduler(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Scheduler")
 }
+
+var _ = BeforeSuite(func(ctx context.Context) {
+	if !e2esched.IsSchedulerImageValidationEnabled() {
+		// for e2e verification we disable the image validation because handling pulling images in the CI from the
+		// production registry is troublesome, and so is handling changing the digests on each branch. Testing e2e
+		// for the image validation will be handled in a separate test.
+		By("identify the source of operator installation and disable scheduler image validation")
+		var err error
+		restoreFunc, err := e2eenvvar.SetOperatorEnvVar(ctx, e2eclient.Client, intsched.SchedulerImageValidationEnvVar, "false")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func(cleanupCtx context.Context) {
+			By("restoring scheduler image validation settings")
+			Expect(restoreFunc(cleanupCtx)).To(Succeed())
+		})
+	}
+})

--- a/test/e2e/sched/uninstall/test_suite_uninstall_test.go
+++ b/test/e2e/sched/uninstall/test_suite_uninstall_test.go
@@ -17,9 +17,13 @@
 package uninstall
 
 import (
+	"context"
 	"testing"
 
+	intsched "github.com/openshift-kni/numaresources-operator/internal/api/scheduler"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/internal/clients"
+	e2eenvvar "github.com/openshift-kni/numaresources-operator/test/internal/envvar"
+	e2esched "github.com/openshift-kni/numaresources-operator/test/internal/nrosched"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -30,7 +34,21 @@ func TestInstall(t *testing.T) {
 	RunSpecs(t, "Install")
 }
 
-var _ = BeforeSuite(func() {
+var _ = BeforeSuite(func(ctx context.Context) {
 	By("Creating all test resources")
 	Expect(e2eclient.ClientsEnabled).To(BeTrue(), "failed to create runtime-controller client")
+
+	if !e2esched.IsSchedulerImageValidationEnabled() {
+		// for e2e verification we disable the image validation because handling pulling images in the CI from the
+		// production registry is troublesome, and so is handling changing the digests on each branch. Testing e2e
+		// for the image validation will be handled in a separate test.
+		By("identify the source of operator installation and disable scheduler image validation")
+		var err error
+		restoreFunc, err := e2eenvvar.SetOperatorEnvVar(ctx, e2eclient.Client, intsched.SchedulerImageValidationEnvVar, "false")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func(cleanupCtx context.Context) {
+			By("restoring scheduler image validation settings")
+			Expect(restoreFunc(cleanupCtx)).To(Succeed())
+		})
+	}
 })

--- a/test/e2e/serial/README.md
+++ b/test/e2e/serial/README.md
@@ -58,6 +58,8 @@ they found it before they run.
   reading it via remote exec. Useful when running the operator locally via `hack/run-local.sh`.
 - `E2E_RTE_CI_IMAGE` (accepts string, e.g `quay.io/openshift-kni/resource-topology-exporter:test-ci`) sets the 
   RTE image to be used for testing purposes particularly for modifying the operator object.
+- `E2E_OPERATOR_SUBSCRIPTION_NAME` (accepts string) sets the subscription name of the installed operator that in case of updates needed on the subscription (such as setting `spec.config.env`) the specified subscription would be used. 
+- `E2E_VALIDATE_SCHEDULER_IMAGE` if set to `true`, the manager controller will be validating the scheduler image. Most useful to run the tests using the production flow. 
   
 ### Tests tagging 
 

--- a/test/e2e/serial/e2e_serial_test.go
+++ b/test/e2e/serial/e2e_serial_test.go
@@ -24,8 +24,11 @@ import (
 	_ "github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests"
 	_ "github.com/openshift-kni/numaresources-operator/test/internal/configuration"
 
+	intsched "github.com/openshift-kni/numaresources-operator/internal/api/scheduler"
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/internal/clients"
+	e2eenvvar "github.com/openshift-kni/numaresources-operator/test/internal/envvar"
+	e2esched "github.com/openshift-kni/numaresources-operator/test/internal/nrosched"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -46,6 +49,21 @@ var _ = BeforeSuite(func() {
 	Expect(serialconfig.CheckNodesTopology(ctx)).Should(Succeed())
 	serialconfig.Setup()
 	setupExecuted = true
+
+	if !e2esched.IsSchedulerImageValidationEnabled() {
+		// for e2e verification we disable the image validation because handling pulling images in the CI from the
+		// production registry is troublesome, and so is handling changing the digests on each branch. Testing e2e
+		// for the image validation will be handled in a separate test.
+		By("identify the source of operator installation and disable scheduler image validation")
+		var err error
+		restoreFunc, err := e2eenvvar.SetOperatorEnvVar(ctx, e2eclient.Client, intsched.SchedulerImageValidationEnvVar, "false")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func(cleanupCtx context.Context) {
+			By("restoring scheduler image validation settings")
+			Expect(restoreFunc(cleanupCtx)).To(Succeed())
+		})
+	}
+
 })
 
 var _ = AfterSuite(func() {

--- a/test/internal/consts/consts.go
+++ b/test/internal/consts/consts.go
@@ -1,0 +1,17 @@
+package consts
+
+const (
+	// This is the name and the package name of the subscription spec in the operator subscription CRD.
+	// in operator subscription it would be found under `spec.name` or `spec.package`
+	SubscriptionSpecNamePackage = "numaresources-operator"
+
+	OperatorDeploymentName   = "numaresources-controller-manager"
+	OperatorManagerContainer = "manager"
+)
+
+var (
+	OperatorDeploymentLabels = map[string]string{
+		"control-plane": "controller-manager",
+		"app":           "numaresources-operator",
+	}
+)

--- a/test/internal/envvar/envvar.go
+++ b/test/internal/envvar/envvar.go
@@ -1,0 +1,480 @@
+/*
+ * Copyright 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package envvar
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	k8swait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift-kni/numaresources-operator/internal/podlist"
+	"github.com/openshift-kni/numaresources-operator/internal/wait"
+	"github.com/openshift-kni/numaresources-operator/test/internal/consts"
+)
+
+var subscriptionGVK = schema.GroupVersionKind{
+	Group:   "operators.coreos.com",
+	Version: "v1alpha1",
+	Kind:    "Subscription",
+}
+
+type restoreFunc func(ctx context.Context) error
+
+var noOpRestoreFunc restoreFunc = func(ctx context.Context) error { return nil }
+
+// SetOperatorEnvVar sets envName to envValue on the operator's OLM subscription when present,
+// otherwise on the manager container in the operator deployment. It returns a restore function.
+func SetOperatorEnvVar(ctx context.Context, cli client.Client, envName, envValue string) (restoreFunc, error) {
+	dp, err := findOperatorDeployment(ctx, cli)
+	if err != nil {
+		return nil, err
+	}
+
+	sub, err := findOperatorSubscription(ctx, cli, dp.Namespace)
+	if err == nil {
+		klog.InfoS("setting operator env via OLM subscription", "name", sub.GetName(), "namespace", sub.GetNamespace(), "env", envName, "value", envValue)
+		return setOperatorEnvViaSubscription(ctx, cli, sub, envName, envValue)
+	}
+	if !errors.IsNotFound(err) {
+		return nil, err
+	}
+
+	klog.InfoS("setting operator env via operator deployment", "name", dp.Name, "namespace", dp.Namespace, "env", envName, "value", envValue)
+	return setOperatorEnvViaDeployment(ctx, cli, dp, envName, envValue)
+}
+
+func findOperatorSubscription(ctx context.Context, cli client.Client, fromNamespace string) (*unstructured.Unstructured, error) {
+	subList := &unstructured.UnstructuredList{}
+	subList.SetGroupVersionKind(subscriptionGVK.GroupVersion().WithKind("SubscriptionList"))
+
+	if err := cli.List(ctx, subList, client.InNamespace(fromNamespace)); err != nil {
+		return nil, err
+	}
+
+	// use the subscription name option if set for more flexxibility and debugging purposes
+	subName := os.Getenv("E2E_OPERATOR_SUBSCRIPTION_NAME")
+	if subName != "" {
+		for i := range subList.Items {
+			if subList.Items[i].GetName() == subName {
+				return subList.Items[i].DeepCopy(), nil
+			}
+		}
+	}
+
+	// in case the subscription name is not set, we pick the subscription that has the correct package name based
+	// on the subscription spec. Some OLM installations configures the only one of either the package or the name,
+	// but either way they have similar value.
+	for i := range subList.Items {
+		pkg, pkgFound, pkgErr := unstructured.NestedString(subList.Items[i].Object, "spec", "package")
+		name, nameFound, nameErr := unstructured.NestedString(subList.Items[i].Object, "spec", "name")
+		if pkgErr != nil && nameErr != nil {
+			return nil, fmt.Errorf("failed to get package or name from subscription: pkgErr=%v nameErr=%v sub=%v", pkgErr, nameErr, subList.Items[i].Object)
+		}
+		if pkgFound {
+			if pkg == consts.SubscriptionSpecNamePackage {
+				return subList.Items[i].DeepCopy(), nil
+			}
+		}
+		if nameFound {
+			if name == consts.SubscriptionSpecNamePackage {
+				return subList.Items[i].DeepCopy(), nil
+			}
+		}
+	}
+	klog.InfoS("no subscription found with the correct package name", "subscriptions", subList.Items)
+	return nil, errors.NewNotFound(schema.GroupResource{Group: subscriptionGVK.Group, Resource: "subscriptions"}, subName)
+}
+
+func findOperatorDeployment(ctx context.Context, cli client.Client) (*appsv1.Deployment, error) {
+	dpList := &appsv1.DeploymentList{}
+	if err := cli.List(ctx, dpList, client.MatchingLabels(consts.OperatorDeploymentLabels)); err != nil {
+		return nil, err
+	}
+
+	for i := range dpList.Items {
+		dp := &dpList.Items[i]
+		if dp.Name != consts.OperatorDeploymentName {
+			continue
+		}
+
+		return dp, nil
+	}
+	return nil, errors.NewNotFound(schema.GroupResource{Group: appsv1.SchemeGroupVersion.Group, Resource: "deployments"}, consts.OperatorDeploymentName)
+}
+
+func setOperatorEnvViaSubscription(ctx context.Context, cli client.Client, sub *unstructured.Unstructured, envName, envValue string) (restoreFunc, error) {
+	dpKey := client.ObjectKey{Namespace: sub.GetNamespace(), Name: consts.OperatorDeploymentName}
+	initialDp, initialPods, err := getPodsForDeployment(ctx, cli, dpKey)
+	if err != nil {
+		return nil, err
+	}
+
+	subKey := client.ObjectKeyFromObject(sub)
+	current := &unstructured.Unstructured{}
+	current.SetGroupVersionKind(subscriptionGVK)
+	if err := cli.Get(ctx, subKey, current); err != nil {
+		return nil, err
+	}
+	originalEnv, err := getSubscriptionEnv(current)
+	if err != nil {
+		return nil, err
+	}
+	klog.InfoS("original env", "env", originalEnv)
+
+	klog.InfoS("checking if the env is already set")
+	originalEnvVars := toEnvVars(originalEnv)
+	if slices.ContainsFunc(originalEnvVars, func(env corev1.EnvVar) bool {
+		return env.Name == envName && env.Value == envValue
+	}) {
+		klog.InfoS("env is already set", "env", envName, "value", envValue)
+		return noOpRestoreFunc, nil
+	}
+
+	updatedEnv := buildSubscriptionWithNewEnvVal(originalEnv, envName, envValue)
+	klog.InfoS("updated env", "env", updatedEnv)
+	// TODO: extract this to a function and use it in creating the restore function
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		current := &unstructured.Unstructured{}
+		current.SetGroupVersionKind(subscriptionGVK)
+		if err := cli.Get(ctx, subKey, current); err != nil {
+			return err
+		}
+		if err := setSubscriptionEnv(current, updatedEnv); err != nil {
+			return err
+		}
+		return cli.Update(ctx, current)
+	}); err != nil {
+		return nil, err
+	}
+	if err := ensureSubscriptionIsUpdated(ctx, cli, subKey, updatedEnv); err != nil {
+		return nil, err
+	}
+	if err := waitForDeploymentRolloutAfterSubscriptionUpdate(ctx, cli, initialDp, initialPods, []corev1.EnvVar{{Name: envName, Value: envValue}}); err != nil {
+		return nil, err
+	}
+
+	return func(ctx context.Context) error {
+		dp, pods, err := getPodsForDeployment(ctx, cli, dpKey)
+		if err != nil {
+			return fmt.Errorf("failed to get deployment details for restore: err=%v", err)
+		}
+
+		klog.InfoS("restoring subscription env", "env", originalEnv)
+		current := &unstructured.Unstructured{}
+		if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			current.SetGroupVersionKind(subscriptionGVK)
+			if err := cli.Get(ctx, subKey, current); err != nil {
+				return err
+			}
+			if err := setSubscriptionEnv(current, originalEnv); err != nil {
+				return err
+			}
+			return cli.Update(ctx, current)
+		}); err != nil {
+			return fmt.Errorf("failed to update subscription during restore: err=%v", err)
+		}
+		if err := ensureSubscriptionIsUpdated(ctx, cli, subKey, originalEnv); err != nil {
+			return err
+		}
+		return waitForDeploymentRolloutAfterSubscriptionUpdate(ctx, cli, dp, pods, originalEnvVars)
+	}, nil
+}
+
+func setOperatorEnvViaDeployment(ctx context.Context, cli client.Client, dp *appsv1.Deployment, envName, envValue string) (restoreFunc, error) {
+	dpKey := client.ObjectKeyFromObject(dp)
+	current := &appsv1.Deployment{}
+	if err := cli.Get(ctx, dpKey, current); err != nil {
+		return nil, err
+	}
+	initialDp := current.DeepCopy()
+	klog.InfoS("initial env", "env", toString(initialDp.Spec.Template.Spec.Containers[0].Env))
+	mngContainerIdx := -1
+	for idx := range dp.Spec.Template.Spec.Containers {
+		if dp.Spec.Template.Spec.Containers[idx].Name == consts.OperatorManagerContainer {
+			mngContainerIdx = idx
+			break
+		}
+	}
+	if mngContainerIdx == -1 {
+		return nil, errors.NewNotFound(schema.GroupResource{Group: appsv1.SchemeGroupVersion.Group, Resource: "containers"}, consts.OperatorManagerContainer)
+	}
+	mngContainer := initialDp.Spec.Template.Spec.Containers[mngContainerIdx].DeepCopy()
+	updated := false
+	for i := range mngContainer.Env {
+		if mngContainer.Env[i].Name == envName {
+			if mngContainer.Env[i].Value == envValue {
+				klog.InfoS("env is already set", "env", envName, "value", envValue)
+				return noOpRestoreFunc, nil
+			}
+			mngContainer.Env[i].Value = envValue
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		mngContainer.Env = append(mngContainer.Env, corev1.EnvVar{Name: envName, Value: envValue})
+	}
+	if err := updateDeploymentContainerAndWaitForRollout(ctx, cli, dpKey, mngContainerIdx, mngContainer); err != nil {
+		return nil, err
+	}
+
+	return func(ctx context.Context) error {
+		return updateDeploymentContainerAndWaitForRollout(ctx, cli, dpKey, mngContainerIdx, initialDp.Spec.Template.Spec.Containers[mngContainerIdx].DeepCopy())
+	}, nil
+}
+
+func getPodsForDeployment(ctx context.Context, cli client.Client, dpKey client.ObjectKey) (*appsv1.Deployment, []corev1.Pod, error) {
+	klog.InfoS("getting deployment pods", "key", dpKey.String())
+	dp := &appsv1.Deployment{}
+	if err := cli.Get(ctx, dpKey, dp); err != nil {
+		return nil, nil, err
+	}
+	pods, err := podlist.With(cli).ByDeployment(ctx, *dp)
+	if len(pods) == 0 || err != nil {
+		return nil, nil, fmt.Errorf("failed to get deployment pods: err=%v pods=%v", err, pods)
+	}
+	return dp, pods, nil
+}
+
+func waitForDeploymentRolloutAfterSubscriptionUpdate(ctx context.Context, cli client.Client, dp *appsv1.Deployment, initialPods []corev1.Pod, expectedEnvVarValues []corev1.EnvVar) error {
+	// Sometimes OLM fails to immediately update the deployment with the new env value,
+	// so we workaround this by explicitly deleting the deployment. Note that recreating
+	// the deployment can also take some time, being affected by the OLM rollout behavior,
+	// hence we give long enough time for its recreation.
+	klog.Info("deleting deployment")
+	if err := cli.Delete(ctx, dp); err != nil {
+		return err
+	}
+
+	err := k8swait.PollUntilContextTimeout(ctx, 10*time.Second, 15*time.Minute, true, func(aContext context.Context) (bool, error) {
+		if err := cli.Get(ctx, client.ObjectKeyFromObject(dp), dp); err != nil {
+			klog.Warningf("failed getting the deployment %s: %v", dp.Name, err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to wait for deployment to be recreated: err=%v", err)
+	}
+	return waitForDeploymentRollout(ctx, cli, dp, initialPods, expectedEnvVarValues)
+}
+
+func waitForDeploymentRollout(ctx context.Context, cli client.Client, dp *appsv1.Deployment, initialPods []corev1.Pod, expectedEnvVarValues []corev1.EnvVar) error {
+	if len(initialPods) == 0 {
+		klog.Info("no initial pods to wait for to be terminated")
+	} else {
+		klog.Info("waiting for initial pods to be terminated")
+		for _, pod := range initialPods {
+			if err := cli.Delete(ctx, &pod); err != nil {
+				if !errors.IsNotFound(err) {
+					return err
+				}
+				continue
+			}
+		}
+
+		err := wait.With(cli).Interval(30*time.Second).Timeout(5*time.Minute).ForPodsAllDeleted(ctx, podlist.ToPods(initialPods))
+		if err != nil {
+			return fmt.Errorf("failed to delete initial pods: err=%v", err)
+		}
+	}
+
+	klog.InfoS("polling deployment until it's updated with the new env value", "expected", toString(expectedEnvVarValues))
+	expectedEnvsSorted := make([]corev1.EnvVar, len(expectedEnvVarValues))
+	copy(expectedEnvsSorted, expectedEnvVarValues)
+	sort.Slice(expectedEnvsSorted, func(i, j int) bool {
+		return expectedEnvsSorted[i].Name < expectedEnvsSorted[j].Name
+	})
+	dpKey := client.ObjectKeyFromObject(dp)
+	updatedDp := &appsv1.Deployment{}
+	err := k8swait.PollUntilContextTimeout(ctx, 10*time.Second, 15*time.Minute, true, func(aContext context.Context) (bool, error) {
+		err := cli.Get(aContext, dpKey, updatedDp)
+		if err != nil {
+			klog.Warningf("failed getting the deployment %s: %v", dpKey.String(), err)
+			return false, err
+		}
+
+		for _, expectedEnv := range expectedEnvVarValues {
+			found := false
+			for _, env := range updatedDp.Spec.Template.Spec.Containers[0].Env {
+				if env.Name == expectedEnv.Name {
+					if env.Value == expectedEnv.Value {
+						found = true
+						break
+					}
+				}
+			}
+			if !found {
+				klog.InfoS("deployment not yet updated with the new env value",
+					"varname", expectedEnv.Name,
+					"varvalue", expectedEnv.Value,
+					"found", toString(updatedDp.Spec.Template.Spec.Containers[0].Env))
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("deployment was not updated with the new env value: err=%v", err)
+	}
+
+	klog.InfoS("deployment updated as expected", "env", toString(updatedDp.Spec.Template.Spec.Containers[0].Env))
+	klog.Info("waiting for updated deployment to be complete")
+	_, err = wait.With(cli).Interval(30*time.Second).Timeout(5*time.Minute).ForDeploymentComplete(ctx, dp)
+	return err
+}
+
+func updateDeploymentContainerAndWaitForRollout(ctx context.Context, cli client.Client, key types.NamespacedName, containerIdx int, newContainer *corev1.Container) error {
+	updatedSuccessfully := false
+	retries := 10
+	interval := 2 * time.Second
+	dp, initialPods, err := getPodsForDeployment(ctx, cli, key)
+	if err != nil {
+		return fmt.Errorf("failed to get deployment details: err=%v", err)
+	}
+
+	klog.Info("updated deployment container")
+	updated := &appsv1.Deployment{}
+	for i := 0; i < retries; i++ {
+		if err := cli.Get(ctx, key, updated); err != nil {
+			continue
+		}
+
+		updated.Spec.Template.Spec.Containers[containerIdx] = *newContainer
+		if err := cli.Update(ctx, updated); err == nil {
+			updatedSuccessfully = true
+			break
+		}
+		time.Sleep(interval)
+	}
+
+	if !updatedSuccessfully {
+		return fmt.Errorf("failed to update deployment %q", key.String())
+	}
+
+	return waitForDeploymentRollout(ctx, cli, dp, initialPods, newContainer.Env)
+}
+
+func getSubscriptionEnv(sub *unstructured.Unstructured) ([]any, error) {
+	env, found, err := unstructured.NestedSlice(sub.Object, "spec", "config", "env")
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return []any{}, nil
+	}
+
+	if len(env) == 0 {
+		return []any{}, nil
+	}
+	cloned := make([]any, len(env))
+	for i, item := range env {
+		if entry, ok := item.(map[string]any); ok {
+			entryCopy := make(map[string]any, len(entry))
+			for k, v := range entry {
+				entryCopy[k] = v
+			}
+			cloned[i] = entryCopy
+			continue
+		}
+		cloned[i] = item
+	}
+	return cloned, nil
+}
+
+func setSubscriptionEnv(sub *unstructured.Unstructured, env []any) error {
+	return unstructured.SetNestedSlice(sub.Object, env, "spec", "config", "env")
+}
+
+func buildSubscriptionWithNewEnvVal(env []any, name, value string) []any {
+	for i, item := range env {
+		entry, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		entryName, _ := entry["name"].(string)
+		if entryName != name {
+			continue
+		}
+		entry["value"] = value
+		env[i] = entry
+		return env
+	}
+	return append(env, map[string]any{
+		"name":  name,
+		"value": value,
+	})
+}
+
+func ensureSubscriptionIsUpdated(ctx context.Context, cli client.Client, subKey client.ObjectKey, expectedEnv []any) error {
+	klog.InfoS("ensuring subscription is updated with the correct env value")
+	current := &unstructured.Unstructured{}
+	current.SetGroupVersionKind(subscriptionGVK)
+	if err := cli.Get(ctx, subKey, current); err != nil {
+		return err
+	}
+	foundEnv, err := getSubscriptionEnv(current)
+	if err != nil {
+		return err
+	}
+	foundEnvVars := toEnvVars(foundEnv)
+	expectedEnvVars := toEnvVars(expectedEnv)
+	if !reflect.DeepEqual(foundEnvVars, expectedEnvVars) {
+		return fmt.Errorf("subscription env is not updated with the correct env value: found=%v expected=%v", foundEnvVars, expectedEnvVars)
+	}
+	return nil
+}
+
+func toString(envs []corev1.EnvVar) string {
+	sb := strings.Builder{}
+	for _, env := range envs {
+		sb.WriteString(fmt.Sprintf("%s=%s, ", env.Name, env.Value))
+	}
+	return sb.String()
+}
+
+func toEnvVars(envs []any) []corev1.EnvVar {
+	envVars := []corev1.EnvVar{}
+	for _, env := range envs {
+		entry, ok := env.(map[string]any)
+		if !ok {
+			continue
+		}
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  entry["name"].(string),
+			Value: entry["value"].(string),
+		})
+	}
+	return envVars
+}

--- a/test/internal/nrosched/nrosched.go
+++ b/test/internal/nrosched/nrosched.go
@@ -19,6 +19,7 @@ package nrosched
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -185,6 +186,13 @@ func CheckNROSchedulerAvailable(ctx context.Context, cli client.Client, schedObj
 	Expect(dpNName.Name).ToNot(BeEmpty(), "scheduler deployment missing: %q", dpNName.String())
 
 	return nroSchedObj
+}
+
+func IsSchedulerImageValidationEnabled() bool {
+	if v, ok := os.LookupEnv("E2E_VALIDATE_SCHEDULER_IMAGE"); ok && v == "true" {
+		return true
+	}
+	return false
 }
 
 func eventToString(ev corev1.Event) string {

--- a/tools/getdigests/getdigests.go
+++ b/tools/getdigests/getdigests.go
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"slices"
+	"strconv"
+	"strings"
+
+	schedulerapi "github.com/openshift-kni/numaresources-operator/internal/api/scheduler"
+)
+
+// This is tool to print json representation of the digests of the images in the current channel
+// and the latest one in the previous channel
+
+// cmdRunner executes a named command and returns its trimmed stdout or an error
+// that includes stderr when available.
+type cmdRunner func(name string, args ...string) (string, error)
+
+// listTagsOutput matches the JSON structure returned by `skopeo list-tags`.
+type listTagsOutput struct {
+	Tags []string `json:"Tags"`
+}
+
+func execRunner(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// getDigests fetches the digests of all tags matching versionString for the
+// current channel, plus the latest tag of the previous channel.
+// prevVersionOverride, when non-empty, is used as the previous version directly
+// instead of auto-calculating it (required when the current minor version is 0,
+// e.g. "5.0" where the previous channel is "4.22").
+func getDigests(run cmdRunner, imageURL string, pullSecretPath string, versionString string, prevVersionOverride string) (schedulerapi.Digests, error) {
+	raw, err := run("skopeo", skopeoListTagsArgs(imageURL, pullSecretPath)...)
+	if err != nil {
+		return schedulerapi.Digests{}, fmt.Errorf("listing tags for %s: %w", imageURL, err)
+	}
+
+	var tagsOut listTagsOutput
+	if err := json.Unmarshal([]byte(raw), &tagsOut); err != nil {
+		return schedulerapi.Digests{}, fmt.Errorf("parsing list-tags output: %w", err)
+	}
+
+	tags := filterTags(tagsOut.Tags, versionString)
+	if len(tags) == 0 {
+		return schedulerapi.Digests{}, fmt.Errorf("no tags found matching version %q", versionString)
+	}
+
+	digests := schedulerapi.Digests{}
+	for _, tag := range tags {
+		digest, err := run("skopeo", skopeoInspectArgs(imageURL, pullSecretPath, tag)...)
+		if err != nil {
+			return schedulerapi.Digests{}, fmt.Errorf("inspecting tag %s: %w", tag, err)
+		}
+
+		// only add the digest if it's not already in the set
+		if slices.Contains(digests.CurrentChannel, digest) {
+			continue
+		}
+
+		digests.AddCurrentChannel(digest)
+	}
+
+	prevVer := prevVersionOverride
+	if prevVer == "" {
+		prevVer, err = previousVersion(versionString)
+		if err != nil {
+			return schedulerapi.Digests{}, err
+		}
+	}
+	prevTag := "v" + prevVer
+	latestOfPrev, err := run("skopeo", skopeoInspectArgs(imageURL, pullSecretPath, prevTag)...)
+	if err != nil {
+		return schedulerapi.Digests{}, fmt.Errorf("failed to get latest of previous channel (%s): %v", prevTag, err)
+	}
+
+	digests.PreviousChannelLast = latestOfPrev
+
+	return digests, nil
+}
+
+// previousVersion returns the version string for the immediately preceding minor release.
+// e.g. "4.20" -> "4.19"
+func previousVersion(versionString string) (string, error) {
+	if versionString == "5.0" {
+		// special case for 5.0, which is the first release of the 5.x series
+		return "4.22", nil
+	}
+
+	parts := strings.SplitN(versionString, ".", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid version format %q: expected X.Y", versionString)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("invalid minor version in %q: %v", versionString, err)
+	}
+	if minor == 0 {
+		// we cannot make a guess for the previous minor version so we error out
+		return "", fmt.Errorf("no previous minor version for %q", versionString)
+	}
+	return fmt.Sprintf("%s.%d", parts[0], minor-1), nil
+}
+
+func skopeoListTagsArgs(imageURL string, pullSecretPath string) []string {
+	args := []string{"list-tags"}
+	if pullSecretPath != "" {
+		args = append(args, "--authfile", pullSecretPath)
+	}
+	args = append(args, "docker://"+imageURL)
+	return args
+}
+
+func skopeoInspectArgs(imageURL string, pullSecretPath string, tag string) []string {
+	args := []string{"inspect"}
+	if pullSecretPath != "" {
+		args = append(args, "--authfile", pullSecretPath)
+	}
+	args = append(args, "--format", "{{.Digest}}")
+	args = append(args, "docker://"+imageURL+":"+tag)
+	return args
+}
+
+func filterTags(tags []string, versionString string) []string {
+	// follow the pattern of X.Y.Z
+	prefix := "v" + versionString + "."
+	var filtered []string
+	for _, tag := range tags {
+		tag = strings.TrimSpace(tag)
+		if strings.HasPrefix(tag, prefix) && !strings.HasSuffix(tag, "-source") {
+			filtered = append(filtered, tag)
+		}
+	}
+	return filtered
+}
+
+func run() error {
+	imageURL := ""
+	pullSecretPath := ""
+	outputFile := ""
+	versionString := ""
+	prevVersionOverride := ""
+
+	flag.StringVar(&imageURL, "image", "", "image URL to query (e.g. registry.redhat.io/openshift4/noderesourcetopology-scheduler-rhel9)")
+	flag.StringVar(&pullSecretPath, "pull-secret", "", "path to the pull secret JSON file for registry authentication")
+	flag.StringVar(&outputFile, "output", "", "path to output file; if not provided, output is written to stdout")
+	flag.StringVar(&versionString, "version", "", "version string to filter tags (e.g. 4.20)")
+	flag.StringVar(&prevVersionOverride, "prev-version", "", "previous channel version to use instead of auto-calculating (required when --version has minor=0, e.g. --version 5.0 --prev-version 4.22)")
+	flag.Parse()
+
+	if imageURL == "" {
+		log.Fatal("--image is required")
+	}
+	if versionString == "" {
+		log.Fatal("--version is required")
+	}
+
+	out := os.Stdout
+	if outputFile != "" {
+		f, err := os.Create(outputFile)
+		if err != nil {
+			return fmt.Errorf("failed to open output file: %w", err)
+		}
+		defer func() {
+			if closeErr := f.Close(); closeErr != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to close output file: %v\n", closeErr)
+			}
+		}()
+		out = f
+	}
+
+	result, err := getDigests(execRunner, imageURL, pullSecretPath, versionString, prevVersionOverride)
+	if err != nil {
+		return fmt.Errorf("getting digests: %w", err)
+	}
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling result to JSON: %w", err)
+	}
+	if _, err := fmt.Fprintln(out, string(data)); err != nil {
+		return fmt.Errorf("writing output: %w", err)
+	}
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/tools/getdigests/getdigests_test.go
+++ b/tools/getdigests/getdigests_test.go
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestFilterTags(t *testing.T) {
+	tests := []struct {
+		name          string
+		tags          []string
+		versionString string
+		expected      []string
+	}{
+		{
+			name:          "filters by version prefix",
+			tags:          []string{"v4.20.0", "v4.20.1", "v4.19.5", "v4.21.0"},
+			versionString: "4.20",
+			expected:      []string{"v4.20.0", "v4.20.1"},
+		},
+		{
+			name:          "excludes source tags",
+			tags:          []string{"v4.20.0", "v4.20.0-source", "v4.20.1"},
+			versionString: "4.20",
+			expected:      []string{"v4.20.0", "v4.20.1"},
+		},
+		{
+			name:          "trims whitespace from tags",
+			tags:          []string{"  v4.20.0  ", "v4.20.1"},
+			versionString: "4.20",
+			expected:      []string{"v4.20.0", "v4.20.1"},
+		},
+		{
+			name:          "does not match partial prefix",
+			tags:          []string{"v4.200.0", "v4.20.0"},
+			versionString: "4.20",
+			expected:      []string{"v4.200.0", "v4.20.0"},
+		},
+		{
+			name:          "no matches returns nil",
+			tags:          []string{"v4.19.0", "v4.21.0"},
+			versionString: "4.20",
+			expected:      nil,
+		},
+		{
+			name:          "empty input returns nil",
+			tags:          []string{},
+			versionString: "4.20",
+			expected:      nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterTags(tc.tags, tc.versionString)
+			if len(got) != len(tc.expected) {
+				t.Fatalf("expected %v (len=%d), got %v (len=%d)", tc.expected, len(tc.expected), got, len(got))
+			}
+			for i := range got {
+				if got[i] != tc.expected[i] {
+					t.Errorf("index %d: expected %q, got %q", i, tc.expected[i], got[i])
+				}
+			}
+		})
+	}
+}
+
+func TestPreviousVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     string
+		expected    string
+		expectError bool
+	}{
+		{name: "normal minor decrement", version: "4.20", expected: "4.19"},
+		{name: "minor version 1", version: "4.1", expected: "4.0"},
+		{name: "different major", version: "5.3", expected: "5.2"},
+		{name: "5.0 maps to 4.22 (cross-major special case)", version: "5.0", expected: "4.22"},
+		{name: "minor version 0 errors", version: "4.0", expectError: true},
+		{name: "no dot in version", version: "420", expectError: true},
+		{name: "non-numeric minor", version: "4.x", expectError: true},
+		{name: "empty string", version: "", expectError: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := previousVersion(tc.version)
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("expected error, got nil (result: %q)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestSkopeoListTagsArgs(t *testing.T) {
+	t.Run("without pull secret", func(t *testing.T) {
+		got := skopeoListTagsArgs("registry.example.com/img", "")
+		want := []string{"list-tags", "docker://registry.example.com/img"}
+		assertStringSlice(t, want, got)
+	})
+
+	t.Run("with pull secret", func(t *testing.T) {
+		got := skopeoListTagsArgs("registry.example.com/img", "/path/to/secret.json")
+		want := []string{"list-tags", "--authfile", "/path/to/secret.json", "docker://registry.example.com/img"}
+		assertStringSlice(t, want, got)
+	})
+}
+
+func TestSkopeoInspectArgs(t *testing.T) {
+	t.Run("without pull secret", func(t *testing.T) {
+		got := skopeoInspectArgs("registry.example.com/img", "", "v4.20.0")
+		want := []string{"inspect", "--format", "{{.Digest}}", "docker://registry.example.com/img:v4.20.0"}
+		assertStringSlice(t, want, got)
+	})
+
+	t.Run("with pull secret", func(t *testing.T) {
+		got := skopeoInspectArgs("registry.example.com/img", "/path/to/secret.json", "v4.20.0")
+		want := []string{"inspect", "--authfile", "/path/to/secret.json", "--format", "{{.Digest}}", "docker://registry.example.com/img:v4.20.0"}
+		assertStringSlice(t, want, got)
+	})
+}
+
+func TestGetDigests(t *testing.T) {
+	fakeDigests := map[string]string{
+		"v4.20.0": "sha256:aaa",
+		"v4.20.1": "sha256:bbb",
+		"v4.19":   "sha256:ccc",
+	}
+
+	rawTags, _ := json.Marshal(listTagsOutput{
+		Tags: []string{"v4.20.0", "v4.20.0-source", "v4.20.1", "v4.19.5"},
+	})
+
+	fakeRunner := func(name string, args ...string) (string, error) {
+		if args[0] == "list-tags" {
+			return string(rawTags), nil
+		}
+		// inspect: last arg is docker://image:tag
+		lastArg := args[len(args)-1]
+		idx := strings.LastIndex(lastArg, ":")
+		tag := lastArg[idx+1:]
+		digest, ok := fakeDigests[tag]
+		if !ok {
+			return "", fmt.Errorf("unknown tag: %s", tag)
+		}
+		return digest, nil
+	}
+
+	result, err := getDigests(fakeRunner, "registry.example.com/img", "", "4.20", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.CurrentChannel) != 2 {
+		t.Errorf("expected 2 current channel entries, got %d: %v", len(result.CurrentChannel), result.CurrentChannel)
+	}
+	for _, wantDigest := range []string{"sha256:aaa", "sha256:bbb"} {
+		if !slices.Contains(result.CurrentChannel, wantDigest) {
+			t.Errorf("expected digest %q in current channel, got %v", wantDigest, result.CurrentChannel)
+		}
+	}
+	if result.PreviousChannelLast != "sha256:ccc" {
+		t.Errorf("expected prev channel digest %q, got %q", "sha256:ccc", result.PreviousChannelLast)
+	}
+}
+
+func TestGetDigests_NoDuplicateDigests(t *testing.T) {
+	// All three tags resolve to the same digest (mirrors the real registry output
+	// seen with v4.22, v4.22.0, v4.22.0-41 all pointing to the same image).
+	const sharedDigest = "sha256:55d3fe347f35c257b6f828ec0da1aeef057f723bbcec1576d4d0f9018fb74fe7"
+
+	rawTags, _ := json.Marshal(listTagsOutput{
+		Tags: []string{"v4.22", "v4.22.0", "v4.22.0-41"},
+	})
+
+	fakeRunner := func(_ string, args ...string) (string, error) {
+		if args[0] == "list-tags" {
+			return string(rawTags), nil
+		}
+		return sharedDigest, nil
+	}
+
+	result, err := getDigests(fakeRunner, "registry.example.com/img", "", "4.22", "4.21")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.CurrentChannel) != 1 {
+		t.Errorf("expected 1 unique digest entry, got %d: %v", len(result.CurrentChannel), result.CurrentChannel)
+	}
+	if !slices.Contains(result.CurrentChannel, sharedDigest) {
+		t.Errorf("expected digest %q in current channel, got %v", sharedDigest, result.CurrentChannel)
+	}
+}
+
+func TestGetDigests_ListTagsError(t *testing.T) {
+	fakeRunner := func(_ string, _ ...string) (string, error) {
+		return "", fmt.Errorf("registry unavailable")
+	}
+	_, err := getDigests(fakeRunner, "registry.example.com/img", "", "4.20", "")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestGetDigests_NoMatchingTags(t *testing.T) {
+	rawTags, _ := json.Marshal(listTagsOutput{Tags: []string{"v4.19.0", "v4.21.0"}})
+	fakeRunner := func(_ string, args ...string) (string, error) {
+		if args[0] == "list-tags" {
+			return string(rawTags), nil
+		}
+		return "", fmt.Errorf("should not be called")
+	}
+	_, err := getDigests(fakeRunner, "registry.example.com/img", "", "4.20", "")
+	if err == nil {
+		t.Fatal("expected error for no matching tags, got nil")
+	}
+}
+
+func TestGetDigests_InvalidVersion(t *testing.T) {
+	rawTags, _ := json.Marshal(listTagsOutput{Tags: []string{"v4.20.0"}})
+	fakeRunner := func(_ string, args ...string) (string, error) {
+		if args[0] == "list-tags" {
+			return string(rawTags), nil
+		}
+		return "sha256:abc", nil
+	}
+	_, err := getDigests(fakeRunner, "registry.example.com/img", "", "420", "")
+	if err == nil {
+		t.Fatal("expected error for invalid version format, got nil")
+	}
+}
+
+func TestGetDigests_PrevChannelFailureIsFatal(t *testing.T) {
+	rawTags, _ := json.Marshal(listTagsOutput{Tags: []string{"v4.20.0"}})
+	fakeRunner := func(_ string, args ...string) (string, error) {
+		if args[0] == "list-tags" {
+			return string(rawTags), nil
+		}
+		// inspect for current channel succeeds, prev channel fails
+		lastArg := args[len(args)-1]
+		if strings.HasSuffix(lastArg, ":v4.19") {
+			return "", fmt.Errorf("prev channel not found")
+		}
+		return "sha256:abc", nil
+	}
+	_, err := getDigests(fakeRunner, "registry.example.com/img", "", "4.20", "")
+	if err == nil {
+		t.Fatal("expected error when previous channel lookup fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to get latest of previous channel") {
+		t.Fatalf("expected previous channel error, got: %v", err)
+	}
+}
+
+func TestGetDigests_PrevVersionOverride(t *testing.T) {
+	fakeDigests := map[string]string{
+		"v5.0.0": "sha256:new",
+		"v4.22":  "sha256:last422",
+	}
+	rawTags, _ := json.Marshal(listTagsOutput{Tags: []string{"v5.0.0"}})
+
+	fakeRunner := func(_ string, args ...string) (string, error) {
+		if args[0] == "list-tags" {
+			return string(rawTags), nil
+		}
+		lastArg := args[len(args)-1]
+		idx := strings.LastIndex(lastArg, ":")
+		tag := lastArg[idx+1:]
+		digest, ok := fakeDigests[tag]
+		if !ok {
+			return "", fmt.Errorf("unknown tag: %s", tag)
+		}
+		return digest, nil
+	}
+
+	// 4.0 has no auto-resolved previous channel without override
+	_, err := getDigests(fakeRunner, "registry.example.com/img", "", "4.0", "")
+	if err == nil {
+		t.Fatal("expected error for 4.0 without override, got nil")
+	}
+
+	// 5.0 auto-resolves to 4.22; explicit override should succeed too
+	result, err := getDigests(fakeRunner, "registry.example.com/img", "", "5.0", "4.22")
+	if err != nil {
+		t.Fatalf("unexpected error with prev-version override: %v", err)
+	}
+	if !slices.Contains(result.CurrentChannel, "sha256:new") {
+		t.Errorf("expected current channel digest %q, got %v", "sha256:new", result.CurrentChannel)
+	}
+	if result.PreviousChannelLast != "sha256:last422" {
+		t.Errorf("expected prev channel digest %q, got %q", "sha256:last422", result.PreviousChannelLast)
+	}
+}
+
+func assertStringSlice(t *testing.T, want, got []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("length mismatch: want %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("arg[%d]: want %q, got %q", i, want[i], got[i])
+		}
+	}
+}


### PR DESCRIPTION
run validation on the user-specified scheduler image. The PR provides an option to the cluster-admin to extend the valid set of digests or completely drop the image validation. See commits for more details. 