### PR TITLE
ci: use Go 1.25 (latest patch) to fix govulncheck failures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 env:
-  GOLANG_VERSION: 1.25.11
+  GOLANG_VERSION: 1.25
 
 defaults:
   run:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,7 +35,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v5
       with:
-        go-version: 1.25.11
+        go-version: 1.25
 
     - name: Verify modules
       run: go mod verify

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -14,7 +14,7 @@ on:
       - main
 
 env:
-  GOLANG_VERSION: 1.25.11
+  GOLANG_VERSION: 1.25
 
 defaults:
   run:

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/openshift-kni/numaresources-operator
 
 go 1.25.0
 
-toolchain go1.25.11
-
 require (
 	github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492
 	github.com/coreos/ignition/v2 v2.18.0


### PR DESCRIPTION
## Summary
Set `GOLANG_VERSION` to 1.25 in CI workflows so the setup-go action
resolves to the latest 1.25.x patch, and drop the pinned toolchain
directive from go.mod. 

This fixes [GO-2026-5856 (crypto/tls)](https://pkg.go.dev/vuln/GO-2026-5856) and
[GO-2026-4970 (os)](https://pkg.go.dev/vuln/GO-2026-4970) without requiring a bump for every future patch.

AIA: Primarily AI, New content, Human-initiated, Reviewed, Claude Opus 4.6 v1.0
Signed-off-by: Talor Itzhak <titzhak@redhat.com>

## Test plan
- [x] CI govulncheck pass should now succeed
- [ ] Verify no regressions in unit/e2e tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)