### PR TITLE
Revert FBC bundle update to unblock ongoing release

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,3 +1,3 @@
 ---
 # When we are ready to ship the first Konflux release, replace this with the nudge to the quay build
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-20@sha256:d00b0439ce4e8e0f85392abfbc8e1428943c75dbdbbc1e375f38d4777b9e94d7
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-20@sha256:9974e0da95dd25771256516541093b3fb7f3827e6cee7e12f5a00a642ef2d226


### PR DESCRIPTION
The bundle digest was updated while there is an ongoing release with the old bundle.