### PR TITLE
CNF-25747: Upstream release-config version bump (4.21.3)

### DIFF
--- a/.konflux/bundle/overlay/release.in.yaml
+++ b/.konflux/bundle/overlay/release.in.yaml
@@ -6,8 +6,8 @@ variables:
 
       You can find additional guidance in the upstream repository: https://github.com/openshift-kni/numaresources-operator
   display_name: "NUMA Resources Operator"
-  manager_version: "numaresources-operator.v4.21.3"
+  manager_version: "numaresources-operator.v4.21.4"
   # min_kube_version should match ocp
   # https://access.redhat.com/solutions/4870701
   min_kube_version: "1.32.0"
-  version: "4.21.3"
+  version: "4.21.4"


### PR DESCRIPTION
now that 4.21.3 is released, bump to 4.21.4.