### PR TITLE
CNF-25795: Upstream release-config version bump (4.20.3)

### DIFF
--- a/.konflux/bundle/overlay/release.in.yaml
+++ b/.konflux/bundle/overlay/release.in.yaml
@@ -6,8 +6,8 @@ variables:
 
       You can find additional guidance in the upstream repository: https://github.com/openshift-kni/numaresources-operator
   display_name: "NUMA Resources Operator"
-  manager_version: "numaresources-operator.v4.20.3"
+  manager_version: "numaresources-operator.v4.20.4"
   # min_kube_version should match ocp
   # https://access.redhat.com/solutions/4870701
   min_kube_version: "1.23.0"
-  version: "4.20.3"
+  version: "4.20.4"

--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,3 +1,3 @@
 ---
 # When we are ready to ship the first Konflux release, replace this with the nudge to the quay build
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-20@sha256:9974e0da95dd25771256516541093b3fb7f3827e6cee7e12f5a00a642ef2d226
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-20@sha256:d00b0439ce4e8e0f85392abfbc8e1428943c75dbdbbc1e375f38d4777b9e94d7


### PR DESCRIPTION
now that 4.20.3 is released, bump to 4.20.4.