### PR TITLE
e2e: add test to check the image validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ binary-e2e-uninstall: generate-source ## Build uninstall e2e test binary.
 
 .PHONY: binary-e2e-sched
 binary-e2e-sched: generate-source ## Build scheduler e2e test binary.
-	go test -c -v -o bin/e2e-nrop-sched.test ./test/e2e/sched
+	go test -c -v -o bin/e2e-nrop-sched.test ./test/e2e/sched && go test -c -v -o bin/e2e-nrop-sched-image-validation.test ./test/e2e/sched/image_validation
 
 .PHONY: binary-e2e-serial
 binary-e2e-serial: generate-source ## Build serial e2e test binary.

--- a/hack/run-test-e2e.sh
+++ b/hack/run-test-e2e.sh
@@ -54,6 +54,7 @@ if [ "$ENABLE_SCHED_TESTS" = true ]; then
   # --flake-attempts: rerun the test if it fails
   # -requireSuite: fail if tests are not executed because of missing suite
   ${BIN_DIR}/e2e-nrop-sched.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.flake-attempts=2 --ginkgo.junit-report=${REPORT_DIR}/e2e-sched.xml
+  ${BIN_DIR}/e2e-nrop-sched-image-validation.test ${NO_COLOR} --ginkgo.v --ginkgo.timeout=5h --ginkgo.flake-attempts=2 --ginkgo.junit-report=${REPORT_DIR}/e2e-sched-image-validation.xml
 
   if [ "$ENABLE_CLEANUP" = true ]; then
     echo "Running NROScheduler uninstall test suite";

--- a/test/e2e/sched/image_validation/test_suite_validation_test.go
+++ b/test/e2e/sched/image_validation/test_suite_validation_test.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sched
+
+import (
+	"context"
+	"testing"
+
+	e2eclient "github.com/openshift-kni/numaresources-operator/test/internal/clients"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// TestSchedulerImageValidation tests the image validation logic for the scheduler with default validation behavior, which is
+// enabled at the time of writing this test. We could have added this test under sched/sched_test.go, but because that suite
+// is disabling the validation at suite level, we would need to enable that again via updating the subcription multiple
+// consecutive times, which proved in prow and local CI runs to be flaky in terms of the time it takes for the updates of
+// the subscription environment variables to be reflected on the operator deployment, after consecutive updates of the same
+// variable.
+
+func TestScheduler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Scheduler")
+}
+
+var _ = BeforeSuite(func(ctx context.Context) {
+	Expect(e2eclient.ClientsEnabled).To(BeTrue(), "failed to create runtime-controller client")
+})

--- a/test/e2e/sched/image_validation/validation_test.go
+++ b/test/e2e/sched/image_validation/validation_test.go
@@ -1,0 +1,131 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sched
+
+import (
+	"context"
+	"time"
+
+	metahelper "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	klog "k8s.io/klog/v2"
+
+	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
+	intsched "github.com/openshift-kni/numaresources-operator/internal/api/scheduler"
+	"github.com/openshift-kni/numaresources-operator/pkg/status"
+	e2eclient "github.com/openshift-kni/numaresources-operator/test/internal/clients"
+	e2eenvvar "github.com/openshift-kni/numaresources-operator/test/internal/envvar"
+	e2efixture "github.com/openshift-kni/numaresources-operator/test/internal/fixture"
+	"github.com/openshift-kni/numaresources-operator/test/internal/objects"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("[Scheduler] scheduler object updates", func() {
+	It("should degrade status when scheduler image is invalid and validation is enabled - default operator installation", func(ctx context.Context) {
+		initialSched := &nropv1.NUMAResourcesScheduler{}
+		nroSchedKey := objects.NROSchedObjectKey()
+		Expect(e2eclient.Client.Get(ctx, nroSchedKey, initialSched)).ToNot(HaveOccurred(), "cannot get %q in the cluster", nroSchedKey.String())
+
+		testSchedObj := &nropv1.NUMAResourcesScheduler{}
+		// existing image but not valid because it's not pinned to a specific digest
+		invalidImage := "quay.io/openshift-kni/scheduler-plugins:4.12-snapshot"
+		e2efixture.By("switching the NROS image to %s which does not pass the image validation criteria - not pinned by digest", invalidImage)
+		Eventually(func(g Gomega) {
+			g.Expect(e2eclient.Client.Get(ctx, nroSchedKey, testSchedObj)).To(Succeed())
+			testSchedObj.Spec.SchedulerImage = invalidImage
+			g.Expect(e2eclient.Client.Update(ctx, testSchedObj)).To(Succeed())
+		}).WithTimeout(time.Minute).WithPolling(time.Second * 10).Should(Succeed())
+
+		DeferCleanup(func(cleanupCtx context.Context) {
+			e2efixture.By("restore the scheduler image")
+			schedObj := &nropv1.NUMAResourcesScheduler{}
+			Eventually(func(g Gomega) {
+				g.Expect(e2eclient.Client.Get(cleanupCtx, nroSchedKey, schedObj)).To(Succeed())
+				schedObj.Spec.SchedulerImage = initialSched.Spec.SchedulerImage
+				g.Expect(e2eclient.Client.Update(cleanupCtx, schedObj)).To(Succeed())
+			}).WithTimeout(time.Minute).WithPolling(time.Second * 10).Should(Succeed())
+
+			Expect(e2eclient.Client.Get(cleanupCtx, nroSchedKey, schedObj)).To(Succeed())
+			klog.InfoS("scheduler spec", "spec", schedObj.Spec)
+			Expect(schedObj.Spec.SchedulerImage).To(Equal(initialSched.Spec.SchedulerImage))
+		})
+
+		Expect(e2eclient.Client.Get(ctx, nroSchedKey, testSchedObj)).To(Succeed())
+		klog.InfoS("scheduler spec", "spec", testSchedObj.Spec)
+		Expect(testSchedObj.Spec.SchedulerImage).To(Equal(invalidImage))
+
+		Eventually(func(g Gomega) {
+			g.Expect(e2eclient.Client.Get(ctx, nroSchedKey, testSchedObj)).To(Succeed())
+			klog.InfoS("scheduler conditions", "conditions", testSchedObj.Status.Conditions)
+
+			degradedCondition := metahelper.FindStatusCondition(testSchedObj.Status.Conditions, status.ConditionDegraded)
+			g.Expect(degradedCondition).ToNot(BeNil(), "degraded condition not found")
+			g.Expect(degradedCondition.Status).To(Equal(metav1.ConditionTrue), "degraded condition status is not true")
+			g.Expect(degradedCondition.Reason).To(Equal(string(status.ReasonInvalidSchedulerImage)), "degraded condition reason is not untrusted scheduler image")
+		}).WithTimeout(5 * time.Minute).WithPolling(time.Second * 10).Should(Succeed())
+
+		// this is an actual valid sha for 4.12-snapshot image. No need to pull it dynamically as we know it's valid,
+		// and for this test we just want to test the validation logic and the scheduler conditions.
+		digest := "sha256:c1b0456fa8b7b96325a9cd2509c19c1e407e9d2cd7523ca62dd5db30cadb73b9"
+		invalidImage = "quay.io/openshift-kni/scheduler-plugins@" + digest
+		e2efixture.By("switching the NROS image to %s which does not pass the image validation criteria - digest not trusted", invalidImage)
+		Eventually(func(g Gomega) {
+			g.Expect(e2eclient.Client.Get(ctx, nroSchedKey, testSchedObj)).To(Succeed())
+			testSchedObj.Spec.SchedulerImage = invalidImage
+			g.Expect(e2eclient.Client.Update(ctx, testSchedObj)).To(Succeed())
+		}).WithTimeout(time.Minute).WithPolling(time.Second * 10).Should(Succeed())
+
+		Expect(e2eclient.Client.Get(ctx, nroSchedKey, testSchedObj)).To(Succeed())
+		klog.InfoS("scheduler spec", "spec", testSchedObj.Spec)
+		Expect(testSchedObj.Spec.SchedulerImage).To(Equal(invalidImage))
+
+		Eventually(func(g Gomega) {
+			g.Expect(e2eclient.Client.Get(ctx, nroSchedKey, testSchedObj)).To(Succeed())
+			klog.InfoS("scheduler conditions", "conditions", testSchedObj.Status.Conditions)
+
+			degradedCondition := metahelper.FindStatusCondition(testSchedObj.Status.Conditions, status.ConditionDegraded)
+			g.Expect(degradedCondition).ToNot(BeNil(), "degraded condition not found")
+			g.Expect(degradedCondition.ObservedGeneration).To(Equal(testSchedObj.Generation), "degraded condition generation mismatch")
+			g.Expect(degradedCondition.Status).To(Equal(metav1.ConditionTrue), "degraded condition status is not true")
+			g.Expect(degradedCondition.Reason).To(Equal(string(status.ReasonInvalidSchedulerImage)), "degraded condition reason is not untrusted scheduler image")
+		}).WithTimeout(5 * time.Minute).WithPolling(time.Second * 10).Should(Succeed())
+
+		By("identify the source of operator installation and disable scheduler image validation")
+		var err error
+		restoreFunc, err := e2eenvvar.SetOperatorEnvVar(ctx, e2eclient.Client, intsched.CustomSchedulerDigestsEnvVar, digest)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func(cleanupCtx context.Context) {
+			By("restoring scheduler image validation settings")
+			Expect(restoreFunc(cleanupCtx)).To(Succeed())
+		})
+
+		Eventually(func(g Gomega) {
+			g.Expect(e2eclient.Client.Get(ctx, nroSchedKey, testSchedObj)).To(Succeed())
+			klog.InfoS("scheduler conditions", "conditions", testSchedObj.Status.Conditions)
+
+			degradedCondition := metahelper.FindStatusCondition(testSchedObj.Status.Conditions, status.ConditionDegraded)
+			g.Expect(degradedCondition).ToNot(BeNil(), "degraded condition not found")
+			g.Expect(degradedCondition.Status).To(Equal(metav1.ConditionFalse), "degraded condition status is true")
+
+			availableCondition := metahelper.FindStatusCondition(testSchedObj.Status.Conditions, status.ConditionAvailable)
+			g.Expect(availableCondition).ToNot(BeNil(), "available condition not found")
+			g.Expect(availableCondition.Status).To(Equal(metav1.ConditionTrue), "available condition status is not true")
+		}).WithTimeout(5 * time.Minute).WithPolling(time.Second * 10).Should(Succeed())
+	})
+})

--- a/test/internal/envvar/envvar.go
+++ b/test/internal/envvar/envvar.go
@@ -278,7 +278,7 @@ func waitForDeploymentRolloutAfterSubscriptionUpdate(ctx context.Context, cli cl
 	}
 
 	err := k8swait.PollUntilContextTimeout(ctx, 10*time.Second, 15*time.Minute, true, func(aContext context.Context) (bool, error) {
-		if err := cli.Get(ctx, client.ObjectKeyFromObject(dp), dp); err != nil {
+		if err := cli.Get(aContext, client.ObjectKeyFromObject(dp), dp); err != nil {
 			klog.Warningf("failed getting the deployment %s: %v", dp.Name, err)
 			return false, nil
 		}


### PR DESCRIPTION
Add an e2e test to verify the image validation causing the scheduler CR
to be degraded after not complying to the validation criteria.