### PR TITLE
[release-4.22] gh: use latest govulncheck

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -35,8 +35,8 @@ jobs:
       - name: Show current working directory
         run: pwd
 
-      # Use manual govulncheck install instead of golang/govulncheck-action
-      # because the action always pulls govulncheck@latest which can break
-      # with newer Go versions. See https://github.com/golang/go/issues/80059
       - name: Run govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3 && govulncheck ./...
+        uses: golang/govulncheck-action@v1
+        with:
+          go-package: "./..."
+          go-version: ${{ env.GOLANG_VERSION }}


### PR DESCRIPTION
Now that https://github.com/golang/go/issues/80059 is fixed, we shall align back to use latest version.
