### PR TITLE
tools: getdigests: support EUS digest specification

### DIFF
--- a/internal/api/scheduler/digests.go
+++ b/internal/api/scheduler/digests.go
@@ -71,6 +71,9 @@ func loadDigests() sets.Set[string] {
 
 	digests := sets.New(d.CurrentChannel...)
 	digests.Insert(d.PreviousChannelLast)
+	if d.EUSChannelLast != "" {
+		digests.Insert(d.EUSChannelLast)
+	}
 
 	userDigests := getUserImageDigests()
 	digests.Insert(userDigests...)
@@ -78,6 +81,7 @@ func loadDigests() sets.Set[string] {
 	klog.V(4).InfoS("trusted set of scheduler images",
 		"fromCurrentChannel", d.CurrentChannel,
 		"latestFromPreviousChannel", d.PreviousChannelLast,
+		"latestFromEUSChannel", d.EUSChannelLast,
 		"customDigests", userDigests)
 
 	return digests

--- a/internal/api/scheduler/digests_test.go
+++ b/internal/api/scheduler/digests_test.go
@@ -30,6 +30,9 @@ func loadEmbeddedDigests() sets.Set[string] {
 	}
 	digests := sets.New(d.CurrentChannel...)
 	digests.Insert(d.PreviousChannelLast)
+	if d.EUSChannelLast != "" {
+		digests.Insert(d.EUSChannelLast)
+	}
 	return digests
 }
 

--- a/internal/api/scheduler/types.go
+++ b/internal/api/scheduler/types.go
@@ -26,6 +26,7 @@ type ImageValidation struct {
 type Digests struct {
 	CurrentChannel      []string `json:"current_channel"`
 	PreviousChannelLast string   `json:"prev_channel_last"`
+	EUSChannelLast      string   `json:"eus_channel_last"`
 }
 
 func (ti *Digests) AddCurrentChannel(digest string) {

--- a/tools/getdigests/getdigests.go
+++ b/tools/getdigests/getdigests.go
@@ -30,8 +30,10 @@ import (
 	schedulerapi "github.com/openshift-kni/numaresources-operator/internal/api/scheduler"
 )
 
-// This is tool to print json representation of the digests of the images in the current channel
-// and the latest one in the previous channel
+// This tool prints a JSON representation of:
+// - unique digests for all vX.Y.* tags in the current image repository
+// - the digest of the previous-channel image URL
+// - optionally, the digest of the EUS-channel image URL
 
 // cmdRunner executes a named command and returns its trimmed stdout or an error
 // that includes stderr when available.
@@ -40,6 +42,13 @@ type cmdRunner func(name string, args ...string) (string, error)
 // listTagsOutput matches the JSON structure returned by `skopeo list-tags`.
 type listTagsOutput struct {
 	Tags []string `json:"Tags"`
+}
+
+// imageRef is a repository reference plus a tag of the form vX.Y.
+type imageRef struct {
+	Repository string // e.g. registry.redhat.io/openshift4/noderesourcetopology-scheduler-rhel9
+	Tag        string // e.g. v4.20
+	Version    string // e.g. 4.20 (Tag without leading "v")
 }
 
 func execRunner(name string, args ...string) (string, error) {
@@ -54,15 +63,63 @@ func execRunner(name string, args ...string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// getDigests fetches the digests of all tags matching versionString for the
-// current channel, plus the latest tag of the previous channel.
-// prevVersionOverride, when non-empty, is used as the previous version directly
-// instead of auto-calculating it (required when the current minor version is 0,
-// e.g. "5.0" where the previous channel is "4.22").
-func getDigests(run cmdRunner, imageURL string, pullSecretPath string, versionString string, prevVersionOverride string) (schedulerapi.Digests, error) {
-	raw, err := run("skopeo", skopeoListTagsArgs(imageURL, pullSecretPath)...)
+// parseImageURL splits a full image URL with a vX.Y tag into repository and version.
+// Expected form: registry.example.com/path/image:v4.20
+// NOTE: no validation is done on the image URL format, so the user must ensure it is valid.
+func parseImageURL(fullURL string) (imageRef, error) {
+	fullURL = strings.TrimSpace(fullURL)
+	if fullURL == "" {
+		return imageRef{}, fmt.Errorf("image URL is empty")
+	}
+
+	idx := strings.LastIndex(fullURL, ":")
+	if idx < 0 {
+		return imageRef{}, fmt.Errorf("image URL %q missing tag; expected form registry/image:vX.Y", fullURL)
+	}
+	// Avoid treating host:port as a tag separator when no tag is present.
+	// A valid tag always starts with 'v' after the last colon for our use case.
+	repo := fullURL[:idx]
+	tag := fullURL[idx+1:]
+	if repo == "" || tag == "" {
+		return imageRef{}, fmt.Errorf("image URL %q missing repository or tag; expected form registry/image:vX.Y", fullURL)
+	}
+	if !strings.HasPrefix(tag, "v") {
+		return imageRef{}, fmt.Errorf("image URL tag %q must be of form vX.Y", tag)
+	}
+	version := strings.TrimPrefix(tag, "v")
+	parts := strings.SplitN(version, ".", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return imageRef{}, fmt.Errorf("image URL tag %q must be of form vX.Y", tag)
+	}
+	// Reject patch-level tags like v4.20.1 — the tool expects channel tags vX.Y (minor)
+	if strings.Contains(parts[1], ".") {
+		return imageRef{}, fmt.Errorf("image URL tag %q must be of form vX.Y (no patch component)", tag)
+	}
+	if _, err := strconv.Atoi(parts[0]); err != nil {
+		return imageRef{}, fmt.Errorf("image URL tag %q must be of form vX.Y where X and Y are integers", tag)
+	}
+	if _, err := strconv.Atoi(parts[1]); err != nil {
+		return imageRef{}, fmt.Errorf("image URL tag %q must be of form vX.Y where X and Y are integers", tag)
+	}
+
+	return imageRef{Repository: repo, Tag: tag, Version: version}, nil
+}
+
+// getDigests fetches unique digests for all vX.Y.* tags from currentURL's repository,
+// the digest of prevURL, and optionally the digest of eusURL.
+func getDigests(run cmdRunner, pullSecretPath string, currentURL string, prevURL string, eusURL string) (schedulerapi.Digests, error) {
+	current, err := parseImageURL(currentURL)
 	if err != nil {
-		return schedulerapi.Digests{}, fmt.Errorf("listing tags for %s: %w", imageURL, err)
+		return schedulerapi.Digests{}, fmt.Errorf("parsing --current-url: %w", err)
+	}
+	prev, err := parseImageURL(prevURL)
+	if err != nil {
+		return schedulerapi.Digests{}, fmt.Errorf("parsing --prev-url: %w", err)
+	}
+
+	raw, err := run("skopeo", skopeoListTagsArgs(current.Repository, pullSecretPath)...)
+	if err != nil {
+		return schedulerapi.Digests{}, fmt.Errorf("listing tags for %s: %w", currentURL, err)
 	}
 
 	var tagsOut listTagsOutput
@@ -70,14 +127,14 @@ func getDigests(run cmdRunner, imageURL string, pullSecretPath string, versionSt
 		return schedulerapi.Digests{}, fmt.Errorf("parsing list-tags output: %w", err)
 	}
 
-	tags := filterTags(tagsOut.Tags, versionString)
+	tags := filterTags(tagsOut.Tags, current.Version)
 	if len(tags) == 0 {
-		return schedulerapi.Digests{}, fmt.Errorf("no tags found matching version %q", versionString)
+		return schedulerapi.Digests{}, fmt.Errorf("no tags found matching version %q in %s", current.Version, current.Repository)
 	}
 
 	digests := schedulerapi.Digests{}
 	for _, tag := range tags {
-		digest, err := run("skopeo", skopeoInspectArgs(imageURL, pullSecretPath, tag)...)
+		digest, err := run("skopeo", skopeoInspectArgs(current.Repository, pullSecretPath, tag)...)
 		if err != nil {
 			return schedulerapi.Digests{}, fmt.Errorf("inspecting tag %s: %w", tag, err)
 		}
@@ -90,45 +147,25 @@ func getDigests(run cmdRunner, imageURL string, pullSecretPath string, versionSt
 		digests.AddCurrentChannel(digest)
 	}
 
-	prevVer := prevVersionOverride
-	if prevVer == "" {
-		prevVer, err = previousVersion(versionString)
-		if err != nil {
-			return schedulerapi.Digests{}, err
-		}
-	}
-	prevTag := "v" + prevVer
-	latestOfPrev, err := run("skopeo", skopeoInspectArgs(imageURL, pullSecretPath, prevTag)...)
+	latestOfPrev, err := run("skopeo", skopeoInspectArgs(prev.Repository, pullSecretPath, prev.Tag)...)
 	if err != nil {
-		return schedulerapi.Digests{}, fmt.Errorf("failed to get latest of previous channel (%s): %v", prevTag, err)
+		return schedulerapi.Digests{}, fmt.Errorf("failed to get digest of previous channel (%s:%s): %v", prev.Repository, prev.Tag, err)
 	}
-
 	digests.PreviousChannelLast = latestOfPrev
 
+	if eusURL != "" {
+		eus, err := parseImageURL(eusURL)
+		if err != nil {
+			return schedulerapi.Digests{}, fmt.Errorf("parsing --eus-url: %w", err)
+		}
+		latestOfEUS, err := run("skopeo", skopeoInspectArgs(eus.Repository, pullSecretPath, eus.Tag)...)
+		if err != nil {
+			return schedulerapi.Digests{}, fmt.Errorf("failed to get digest of EUS channel (%s:%s): %v", eus.Repository, eus.Tag, err)
+		}
+		digests.EUSChannelLast = latestOfEUS
+	}
+
 	return digests, nil
-}
-
-// previousVersion returns the version string for the immediately preceding minor release.
-// e.g. "4.20" -> "4.19"
-func previousVersion(versionString string) (string, error) {
-	if versionString == "5.0" {
-		// special case for 5.0, which is the first release of the 5.x series
-		return "4.22", nil
-	}
-
-	parts := strings.SplitN(versionString, ".", 2)
-	if len(parts) != 2 {
-		return "", fmt.Errorf("invalid version format %q: expected X.Y", versionString)
-	}
-	minor, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return "", fmt.Errorf("invalid minor version in %q: %v", versionString, err)
-	}
-	if minor == 0 {
-		// we cannot make a guess for the previous minor version so we error out
-		return "", fmt.Errorf("no previous minor version for %q", versionString)
-	}
-	return fmt.Sprintf("%s.%d", parts[0], minor-1), nil
 }
 
 func skopeoListTagsArgs(imageURL string, pullSecretPath string) []string {
@@ -164,24 +201,24 @@ func filterTags(tags []string, versionString string) []string {
 }
 
 func run() error {
-	imageURL := ""
+	currentURL := ""
+	prevURL := ""
+	eusURL := ""
 	pullSecretPath := ""
 	outputFile := ""
-	versionString := ""
-	prevVersionOverride := ""
 
-	flag.StringVar(&imageURL, "image", "", "image URL to query (e.g. registry.redhat.io/openshift4/noderesourcetopology-scheduler-rhel9)")
+	flag.StringVar(&currentURL, "current-url", "", "full image URL for the current channel with a vX.Y tag (e.g. registry.redhat.io/openshift4/noderesourcetopology-scheduler-rhel9:v4.20)")
+	flag.StringVar(&prevURL, "prev-url", "", "full image URL for the previous channel with a vX.Y tag (e.g. registry.redhat.io/openshift4/noderesourcetopology-scheduler-rhel9:v4.19)")
+	flag.StringVar(&eusURL, "eus-url", "", "optional full image URL for the EUS channel with a vX.Y tag (e.g. registry.redhat.io/openshift4/noderesourcetopology-scheduler-rhel9:v4.18)")
 	flag.StringVar(&pullSecretPath, "pull-secret", "", "path to the pull secret JSON file for registry authentication")
 	flag.StringVar(&outputFile, "output", "", "path to output file; if not provided, output is written to stdout")
-	flag.StringVar(&versionString, "version", "", "version string to filter tags (e.g. 4.20)")
-	flag.StringVar(&prevVersionOverride, "prev-version", "", "previous channel version to use instead of auto-calculating (required when --version has minor=0, e.g. --version 5.0 --prev-version 4.22)")
 	flag.Parse()
 
-	if imageURL == "" {
-		log.Fatal("--image is required")
+	if currentURL == "" {
+		log.Fatal("--current-url is required")
 	}
-	if versionString == "" {
-		log.Fatal("--version is required")
+	if prevURL == "" {
+		log.Fatal("--prev-url is required")
 	}
 
 	out := os.Stdout
@@ -198,7 +235,7 @@ func run() error {
 		out = f
 	}
 
-	result, err := getDigests(execRunner, imageURL, pullSecretPath, versionString, prevVersionOverride)
+	result, err := getDigests(execRunner, pullSecretPath, currentURL, prevURL, eusURL)
 	if err != nil {
 		return fmt.Errorf("getting digests: %w", err)
 	}

--- a/tools/getdigests/getdigests_test.go
+++ b/tools/getdigests/getdigests_test.go
@@ -24,6 +24,86 @@ import (
 	"testing"
 )
 
+func TestParseImageURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantRepo    string
+		wantTag     string
+		wantVersion string
+		expectError bool
+	}{
+		{
+			name:        "valid channel tag",
+			input:       "registry.example.com/img:v4.20",
+			wantRepo:    "registry.example.com/img",
+			wantTag:     "v4.20",
+			wantVersion: "4.20",
+		},
+		{
+			name:        "nested path",
+			input:       "registry.redhat.io/openshift4/noderesourcetopology-scheduler-rhel9:v4.16",
+			wantRepo:    "registry.redhat.io/openshift4/noderesourcetopology-scheduler-rhel9",
+			wantTag:     "v4.16",
+			wantVersion: "4.16",
+		},
+		{
+			name:        "missing tag",
+			input:       "registry.example.com/img",
+			expectError: true,
+		},
+		{
+			name:        "empty",
+			input:       "",
+			expectError: true,
+		},
+		{
+			name:        "tag without v prefix",
+			input:       "registry.example.com/img:4.20",
+			expectError: true,
+		},
+		{
+			name:        "patch-level tag rejected",
+			input:       "registry.example.com/img:v4.20.1",
+			expectError: true,
+		},
+		{
+			name:        "nonnumeric minor rejected",
+			input:       "registry.example.com/img:v4.foo",
+			expectError: true,
+		},
+		{
+			name:        "prerelease-style minor rejected",
+			input:       "registry.example.com/img:v4.20-rc",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseImageURL(tc.input)
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("expected error, got nil (result: %+v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Repository != tc.wantRepo {
+				t.Errorf("Repository: got %q want %q", got.Repository, tc.wantRepo)
+			}
+			if got.Tag != tc.wantTag {
+				t.Errorf("Tag: got %q want %q", got.Tag, tc.wantTag)
+			}
+			if got.Version != tc.wantVersion {
+				t.Errorf("Version: got %q want %q", got.Version, tc.wantVersion)
+			}
+		})
+	}
+}
+
 func TestFilterTags(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -53,7 +133,7 @@ func TestFilterTags(t *testing.T) {
 			name:          "does not match partial prefix",
 			tags:          []string{"v4.200.0", "v4.20.0"},
 			versionString: "4.20",
-			expected:      []string{"v4.200.0", "v4.20.0"},
+			expected:      []string{"v4.20.0"},
 		},
 		{
 			name:          "no matches returns nil",
@@ -79,42 +159,6 @@ func TestFilterTags(t *testing.T) {
 				if got[i] != tc.expected[i] {
 					t.Errorf("index %d: expected %q, got %q", i, tc.expected[i], got[i])
 				}
-			}
-		})
-	}
-}
-
-func TestPreviousVersion(t *testing.T) {
-	tests := []struct {
-		name        string
-		version     string
-		expected    string
-		expectError bool
-	}{
-		{name: "normal minor decrement", version: "4.20", expected: "4.19"},
-		{name: "minor version 1", version: "4.1", expected: "4.0"},
-		{name: "different major", version: "5.3", expected: "5.2"},
-		{name: "5.0 maps to 4.22 (cross-major special case)", version: "5.0", expected: "4.22"},
-		{name: "minor version 0 errors", version: "4.0", expectError: true},
-		{name: "no dot in version", version: "420", expectError: true},
-		{name: "non-numeric minor", version: "4.x", expectError: true},
-		{name: "empty string", version: "", expectError: true},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got, err := previousVersion(tc.version)
-			if tc.expectError {
-				if err == nil {
-					t.Errorf("expected error, got nil (result: %q)", got)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if got != tc.expected {
-				t.Errorf("expected %q, got %q", tc.expected, got)
 			}
 		})
 	}
@@ -150,31 +194,32 @@ func TestSkopeoInspectArgs(t *testing.T) {
 
 func TestGetDigests(t *testing.T) {
 	fakeDigests := map[string]string{
-		"v4.20.0": "sha256:aaa",
-		"v4.20.1": "sha256:bbb",
-		"v4.19":   "sha256:ccc",
+		"registry.example.com/current:v4.20.0": "sha256:aaa",
+		"registry.example.com/current:v4.20.1": "sha256:bbb",
+		"registry.example.com/prev:v4.19":      "sha256:ccc",
 	}
 
 	rawTags, _ := json.Marshal(listTagsOutput{
 		Tags: []string{"v4.20.0", "v4.20.0-source", "v4.20.1", "v4.19.5"},
 	})
 
-	fakeRunner := func(name string, args ...string) (string, error) {
+	fakeRunner := func(_ string, args ...string) (string, error) {
 		if args[0] == "list-tags" {
 			return string(rawTags), nil
 		}
-		// inspect: last arg is docker://image:tag
 		lastArg := args[len(args)-1]
-		idx := strings.LastIndex(lastArg, ":")
-		tag := lastArg[idx+1:]
-		digest, ok := fakeDigests[tag]
+		ref := strings.TrimPrefix(lastArg, "docker://")
+		digest, ok := fakeDigests[ref]
 		if !ok {
-			return "", fmt.Errorf("unknown tag: %s", tag)
+			return "", fmt.Errorf("unknown ref: %s", ref)
 		}
 		return digest, nil
 	}
 
-	result, err := getDigests(fakeRunner, "registry.example.com/img", "", "4.20", "")
+	result, err := getDigests(fakeRunner, "",
+		"registry.example.com/current:v4.20",
+		"registry.example.com/prev:v4.19",
+		"")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -189,6 +234,66 @@ func TestGetDigests(t *testing.T) {
 	}
 	if result.PreviousChannelLast != "sha256:ccc" {
 		t.Errorf("expected prev channel digest %q, got %q", "sha256:ccc", result.PreviousChannelLast)
+	}
+	if result.EUSChannelLast != "" {
+		t.Errorf("expected empty EUS channel digest, got %q", result.EUSChannelLast)
+	}
+}
+
+func TestGetDigests_WithEUS(t *testing.T) {
+	fakeDigests := map[string]string{
+		"registry.example.com/current:v4.20.0": "sha256:aaa",
+		"registry.example.com/prev:v4.19":      "sha256:bbb",
+		"registry.example.com/eus:v4.16":       "sha256:eus",
+	}
+	rawTags, _ := json.Marshal(listTagsOutput{Tags: []string{"v4.20.0"}})
+
+	fakeRunner := func(_ string, args ...string) (string, error) {
+		if args[0] == "list-tags" {
+			return string(rawTags), nil
+		}
+		ref := strings.TrimPrefix(args[len(args)-1], "docker://")
+		digest, ok := fakeDigests[ref]
+		if !ok {
+			return "", fmt.Errorf("unknown ref: %s", ref)
+		}
+		return digest, nil
+	}
+
+	result, err := getDigests(fakeRunner, "",
+		"registry.example.com/current:v4.20",
+		"registry.example.com/prev:v4.19",
+		"registry.example.com/eus:v4.16")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.EUSChannelLast != "sha256:eus" {
+		t.Errorf("expected EUS digest %q, got %q", "sha256:eus", result.EUSChannelLast)
+	}
+}
+
+func TestGetDigests_EUSFailureIsFatal(t *testing.T) {
+	rawTags, _ := json.Marshal(listTagsOutput{Tags: []string{"v4.20.0"}})
+	fakeRunner := func(_ string, args ...string) (string, error) {
+		if args[0] == "list-tags" {
+			return string(rawTags), nil
+		}
+		ref := strings.TrimPrefix(args[len(args)-1], "docker://")
+		if strings.Contains(ref, "eus") {
+			return "", fmt.Errorf("eus channel not found")
+		}
+		return "sha256:abc", nil
+	}
+
+	_, err := getDigests(fakeRunner, "",
+		"registry.example.com/current:v4.20",
+		"registry.example.com/prev:v4.19",
+		"registry.example.com/eus:v4.16")
+	if err == nil {
+		t.Fatal("expected error when EUS channel lookup fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to get digest of EUS channel") {
+		t.Fatalf("expected EUS channel error, got: %v", err)
 	}
 }
 
@@ -208,7 +313,10 @@ func TestGetDigests_NoDuplicateDigests(t *testing.T) {
 		return sharedDigest, nil
 	}
 
-	result, err := getDigests(fakeRunner, "registry.example.com/img", "", "4.22", "4.21")
+	result, err := getDigests(fakeRunner, "",
+		"registry.example.com/current:v4.22",
+		"registry.example.com/prev:v4.21",
+		"")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -225,7 +333,10 @@ func TestGetDigests_ListTagsError(t *testing.T) {
 	fakeRunner := func(_ string, _ ...string) (string, error) {
 		return "", fmt.Errorf("registry unavailable")
 	}
-	_, err := getDigests(fakeRunner, "registry.example.com/img", "", "4.20", "")
+	_, err := getDigests(fakeRunner, "",
+		"registry.example.com/current:v4.20",
+		"registry.example.com/prev:v4.19",
+		"")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -239,23 +350,25 @@ func TestGetDigests_NoMatchingTags(t *testing.T) {
 		}
 		return "", fmt.Errorf("should not be called")
 	}
-	_, err := getDigests(fakeRunner, "registry.example.com/img", "", "4.20", "")
+	_, err := getDigests(fakeRunner, "",
+		"registry.example.com/current:v4.20",
+		"registry.example.com/prev:v4.19",
+		"")
 	if err == nil {
 		t.Fatal("expected error for no matching tags, got nil")
 	}
 }
 
-func TestGetDigests_InvalidVersion(t *testing.T) {
-	rawTags, _ := json.Marshal(listTagsOutput{Tags: []string{"v4.20.0"}})
-	fakeRunner := func(_ string, args ...string) (string, error) {
-		if args[0] == "list-tags" {
-			return string(rawTags), nil
-		}
-		return "sha256:abc", nil
+func TestGetDigests_InvalidCurrentURL(t *testing.T) {
+	fakeRunner := func(_ string, _ ...string) (string, error) {
+		return "", fmt.Errorf("should not be called")
 	}
-	_, err := getDigests(fakeRunner, "registry.example.com/img", "", "420", "")
+	_, err := getDigests(fakeRunner, "",
+		"registry.example.com/current",
+		"registry.example.com/prev:v4.19",
+		"")
 	if err == nil {
-		t.Fatal("expected error for invalid version format, got nil")
+		t.Fatal("expected error for invalid current URL, got nil")
 	}
 }
 
@@ -265,26 +378,28 @@ func TestGetDigests_PrevChannelFailureIsFatal(t *testing.T) {
 		if args[0] == "list-tags" {
 			return string(rawTags), nil
 		}
-		// inspect for current channel succeeds, prev channel fails
 		lastArg := args[len(args)-1]
 		if strings.HasSuffix(lastArg, ":v4.19") {
 			return "", fmt.Errorf("prev channel not found")
 		}
 		return "sha256:abc", nil
 	}
-	_, err := getDigests(fakeRunner, "registry.example.com/img", "", "4.20", "")
+	_, err := getDigests(fakeRunner, "",
+		"registry.example.com/current:v4.20",
+		"registry.example.com/prev:v4.19",
+		"")
 	if err == nil {
 		t.Fatal("expected error when previous channel lookup fails, got nil")
 	}
-	if !strings.Contains(err.Error(), "failed to get latest of previous channel") {
+	if !strings.Contains(err.Error(), "failed to get digest of previous channel") {
 		t.Fatalf("expected previous channel error, got: %v", err)
 	}
 }
 
-func TestGetDigests_PrevVersionOverride(t *testing.T) {
+func TestGetDigests_DifferentImageBases(t *testing.T) {
 	fakeDigests := map[string]string{
-		"v5.0.0": "sha256:new",
-		"v4.22":  "sha256:last422",
+		"registry.example.com/scheduler-rhel9:v5.0.0": "sha256:new",
+		"registry.example.com/scheduler-rhel8:v4.22":  "sha256:last422",
 	}
 	rawTags, _ := json.Marshal(listTagsOutput{Tags: []string{"v5.0.0"}})
 
@@ -292,26 +407,20 @@ func TestGetDigests_PrevVersionOverride(t *testing.T) {
 		if args[0] == "list-tags" {
 			return string(rawTags), nil
 		}
-		lastArg := args[len(args)-1]
-		idx := strings.LastIndex(lastArg, ":")
-		tag := lastArg[idx+1:]
-		digest, ok := fakeDigests[tag]
+		ref := strings.TrimPrefix(args[len(args)-1], "docker://")
+		digest, ok := fakeDigests[ref]
 		if !ok {
-			return "", fmt.Errorf("unknown tag: %s", tag)
+			return "", fmt.Errorf("unknown ref: %s", ref)
 		}
 		return digest, nil
 	}
 
-	// 4.0 has no auto-resolved previous channel without override
-	_, err := getDigests(fakeRunner, "registry.example.com/img", "", "4.0", "")
-	if err == nil {
-		t.Fatal("expected error for 4.0 without override, got nil")
-	}
-
-	// 5.0 auto-resolves to 4.22; explicit override should succeed too
-	result, err := getDigests(fakeRunner, "registry.example.com/img", "", "5.0", "4.22")
+	result, err := getDigests(fakeRunner, "",
+		"registry.example.com/scheduler-rhel9:v5.0",
+		"registry.example.com/scheduler-rhel8:v4.22",
+		"")
 	if err != nil {
-		t.Fatalf("unexpected error with prev-version override: %v", err)
+		t.Fatalf("unexpected error with different image bases: %v", err)
 	}
 	if !slices.Contains(result.CurrentChannel, "sha256:new") {
 		t.Errorf("expected current channel digest %q, got %v", "sha256:new", result.CurrentChannel)


### PR DESCRIPTION
Upgrades can happen from EUS releases, so allow the latest digest from the EUS stream similarly to the previous direct stream. The only difference is that providing it is optional.

AI-attribution: AIA PAI Hin R Cursor 3.1.7 v1.0