### PR TITLE
sched: enable default preemption

### DIFF
--- a/api/v1/numaresourcesscheduler_defaults.go
+++ b/api/v1/numaresourcesscheduler_defaults.go
@@ -53,6 +53,8 @@ func SetDefaults_NUMAResourcesSchedulerSpec(spec *NUMAResourcesSchedulerSpec) {
 			Type: defaultScoringStrategy,
 		}
 	}
+	// do not set preemptionMode default value to differentiate between unset and set values
+
 	// do not set replicas default value
 	// it will be computed later
 }

--- a/api/v1/numaresourcesscheduler_types.go
+++ b/api/v1/numaresourcesscheduler_types.go
@@ -45,6 +45,17 @@ const (
 	SchedulerInformerDedicated SchedulerInformerMode = "Dedicated"
 )
 
+// +kubebuilder:validation:Enum=Enabled;Disabled
+type PreemptionMode string
+
+const (
+	// PreemptionEnabled enables NUMA-aware preemption in the NodeResourceTopologyMatch plugin.
+	PreemptionEnabled PreemptionMode = "Enabled"
+
+	// PreemptionDisabled disables NUMA-aware preemption in the NodeResourceTopologyMatch plugin.
+	PreemptionDisabled PreemptionMode = "Disabled"
+)
+
 // +kubebuilder:validation:Enum=MostAllocated;BalancedAllocation;LeastAllocated
 type ScoringStrategyType string
 
@@ -114,6 +125,11 @@ type NUMAResourcesSchedulerSpec struct {
 	// +optional
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Scheduler scoring strategy setting",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	ScoringStrategy *ScoringStrategyParams `json:"scoringStrategy,omitempty"`
+	// PreemptionMode controls NUMA-aware preemption in the NodeResourceTopologyMatch plugin.
+	// When unset, preemption is disabled by default. Set explicitly to Enabled to enable preemption.
+	// +optional
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Scheduler preemption mode setting",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	PreemptionMode *PreemptionMode `json:"preemptionMode,omitempty"`
 	// Replicas control how many scheduler pods must be configured for High Availability (HA)
 	// +optional
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Scheduler replicas",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:int"}

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -274,6 +274,11 @@ func (in *NUMAResourcesSchedulerSpec) DeepCopyInto(out *NUMAResourcesSchedulerSp
 		*out = new(ScoringStrategyParams)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PreemptionMode != nil {
+		in, out := &in.PreemptionMode, &out.PreemptionMode
+		*out = new(PreemptionMode)
+		**out = **in
+	}
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
 		*out = new(int32)

--- a/bundle/manifests/nodetopology.openshift.io_numaresourcesschedulers.yaml
+++ b/bundle/manifests/nodetopology.openshift.io_numaresourcesschedulers.yaml
@@ -75,6 +75,14 @@ spec:
                 - Trace
                 - TraceAll
                 type: string
+              preemptionMode:
+                description: |-
+                  PreemptionMode controls NUMA-aware preemption in the NodeResourceTopologyMatch plugin.
+                  When unset, preemption is disabled by default. Set explicitly to Enabled to enable preemption.
+                enum:
+                - Enabled
+                - Disabled
+                type: string
               replicas:
                 description: Replicas control how many scheduler pods must be configured
                   for High Availability (HA)

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -66,7 +66,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-07-14T08:24:59Z"
+    createdAt: "2026-08-18T10:28:38Z"
     features.operators.openshift.io/cnf: "true"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -295,6 +295,13 @@ spec:
           Defaults to "Normal".
         displayName: Scheduler log verbosity
         path: logLevel
+      - description: |-
+          PreemptionMode controls NUMA-aware preemption in the NodeResourceTopologyMatch plugin.
+          When unset, preemption is disabled by default. Set explicitly to Enabled to enable preemption.
+        displayName: Scheduler preemption mode setting
+        path: preemptionMode
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Replicas control how many scheduler pods must be configured for
           High Availability (HA)
         displayName: Scheduler replicas

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesschedulers.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesschedulers.yaml
@@ -75,6 +75,14 @@ spec:
                 - Trace
                 - TraceAll
                 type: string
+              preemptionMode:
+                description: |-
+                  PreemptionMode controls NUMA-aware preemption in the NodeResourceTopologyMatch plugin.
+                  When unset, preemption is disabled by default. Set explicitly to Enabled to enable preemption.
+                enum:
+                - Enabled
+                - Disabled
+                type: string
               replicas:
                 description: Replicas control how many scheduler pods must be configured
                   for High Availability (HA)

--- a/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
@@ -230,6 +230,13 @@ spec:
           Defaults to "Normal".
         displayName: Scheduler log verbosity
         path: logLevel
+      - description: |-
+          PreemptionMode controls NUMA-aware preemption in the NodeResourceTopologyMatch plugin.
+          When unset, preemption is disabled by default. Set explicitly to Enabled to enable preemption.
+        displayName: Scheduler preemption mode setting
+        path: preemptionMode
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Replicas control how many scheduler pods must be configured for
           High Availability (HA)
         displayName: Scheduler replicas

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/k8stopologyawareschedwg/deployer v0.24.0
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.2
 	github.com/k8stopologyawareschedwg/podfingerprint v0.2.3
-	github.com/k8stopologyawareschedwg/resource-topology-exporter v0.24.0
+	github.com/k8stopologyawareschedwg/resource-topology-exporter v0.25.0
 	github.com/mdomke/git-semver v1.0.0
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
@@ -78,6 +78,7 @@ require (
 	github.com/jeremywohl/flatten/v2 v2.0.0-20211013061545-07e4a09fb8e4 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/k8stopologyawareschedwg/numaplacement v0.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
 	github.com/jaypipes/ghw v0.21.3-0.20260109185716-ee0aed93f45d
-	github.com/k8stopologyawareschedwg/deployer v0.24.0
+	github.com/k8stopologyawareschedwg/deployer v0.24.2
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.2
 	github.com/k8stopologyawareschedwg/podfingerprint v0.2.3
 	github.com/k8stopologyawareschedwg/resource-topology-exporter v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -114,10 +114,12 @@ github.com/k8stopologyawareschedwg/deployer v0.24.0 h1:ieRgSJ7mQmMAWo7Vu2wXvbpBf
 github.com/k8stopologyawareschedwg/deployer v0.24.0/go.mod h1:ZkZiHYIpeXS5+QUUA4+b/TiFBZpQYsecJMAk0uX+jTM=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.2 h1:uAwqOtyrFYggq3pVf3hs1XKkBxrQ8dkgjWz3LCLJsiY=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.2/go.mod h1:LBzS4n6GX1C69tzSd5EibZ9cGOXFuHP7GxEMDYVe1sM=
+github.com/k8stopologyawareschedwg/numaplacement v0.1.0 h1:Y1GxVAAc+FVewXRdnPfXT8DM8yICPsM8kLHh4I7f7uU=
+github.com/k8stopologyawareschedwg/numaplacement v0.1.0/go.mod h1:wU3DV2l+5mzMLufnTYhtsiyXqiNwfDMN0Hq29c+qXU4=
 github.com/k8stopologyawareschedwg/podfingerprint v0.2.3 h1:nVKmzn6g7CHhDtB+jG85Db/B/ALRY9VLh5ueAfVPEHU=
 github.com/k8stopologyawareschedwg/podfingerprint v0.2.3/go.mod h1:E0bjgihZTSwRIJVjNV45Lm0C/j5w+YkGSnfpYXoI8Ws=
-github.com/k8stopologyawareschedwg/resource-topology-exporter v0.24.0 h1:1GKIZyxZH6fp8ckQHHFWBs0gjbvjUURYPoa6Mah7xGk=
-github.com/k8stopologyawareschedwg/resource-topology-exporter v0.24.0/go.mod h1:J9li0VDP3ogNEBaikyCZqHiPg5kYmcn1m0qTk4q8BA0=
+github.com/k8stopologyawareschedwg/resource-topology-exporter v0.25.0 h1:GvZiWAoY8CTEHPB49BLKHhe+NjkrXdQKjawZAZKi0QU=
+github.com/k8stopologyawareschedwg/resource-topology-exporter v0.25.0/go.mod h1:HuyWeTKYUZ3KKKPn6VOSOGGYcMpdheJyrvcMAh/6e+A=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
-github.com/k8stopologyawareschedwg/deployer v0.24.0 h1:ieRgSJ7mQmMAWo7Vu2wXvbpBf1CYKxAZamyGAWC7FZ8=
-github.com/k8stopologyawareschedwg/deployer v0.24.0/go.mod h1:ZkZiHYIpeXS5+QUUA4+b/TiFBZpQYsecJMAk0uX+jTM=
+github.com/k8stopologyawareschedwg/deployer v0.24.2 h1:S94DztuSZ9ZNkeICT2pCfP/xox9yENCR/k4SsxdbnkE=
+github.com/k8stopologyawareschedwg/deployer v0.24.2/go.mod h1:ZkZiHYIpeXS5+QUUA4+b/TiFBZpQYsecJMAk0uX+jTM=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.2 h1:uAwqOtyrFYggq3pVf3hs1XKkBxrQ8dkgjWz3LCLJsiY=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.2/go.mod h1:LBzS4n6GX1C69tzSd5EibZ9cGOXFuHP7GxEMDYVe1sM=
 github.com/k8stopologyawareschedwg/numaplacement v0.1.0 h1:Y1GxVAAc+FVewXRdnPfXT8DM8yICPsM8kLHh4I7f7uU=

--- a/internal/controller/numaresourcesscheduler_controller.go
+++ b/internal/controller/numaresourcesscheduler_controller.go
@@ -514,6 +514,13 @@ func configParamsFromSchedSpec(schedSpec nropv1.NUMAResourcesSchedulerSpec, cach
 		})
 	}
 	params.ScoringStrategy.Resources = resources
+
+	if schedSpec.PreemptionMode != nil && *schedSpec.PreemptionMode == nropv1.PreemptionEnabled {
+		params.PreemptionMode = ptr.To(k8swgmanifests.PreemptionEnabled)
+	} else {
+		params.PreemptionMode = nil
+	}
+
 	params.Cache.ResyncMethod = &resyncMethod
 	params.Cache.ForeignPodsDetectMode = &foreignPodsDetect
 	params.Cache.InformerMode = &informerMode

--- a/internal/controller/numaresourcesscheduler_controller_test.go
+++ b/internal/controller/numaresourcesscheduler_controller_test.go
@@ -708,6 +708,81 @@ var _ = Describe("Test NUMAResourcesScheduler Reconcile", func() {
 
 		})
 
+		It("should not configure preemptionMode when unset", func(ctx context.Context) {
+			key := client.ObjectKeyFromObject(nrs)
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).ToNot(HaveOccurred())
+
+			cm := schedulerConfigMap(ctx, reconciler.Client)
+			Expect(cm).To(HaveSchedulerPreemptionMode(""))
+		})
+
+		It("should allow to change preemptionMode from Enabled to Disabled explicitly", func(ctx context.Context) {
+			key := client.ObjectKeyFromObject(nrs)
+			nrs := nrs.DeepCopy()
+			nrs.Spec.PreemptionMode = ptr.To(nropv1.PreemptionEnabled)
+			Eventually(func(g Gomega) {
+				g.Expect(reconciler.Client.Update(ctx, nrs)).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(Succeed())
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(schedulerConfigMap(ctx, reconciler.Client)).To(HaveSchedulerPreemptionMode(string(nropv1.PreemptionEnabled)))
+
+			Expect(reconciler.Client.Get(ctx, key, nrs)).To(Succeed())
+			nrs.Spec.PreemptionMode = ptr.To(nropv1.PreemptionDisabled)
+			Eventually(func(g Gomega) {
+				g.Expect(reconciler.Client.Update(ctx, nrs)).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(Succeed())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(schedulerConfigMap(ctx, reconciler.Client)).To(HaveSchedulerPreemptionMode(""))
+		})
+
+		It("should allow to change preemptionMode from Disabled to Enabled explicitly", func(ctx context.Context) {
+			key := client.ObjectKeyFromObject(nrs)
+
+			nrs := nrs.DeepCopy()
+			nrs.Spec.PreemptionMode = ptr.To(nropv1.PreemptionDisabled)
+			Eventually(func(g Gomega) {
+				g.Expect(reconciler.Client.Update(ctx, nrs)).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(Succeed())
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(schedulerConfigMap(ctx, reconciler.Client)).To(HaveSchedulerPreemptionMode(""))
+
+			Expect(reconciler.Client.Get(ctx, key, nrs)).To(Succeed())
+
+			nrs.Spec.PreemptionMode = ptr.To(nropv1.PreemptionEnabled)
+			Eventually(func(g Gomega) {
+				g.Expect(reconciler.Client.Update(ctx, nrs)).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(Succeed())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(schedulerConfigMap(ctx, reconciler.Client)).To(HaveSchedulerPreemptionMode(string(nropv1.PreemptionEnabled)))
+		})
+
+		It("should allow to change preemptionMode from Enabled to unset (clear the value)", func(ctx context.Context) {
+			key := client.ObjectKeyFromObject(nrs)
+
+			nrs := nrs.DeepCopy()
+			nrs.Spec.PreemptionMode = ptr.To(nropv1.PreemptionEnabled)
+			Eventually(func(g Gomega) {
+				g.Expect(reconciler.Client.Update(ctx, nrs)).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(Succeed())
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(schedulerConfigMap(ctx, reconciler.Client)).To(HaveSchedulerPreemptionMode(string(nropv1.PreemptionEnabled)))
+
+			Expect(reconciler.Client.Get(ctx, key, nrs)).To(Succeed())
+			nrs.Spec.PreemptionMode = nil
+			Eventually(func(g Gomega) {
+				g.Expect(reconciler.Client.Update(ctx, nrs)).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(Succeed())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(schedulerConfigMap(ctx, reconciler.Client)).To(HaveSchedulerPreemptionMode(""))
+		})
+
 		It("should allow to change the ScoringStrategy resources", func() {
 			nrs := nrs.DeepCopy()
 			nrs.Spec.ScoringStrategy = &nropv1.ScoringStrategyParams{}
@@ -1353,6 +1428,48 @@ func HaveTheSameResourceRequirements(expectedRR corev1.ResourceRequirements) typ
 		}
 		return reflect.DeepEqual(cnt.Resources, expectedRR), nil
 	}).WithTemplate("Deployment {{.Actual.Namespace}}/{{.Actual.Name}} resources request mismatch")
+}
+
+func HaveSchedulerPreemptionMode(want string) types.GomegaMatcher {
+	expected := want
+	if want == "" {
+		expected = "unset"
+	}
+
+	return gcustom.MakeMatcher(func(cm *corev1.ConfigMap) (bool, error) {
+		if cm == nil {
+			return false, fmt.Errorf("config map is nil")
+		}
+
+		confRaw := cm.Data[sched.SchedulerConfigFileName]
+		cfgs, err := depmanifests.DecodeSchedulerProfilesFromData([]byte(confRaw))
+		if err != nil {
+			return false, err
+		}
+		if len(cfgs) != 1 {
+			return false, fmt.Errorf("unexpected config params count: %d", len(cfgs))
+		}
+		cfg := cfgs[0]
+
+		if want == "" {
+			return cfg.PreemptionMode == nil, nil
+		}
+		if cfg.PreemptionMode == nil {
+			return false, nil
+		}
+		return *cfg.PreemptionMode == want, nil
+	}).WithTemplate("scheduler config preemptionMode should be {{.Data}}").WithTemplateData(expected)
+}
+
+func schedulerConfigMap(ctx context.Context, cli client.Client) *corev1.ConfigMap {
+	GinkgoHelper()
+
+	cm := &corev1.ConfigMap{}
+	Expect(cli.Get(ctx, client.ObjectKey{
+		Name:      "topo-aware-scheduler-config",
+		Namespace: testNamespace,
+	}, cm)).To(Succeed())
+	return cm
 }
 
 func pop(m map[string]string, k string) string {

--- a/pkg/numaresourcesscheduler/manifests/yaml/configmap.nrt.yaml
+++ b/pkg/numaresourcesscheduler/manifests/yaml/configmap.nrt.yaml
@@ -15,6 +15,8 @@ data:
           multiPoint:
             disabled:
               - name: DynamicResources
+            enabled:
+              - name: NodeResourceTopologyMatch
           filter:
             disabled:
               - name: '*'
@@ -33,12 +35,6 @@ data:
               - name: VolumeZone
               - name: PodTopologySpread
               - name: InterPodAffinity
-          reserve:
-            enabled:
-              - name: NodeResourceTopologyMatch
-          score:
-            enabled:
-              - name: NodeResourceTopologyMatch
         # optional plugin configs
         pluginConfig:
         - name: NodeResourceTopologyMatch

--- a/rte/main.go
+++ b/rte/main.go
@@ -15,7 +15,6 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"runtime"
@@ -99,9 +98,11 @@ func main() {
 		cli = podexclude.NewFromLister(cli, parsedArgs.Global.Debug, parsedArgs.Resourcemonitor.PodExclude)
 	}
 
+	ctx := ctrl.SetupSignalHandler()
+
 	if parsedArgs.Resourcemonitor.ExcludeTerminalPods {
 		klog.Infof("terminal pods are filtered from the PodResourcesLister client")
-		cli, err = terminalpods.NewFromLister(context.TODO(), cli, k8scli, time.Minute, parsedArgs.Global.Debug)
+		cli, err = terminalpods.NewFromLister(ctx, cli, k8scli, time.Minute, parsedArgs.Global.Debug)
 		if err != nil {
 			klog.Fatalf("failed to get PodResourceAPI client: %v", err)
 		}
@@ -127,7 +128,7 @@ func main() {
 		},
 		NRTCli: nrtcli,
 	}
-	err = resourcetopologyexporter.Execute(hnd, parsedArgs.NRTupdater, parsedArgs.Resourcemonitor, parsedArgs.RTE)
+	err = resourcetopologyexporter.Execute(ctx, hnd, parsedArgs.NRTupdater, parsedArgs.Resourcemonitor, parsedArgs.RTE)
 	if err != nil {
 		klog.Fatalf("failed to execute: %v", err)
 	}

--- a/test/e2e/serial/tests/priority-based-placement.go
+++ b/test/e2e/serial/tests/priority-based-placement.go
@@ -31,14 +31,17 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 
+	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
 	intbaseload "github.com/openshift-kni/numaresources-operator/internal/baseload"
 	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
+	"github.com/openshift-kni/numaresources-operator/pkg/status"
 	numacellapi "github.com/openshift-kni/numaresources-operator/test/deviceplugin/pkg/numacell/api"
 	"github.com/openshift-kni/numaresources-operator/test/e2e/label"
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
@@ -108,456 +111,493 @@ var _ = Describe("[serial][disruptive][preemption] priority-based workload place
 		Expect(e2efixture.Teardown(fxt)).ToNot(HaveOccurred())
 	})
 
-	When("one node is schedulable and the others are unschedulable", func() {
-		var (
-			targetNodeName string
-			nrtCandidates  []nrtv1alpha2.NodeResourceTopology
-		)
-		type testCase struct {
-			fillerPodPriorityClassName string
-			newPodPriorityClassName    string
-			evictionExpected           bool
-		}
-
+	When("preemptionMode is set to Enabled", func() {
 		BeforeEach(func(ctx context.Context) {
-			targetNodeName = ""
-			nrtCandidates = e2enrt.FilterZoneCountEqual(nrtList.Items, 2)
-			if len(nrtCandidates) < 1 {
-				e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA zones: found %d", len(nrtCandidates))
-			}
+			initialNroSchedObj := &nropv1.NUMAResourcesScheduler{}
+			nroSchedKey := objects.NROSchedObjectKey()
+			Expect(fxt.Client.Get(ctx, nroSchedKey, initialNroSchedObj)).To(Succeed(), "cannot get %q in the cluster", nroSchedKey.String())
 
-			nrtCandidates = e2enrt.FilterByTopologyManagerPolicy(nrtCandidates, intnrt.SingleNUMANode)
-			if len(nrtCandidates) < 1 {
-				e2efixture.Skipf(fxt, "not enough nodes with SingleNUMANode policy - found %d", len(nrtCandidates))
-			}
-
-			nrtNames := e2enrt.AccumulateNames(nrtCandidates)
-			for nname := range nrtNames {
-				node := &corev1.Node{}
-				Expect(fxt.Client.Get(ctx, client.ObjectKey{Name: nname}, node)).To(Succeed())
-				if !node.Spec.Unschedulable {
-					// pick the first schedulable node as a target node for simplicity
-					targetNodeName = nname
-					break
-				}
-			}
-			Expect(targetNodeName).ToNot(BeEmpty(), "no schedulable node found")
-			klog.InfoS("target node for preemption test", "nodeName", targetNodeName)
-
-			By("cordoning all nodes except the target node")
-			var cordonedNodeNames []string
-			nodeList := &corev1.NodeList{}
-			Expect(fxt.Client.List(ctx, nodeList)).To(Succeed(), "cannot list cluster nodes")
-			cordonPatch := client.RawPatch(types.MergePatchType, []byte(`{"spec":{"unschedulable":true}}`))
-			uncordonPatch := client.RawPatch(types.MergePatchType, []byte(`{"spec":{"unschedulable":false}}`))
-
-			DeferCleanup(func(ctxA context.Context) {
-				By("uncordoning all nodes cordoned during test setup")
-				for _, nodeName := range cordonedNodeNames {
-					nodeObj := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
-					Expect(fxt.Client.Patch(ctxA, nodeObj, uncordonPatch)).To(Succeed(), "cannot uncordon node %q", nodeName)
-					klog.InfoS("uncordoned node", "nodeName", nodeName)
-				}
-			})
-
-			for i := range nodeList.Items {
-				node := &nodeList.Items[i]
-				if node.Name == targetNodeName || node.Spec.Unschedulable {
-					continue
-				}
-				Expect(fxt.Client.Patch(ctx, &nodeList.Items[i], cordonPatch)).To(Succeed(), "cannot cordon node %q", node.Name)
-				cordonedNodeNames = append(cordonedNodeNames, node.Name)
-				klog.InfoS("cordoned node", "nodeName", node.Name)
+			if initialNroSchedObj.Spec.PreemptionMode == nil || *initialNroSchedObj.Spec.PreemptionMode != nropv1.PreemptionEnabled {
+				By("setting preemption mode to Enabled")
+				setPreemptionMode(ctx, fxt, nroSchedKey, ptr.To(nropv1.PreemptionEnabled))
+				DeferCleanup(func(ctxA context.Context) {
+					By("reverting preemption mode")
+					setPreemptionMode(ctxA, fxt, nroSchedKey, initialNroSchedObj.Spec.PreemptionMode)
+				})
 			}
 		})
 
-		DescribeTable(
-			"priority-based workload placement should work as expected", Label(label.Tier2), func(ctx context.Context, tc testCase) {
-				e2efixture.By("filler priority class: %q, new pod priority class: %q, eviction expected: %v",
-					tc.fillerPodPriorityClassName, tc.newPodPriorityClassName, tc.evictionExpected)
+		When("one node is schedulable and the others are unschedulable", func() {
+			var (
+				targetNodeName string
+				nrtCandidates  []nrtv1alpha2.NodeResourceTopology
+			)
+			type testCase struct {
+				fillerPodPriorityClassName string
+				newPodPriorityClassName    string
+				evictionExpected           bool
+			}
 
-				nrtInfo, err := e2enrt.FindFromList(nrtList.Items, targetNodeName)
-				Expect(err).ToNot(HaveOccurred(), "no NRT data for target node %q", targetNodeName)
-
-				baseload, err := intbaseload.ForNode(fxt.Client, ctx, targetNodeName)
-				Expect(err).ToNot(HaveOccurred(), "cannot get base load for %q", targetNodeName)
-				klog.InfoS("node base load", "nodeName", targetNodeName, "resources", baseload.Resources)
-
-				By("creating filler pods to fully saturate the target node resources")
-				var fillerPods []*corev1.Pod
-				for _, zone := range nrtInfo.Zones {
-					padPod, err := makePaddingPod(fxt, fxt.Namespace.Name, targetNodeName, zone, baseload.Resources)
-					Expect(err).ToNot(HaveOccurred(), "cannot create padding pod spec for node %q zone %q", targetNodeName, zone.Name)
-
-					if tc.fillerPodPriorityClassName != "" {
-						padPod.Spec.PriorityClassName = tc.fillerPodPriorityClassName
-					}
-					padPod.Spec.SchedulerName = serialconfig.Config.SchedulerName
-
-					pinnedPod, err := pinPodTo(padPod, targetNodeName, zone.Name)
-					Expect(err).ToNot(HaveOccurred(), "cannot pin filler pod to node %q zone %q", targetNodeName, zone.Name)
-
-					Expect(fxt.Client.Create(ctx, pinnedPod)).To(Succeed(), "cannot create filler pod for zone %q", zone.Name)
-					fillerPods = append(fillerPods, pinnedPod)
-				}
-
-				By("waiting for filler pods to be running")
-				failedPodIds := e2efixture.WaitForPaddingPodsRunning(ctx, fxt, fillerPods)
-				Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
-
-				By("waiting for the NRT data to settle")
-				e2efixture.MustSettleNRT(fxt)
-
-				fillersNameToUID := getNamesToUIDs(ctx, fxt.Client, fillerPods)
-
-				By("creating the new workload pod")
-				testPod := objects.NewTestPodPause(fxt.Namespace.Name, "test-workload")
-				testPod.Spec.SchedulerName = serialconfig.Config.SchedulerName
-				if tc.newPodPriorityClassName != "" {
-					testPod.Spec.PriorityClassName = tc.newPodPriorityClassName
-				}
-				// this will trigger the preemption logic
-				testPodRes := fillerPods[0].Spec.Containers[0].Resources.Limits
-				testPod.Spec.Containers[0].Resources = corev1.ResourceRequirements{
-					Limits:   testPodRes,
-					Requests: testPodRes,
-				}
-
-				Expect(fxt.Client.Create(ctx, testPod)).To(Succeed(), "cannot create test workload pod")
-
-				if tc.evictionExpected {
-					By("verifying one filler pod is preempted and evicted")
-					evicted := sets.New[string]()
-					Eventually(func(g Gomega) {
-						for _, fp := range fillerPods {
-							pod := &corev1.Pod{}
-							err := fxt.Client.Get(ctx, client.ObjectKeyFromObject(fp), pod)
-							if apierrors.IsNotFound(err) {
-								evicted.Insert(fp.Name)
-							}
-						}
-						g.Expect(evicted.Len()).To(Equal(1), "expected one filler pod to be evicted, got %d", evicted.Len())
-					}).WithTimeout(pendingTimeout).WithPolling(10*time.Second).Should(Succeed(), "failed to have the pod running")
-					By("verifying test pod becomes running after preemption")
-					updatedPod, err := wait.With(fxt.Client).Timeout(pendingTimeout).ForPodPhase(ctx, testPod.Namespace, testPod.Name, corev1.PodRunning)
-					if err != nil {
-						_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
-					}
-					Expect(err).ToNot(HaveOccurred(), "test pod did not become Running after preemption")
-
-					By("verifying the rest of the filler pods continue to run")
-					Consistently(func(g Gomega) {
-						for _, fp := range fillerPods {
-							if evicted.Has(fp.Name) {
-								continue
-							}
-							pod := &corev1.Pod{}
-							g.Expect(fxt.Client.Get(ctx, client.ObjectKeyFromObject(fp), pod)).To(Succeed())
-							g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning), "pod %s/%s is not running", pod.Namespace, pod.Name)
-							g.Expect(pod.DeletionTimestamp).To(BeNil(), "filler pod %q should not have been evicted", fp.Name)
-						}
-					}).WithTimeout(2*time.Minute).WithPolling(10*time.Second).Should(Succeed(), "more than one filler pod was evicted")
-				} else {
-					evictionNotExpected(ctx, fxt.Client, testPod, fillerPods, fillersNameToUID)
-				}
-			},
-			Entry("default-priority fillers vs default-priority new workload",
-				testCase{fillerPodPriorityClassName: "", newPodPriorityClassName: "", evictionExpected: false}),
-
-			Entry("default-priority fillers vs system-node-critical new workload",
-				testCase{fillerPodPriorityClassName: "", newPodPriorityClassName: systemNodeCriticalPriorityClassName, evictionExpected: true}),
-
-			Entry("system-node-critical fillers vs default-priority new workload",
-				testCase{fillerPodPriorityClassName: systemNodeCriticalPriorityClassName, newPodPriorityClassName: "", evictionExpected: false}),
-
-			Entry("system-node-critical fillers vs system-node-critical new workload",
-				testCase{fillerPodPriorityClassName: systemNodeCriticalPriorityClassName, newPodPriorityClassName: systemNodeCriticalPriorityClassName, evictionExpected: false}),
-
-			Entry("custom low-priority fillers vs custom medium-priority new workload",
-				testCase{fillerPodPriorityClassName: customLowPriorityClassName, newPodPriorityClassName: customMediumPriorityClassName, evictionExpected: true}),
-
-			Entry("custom medium-priority fillers vs custom low-priority new workload",
-				testCase{fillerPodPriorityClassName: customMediumPriorityClassName, newPodPriorityClassName: customLowPriorityClassName, evictionExpected: false}),
-		)
-
-		When("filler pods have mixed priorities", func() {
-			var targetNRT *nrtv1alpha2.NodeResourceTopology
 			BeforeEach(func(ctx context.Context) {
-				var err error
-				targetNRT, err = e2enrt.FindFromList(nrtList.Items, targetNodeName)
-				// error should never happen by now
-				Expect(err).ToNot(HaveOccurred(), "no NRT data for target node %q", targetNodeName)
-			})
-
-			It("should remain pending when the new pod is not priority enough despite the node-level sufficient space", func(ctx context.Context) {
-				By("setting up the cluster for running the test resources")
-				// Scheduling all pods including the fillers should be all done by the NUMA-aware scheduler as this is
-				// part of testing the preemption functionality.
-				// test description:
-				// **The most important key for this test is that it will depend on the baseload to calculate the resources requests for filler pods and the
-				// preemptor pods.**
-				// At this point we know for sure that the node has exactly 2 NUMA zones so we distribute the filler pods with mixed
-				// priorities between the two zones:
-				// - One default-priority filler pod with two containers, pinned to the first zone; each container with resources requests= baseload
-				// - One default-priority filler pod with two containers, pinned to the second zone; each container with resources requests= baseload
-				// - One medium-priority filler pod in the first zone; resources requests= all but the baseload; minimum resources requests= 4x baseload
-				// - One medium-priority filler pod in the second zone; resources requests= all but the baseload; minimum resources requests= 4x baseload
-				// Given the above distribution, we skip the test if any of the zones have less than 2 + 4 + 1 = 7x baseload.
-				//
-				// The test pod (preemptor), in both test phases, will request 4x the baseload, why? because using this design we know exactly what to
-				// expect in terms of correct evictions:
-				// - phase-1: low-priority test pod (is higher than the default priority): the pod is qualified to evict the default priority filler pods,
-				// and the most free resources state on the node would be:
-				// free resources on node level= 6x baseload
-				// free resources in zone 1= 3x baseload
-				// free resources in zone 2= 3x baseload
-				// so the preemptor pod will remain pending because evicting only default-priority pods is not sufficient, and given it is low-priority,
-				// it is not qualified to evict the medium-priority filler pods.
-				//
-				// - phase-2: high-priority test pod: the pod is qualified to evict all of the fillers, but we want to ensure that it evicts the least
-				// amount of pods that are sufficient to make the pod fit, and not falsely evict pods even if they have lower priority. Thus one medium-
-				// priority filler pod will be evicted and the rest will stay running.
-				baseload, err := intbaseload.ForNode(fxt.Client, ctx, targetNodeName)
-				Expect(err).ToNot(HaveOccurred(), "cannot get base load for %q", targetNodeName)
-				klog.InfoS("node base load", "nodeName", targetNodeName, "resources", baseload.Resources)
-
-				leastEnoughResourcesPerZone := corev1.ResourceList{}
-				for resName, resQty := range baseload.Resources {
-					// 1 baseload + 2 for default-priority fillers + 4 for test pod
-					resQty.Mul(7)
-					leastEnoughResourcesPerZone[resName] = resQty
-				}
-				for idx, zone := range targetNRT.Zones {
-					for _, ri := range zone.Resources {
-						zoneAvailable := ri.Available
-						leastQty := leastEnoughResourcesPerZone[corev1.ResourceName(ri.Name)]
-						if zoneAvailable.Cmp(leastQty) < 0 {
-							e2efixture.Skipf(fxt, "not enough availableresources in zone %d to fit the test pod: least required resources per zone are %s, found %s", idx, leastQty.String(), zoneAvailable.String())
-						}
-					}
+				targetNodeName = ""
+				nrtCandidates = e2enrt.FilterZoneCountEqual(nrtList.Items, 2)
+				if len(nrtCandidates) < 1 {
+					e2efixture.Skipf(fxt, "not enough nodes with 2 NUMA zones: found %d", len(nrtCandidates))
 				}
 
-				// first pod with two containers, pinned to the first zone
-				defaultPriorityPodResZone0 := baseload.Resources.DeepCopy()
-				defaultPriorityPodResZone0[numacellapi.MakeResourceName(0)] = resource.MustParse("1")
-				defaultPriorityPod1 := objects.NewTestPodPause(fxt.Namespace.Name, "default-priority-filler-1")
-				defaultPriorityPod1.Spec.SchedulerName = serialconfig.Config.SchedulerName
-				defaultPriorityPod1.Spec.Containers[0].Resources = corev1.ResourceRequirements{
-					Limits:   defaultPriorityPodResZone0,
-					Requests: defaultPriorityPodResZone0,
-				}
-				containers := []corev1.Container{defaultPriorityPod1.Spec.Containers[0], *defaultPriorityPod1.Spec.Containers[0].DeepCopy()}
-				containers[1].Name = "cnt-2"
-				defaultPriorityPod1.Spec.Containers = containers
-
-				// second pod with two containers, pinned to the second zone
-				defaultPriorityPodResZone1 := baseload.Resources.DeepCopy()
-				defaultPriorityPodResZone1[numacellapi.MakeResourceName(1)] = resource.MustParse("1")
-				cntResourcesZone1 := corev1.ResourceRequirements{
-					Limits:   defaultPriorityPodResZone1,
-					Requests: defaultPriorityPodResZone1,
-				}
-				defaultPriorityPod2 := defaultPriorityPod1.DeepCopy()
-				defaultPriorityPod2.Name = "default-priority-filler-2"
-				defaultPriorityPod2.Spec.Containers[0].Resources = cntResourcesZone1
-				defaultPriorityPod2.Spec.Containers[1].Resources = cntResourcesZone1
-
-				fillerPods := []*corev1.Pod{defaultPriorityPod1, defaultPriorityPod2}
-
-				klog.Info("creating default-priority filler pods")
-				Expect(fxt.Client.Create(ctx, defaultPriorityPod1)).To(Succeed(), "cannot create victim pod 1")
-				Expect(fxt.Client.Create(ctx, defaultPriorityPod2)).To(Succeed(), "cannot create victim pod 2")
-				failedPodIds := e2efixture.WaitForPaddingPodsRunning(ctx, fxt, []*corev1.Pod{defaultPriorityPod1, defaultPriorityPod2})
-				Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
-
-				klog.Info("waiting for the NRT data to settle")
-				e2efixture.MustSettleNRT(fxt)
-				updatedNRT, err := e2enrt.GetUpdatedForNode(fxt.Client, ctx, *targetNRT, 1*time.Minute)
-				Expect(err).ToNot(HaveOccurred())
-
-				klog.Info("creating medium-priority filler pods")
-				mediumPriorityPods := []*corev1.Pod{}
-				for idx, zone := range updatedNRT.Zones {
-					paddingPod, err := makePaddingPod(fxt, fxt.Namespace.Name, targetNodeName, zone, baseload.Resources)
-					Expect(err).ToNot(HaveOccurred(), "cannot create padding pod spec for node %q zone %q", targetNodeName, zone.Name)
-					paddingPod.Name = fmt.Sprintf("medium-priority-filler-%d", idx+1)
-					paddingPod.Spec.PriorityClassName = customMediumPriorityClassName
-					paddingPod.Spec.SchedulerName = serialconfig.Config.SchedulerName
-
-					pinnedPod, err := pinPodTo(paddingPod, targetNodeName, zone.Name)
-					Expect(err).ToNot(HaveOccurred(), "cannot pin filler pod to node %q zone %q", targetNodeName, zone.Name)
-
-					Expect(fxt.Client.Create(ctx, pinnedPod)).To(Succeed(), "cannot create filler pod for zone %q", zone.Name)
-					mediumPriorityPods = append(mediumPriorityPods, pinnedPod)
-					fillerPods = append(fillerPods, pinnedPod)
+				nrtCandidates = e2enrt.FilterByTopologyManagerPolicy(nrtCandidates, intnrt.SingleNUMANode)
+				if len(nrtCandidates) < 1 {
+					e2efixture.Skipf(fxt, "not enough nodes with SingleNUMANode policy - found %d", len(nrtCandidates))
 				}
 
-				klog.Info("waiting for medium-priority filler pods to be running")
-				failedPodIds = e2efixture.WaitForPaddingPodsRunning(ctx, fxt, mediumPriorityPods)
-				Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
-
-				klog.Info("waiting for the NRT data to settle")
-				e2efixture.MustSettleNRT(fxt)
-
-				fillersNameToUID := getNamesToUIDs(ctx, fxt.Client, fillerPods)
-
-				By("phase-1: low-priority test pod should remain pending because evicting only default-priority pods is not sufficient")
-				testPodTemplate := objects.NewTestPodPause(fxt.Namespace.Name, "test-workload")
-				testPodTemplate.Spec.SchedulerName = serialconfig.Config.SchedulerName
-				testPodTemplate.Spec.PriorityClassName = customLowPriorityClassName
-				testPodRes := corev1.ResourceList{}
-				for resName, resQty := range baseload.Resources {
-					resQty.Mul(4)
-					testPodRes[resName] = resQty
-				}
-				testPodTemplate.Spec.Containers[0].Resources = corev1.ResourceRequirements{
-					Limits:   testPodRes,
-					Requests: testPodRes,
-				}
-
-				testPodPhase1 := testPodTemplate.DeepCopy()
-				testPodPhase1.Name = "preemptor-phase-1"
-				Expect(fxt.Client.Create(ctx, testPodPhase1)).To(Succeed(), "cannot create test workload pod")
-
-				evictionNotExpected(ctx, fxt.Client, testPodPhase1, fillerPods, fillersNameToUID)
-
-				klog.Info("deleting phase-1 test pod")
-				Expect(fxt.Client.Delete(ctx, testPodPhase1)).To(Succeed())
-				Expect(wait.With(fxt.Client).Timeout(pendingTimeout).ForPodDeleted(ctx, testPodPhase1.Namespace, testPodPhase1.Name)).
-					To(Succeed(), "failed to delete test pod")
-
-				By("phase-2: high-priority test pod should become running after evicting only the least amount of filler pods so that the new pod may fit")
-				testPodPhase2 := testPodTemplate.DeepCopy()
-				testPodPhase2.Name = "preemptor-phase-2"
-				testPodPhase2.Spec.PriorityClassName = customHighPriorityClassName
-				Expect(fxt.Client.Create(ctx, testPodPhase2)).To(Succeed(), "cannot create preemptor pod phase 2")
-
-				klog.Info("verifying test pod phase 2 becomes running")
-				updatedPod, err := wait.With(fxt.Client).Timeout(pendingTimeout).ForPodPhase(ctx, testPodPhase2.Namespace, testPodPhase2.Name, corev1.PodRunning)
-				if err != nil {
-					_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
-				}
-				Expect(err).ToNot(HaveOccurred(), "test pod phase 2 did not become Running after preemption")
-
-				// from earlier steps we already guaranteed that the eviction will happen to one of the medium-priority filler pods because it is the
-				// only sufficient option. which also means we need to ensure that the rest of the filler pods are not evicted.
-				klog.Info("verifying one of the medium-priority filler pod is evicted and the rest are still running")
-				evictedPod := &corev1.Pod{}
-				for _, medPod := range mediumPriorityPods {
-					pod := &corev1.Pod{}
-					err := fxt.Client.Get(ctx, client.ObjectKeyFromObject(medPod), pod)
-					if apierrors.IsNotFound(err) {
-						evictedPod = medPod
+				nrtNames := e2enrt.AccumulateNames(nrtCandidates)
+				for nname := range nrtNames {
+					node := &corev1.Node{}
+					Expect(fxt.Client.Get(ctx, client.ObjectKey{Name: nname}, node)).To(Succeed())
+					if !node.Spec.Unschedulable {
+						// pick the first schedulable node as a target node for simplicity
+						targetNodeName = nname
 						break
 					}
 				}
-				Expect(evictedPod.Name).ToNot(BeEmpty(), "no medium-priority filler pod was evicted")
+				Expect(targetNodeName).ToNot(BeEmpty(), "no schedulable node found")
+				klog.InfoS("target node for preemption test", "nodeName", targetNodeName)
 
-				keptRunningPods := []*corev1.Pod{}
-				for _, pod := range fillerPods {
-					if pod.Name == evictedPod.Name {
+				By("cordoning all nodes except the target node")
+				var cordonedNodeNames []string
+				nodeList := &corev1.NodeList{}
+				Expect(fxt.Client.List(ctx, nodeList)).To(Succeed(), "cannot list cluster nodes")
+				cordonPatch := client.RawPatch(types.MergePatchType, []byte(`{"spec":{"unschedulable":true}}`))
+				uncordonPatch := client.RawPatch(types.MergePatchType, []byte(`{"spec":{"unschedulable":false}}`))
+
+				DeferCleanup(func(ctxA context.Context) {
+					By("uncordoning all nodes cordoned during test setup")
+					for _, nodeName := range cordonedNodeNames {
+						nodeObj := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+						Expect(fxt.Client.Patch(ctxA, nodeObj, uncordonPatch)).To(Succeed(), "cannot uncordon node %q", nodeName)
+						klog.InfoS("uncordoned node", "nodeName", nodeName)
+					}
+				})
+
+				for i := range nodeList.Items {
+					node := &nodeList.Items[i]
+					if node.Name == targetNodeName || node.Spec.Unschedulable {
 						continue
 					}
-					keptRunningPods = append(keptRunningPods, pod)
+					Expect(fxt.Client.Patch(ctx, &nodeList.Items[i], cordonPatch)).To(Succeed(), "cannot cordon node %q", node.Name)
+					cordonedNodeNames = append(cordonedNodeNames, node.Name)
+					klog.InfoS("cordoned node", "nodeName", node.Name)
 				}
-				klog.Info("verifying the rest of the filler pods continue to run")
-				Expect(ensurePodsNotEvicted(ctx, fxt.Client, keptRunningPods, fillersNameToUID, 1*time.Minute, 10*time.Second)).
-					To(Succeed(), "failed to have the filler pods running")
 			})
-		})
 
-		When("pods are created in bursts", func() {
-			It("should not falsely evict pods because the cache in not yet updated", func(ctx context.Context) {
-				// Create a burst of pods with low priority that all requesting the same amount of resources
-				// derived from the base load's CPUs. Then additional couple of pods that request the same
-				// resources but with higher priority. The goal of this test is to ensure that even when the
-				// NRT cache is not updated, the preemption logic also fails and would not evict pods on dirty state.
+			DescribeTable(
+				"priority-based workload placement should work as expected", Label(label.Tier2), func(ctx context.Context, tc testCase) {
+					e2efixture.By("filler priority class: %q, new pod priority class: %q, eviction expected: %v",
+						tc.fillerPodPriorityClassName, tc.newPodPriorityClassName, tc.evictionExpected)
 
-				baseload, err := intbaseload.ForNode(fxt.Client, ctx, targetNodeName)
-				Expect(err).ToNot(HaveOccurred(), "cannot get base load for %q", targetNodeName)
-				klog.InfoS("node base load", "nodeName", targetNodeName, "resources", baseload.Resources)
+					nrtInfo, err := e2enrt.FindFromList(nrtList.Items, targetNodeName)
+					Expect(err).ToNot(HaveOccurred(), "no NRT data for target node %q", targetNodeName)
 
-				// the less resources the more challenging it is for the preemption logic on dirty state
-				perPodCPURequest := baseload.CPU().DeepCopy()
+					baseload, err := intbaseload.ForNode(fxt.Client, ctx, targetNodeName)
+					Expect(err).ToNot(HaveOccurred(), "cannot get base load for %q", targetNodeName)
+					klog.InfoS("node base load", "nodeName", targetNodeName, "resources", baseload.Resources)
 
-				targetNRT, err := e2enrt.FindFromList(nrtList.Items, targetNodeName)
-				Expect(err).ToNot(HaveOccurred(), "no NRT data for target node %q", targetNodeName)
+					By("creating filler pods to fully saturate the target node resources")
+					var fillerPods []*corev1.Pod
+					for _, zone := range nrtInfo.Zones {
+						padPod, err := makePaddingPod(fxt, fxt.Namespace.Name, targetNodeName, zone, baseload.Resources)
+						Expect(err).ToNot(HaveOccurred(), "cannot create padding pod spec for node %q zone %q", targetNodeName, zone.Name)
 
-				totalCPUCount := 0
-				for _, zone := range targetNRT.Zones {
-					minCount := 0
-					for _, ri := range zone.Resources {
-						if ri.Name != "cpu" {
+						if tc.fillerPodPriorityClassName != "" {
+							padPod.Spec.PriorityClassName = tc.fillerPodPriorityClassName
+						}
+						padPod.Spec.SchedulerName = serialconfig.Config.SchedulerName
+
+						pinnedPod, err := pinPodTo(padPod, targetNodeName, zone.Name)
+						Expect(err).ToNot(HaveOccurred(), "cannot pin filler pod to node %q zone %q", targetNodeName, zone.Name)
+
+						Expect(fxt.Client.Create(ctx, pinnedPod)).To(Succeed(), "cannot create filler pod for zone %q", zone.Name)
+						fillerPods = append(fillerPods, pinnedPod)
+					}
+
+					By("waiting for filler pods to be running")
+					failedPodIds := e2efixture.WaitForPaddingPodsRunning(ctx, fxt, fillerPods)
+					Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
+
+					By("waiting for the NRT data to settle")
+					e2efixture.MustSettleNRT(fxt)
+
+					fillersNameToUID := getNamesToUIDs(ctx, fxt.Client, fillerPods)
+
+					By("creating the new workload pod")
+					testPod := objects.NewTestPodPause(fxt.Namespace.Name, "test-workload")
+					testPod.Spec.SchedulerName = serialconfig.Config.SchedulerName
+					if tc.newPodPriorityClassName != "" {
+						testPod.Spec.PriorityClassName = tc.newPodPriorityClassName
+					}
+					// this will trigger the preemption logic
+					testPodRes := fillerPods[0].Spec.Containers[0].Resources.Limits
+					testPod.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+						Limits:   testPodRes,
+						Requests: testPodRes,
+					}
+
+					Expect(fxt.Client.Create(ctx, testPod)).To(Succeed(), "cannot create test workload pod")
+
+					if tc.evictionExpected {
+						By("verifying one filler pod is preempted and evicted")
+						evicted := sets.New[string]()
+						Eventually(func(g Gomega) {
+							for _, fp := range fillerPods {
+								pod := &corev1.Pod{}
+								err := fxt.Client.Get(ctx, client.ObjectKeyFromObject(fp), pod)
+								if apierrors.IsNotFound(err) {
+									evicted.Insert(fp.Name)
+								}
+							}
+							g.Expect(evicted.Len()).To(Equal(1), "expected one filler pod to be evicted, got %d", evicted.Len())
+						}).WithTimeout(pendingTimeout).WithPolling(10*time.Second).Should(Succeed(), "failed to have the pod running")
+						By("verifying test pod becomes running after preemption")
+						updatedPod, err := wait.With(fxt.Client).Timeout(pendingTimeout).ForPodPhase(ctx, testPod.Namespace, testPod.Name, corev1.PodRunning)
+						if err != nil {
+							_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
+						}
+						Expect(err).ToNot(HaveOccurred(), "test pod did not become Running after preemption")
+
+						By("verifying the rest of the filler pods continue to run")
+						Consistently(func(g Gomega) {
+							for _, fp := range fillerPods {
+								if evicted.Has(fp.Name) {
+									continue
+								}
+								pod := &corev1.Pod{}
+								g.Expect(fxt.Client.Get(ctx, client.ObjectKeyFromObject(fp), pod)).To(Succeed())
+								g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning), "pod %s/%s is not running", pod.Namespace, pod.Name)
+								g.Expect(pod.DeletionTimestamp).To(BeNil(), "filler pod %q should not have been evicted", fp.Name)
+							}
+						}).WithTimeout(2*time.Minute).WithPolling(10*time.Second).Should(Succeed(), "more than one filler pod was evicted")
+					} else {
+						evictionNotExpected(ctx, fxt.Client, testPod, fillerPods, fillersNameToUID)
+					}
+				},
+				Entry("default-priority fillers vs default-priority new workload",
+					testCase{fillerPodPriorityClassName: "", newPodPriorityClassName: "", evictionExpected: false}),
+
+				Entry("default-priority fillers vs system-node-critical new workload",
+					testCase{fillerPodPriorityClassName: "", newPodPriorityClassName: systemNodeCriticalPriorityClassName, evictionExpected: true}),
+
+				Entry("system-node-critical fillers vs default-priority new workload",
+					testCase{fillerPodPriorityClassName: systemNodeCriticalPriorityClassName, newPodPriorityClassName: "", evictionExpected: false}),
+
+				Entry("system-node-critical fillers vs system-node-critical new workload",
+					testCase{fillerPodPriorityClassName: systemNodeCriticalPriorityClassName, newPodPriorityClassName: systemNodeCriticalPriorityClassName, evictionExpected: false}),
+
+				Entry("custom low-priority fillers vs custom medium-priority new workload",
+					testCase{fillerPodPriorityClassName: customLowPriorityClassName, newPodPriorityClassName: customMediumPriorityClassName, evictionExpected: true}),
+
+				Entry("custom medium-priority fillers vs custom low-priority new workload",
+					testCase{fillerPodPriorityClassName: customMediumPriorityClassName, newPodPriorityClassName: customLowPriorityClassName, evictionExpected: false}),
+			)
+
+			When("filler pods have mixed priorities", func() {
+				var targetNRT *nrtv1alpha2.NodeResourceTopology
+				BeforeEach(func(ctx context.Context) {
+					var err error
+					targetNRT, err = e2enrt.FindFromList(nrtList.Items, targetNodeName)
+					// error should never happen by now
+					Expect(err).ToNot(HaveOccurred(), "no NRT data for target node %q", targetNodeName)
+				})
+
+				It("should remain pending when the new pod is not priority enough despite the node-level sufficient space", func(ctx context.Context) {
+					By("setting up the cluster for running the test resources")
+					// Scheduling all pods including the fillers should be all done by the NUMA-aware scheduler as this is
+					// part of testing the preemption functionality.
+					// test description:
+					// **The most important key for this test is that it will depend on the baseload to calculate the resources requests for filler pods and the
+					// preemptor pods.**
+					// At this point we know for sure that the node has exactly 2 NUMA zones so we distribute the filler pods with mixed
+					// priorities between the two zones:
+					// - One default-priority filler pod with two containers, pinned to the first zone; each container with resources requests= baseload
+					// - One default-priority filler pod with two containers, pinned to the second zone; each container with resources requests= baseload
+					// - One medium-priority filler pod in the first zone; resources requests= all but the baseload; minimum resources requests= 4x baseload
+					// - One medium-priority filler pod in the second zone; resources requests= all but the baseload; minimum resources requests= 4x baseload
+					// Given the above distribution, we skip the test if any of the zones have less than 2 + 4 + 1 = 7x baseload.
+					//
+					// The test pod (preemptor), in both test phases, will request 4x the baseload, why? because using this design we know exactly what to
+					// expect in terms of correct evictions:
+					// - phase-1: low-priority test pod (is higher than the default priority): the pod is qualified to evict the default priority filler pods,
+					// and the most free resources state on the node would be:
+					// free resources on node level= 6x baseload
+					// free resources in zone 1= 3x baseload
+					// free resources in zone 2= 3x baseload
+					// so the preemptor pod will remain pending because evicting only default-priority pods is not sufficient, and given it is low-priority,
+					// it is not qualified to evict the medium-priority filler pods.
+					//
+					// - phase-2: high-priority test pod: the pod is qualified to evict all of the fillers, but we want to ensure that it evicts the least
+					// amount of pods that are sufficient to make the pod fit, and not falsely evict pods even if they have lower priority. Thus one medium-
+					// priority filler pod will be evicted and the rest will stay running.
+					baseload, err := intbaseload.ForNode(fxt.Client, ctx, targetNodeName)
+					Expect(err).ToNot(HaveOccurred(), "cannot get base load for %q", targetNodeName)
+					klog.InfoS("node base load", "nodeName", targetNodeName, "resources", baseload.Resources)
+
+					leastEnoughResourcesPerZone := corev1.ResourceList{}
+					for resName, resQty := range baseload.Resources {
+						// 1 baseload + 2 for default-priority fillers + 4 for test pod
+						resQty.Mul(7)
+						leastEnoughResourcesPerZone[resName] = resQty
+					}
+					for idx, zone := range targetNRT.Zones {
+						for _, ri := range zone.Resources {
+							zoneAvailable := ri.Available
+							leastQty := leastEnoughResourcesPerZone[corev1.ResourceName(ri.Name)]
+							if zoneAvailable.Cmp(leastQty) < 0 {
+								e2efixture.Skipf(fxt, "not enough availableresources in zone %d to fit the test pod: least required resources per zone are %s, found %s", idx, leastQty.String(), zoneAvailable.String())
+							}
+						}
+					}
+
+					// first pod with two containers, pinned to the first zone
+					defaultPriorityPodResZone0 := baseload.Resources.DeepCopy()
+					defaultPriorityPodResZone0[numacellapi.MakeResourceName(0)] = resource.MustParse("1")
+					defaultPriorityPod1 := objects.NewTestPodPause(fxt.Namespace.Name, "default-priority-filler-1")
+					defaultPriorityPod1.Spec.SchedulerName = serialconfig.Config.SchedulerName
+					defaultPriorityPod1.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+						Limits:   defaultPriorityPodResZone0,
+						Requests: defaultPriorityPodResZone0,
+					}
+					containers := []corev1.Container{defaultPriorityPod1.Spec.Containers[0], *defaultPriorityPod1.Spec.Containers[0].DeepCopy()}
+					containers[1].Name = "cnt-2"
+					defaultPriorityPod1.Spec.Containers = containers
+
+					// second pod with two containers, pinned to the second zone
+					defaultPriorityPodResZone1 := baseload.Resources.DeepCopy()
+					defaultPriorityPodResZone1[numacellapi.MakeResourceName(1)] = resource.MustParse("1")
+					cntResourcesZone1 := corev1.ResourceRequirements{
+						Limits:   defaultPriorityPodResZone1,
+						Requests: defaultPriorityPodResZone1,
+					}
+					defaultPriorityPod2 := defaultPriorityPod1.DeepCopy()
+					defaultPriorityPod2.Name = "default-priority-filler-2"
+					defaultPriorityPod2.Spec.Containers[0].Resources = cntResourcesZone1
+					defaultPriorityPod2.Spec.Containers[1].Resources = cntResourcesZone1
+
+					fillerPods := []*corev1.Pod{defaultPriorityPod1, defaultPriorityPod2}
+
+					klog.Info("creating default-priority filler pods")
+					Expect(fxt.Client.Create(ctx, defaultPriorityPod1)).To(Succeed(), "cannot create victim pod 1")
+					Expect(fxt.Client.Create(ctx, defaultPriorityPod2)).To(Succeed(), "cannot create victim pod 2")
+					failedPodIds := e2efixture.WaitForPaddingPodsRunning(ctx, fxt, []*corev1.Pod{defaultPriorityPod1, defaultPriorityPod2})
+					Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
+
+					klog.Info("waiting for the NRT data to settle")
+					e2efixture.MustSettleNRT(fxt)
+					updatedNRT, err := e2enrt.GetUpdatedForNode(fxt.Client, ctx, *targetNRT, 1*time.Minute)
+					Expect(err).ToNot(HaveOccurred())
+
+					klog.Info("creating medium-priority filler pods")
+					mediumPriorityPods := []*corev1.Pod{}
+					for idx, zone := range updatedNRT.Zones {
+						paddingPod, err := makePaddingPod(fxt, fxt.Namespace.Name, targetNodeName, zone, baseload.Resources)
+						Expect(err).ToNot(HaveOccurred(), "cannot create padding pod spec for node %q zone %q", targetNodeName, zone.Name)
+						paddingPod.Name = fmt.Sprintf("medium-priority-filler-%d", idx+1)
+						paddingPod.Spec.PriorityClassName = customMediumPriorityClassName
+						paddingPod.Spec.SchedulerName = serialconfig.Config.SchedulerName
+
+						pinnedPod, err := pinPodTo(paddingPod, targetNodeName, zone.Name)
+						Expect(err).ToNot(HaveOccurred(), "cannot pin filler pod to node %q zone %q", targetNodeName, zone.Name)
+
+						Expect(fxt.Client.Create(ctx, pinnedPod)).To(Succeed(), "cannot create filler pod for zone %q", zone.Name)
+						mediumPriorityPods = append(mediumPriorityPods, pinnedPod)
+						fillerPods = append(fillerPods, pinnedPod)
+					}
+
+					klog.Info("waiting for medium-priority filler pods to be running")
+					failedPodIds = e2efixture.WaitForPaddingPodsRunning(ctx, fxt, mediumPriorityPods)
+					Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
+
+					klog.Info("waiting for the NRT data to settle")
+					e2efixture.MustSettleNRT(fxt)
+
+					fillersNameToUID := getNamesToUIDs(ctx, fxt.Client, fillerPods)
+
+					By("phase-1: low-priority test pod should remain pending because evicting only default-priority pods is not sufficient")
+					testPodTemplate := objects.NewTestPodPause(fxt.Namespace.Name, "test-workload")
+					testPodTemplate.Spec.SchedulerName = serialconfig.Config.SchedulerName
+					testPodTemplate.Spec.PriorityClassName = customLowPriorityClassName
+					testPodRes := corev1.ResourceList{}
+					for resName, resQty := range baseload.Resources {
+						resQty.Mul(4)
+						testPodRes[resName] = resQty
+					}
+					testPodTemplate.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+						Limits:   testPodRes,
+						Requests: testPodRes,
+					}
+
+					testPodPhase1 := testPodTemplate.DeepCopy()
+					testPodPhase1.Name = "preemptor-phase-1"
+					Expect(fxt.Client.Create(ctx, testPodPhase1)).To(Succeed(), "cannot create test workload pod")
+
+					evictionNotExpected(ctx, fxt.Client, testPodPhase1, fillerPods, fillersNameToUID)
+
+					klog.Info("deleting phase-1 test pod")
+					Expect(fxt.Client.Delete(ctx, testPodPhase1)).To(Succeed())
+					Expect(wait.With(fxt.Client).Timeout(pendingTimeout).ForPodDeleted(ctx, testPodPhase1.Namespace, testPodPhase1.Name)).
+						To(Succeed(), "failed to delete test pod")
+
+					By("phase-2: high-priority test pod should become running after evicting only the least amount of filler pods so that the new pod may fit")
+					testPodPhase2 := testPodTemplate.DeepCopy()
+					testPodPhase2.Name = "preemptor-phase-2"
+					testPodPhase2.Spec.PriorityClassName = customHighPriorityClassName
+					Expect(fxt.Client.Create(ctx, testPodPhase2)).To(Succeed(), "cannot create preemptor pod phase 2")
+
+					klog.Info("verifying test pod phase 2 becomes running")
+					updatedPod, err := wait.With(fxt.Client).Timeout(pendingTimeout).ForPodPhase(ctx, testPodPhase2.Namespace, testPodPhase2.Name, corev1.PodRunning)
+					if err != nil {
+						_ = objects.LogEventsForPod(fxt.K8sClient, updatedPod.Namespace, updatedPod.Name)
+					}
+					Expect(err).ToNot(HaveOccurred(), "test pod phase 2 did not become Running after preemption")
+
+					// from earlier steps we already guaranteed that the eviction will happen to one of the medium-priority filler pods because it is the
+					// only sufficient option. which also means we need to ensure that the rest of the filler pods are not evicted.
+					klog.Info("verifying one of the medium-priority filler pod is evicted and the rest are still running")
+					evictedPod := &corev1.Pod{}
+					for _, medPod := range mediumPriorityPods {
+						pod := &corev1.Pod{}
+						err := fxt.Client.Get(ctx, client.ObjectKeyFromObject(medPod), pod)
+						if apierrors.IsNotFound(err) {
+							evictedPod = medPod
+							break
+						}
+					}
+					Expect(evictedPod.Name).ToNot(BeEmpty(), "no medium-priority filler pod was evicted")
+
+					keptRunningPods := []*corev1.Pod{}
+					for _, pod := range fillerPods {
+						if pod.Name == evictedPod.Name {
 							continue
 						}
+						keptRunningPods = append(keptRunningPods, pod)
+					}
+					klog.Info("verifying the rest of the filler pods continue to run")
+					Expect(ensurePodsNotEvicted(ctx, fxt.Client, keptRunningPods, fillersNameToUID, 1*time.Minute, 10*time.Second)).
+						To(Succeed(), "failed to have the filler pods running")
+				})
+			})
 
-						total := perPodCPURequest.DeepCopy()
-						count := 0
-						for {
-							totalWithBaseload := total.DeepCopy()
-							totalWithBaseload.Add(baseload.CPU())
-							if ri.Available.Cmp(totalWithBaseload) < 0 {
-								// high enough number of pods to trigger a chance of a race and challenge the preemption logic
-								if count < 4 {
-									e2efixture.Skipf(fxt, "not enough available resources in zone %s to fit the test pods: %s", zone.Name, ri.Available.String())
-								}
-								break
+			When("pods are created in bursts", func() {
+				It("should not falsely evict pods because the cache in not yet updated", func(ctx context.Context) {
+					// Create a burst of pods with low priority that all requesting the same amount of resources
+					// derived from the base load's CPUs. Then additional couple of pods that request the same
+					// resources but with higher priority. The goal of this test is to ensure that even when the
+					// NRT cache is not updated, the preemption logic also fails and would not evict pods on dirty state.
+
+					baseload, err := intbaseload.ForNode(fxt.Client, ctx, targetNodeName)
+					Expect(err).ToNot(HaveOccurred(), "cannot get base load for %q", targetNodeName)
+					klog.InfoS("node base load", "nodeName", targetNodeName, "resources", baseload.Resources)
+
+					// the less resources the more challenging it is for the preemption logic on dirty state
+					perPodCPURequest := baseload.CPU().DeepCopy()
+
+					targetNRT, err := e2enrt.FindFromList(nrtList.Items, targetNodeName)
+					Expect(err).ToNot(HaveOccurred(), "no NRT data for target node %q", targetNodeName)
+
+					totalCPUCount := 0
+					for _, zone := range targetNRT.Zones {
+						minCount := 0
+						for _, ri := range zone.Resources {
+							if ri.Name != "cpu" {
+								continue
 							}
-							count++
-							klog.InfoS("current count calculation", "zone", zone.Name, "resourceName", ri.Name, "currentCount", count)
-							total.Add(perPodCPURequest.DeepCopy())
+
+							total := perPodCPURequest.DeepCopy()
+							count := 0
+							for {
+								totalWithBaseload := total.DeepCopy()
+								totalWithBaseload.Add(baseload.CPU())
+								if ri.Available.Cmp(totalWithBaseload) < 0 {
+									// high enough number of pods to trigger a chance of a race and challenge the preemption logic
+									if count < 4 {
+										e2efixture.Skipf(fxt, "not enough available resources in zone %s to fit the test pods: %s", zone.Name, ri.Available.String())
+									}
+									break
+								}
+								count++
+								klog.InfoS("current count calculation", "zone", zone.Name, "resourceName", ri.Name, "currentCount", count)
+								total.Add(perPodCPURequest.DeepCopy())
+							}
+							klog.InfoS("pod count per resource", "zone", zone.Name, "resourceName", ri.Name, "currentCount", count, "currenMinCount", minCount)
+							if minCount == 0 || count < minCount {
+								minCount = count
+								klog.InfoS("new min count", "zone", zone.Name, "resourceName", ri.Name, "newMinCount", minCount)
+							}
 						}
-						klog.InfoS("pod count per resource", "zone", zone.Name, "resourceName", ri.Name, "currentCount", count, "currenMinCount", minCount)
-						if minCount == 0 || count < minCount {
-							minCount = count
-							klog.InfoS("new min count", "zone", zone.Name, "resourceName", ri.Name, "newMinCount", minCount)
+						totalCPUCount += minCount
+					}
+
+					podtemplate := objects.NewTestPodPause(fxt.Namespace.Name, "test-workload")
+					podtemplate.Spec.SchedulerName = serialconfig.Config.SchedulerName
+					podtemplate.Spec.PriorityClassName = customLowPriorityClassName
+					singlePodResources := corev1.ResourceList{
+						corev1.ResourceName("cpu"):    perPodCPURequest,
+						corev1.ResourceName("memory"): resource.MustParse("32Mi"), // arbitrary small memory request
+					}
+
+					podtemplate.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+						Limits:   singlePodResources,
+						Requests: singlePodResources,
+					}
+
+					pods := []*corev1.Pod{}
+					for i := 0; i < totalCPUCount; i++ {
+						pod := podtemplate.DeepCopy()
+						pod.Name = fmt.Sprintf("pod-%d", i)
+
+						// last 2 pods make them with high priority
+						if i > totalCPUCount-3 {
+							pod.Spec.PriorityClassName = customHighPriorityClassName
 						}
+						Expect(fxt.Client.Create(ctx, pod)).To(Succeed(), "cannot create test workload pod")
+						pods = append(pods, pod)
 					}
-					totalCPUCount += minCount
-				}
 
-				podtemplate := objects.NewTestPodPause(fxt.Namespace.Name, "test-workload")
-				podtemplate.Spec.SchedulerName = serialconfig.Config.SchedulerName
-				podtemplate.Spec.PriorityClassName = customLowPriorityClassName
-				singlePodResources := corev1.ResourceList{
-					corev1.ResourceName("cpu"):    perPodCPURequest,
-					corev1.ResourceName("memory"): resource.MustParse("32Mi"), // arbitrary small memory request
-				}
+					klog.Info("waiting for the pods to be running")
+					failedPodIds := e2efixture.WaitForPaddingPodsRunning(ctx, fxt, pods)
+					Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
 
-				podtemplate.Spec.Containers[0].Resources = corev1.ResourceRequirements{
-					Limits:   singlePodResources,
-					Requests: singlePodResources,
-				}
+					klog.Info("waiting for the NRT data to settle")
+					e2efixture.MustSettleNRT(fxt)
 
-				pods := []*corev1.Pod{}
-				for i := 0; i < totalCPUCount; i++ {
-					pod := podtemplate.DeepCopy()
-					pod.Name = fmt.Sprintf("pod-%d", i)
-
-					// last 2 pods make them with high priority
-					if i > totalCPUCount-3 {
-						pod.Spec.PriorityClassName = customHighPriorityClassName
+					klog.Info("ensure all pods are kept running")
+					for _, pod := range pods {
+						Expect(fxt.Client.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(Succeed(), "cannot get pod %q", pod.Name)
+						Expect(pod.Status.Phase).To(Equal(corev1.PodRunning), "pod %s/%s is not running", pod.Namespace, pod.Name)
 					}
-					Expect(fxt.Client.Create(ctx, pod)).To(Succeed(), "cannot create test workload pod")
-					pods = append(pods, pod)
-				}
-
-				klog.Info("waiting for the pods to be running")
-				failedPodIds := e2efixture.WaitForPaddingPodsRunning(ctx, fxt, pods)
-				Expect(failedPodIds).To(BeEmpty(), "some padding pods have failed to run")
-
-				klog.Info("waiting for the NRT data to settle")
-				e2efixture.MustSettleNRT(fxt)
-
-				klog.Info("ensure all pods are kept running")
-				for _, pod := range pods {
-					Expect(fxt.Client.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(Succeed(), "cannot get pod %q", pod.Name)
-					Expect(pod.Status.Phase).To(Equal(corev1.PodRunning), "pod %s/%s is not running", pod.Namespace, pod.Name)
-				}
+				})
 			})
 		})
 	})
 })
+
+func setPreemptionMode(ctx context.Context, fxt *e2efixture.Fixture, key client.ObjectKey, newMode *nropv1.PreemptionMode) {
+	GinkgoHelper()
+
+	e2efixture.By("setting preemption mode to %v", newMode)
+	Eventually(func(g Gomega) {
+		obj := &nropv1.NUMAResourcesScheduler{}
+		g.Expect(fxt.Client.Get(ctx, key, obj)).To(Succeed())
+		obj.Spec.PreemptionMode = newMode
+		g.Expect(fxt.Client.Update(ctx, obj)).To(Succeed())
+	}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+
+	e2efixture.By("verifying the scheduler object was updated properly with the new value %v", newMode)
+	updatedSchedObj := &nropv1.NUMAResourcesScheduler{}
+	Eventually(func(g Gomega) error {
+		g.Expect(fxt.Client.Get(ctx, key, updatedSchedObj)).To(Succeed())
+		return isNROSchedSyncedAt(&updatedSchedObj.Status, status.ConditionAvailable, updatedSchedObj.Generation)
+	}).WithTimeout(time.Minute).WithPolling(time.Second*15).Should(Succeed(), "failed to update the schedulerName field")
+	Expect(updatedSchedObj.Spec.PreemptionMode).To(Equal(newMode), "failed to update the schedulerName field,expected %v but found %v", newMode, updatedSchedObj.Spec.PreemptionMode)
+}
 
 func evictionNotExpected(ctx context.Context, cli client.Client, testPod *corev1.Pod, fillerPods []*corev1.Pod, fillersNameToUID map[string]types.UID) {
 	GinkgoHelper()

--- a/vendor/github.com/k8stopologyawareschedwg/deployer/pkg/manifests/schedparams.go
+++ b/vendor/github.com/k8stopologyawareschedwg/deployer/pkg/manifests/schedparams.go
@@ -55,6 +55,11 @@ const (
 )
 
 const (
+	PreemptionEnabled  = "Enabled"
+	PreemptionDisabled = "Disabled"
+)
+
+const (
 	LeaderElectionDefaultName      = "nrtmatch-scheduler"
 	LeaderElectionDefaultNamespace = "tas-scheduler"
 )
@@ -141,6 +146,17 @@ func ValidateScoringStrategyType(value string) error {
 	}
 }
 
+func ValidatePreemptionMode(value string) error {
+	switch value {
+	case PreemptionEnabled:
+		return nil
+	case PreemptionDisabled:
+		return nil
+	default:
+		return fmt.Errorf("unsupported preemptionMode: %v", value)
+	}
+}
+
 type LeaderElectionParams struct {
 	LeaderElect       bool   `json:"leaderElect"`
 	ResourceNamespace string `json:"resourceNamespace,omitempty"`
@@ -162,6 +178,7 @@ type ConfigParams struct {
 	Cache           *ConfigCacheParams     `json:"cache"`
 	ScoringStrategy *ScoringStrategyParams `json:"scoringStrategy,omitempty"`
 	LeaderElection  *LeaderElectionParams  `json:"leaderElection"`
+	PreemptionMode  *string                `json:"preemptionMode,omitempty"`
 }
 
 func DecodeSchedulerProfilesFromData(data []byte) ([]ConfigParams, error) {
@@ -359,6 +376,17 @@ func extractParams(profileName string, args map[string]interface{}) (ConfigParam
 			}
 			params.ScoringStrategy.Resources = resources
 		}
+	}
+
+	preemptionMode, ok, err := unstructured.NestedString(args, "preemptionMode")
+	if err != nil {
+		return params, fmt.Errorf("cannot process field preemptionMode: %w", err)
+	}
+	if ok {
+		if err := ValidatePreemptionMode(preemptionMode); err != nil {
+			return params, err
+		}
+		params.PreemptionMode = &preemptionMode
 	}
 
 	return params, nil

--- a/vendor/github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate/sched/render.go
+++ b/vendor/github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate/sched/render.go
@@ -263,6 +263,12 @@ func updateArgs(args map[string]interface{}, params *manifests.ConfigParams) (bo
 		}
 	}
 
+	preemptionArgsUpdated, err := updatePreemptionArgs(args, params)
+	if err != nil {
+		return updated > 0, err
+	}
+	updated += preemptionArgsUpdated
+
 	return updated > 0, ensureBackwardCompatibility(args)
 }
 
@@ -342,6 +348,30 @@ func updateScoringStrategyArgs(args map[string]interface{}, params *manifests.Co
 	}
 
 	return updated, nil
+}
+
+func updatePreemptionArgs(args map[string]interface{}, params *manifests.ConfigParams) (int, error) {
+	if params.PreemptionMode == nil {
+		if _, ok, err := unstructured.NestedString(args, "preemptionMode"); err != nil {
+			return 0, err
+		} else if ok {
+			// remove for backward compatibility
+			delete(args, "preemptionMode")
+			return 1, nil
+		}
+		return 0, nil
+	}
+
+	preemptionMode := *params.PreemptionMode // shortcut
+	err := manifests.ValidatePreemptionMode(preemptionMode)
+	if err != nil {
+		return 0, err
+	}
+	err = unstructured.SetNestedField(args, preemptionMode, "preemptionMode")
+	if err != nil {
+		return 0, err
+	}
+	return 1, nil
 }
 
 func ensureBackwardCompatibility(args map[string]interface{}) error {

--- a/vendor/github.com/k8stopologyawareschedwg/numaplacement/.gitignore
+++ b/vendor/github.com/k8stopologyawareschedwg/numaplacement/.gitignore
@@ -1,0 +1,2 @@
+coverage.out
+_out/

--- a/vendor/github.com/k8stopologyawareschedwg/numaplacement/LICENSE
+++ b/vendor/github.com/k8stopologyawareschedwg/numaplacement/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/k8stopologyawareschedwg/numaplacement/Makefile
+++ b/vendor/github.com/k8stopologyawareschedwg/numaplacement/Makefile
@@ -1,0 +1,54 @@
+##@ general
+
+default: test-unit
+
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-36s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ tools
+
+tools: leb89dump  ## Build all tools
+
+leb89dump: tools/leb89dump/main.go  ## Build the LEB89 alphabet dump tool
+	go build -o _out/$@ ./tools/leb89dump
+
+PKGS = $(shell go list ./... | grep -v /tools/)
+PKGS_UNIT = $(shell go list ./... | grep -vE 'tools/|test/codec$$|examples/')
+
+##@ testing
+
+test-unit:  ## Run unit tests
+	go test $(PKGS_UNIT)
+
+test-integration:  ## Run integration tests
+	go test ./test/codec/...
+
+test-unit-cover:  ## Run unit tests with coverage report
+	go test -coverprofile=coverage.out $(PKGS)
+
+cover-view:  ## View the console coverage report
+	go tool cover -func=coverage.out
+
+cover-view-html:  ## View the HTML coverage report
+	go tool cover -html=coverage.out
+
+##@ quality
+
+fmt-check: ## Check gofmt formatting
+	@out="$$(gofmt -l . 2>&1)"; status="$$?"; \
+	if [ "$$status" -ne 0 ]; then \
+		echo "$$out"; \
+		exit "$$status"; \
+	fi; \
+	unformatted="$$out"; \
+	if [ -n "$$unformatted" ]; then \
+		echo "The following files are not gofmt-formatted:"; \
+		echo "$$unformatted"; \
+		exit 1; \
+	fi
+
+lint: ## Run static checks
+	go vet $(PKGS)
+
+vuln-check: ## Run govulncheck against all packages
+	go run golang.org/x/vuln/cmd/govulncheck@latest ./...

--- a/vendor/github.com/k8stopologyawareschedwg/numaplacement/README.md
+++ b/vendor/github.com/k8stopologyawareschedwg/numaplacement/README.md
@@ -1,0 +1,30 @@
+[![Go Reference](https://pkg.go.dev/badge/github.com/k8stopologyawareschedwg/numaplacement.svg)](https://pkg.go.dev/github.com/k8stopologyawareschedwg/numaplacement)
+
+# numaplacement: efficient per-NUMA container placement encoding
+
+This package provides wire-efficient encoding of the NUMA placement of kubernetes containers.
+"NUMA Placement" means the single NUMA node from which a container gets all its exclusively assigned resources,
+like devices, CPU cores, memory areas. If, for example, a container C1 has all resources assigned and pinned
+to the same NUMA node N, we therefore classify C1 with NUMA Affinity to N (C1=N).
+Multi-affinity is not supported yet.
+
+## Status
+
+pre-alpha. Subject to change without notice. Please wait for tagged and official releases.
+
+## Example
+
+A runnable end-to-end encoder/decoder example is available in:
+
+- `examples/codec/main.go`
+
+Run it with:
+
+```bash
+go run ./examples/codec
+```
+
+## LICENSE
+
+apache v2
+

--- a/vendor/github.com/k8stopologyawareschedwg/numaplacement/doc.go
+++ b/vendor/github.com/k8stopologyawareschedwg/numaplacement/doc.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Red Hat, Inc.
+
+// Package numaplacement efficiently encodes the per-NUMA placement of
+// containers with exclusively assigned resources, so they can themselves
+// be considered "affine" to a NUMA node.
+//
+// The encoding uses LEB89, a self-delimiting variable-length encoding that
+// maps non-negative integers to sequences of printable ASCII characters.
+// See leb89/doc.go for details.
+//
+// Both the node agent and the scheduler independently produce the same
+// deterministic ordered list of container hashes, and per-NUMA
+// offset vectors reference positions in that list.
+// This package is expected to be in concert with the noderesourcetopology-api
+// kubernetes datatype, but does not depend on it.
+
+package numaplacement

--- a/vendor/github.com/k8stopologyawareschedwg/numaplacement/leb89/doc.go
+++ b/vendor/github.com/k8stopologyawareschedwg/numaplacement/leb89/doc.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// LEB89 is a self-delimiting, variable-length integer encoding inspired by
+// LEB128 (Little-Endian Base 128), the variable-length encoding used in
+// DWARF debug info and WebAssembly. Where LEB128 splits each byte into a
+// 7-bit payload and a 1-bit continuation flag over the full 0x00-0xFF range,
+// LEB89 applies the same principle over an alphabet of 89 printable ASCII
+// characters that are safe to embed verbatim in JSON strings.
+//
+// The "89" in the name refers to the alphabet size: the 94 printable ASCII
+// characters (0x21-0x7E) minus the 5 that Go's json.Marshal escapes or
+// expands (" & < > \). The 89 characters are split into 64 terminal
+// symbols (which end a value, analogous to LEB128's continuation bit = 0)
+// and 25 continuation symbols (which signal more digits follow, analogous
+// to LEB128's continuation bit = 1). This yields a mixed-radix encoding:
+// the final digit is base-64, all preceding digits are base-25.
+//
+// The result is a compact encoding where every output byte
+// is a single safe printable ASCII character.
+package leb89

--- a/vendor/github.com/k8stopologyawareschedwg/numaplacement/leb89/leb89.go
+++ b/vendor/github.com/k8stopologyawareschedwg/numaplacement/leb89/leb89.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package leb89
+
+import "strings"
+
+const (
+	Unmapped int32 = -1
+)
+
+const (
+	AlphabetSize    = 89
+	NumTerminal     = 64
+	NumContinuation = 25 // 89 - 64
+)
+
+// safeASCII holds the 89 printable ASCII characters that Go's json.Marshal
+// passes through without escaping: all of 0x21-0x7E except " & < > \
+var safeASCII [89]byte
+
+// asciiIndex is the reverse map: byte -> index in safeASCII, -1 if unmapped.
+var asciiIndex [128]int
+
+func init() {
+	idx := 0
+	for b := byte(0x21); b <= 0x7E; b++ {
+		if b == '"' || b == '&' || b == '<' || b == '>' || b == '\\' {
+			continue
+		}
+		safeASCII[idx] = b
+		idx++
+	}
+	for i := range asciiIndex {
+		asciiIndex[i] = int(Unmapped)
+	}
+	for i, b := range safeASCII {
+		asciiIndex[b] = i
+	}
+}
+
+// EncodeInto encodes v >= 0 as a LEB89 character sequence written to w.
+// Values 0-63: 1 character (terminal).
+// Values 64-1663: 2 characters (1 continuation + terminal).
+// Values 1664-40063: 3 characters (2 continuations + terminal).
+//
+// v must be non-negative. Negative values will cause an array index
+// out of bounds panic. In the normal encoder flow, v is always a
+// non-negative offset or a delta between sorted ascending offsets,
+// so negative values cannot occur.
+func EncodeInto(w *strings.Builder, v int32) {
+	if v < int32(NumTerminal) {
+		w.WriteByte(safeASCII[v])
+		return
+	}
+	v -= int32(NumTerminal)
+
+	terminal := v % int32(NumTerminal)
+	v /= int32(NumTerminal)
+
+	var digits [8]int32
+	n := 0
+	for {
+		digits[n] = v % int32(NumContinuation)
+		n++
+		v /= int32(NumContinuation)
+		if v == 0 {
+			break
+		}
+	}
+	for i := n - 1; i >= 0; i-- {
+		w.WriteByte(safeASCII[NumTerminal+digits[i]])
+	}
+	w.WriteByte(safeASCII[terminal])
+}
+
+// EncodeIntoString encodes v >= 0 as a LEB89 string.
+// Convenience wrapper around EncodeInto for single-value encoding.
+func EncodeIntoString(v int32) string {
+	var w strings.Builder
+	EncodeInto(&w, v)
+	return w.String()
+}
+
+// DecodeFromString reads one LEB89-encoded value from s[pos:].
+// Returns (value, newPos). Returns (Unmapped, pos) on malformed input.
+func DecodeFromString(s string, pos int) (int32, int) {
+	var contValue int32
+	nCont := 0
+	for pos < len(s) {
+		idx := asciiIndex[s[pos]]
+		pos++
+		if idx < NumTerminal {
+			if nCont == 0 {
+				return int32(idx), pos
+			}
+			return int32(NumTerminal) + contValue*int32(NumTerminal) + int32(idx), pos
+		}
+		contValue = contValue*int32(NumContinuation) + int32(idx-NumTerminal)
+		nCont++
+	}
+	return Unmapped, pos
+}

--- a/vendor/github.com/k8stopologyawareschedwg/numaplacement/numaplacement.go
+++ b/vendor/github.com/k8stopologyawareschedwg/numaplacement/numaplacement.go
@@ -1,0 +1,607 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Red Hat, Inc.
+
+package numaplacement
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/k8stopologyawareschedwg/numaplacement/leb89"
+)
+
+const (
+	// AttributeMetadata is the NRT top-level attribute declaring the version
+	// of the container offsets and how the data is constructed
+	AttributeMetadata = "topology.node.k8s.io/numaplacement-metadata"
+
+	// AttributeVector is the NRT per-zone attribute carrying the
+	// LEB89-encoded delta vector of container offsets placed on that NUMA.
+	AttributeVector = "topology.node.k8s.io/numaplacement-vector"
+)
+
+const (
+	// Prefix is the string common to all the fingerprints
+	// A prefix is always 4 bytes long
+	Prefix = "npv0"
+	// Version is the version of this fingerprint. You should
+	// only compare compatible versions.
+	// A Version is always 4 bytes long, in the form v\X\X\X
+	Version = "v001"
+	// Unknown is the conventional unset/unknown value for int fields
+	Unknown = -1
+)
+
+const (
+	metadataSeparator = "::"
+)
+
+var (
+	ErrMalformedMetadata              = errors.New("malformed metadata")
+	ErrUnknownMetadata                = errors.New("unknown metadata field")
+	ErrMalformedMetadataPair          = errors.New("malformed metadata pair")
+	ErrMissingMetadataKey             = errors.New("missing metadata key")
+	ErrMissingMetadataValue           = errors.New("missing metadata value")
+	ErrInconsistentContainerSet       = errors.New("inconsistent container set")
+	ErrInconsistentBusiestNode        = errors.New("inconsistent busiest node data")
+	ErrUnknownBusiestNode             = errors.New("unknown busiest node")
+	ErrInconsistentNUMANodes          = errors.New("inconsistent NUMA node count")
+	ErrInconsistentNUMAVectors        = errors.New("inconsistent NUMA vector data")
+	ErrCorruptedNUMAVector            = errors.New("corrupted NUMA vector")
+	ErrDuplicatedNUMAVector           = errors.New("duplicated data in multiple NUMA vectors")
+	ErrUnknownContainer               = errors.New("unknown container")
+	ErrWrongNUMAAffinity              = errors.New("wrong NUMA affinity")
+	ErrUnsupportedUnknownNUMAAffinity = errors.New("unknown NUMA affinity not supported")
+	ErrUnsupportedVectorEncoding      = errors.New("unsupported vector encoding")
+)
+
+// Hasher implements the subset of stdlib methods this package needs.
+type Hasher interface {
+	Reset()
+	WriteString(string) (int, error)
+	Sum64() uint64
+}
+
+// ContainerID contains the identification attributes for a Container.
+type ContainerID struct {
+	Namespace     string
+	PodName       string
+	ContainerName string
+}
+
+// String returns the human-oriented string representation of a ContainerID
+func (ci ContainerID) String() string {
+	return ci.Namespace + "/" + ci.PodName + "/" + ci.ContainerName
+}
+
+// HashWith returns the canonical hash representation of this ContainerID,
+// reusing a given hasher. We assume a xxhash implementation.
+func (ci ContainerID) HashWith(hasher Hasher) uint64 {
+	hasher.Reset()
+	hasher.WriteString(ci.Namespace)
+	hasher.WriteString("\x00")
+	hasher.WriteString(ci.PodName)
+	hasher.WriteString("\x00")
+	hasher.WriteString(ci.ContainerName)
+	return hasher.Sum64()
+}
+
+// Hash() returns the canonical xxhash representation of this ContainerID
+func (ci ContainerID) Hash() uint64 {
+	return ci.HashWith(xxhash.New())
+}
+
+// ContainerAffinity maps a container through its ContainerID to a NUMA Node.
+type ContainerAffinity struct {
+	ID       ContainerID
+	NUMANode int
+}
+
+// VectorEncoding identifies the encoding used for per-NUMA vectors.
+// Values are short strings (<=8 chars) allocated per-package.
+const (
+	VectorEncodingLEB89 string = "leb89"
+)
+
+// Payload is the encoder output which can be added to or derived from the NRT content
+// Payload represents (a slightly abstracted) wire data because this package wants
+// to avoid direct manipulation, therefore direct dependency, on NRT objects.
+// Furthermore, abstracting the payload from the data format allows us to generalize
+// easily the applicability of this package.
+type Payload struct {
+	// Number of containers this info represents
+	Containers int `numaloc:"cc"`
+	// Number of NUMA nodes
+	NUMANodes int `numaloc:"nn"`
+	// Index of busiest NUMA node, therefore omitted on wire
+	BusiestNode int `numaloc:"bn"`
+	// VectorEncoding reports the meaning of the Vector data
+	VectorEncoding string `numaloc:"ve"`
+	// map NUMANodeID -> vector placement
+	Vectors map[int]string
+}
+
+// EmptyPayload constructs an empty valid Payload. Expected to be used mostly in tests.
+func EmptyPayload(ve string, busiestNode int) Payload {
+	return Payload{
+		NUMANodes:      1,
+		BusiestNode:    busiestNode,
+		VectorEncoding: ve,
+		Vectors:        make(map[int]string),
+	}
+}
+
+// Validate checks the consistency of internal payload fields, returns nil
+// if everything looks good, error otherwise detailing the failure.
+// Validate will NOT check the semantic of the vectors: it will not validate
+// or decode the leb89 encoding; errors in the encoded vector can be
+// caught at decoding stage.
+func (pl Payload) Validate(validateFunc func(Payload) error) error {
+	if err := validateFunc(pl); err != nil {
+		return err
+	}
+	if pl.Containers < 0 {
+		return ErrInconsistentContainerSet
+	}
+	if pl.NUMANodes <= 0 {
+		return ErrInconsistentNUMANodes
+	}
+	if pl.Containers == 0 && len(pl.Vectors) > 0 {
+		return ErrInconsistentNUMAVectors
+	}
+	if len(pl.Vectors) > pl.NUMANodes {
+		return ErrInconsistentNUMAVectors
+	}
+	if pl.BusiestNode >= pl.NUMANodes {
+		return ErrInconsistentBusiestNode
+	}
+	for numaNode := range pl.Vectors {
+		if numaNode < 0 || numaNode >= pl.NUMANodes {
+			return ErrCorruptedNUMAVector
+		}
+	}
+	return nil
+}
+
+type metaField struct {
+	name   string
+	ptrInt *int
+	ptrStr *string
+}
+
+func setMetaField(fields []metaField, rawField string) error {
+	idx := strings.Index(rawField, "=")
+	if idx == -1 {
+		return ErrMalformedMetadataPair
+	}
+	if idx == 0 {
+		return ErrMissingMetadataKey
+	}
+	if idx >= len(rawField)-1 {
+		return ErrMissingMetadataValue
+	}
+	fieldName := rawField[:idx]
+	if fieldName == "ve" {
+		fieldVal := rawField[idx+1:]
+		for _, field := range fields {
+			if field.name == fieldName {
+				*field.ptrStr = fieldVal
+			}
+		}
+		return nil
+	}
+	fieldVal, err := strconv.Atoi(rawField[idx+1:])
+	if err != nil {
+		return fmt.Errorf("error while parsing %q: %w", rawField, err)
+	}
+	for _, field := range fields {
+		if field.name == fieldName {
+			*field.ptrInt = fieldVal
+			return nil
+		}
+	}
+	return ErrUnknownMetadata
+}
+
+// UnpackMetadataInto updates the Payload metadata fields from the given encoded
+// metadata string.
+// On failure, the returned error is not nil and partial changes may have been
+// done to the Payload argument.
+func UnpackMetadataInto(pl *Payload, metadata string) error {
+	fields := []metaField{
+		{
+			name:   "ve",
+			ptrStr: &pl.VectorEncoding,
+		},
+		{
+			name:   "cc",
+			ptrInt: &pl.Containers,
+		},
+		{
+			name:   "nn",
+			ptrInt: &pl.NUMANodes,
+		},
+		{
+			name:   "bn",
+			ptrInt: &pl.BusiestNode,
+		},
+	}
+	metaPfx := Prefix + Version + metadataSeparator
+	if !strings.HasPrefix(metadata, metaPfx) {
+		return ErrMalformedMetadata
+	}
+	for _, field := range fields {
+		if field.ptrInt != nil {
+			*field.ptrInt = Unknown
+		}
+		if field.ptrStr != nil {
+			*field.ptrStr = ""
+		}
+	}
+	for _, rawField := range strings.Split(strings.TrimPrefix(metadata, metaPfx), metadataSeparator) {
+		if err := setMetaField(fields, rawField); err != nil {
+			return fmt.Errorf("error while setting %q: %w", rawField, err)
+		}
+	}
+	return nil
+}
+
+// PackMetadata encodes the Payload metadata fields into a string representation.
+func (pl Payload) PackMetadata() string {
+	vals := []string{
+		fmt.Sprintf("ve=%s", pl.VectorEncoding),
+		fmt.Sprintf("cc=%d", pl.Containers),
+		fmt.Sprintf("nn=%d", pl.NUMANodes),
+		fmt.Sprintf("bn=%d", pl.BusiestNode),
+	}
+	return Prefix + Version + metadataSeparator + strings.Join(vals, metadataSeparator)
+}
+
+// EncodePerNUMAVector delta-encodes a sorted slice of container offsets into
+// a LEB89 string. The first offset is stored as-is; subsequent offsets are
+// stored as deltas from the previous value.
+//
+// The input MUST be sorted in ascending order. When called through
+// Encoder.Result(), this is guaranteed because offsets are indices into a
+// sorted hash slice and are appended in iteration order. Unsorted input
+// would produce negative deltas, which will panic in leb89.EncodeInto.
+func EncodePerNUMAVector(sortedOffsets []int32) string {
+	if len(sortedOffsets) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.Grow(len(sortedOffsets) + len(sortedOffsets)/8)
+	leb89.EncodeInto(&sb, sortedOffsets[0])
+	for i := 1; i < len(sortedOffsets); i++ {
+		leb89.EncodeInto(&sb, sortedOffsets[i]-sortedOffsets[i-1])
+	}
+	return sb.String()
+}
+
+// DecodePerNUMAVector decodes a LEB89 string back into a sorted slice of
+// container offsets (the inverse of EncodePerNUMAVector).
+func DecodePerNUMAVector(s string) []int32 {
+	if len(s) == 0 {
+		return []int32{}
+	}
+	out := make([]int32, 0, len(s))
+	pos := 0
+	prev := int32(0)
+	first := true
+	for pos < len(s) {
+		v, newPos := leb89.DecodeFromString(s, pos)
+		if first {
+			out = append(out, v)
+			prev = v
+			first = false
+		} else {
+			prev += v
+			out = append(out, prev)
+		}
+		pos = newPos
+	}
+	return out
+}
+
+// Encoder handles a full set of containers by their name, and their affinity,
+// and produces a Payload which compactly represents the affinities vectors.
+// Containers can be added in a streaming manner, not necessarily in one go,
+// but once the Payload is created, the Encoder instance must be discarded.
+type Encoder struct {
+	numaNodes    int
+	numaLocality map[uint64]int // hash->numaID
+	hasher       *xxhash.Digest
+}
+
+// NewEncoder creates a new Encoder object for the given NUMA Nodes count,
+// optionally encoding the given ContainerAffinities. Even though it is
+// supported, the NUMA Node count should usually never change in the
+// lifetime of the program.
+// If duplicate Affinities are given (same ID with different Affinity) the
+// latest added wins and the previous instances are silently discarded.
+func NewEncoder(numaNodes int, cas ...ContainerAffinity) (*Encoder, error) {
+	if numaNodes <= 0 {
+		return nil, ErrInconsistentNUMANodes
+	}
+	enc := &Encoder{
+		numaNodes:    numaNodes,
+		hasher:       xxhash.New(),
+		numaLocality: make(map[uint64]int, len(cas)),
+	}
+	return enc.Encode(cas...)
+}
+
+// Containers return the number of containers this encoder knows about
+func (enc *Encoder) Containers() int {
+	return len(enc.numaLocality)
+}
+
+// NUMANodes return the number of NUMA nodes this encoder knows about
+func (enc *Encoder) NUMANodes() int {
+	return enc.numaNodes
+}
+
+// Encode encodes the given ContainerAffinities.
+// If duplicate Affinities are given (same ID with different Affinity) the
+// latest added wins and the previous instances are silently discarded.
+func (enc *Encoder) Encode(cas ...ContainerAffinity) (*Encoder, error) {
+	for _, ca := range cas {
+		if ca.NUMANode == Unknown {
+			return nil, ErrUnsupportedUnknownNUMAAffinity
+		}
+		if ca.NUMANode != Unknown && ca.NUMANode < 0 {
+			return nil, ErrWrongNUMAAffinity
+		}
+		if ca.NUMANode > enc.numaNodes-1 {
+			return nil, ErrWrongNUMAAffinity
+		}
+		hval := ca.ID.HashWith(enc.hasher)
+		enc.numaLocality[hval] = ca.NUMANode
+	}
+	return enc, nil
+}
+
+// EncodeContainer encode a container affinity through its essential attributes.
+// If duplicate Affinities are given (same ID with different Affinity) the
+// latest added wins and the previous instances are silently discarded.
+func (enc *Encoder) EncodeContainer(namespace, podName, containerName string, numaAffinity int) (*Encoder, error) {
+	return enc.Encode(ContainerAffinity{
+		ID: ContainerID{
+			Namespace:     namespace,
+			PodName:       podName,
+			ContainerName: containerName,
+		},
+		NUMANode: numaAffinity,
+	})
+}
+
+// Result finalizes the encoding of a set of ContainerAffinities.
+// On failure, the Payload must be ignored and the error is not nil.
+func (enc *Encoder) Result() (Payload, error) {
+	pl := Payload{
+		Containers:     len(enc.numaLocality),
+		NUMANodes:      enc.numaNodes,
+		BusiestNode:    Unknown,
+		VectorEncoding: VectorEncodingLEB89,
+		Vectors:        make(map[int]string),
+	}
+	if len(enc.numaLocality) == 0 {
+		pl.BusiestNode = 0
+		return pl, nil
+	}
+	hashes := SortedKeys(enc.numaLocality)
+	perNuma := make(map[int][]int32, enc.numaNodes)
+	for idx, hval := range hashes {
+		numaNode := enc.numaLocality[hval]
+		perNuma[numaNode] = append(perNuma[numaNode], int32(idx))
+	}
+	busiestNodeCount := 0
+	numaNodes := SortedKeys(perNuma)
+	for _, numaNode := range numaNodes {
+		vec := perNuma[numaNode]
+		if len(vec) > busiestNodeCount {
+			busiestNodeCount = len(vec)
+			pl.BusiestNode = numaNode
+		}
+	}
+	for numaNode, vec := range perNuma {
+		if numaNode == pl.BusiestNode {
+			continue
+		}
+		// vec can't have zero length by construction
+		pl.Vectors[numaNode] = EncodePerNUMAVector(vec)
+	}
+	return pl, nil
+}
+
+// Info represents compactly-stored NUMA locality information.
+// This is the data the consumer side should store and keep up to date.
+type Info interface {
+	Containers() int
+	NUMAAffinity(id ContainerID) (int, error)
+	NUMAAffinityContainer(namespace, podName, containerName string) (int, error)
+}
+
+type EncodedInfo struct {
+	numaLocality map[uint64]int // hash->numaID
+}
+
+// NewInfo create a new empty Info struct.
+// Info is *not* safe to be called concurrently except for the
+// NUMAAffinity/NUMAAffinityContainer query functions.
+// The caller must handle its own locking.
+func NewEncodedInfo() *EncodedInfo {
+	return &EncodedInfo{
+		numaLocality: make(map[uint64]int),
+	}
+}
+
+// Containers returns the count of the containers we know about.
+func (info *EncodedInfo) Containers() int {
+	return len(info.numaLocality)
+}
+
+// Equal returns true if this info has equal value to the given one, false otherwise.
+func (info *EncodedInfo) Equal(obj *EncodedInfo) bool {
+	return reflect.DeepEqual(info.numaLocality, obj.numaLocality)
+}
+
+// Update clones the numalocality semantics from the given `data`.
+func (info *EncodedInfo) Update(data *EncodedInfo) {
+	info.numaLocality = maps.Clone(data.numaLocality)
+}
+
+// Take moves the numalocality semantics from the given `data`.
+func (info *EncodedInfo) Take(data *EncodedInfo) {
+	info.numaLocality = data.numaLocality
+	data.numaLocality = nil
+}
+
+// NUMAAffinity returns the NUMA Node mapping of a given ContainerID.
+// On failure, the affinity is not relevant and the error is not nil
+func (info *EncodedInfo) NUMAAffinity(id ContainerID) (int, error) {
+	numaNode, ok := info.numaLocality[id.Hash()]
+	if !ok {
+		return -1, ErrUnknownContainer
+	}
+	return numaNode, nil
+}
+
+// NUMAAffinityContainer returns the NUMA Node mapping of a given Container by its attributes.
+// On failure, the affinity is not relevant and the error is not nil
+func (info *EncodedInfo) NUMAAffinityContainer(namespace, podName, containerName string) (int, error) {
+	return info.NUMAAffinity(ContainerID{Namespace: namespace, PodName: podName, ContainerName: containerName})
+}
+
+// Decoder takes a Payload (once, fixed) and needs the full set of expected ContainerIDs
+// which must be verified to be consistent with the encoding side at time of the Payload was generated
+// And produces a Info object which the client code can use to learn the NUMA affinity of a container.
+// Likewise the Encoder, containers can be added in a streaming manner, not necessarily in one go,
+// but once the Info is created from the Payload, the Decoder instance must be discarded.
+type Decoder struct {
+	payload   Payload
+	hashesSet map[uint64]struct{}
+	hasher    *xxhash.Digest
+}
+
+// decoderValidateLEB89 validates the Payload fields under LEB89 encoding constraints.
+func decoderValidateLEB89(pl Payload) error {
+	if pl.VectorEncoding != VectorEncodingLEB89 {
+		return ErrUnsupportedVectorEncoding
+	}
+	if pl.BusiestNode == Unknown {
+		return ErrUnknownBusiestNode
+	}
+	if pl.BusiestNode < 0 || pl.BusiestNode >= pl.NUMANodes {
+		return ErrInconsistentBusiestNode
+	}
+	// LEB89 encoding omits the busiest node (N-1 optimization),
+	// so the vector count must be strictly less than NUMANodes
+	// and no vector may exist for the busiest node.
+	if len(pl.Vectors) >= pl.NUMANodes {
+		return ErrInconsistentNUMAVectors
+	}
+	if _, ok := pl.Vectors[pl.BusiestNode]; ok {
+		return ErrCorruptedNUMAVector
+	}
+
+	return nil
+}
+
+// NewDecoder creates a new Decoder for the given Payload object, optionally prefeeding with
+// the given ContainerIDs.
+// If duplicate ContainerIDs are given the latest added wins and the previous IDs are silently discarded.
+func NewDecoder(pl Payload, ids ...ContainerID) (*Decoder, error) {
+	if err := pl.Validate(decoderValidateLEB89); err != nil {
+		return nil, err
+	}
+	dec := &Decoder{
+		payload:   pl,
+		hashesSet: make(map[uint64]struct{}),
+		hasher:    xxhash.New(),
+	}
+	return dec.Decode(ids...), nil
+}
+
+// Containers return the number of containers this decoder knows about.
+// If duplicate ContainerIDs are given the latest added wins and the previous IDs are silently discarded.
+func (dec *Decoder) Containers() int {
+	return len(dec.hashesSet)
+}
+
+// Decode adds the given set of ContainerIDs to the decoder.
+func (dec *Decoder) Decode(ids ...ContainerID) *Decoder {
+	for _, id := range ids {
+		dec.hashesSet[id.HashWith(dec.hasher)] = struct{}{}
+	}
+	return dec
+}
+
+// DecodeContainer adds the given container through its essential attributes.
+// If duplicate ContainerIDs are given the latest added wins and the previous IDs are silently discarded.
+func (dec *Decoder) DecodeContainer(namespace, podName, containerName string) *Decoder {
+	return dec.Decode(ContainerID{
+		Namespace:     namespace,
+		PodName:       podName,
+		ContainerName: containerName,
+	})
+}
+
+// Result finalizes a Decoder and returns Info object the client code can consume to query the
+// affinity of the given ContainerID set from the Payload. On failure, error is not nil and
+// the Info must be ignored (it is usually `nil`, but is not guaranteed to be `nil`).
+func (dec *Decoder) Result() (Info, error) {
+	if len(dec.hashesSet) != dec.payload.Containers {
+		return nil, ErrInconsistentContainerSet
+	}
+	// BusiestNode range, vector keys, and structural invariants
+	// are already validated by Payload.Validate() in NewDecoder.
+	hashes := SortedKeys(dec.hashesSet)
+	info := NewEncodedInfo()
+	for numaNode, vec := range dec.payload.Vectors {
+		offsets := DecodePerNUMAVector(vec)
+		for _, off := range offsets {
+			// Reject malformed/truncated vectors that decode to negative offsets.
+			// A negative offset would panic when indexing hashes[off].
+			if int(off) < 0 || int(off) >= len(hashes) {
+				return nil, ErrCorruptedNUMAVector
+			}
+			if _, ok := info.numaLocality[hashes[off]]; ok {
+				return nil, ErrDuplicatedNUMAVector
+			}
+			info.numaLocality[hashes[off]] = numaNode
+		}
+	}
+	for _, hval := range hashes {
+		if _, ok := info.numaLocality[hval]; !ok {
+			info.numaLocality[hval] = dec.payload.BusiestNode
+		}
+	}
+	return info, nil
+}
+
+// SortedKeys returns the keys of a map as a sorted slice.
+// Once on Go 1.23+, replace every sortedKeys(m) call with
+// slices.Sorted(maps.Keys(m)), then delete both sortedKeys and mapKeys.
+func SortedKeys[K cmp.Ordered, V any](m map[K]V) []K {
+	keys := mapKeys(m)
+	slices.Sort(keys)
+	return keys
+}
+
+// mapKeys returns the keys of a map as a slice.
+// Once on Go 1.23+, replace with maps.Keys.
+func mapKeys[K comparable, V any](m map[K]V) []K {
+	keys := make([]K, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/cfgdispatch.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/cfgdispatch.go
@@ -69,11 +69,18 @@ func (cm configMap) Duration(key string, out *time.Duration) error {
 	if !ok {
 		return nil
 	}
-	j, ok := val.(float64)
-	if !ok {
-		return fmt.Errorf("key %q has non-float64 value representation %T", key, val)
+	switch v := val.(type) {
+	case float64:
+		*out = time.Duration(v)
+	case string:
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return fmt.Errorf("key %q: %w", key, err)
+		}
+		*out = d
+	default:
+		return fmt.Errorf("key %q has unsupported value type %T", key, val)
 	}
-	*out = time.Duration(j)
 	return nil
 }
 
@@ -108,6 +115,8 @@ func dispatchConfObj(obj map[string]interface{}, pArgs *ProgArgs) error {
 		{key: "nrtUpdater.noPublish", out: &pArgs.NRTupdater.NoPublish},
 		{key: "nrtUpdater.oneShot", out: &pArgs.NRTupdater.Oneshot},
 		{key: "nrtUpdater.hostname", out: &pArgs.NRTupdater.Hostname},
+		{key: "nrtUpdater.patchMode", out: &pArgs.NRTupdater.PatchMode},
+		{key: "nrtUpdater.patchResync", out: &pArgs.NRTupdater.PatchResync},
 		{key: "resourceMonitor.namespace", out: &pArgs.Resourcemonitor.Namespace},
 		{key: "resourceMonitor.sysfsRoot", out: &pArgs.Resourcemonitor.SysfsRoot},
 		{key: "resourceMonitor.refreshNodeResources", out: &pArgs.Resourcemonitor.RefreshNodeResources},
@@ -116,6 +125,7 @@ func dispatchConfObj(obj map[string]interface{}, pArgs *ProgArgs) error {
 		{key: "resourceMonitor.exposeTiming", out: &pArgs.Resourcemonitor.ExposeTiming},
 		{key: "resourceMonitor.podSetFingerprintStatusFile", out: &pArgs.Resourcemonitor.PodSetFingerprintStatusFile},
 		{key: "resourceMonitor.excludeTerminalPods", out: &pArgs.Resourcemonitor.ExcludeTerminalPods},
+		{key: "topologyExporter.kubeletConfigFile", out: &pArgs.RTE.KubeletConfigFile},
 		{key: "topologyExporter.podResourcesSocketPath", out: &pArgs.RTE.PodResourcesSocketPath},
 		{key: "topologyExporter.sleepInterval", out: &pArgs.RTE.SleepInterval},
 		{key: "topologyExporter.podReadinessEnable", out: &pArgs.RTE.PodReadinessEnable},
@@ -124,7 +134,7 @@ func dispatchConfObj(obj map[string]interface{}, pArgs *ProgArgs) error {
 		{key: "topologyExporter.addNRTOwnerEnable", out: &pArgs.RTE.AddNRTOwnerEnable},
 		{key: "topologyExporter.metricsMode", out: &pArgs.RTE.MetricsMode},
 		{key: "topologyExporter.metricsPort", out: &pArgs.RTE.MetricsPort},
-		{key: "topologyExporter.MetricsAddress", out: &pArgs.RTE.MetricsAddress},
+		{key: "topologyExporter.metricsAddress", out: &pArgs.RTE.MetricsAddress},
 		{key: "topologyExporter.metricsTLS.certsDir", out: &pArgs.RTE.MetricsTLSCfg.CertsDir},
 		{key: "topologyExporter.metricsTLS.certFile", out: &pArgs.RTE.MetricsTLSCfg.CertFile},
 		{key: "topologyExporter.metricsTLS.keyFile", out: &pArgs.RTE.MetricsTLSCfg.KeyFile},

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/cfgfile.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/cfgfile.go
@@ -32,7 +32,6 @@ import (
 )
 
 const (
-	DefaultconfigRoot     = "/etc/rte"
 	LegacyExtraConfigPath = "/etc/resource-topology-exporter/config.yaml"
 
 	configDirDaemon = "daemon"
@@ -81,7 +80,7 @@ func fromDaemonFiles(pArgs *ProgArgs, configPathRoot string) error {
 	// 1. we need to distinguish "value not set" from "value with defaults" (language's or our's)
 	//    To do so, using the simple unmashalling is not good enough, because unset values
 	//    will be set to zero values. But we want to LACK unset values, so we know we don't
-	//    apply over the previos iteration, keeping the oldest set value (possibly the default)
+	//    apply over the previous iteration, keeping the latest set value (possibly the default).
 	// 2. hence, we don't use the simple unmarshalling, but we unmarshal to generic maps
 	//    unmarshalled maps will be map[[string]any, possibly nested. But at least we will have
 	//    decoded only the value explicitely given, which makes simple to know when to apply
@@ -89,7 +88,7 @@ func fromDaemonFiles(pArgs *ProgArgs, configPathRoot string) error {
 
 	confObj := make(map[string]interface{})
 
-	configPath := filepath.Join(configPathRoot, "daemon", "config.yaml")
+	configPath := filepath.Join(configPathRoot, configDirDaemon, "config.yaml")
 	klog.Infof("loading configlet: %q", configPath)
 	err := loadConfiglet(confObj, configPath)
 	if err != nil {
@@ -97,7 +96,7 @@ func fromDaemonFiles(pArgs *ProgArgs, configPathRoot string) error {
 	}
 
 	// this directory may be missing, that's expected and fine
-	configletDir := filepath.Join(configPathRoot, "daemon", "config.yaml.d")
+	configletDir := filepath.Join(configPathRoot, configDirDaemon, "config.yaml.d")
 	if configlets, err := ReadConfigletDir(configletDir); err == nil {
 		for _, configlet := range configlets {
 			if !configlet.Type().IsRegular() {

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/config.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/config.go
@@ -50,6 +50,12 @@ func (args GlobalArgs) Clone() GlobalArgs {
 	}
 }
 
+const (
+	DumpConfigStdout string = "-"
+	DumpConfigAbort  string = ".andexit"
+	DumpConfigLog    string = ".log"
+)
+
 type ProgArgs struct {
 	Global          GlobalArgs                    `json:"global,omitempty"`
 	NRTupdater      nrtupdater.Args               `json:"nrtUpdater,omitempty"`
@@ -141,6 +147,7 @@ func LoadArgs(args ...string) (ProgArgs, error) {
 		klog.Infof("config from flags:{{\n%s\n}}", pArgs.ToYAMLString())
 	}
 
+	Canonicalize(&pArgs)
 	err = Validate(&pArgs)
 	if err != nil {
 		return pArgs, err
@@ -188,4 +195,18 @@ func UserHomeDir() (string, error) {
 		return "", SkipDirectory
 	}
 	return filepath.Join(homeDir, ".rte"), nil
+}
+
+func HandleDumpConfig(parsedArgs ProgArgs) bool {
+	conf := parsedArgs.ToYAMLString()
+	if parsedArgs.DumpConfig == DumpConfigLog {
+		klog.Infof("current configuration:\n%s", conf)
+		return false
+	}
+	if parsedArgs.DumpConfig == DumpConfigStdout {
+		fmt.Println(conf)
+		return false
+	}
+	fmt.Println(conf)
+	return true
 }

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/defaults.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/defaults.go
@@ -29,6 +29,8 @@ const (
 
 func SetDefaults(pArgs *ProgArgs) {
 	pArgs.Global.Verbose = 2
+	pArgs.NRTupdater.PatchMode = true
+	pArgs.NRTupdater.PatchResync = 10
 	pArgs.Resourcemonitor.SysfsRoot = "/sys"
 	pArgs.Resourcemonitor.PodSetFingerprint = true
 	pArgs.Resourcemonitor.PodSetFingerprintMethod = podfingerprint.MethodWithExclusiveResources

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/environ.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/environ.go
@@ -19,6 +19,8 @@ package config
 import (
 	"os"
 
+	"k8s.io/klog/v2"
+
 	metricssrv "github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/metrics/server"
 
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podres/middleware/sharedcpuspool"
@@ -55,25 +57,48 @@ func PodSetFingerprintStatusFileFromEnv() string {
 }
 
 func FromEnv(pArgs *ProgArgs) {
+	before := pArgs.Clone()
+
 	if pArgs.NRTupdater.Hostname == "" {
 		pArgs.NRTupdater.Hostname = HostNameFromEnv()
+		if before.NRTupdater.Hostname != pArgs.NRTupdater.Hostname {
+			klog.V(4).Infof("environment override: hostname %q -> %q", before.NRTupdater.Hostname, pArgs.NRTupdater.Hostname)
+		}
 	}
 	if pArgs.RTE.TopologyManagerPolicy == "" {
 		pArgs.RTE.TopologyManagerPolicy = TopologyManagerPolicyFromEnv()
+		if before.RTE.TopologyManagerPolicy != pArgs.RTE.TopologyManagerPolicy {
+			klog.V(4).Infof("environment override: topologyManagerPolicy %q -> %q", before.RTE.TopologyManagerPolicy, pArgs.RTE.TopologyManagerPolicy)
+		}
 	}
 	if pArgs.RTE.TopologyManagerScope == "" {
 		pArgs.RTE.TopologyManagerScope = TopologyManagerScopeFromEnv()
+		if before.RTE.TopologyManagerScope != pArgs.RTE.TopologyManagerScope {
+			klog.V(4).Infof("environment override: topologyManagerScope %q -> %q", before.RTE.TopologyManagerScope, pArgs.RTE.TopologyManagerScope)
+		}
 	}
 	if pArgs.RTE.ReferenceContainer.IsEmpty() {
 		pArgs.RTE.ReferenceContainer = sharedcpuspool.ContainerIdentFromEnv()
+		if before.RTE.ReferenceContainer.String() != pArgs.RTE.ReferenceContainer.String() {
+			klog.V(4).Infof("environment override: referenceContainer %q -> %q", before.RTE.ReferenceContainer.String(), pArgs.RTE.ReferenceContainer.String())
+		}
 	}
 	if pArgs.RTE.MetricsPort == 0 {
 		pArgs.RTE.MetricsPort = metricssrv.PortFromEnv()
+		if before.RTE.MetricsPort != pArgs.RTE.MetricsPort {
+			klog.V(4).Infof("environment override: metricsPort %d -> %d", before.RTE.MetricsPort, pArgs.RTE.MetricsPort)
+		}
 	}
 	if pArgs.RTE.MetricsAddress == "" {
 		pArgs.RTE.MetricsAddress = metricssrv.AddressFromEnv()
+		if before.RTE.MetricsAddress != pArgs.RTE.MetricsAddress {
+			klog.V(4).Infof("environment override: metricsAddress %q -> %q", before.RTE.MetricsAddress, pArgs.RTE.MetricsAddress)
+		}
 	}
 	if pArgs.Resourcemonitor.PodSetFingerprintStatusFile == "" {
 		pArgs.Resourcemonitor.PodSetFingerprintStatusFile = PodSetFingerprintStatusFileFromEnv()
+		if before.Resourcemonitor.PodSetFingerprintStatusFile != pArgs.Resourcemonitor.PodSetFingerprintStatusFile {
+			klog.V(4).Infof("environment override: podSetFingerprintStatusFile %q -> %q", before.Resourcemonitor.PodSetFingerprintStatusFile, pArgs.Resourcemonitor.PodSetFingerprintStatusFile)
+		}
 	}
 }

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/flags.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/flags.go
@@ -52,6 +52,8 @@ func FromFlags(pArgs *ProgArgs, args ...string) (string, string, error) {
 	CommandLine.BoolVar(&pArgs.NRTupdater.NoPublish, "no-publish", pArgs.NRTupdater.NoPublish, "Do not publish discovered features to the cluster-local Kubernetes API server.")
 	CommandLine.BoolVar(&pArgs.NRTupdater.Oneshot, "oneshot", pArgs.NRTupdater.Oneshot, "Update once and exit.")
 	CommandLine.StringVar(&pArgs.NRTupdater.Hostname, "hostname", pArgs.NRTupdater.Hostname, "Override the node hostname.")
+	CommandLine.BoolVar(&pArgs.NRTupdater.PatchMode, "patch-mode", pArgs.NRTupdater.PatchMode, "Send updates using patches.")
+	CommandLine.IntVar(&pArgs.NRTupdater.PatchResync, "patch-resync", pArgs.NRTupdater.PatchResync, "Force a full get+update resync every N patch cycles. 0 means never resync.")
 
 	CommandLine.StringVar(&pArgs.Resourcemonitor.Namespace, "watch-namespace", pArgs.Resourcemonitor.Namespace, "Namespace to watch pods for. Use \"\" for all namespaces.")
 	CommandLine.StringVar(&pArgs.Resourcemonitor.SysfsRoot, "sysfs", pArgs.Resourcemonitor.SysfsRoot, "Top-level component path of sysfs.")
@@ -88,12 +90,7 @@ func FromFlags(pArgs *ProgArgs, args ...string) (string, string, error) {
 	CommandLine.Int64Var(&pArgs.RTE.MaxEventsPerTimeUnit, "max-events-per-second", pArgs.RTE.MaxEventsPerTimeUnit, "Max times per second resources will be scanned and updated")
 
 	CommandLine.BoolVar(&pArgs.Version, "version", pArgs.Version, "Output version and exit")
-	CommandLine.StringVar(&pArgs.DumpConfig, "dump-config", pArgs.DumpConfig, `dump the current configuration to the given file path. Empty string (default) disable the dumping.
-Special targets:
-. "-" for stdout.
-. ".andexit" stdout and exit right after.
-. ".log" to dump in the log".`,
-	)
+	CommandLine.Var(&DumpConfigValue{DumpConfig: &pArgs.DumpConfig}, "dump-config", `dump the current configuration to either stdout (use "-") or the log (use ".log").`)
 
 	err := CommandLine.Parse(args)
 	if err != nil {
@@ -126,4 +123,23 @@ Special targets:
 	}
 	configRoot := params[0]
 	return configRoot, FixExtraConfigPath(configRoot), nil
+}
+
+type DumpConfigValue struct {
+	DumpConfig *string
+}
+
+func (v DumpConfigValue) String() string {
+	if v.DumpConfig == nil {
+		return ""
+	}
+	return *v.DumpConfig
+}
+
+func (v DumpConfigValue) Set(s string) error {
+	if s != DumpConfigStdout && s != DumpConfigAbort && s != DumpConfigLog {
+		return fmt.Errorf("invalid dump config target: %q", s)
+	}
+	*v.DumpConfig = s
+	return nil
 }

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/validation.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/validation.go
@@ -28,19 +28,18 @@ import (
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcemonitor"
 )
 
+func Canonicalize(pArgs *ProgArgs) {
+	pArgs.RTE.MetricsMode = strings.ToLower(pArgs.RTE.MetricsMode)
+	pArgs.Resourcemonitor.PodSetFingerprintMethod = strings.ToLower(pArgs.Resourcemonitor.PodSetFingerprintMethod)
+}
+
 func Validate(pArgs *ProgArgs) error {
-	var err error
-
-	pArgs.RTE.MetricsMode, err = metricssrv.ServingModeIsSupported(pArgs.RTE.MetricsMode)
-	if err != nil {
+	if _, err := metricssrv.ServingModeIsSupported(pArgs.RTE.MetricsMode); err != nil {
 		return err
 	}
-
-	pArgs.Resourcemonitor.PodSetFingerprintMethod, err = resourcemonitor.PFPMethodIsSupported(pArgs.Resourcemonitor.PodSetFingerprintMethod)
-	if err != nil {
+	if _, err := resourcemonitor.PFPMethodIsSupported(pArgs.Resourcemonitor.PodSetFingerprintMethod); err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/metrics/metrics.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/metrics/metrics.go
@@ -46,6 +46,17 @@ var (
 		Name: "rte_wakeup_delay_milliseconds",
 		Help: "The wakeup delay of the monitor code, milliseconds",
 	}, []string{"node", "trigger"})
+
+	NodeResourceTopologyPatchFailure = promauto.With(ctrlmetrics.Registry).NewCounterVec(prometheus.CounterOpts{
+		Name: "rte_noderesourcetopology_patch_failures_total",
+		Help: "The total number of times the NodeResourceTopology patching failed",
+	}, []string{"node", "trigger"})
+
+	NodeResourceTopologyPatchSizeRatio = promauto.With(ctrlmetrics.Registry).NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "rte_noderesourcetopology_patch_size_ratio",
+		Help:    "The ratio of patch size to full object size (0.0 to 1.0)",
+		Buckets: []float64{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0},
+	}, []string{"node"})
 )
 
 func UpdateNodeResourceTopologyWritesMetric(operation, trigger string) {
@@ -56,7 +67,7 @@ func UpdateNodeResourceTopologyWritesMetric(operation, trigger string) {
 	}).Inc()
 }
 
-func UpdatePodResourceApiCallsFailureMetric(funcName string) {
+func UpdatePodResourceApiCallsFailuresMetric(funcName string) {
 	PodResourceApiCallsFailure.With(prometheus.Labels{
 		"node":          nodeName,
 		"function_name": funcName,
@@ -76,6 +87,19 @@ func UpdateWakeupDelayMetric(trigger string, wakeupDelay float64) {
 		"node":    nodeName,
 		"trigger": trigger,
 	}).Set(wakeupDelay)
+}
+
+func UpdateNodeResourceTopologyPatchFailuresMetric(trigger string) {
+	NodeResourceTopologyPatchFailure.With(prometheus.Labels{
+		"node":    nodeName,
+		"trigger": trigger,
+	}).Inc()
+}
+
+func UpdateNodeResourceTopologyPatchSizeRatioMetric(ratio float64) {
+	NodeResourceTopologyPatchSizeRatio.With(prometheus.Labels{
+		"node": nodeName,
+	}).Observe(ratio)
 }
 
 func Setup(nname string) error {

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nrtupdater/nrtupdater.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nrtupdater/nrtupdater.go
@@ -2,6 +2,7 @@ package nrtupdater
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -9,6 +10,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/jsonmergepatch"
 	"k8s.io/klog/v2"
 
 	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
@@ -25,19 +28,27 @@ const (
 	RTEUpdateReactive = "reactive"
 )
 
+var (
+	ErrMissingPreviousNRT = errors.New("missing previous NRT data")
+)
+
 // Command line arguments
 type Args struct {
-	NoPublish  bool   `json:"noPublish,omitempty"`
-	Oneshot    bool   `json:"oneShot,omitempty"`
-	Hostname   string `json:"hostname,omitempty"`
-	KubeConfig string `json:"kubeConfig,omitempty"`
+	NoPublish   bool   `json:"noPublish,omitempty"`
+	Oneshot     bool   `json:"oneShot,omitempty"`
+	Hostname    string `json:"hostname,omitempty"`
+	KubeConfig  string `json:"kubeConfig,omitempty"`
+	PatchMode   bool   `json:"patchMode,omitempty"`
+	PatchResync int    `json:"patchResync,omitempty"`
 }
 
 func (args Args) Clone() Args {
 	return Args{
-		NoPublish: args.NoPublish,
-		Oneshot:   args.Oneshot,
-		Hostname:  args.Hostname,
+		NoPublish:   args.NoPublish,
+		Oneshot:     args.Oneshot,
+		Hostname:    args.Hostname,
+		PatchMode:   args.PatchMode,
+		PatchResync: args.PatchResync,
 	}
 }
 
@@ -56,6 +67,9 @@ type NRTUpdater struct {
 	stopChan   chan struct{}
 	nodeGetter NodeGetter
 	nrtCli     topologyclientset.Interface
+	sendObject func(context.Context, topologyclientset.Interface, MonitorInfo) (*v1alpha2.NodeResourceTopology, error)
+	prevNRT    *v1alpha2.NodeResourceTopology
+	patchCount int
 }
 
 type MonitorInfo struct {
@@ -76,17 +90,25 @@ func NewNRTUpdater(nodeGetter NodeGetter, nrtCli topologyclientset.Interface, ar
 	if nrtCli == nil {
 		return nil, fmt.Errorf("missing NRT client interface")
 	}
-	return &NRTUpdater{
+	upd := NRTUpdater{
 		args:       args,
 		tmConfig:   tmconf,
 		stopChan:   make(chan struct{}),
 		nodeGetter: nodeGetter,
 		nrtCli:     nrtCli,
-	}, nil
+	}
+	if args.PatchMode {
+		klog.Infof("operation mode: patch")
+		upd.sendObject = upd.sendObjectPatch
+	} else {
+		klog.Infof("operation mode: get+update")
+		upd.sendObject = upd.sendObjectUpdate
+	}
+	return &upd, nil
 }
 
-func (te *NRTUpdater) Update(info MonitorInfo) error {
-	return te.updateWithClient(te.nrtCli, info)
+func (te *NRTUpdater) Update(ctx context.Context, info MonitorInfo) error {
+	return te.sendData(ctx, te.nrtCli, info)
 }
 
 func (te *NRTUpdater) Stop() {
@@ -99,7 +121,7 @@ func (te *NRTUpdater) Run(infoChannel <-chan MonitorInfo, condChan chan v1.PodCo
 		case info := <-infoChannel:
 			tsBegin := time.Now()
 			condStatus := v1.ConditionTrue
-			if err := te.Update(info); err != nil {
+			if err := te.Update(context.Background(), info); err != nil {
 				klog.Warningf("failed to update: %v", err)
 				condStatus = v1.ConditionFalse
 			}
@@ -118,14 +140,115 @@ func (te *NRTUpdater) Run(infoChannel <-chan MonitorInfo, condChan chan v1.PodCo
 	}
 }
 
-func (te *NRTUpdater) updateWithClient(cli topologyclientset.Interface, info MonitorInfo) error {
+func (te *NRTUpdater) sendData(ctx context.Context, cli topologyclientset.Interface, info MonitorInfo) error {
 	klog.V(7).Infof("update: sending zone: %v", dump.Object(info.Zones))
-
 	if te.args.NoPublish {
 		return nil
 	}
+	_, err := te.sendObject(ctx, cli, info)
+	return err
+}
 
-	nrt, err := cli.TopologyV1alpha2().NodeResourceTopologies().Get(context.TODO(), te.args.Hostname, metav1.GetOptions{})
+type NRTPatchInfo struct {
+	Patch        []byte
+	FullObjBytes int
+}
+
+func (pi NRTPatchInfo) SizeRatio() float64 {
+	if pi.FullObjBytes == 0 {
+		return 1.0
+	}
+	return float64(len(pi.Patch)) / float64(pi.FullObjBytes)
+}
+
+func MakeNRTPatch(nrtOld, nrtNew *v1alpha2.NodeResourceTopology) (NRTPatchInfo, string, error) {
+	nrtOldJSON, err := json.Marshal(nrtOld)
+	if err != nil {
+		return NRTPatchInfo{}, "marshal_previous", err
+	}
+
+	nrtNewJSON, err := json.Marshal(nrtNew)
+	if err != nil {
+		return NRTPatchInfo{}, "marshal_current", err
+	}
+
+	patch, err := jsonmergepatch.CreateThreeWayJSONMergePatch(nrtOldJSON, nrtNewJSON, nrtOldJSON)
+	if err != nil {
+		return NRTPatchInfo{}, "make_patch", err
+	}
+	return NRTPatchInfo{
+		Patch:        patch,
+		FullObjBytes: len(nrtNewJSON),
+	}, "", nil
+}
+
+func (te *NRTUpdater) patchNRT(ctx context.Context, cli topologyclientset.Interface, info MonitorInfo) (*v1alpha2.NodeResourceTopology, error) {
+	if te.prevNRT == nil {
+		// we intentionally don't log nor record a metric because this can happen in the regular flow and it's a benign error.
+		return nil, ErrMissingPreviousNRT
+	}
+
+	// make the patch ignore metadata, otherwise the patch will attempt
+	// to remove them, and the apiserver will (correctly) refuse it,
+	// falling back to the update path
+	nrtNew := te.prevNRT.DeepCopy()
+	te.updateNRTInfo(nrtNew, info)
+	te.updateOwnerReferences(ctx, nrtNew)
+
+	patchInfo, reason, err := MakeNRTPatch(te.prevNRT, nrtNew)
+	if err != nil {
+		metrics.UpdateNodeResourceTopologyPatchFailuresMetric(reason)
+		klog.Infof("failed to create a patch for the APIServer: %v", err)
+		return nil, err
+	}
+
+	ratio := patchInfo.SizeRatio()
+	klog.V(7).Infof("nrtupdater patch size %d bytes, full object %d bytes, ratio %.2f", len(patchInfo.Patch), patchInfo.FullObjBytes, ratio)
+	metrics.UpdateNodeResourceTopologyPatchSizeRatioMetric(ratio)
+
+	// The NodeResourceTopology API types lack patchStrategy/patchMergeKey struct tags,
+	// so strategic merge patch would fall back to JSON merge patch behavior anyway.
+	// We use MergePatchType to match the actual semantics.
+	nrtUpdated, err := cli.TopologyV1alpha2().NodeResourceTopologies().Patch(ctx, te.prevNRT.Name, types.MergePatchType, patchInfo.Patch, metav1.PatchOptions{})
+	if err != nil {
+		metrics.UpdateNodeResourceTopologyPatchFailuresMetric("send_patch")
+		klog.Infof("failed to send a patch to the APIServer: %v", err)
+		return nil, err
+	}
+
+	te.prevNRT = nrtUpdated
+	return nrtUpdated, nil
+}
+
+func (te *NRTUpdater) needsResync() bool {
+	if te.args.PatchResync <= 0 {
+		return false
+	}
+	return te.patchCount >= te.args.PatchResync
+}
+
+func (te *NRTUpdater) sendObjectPatch(ctx context.Context, cli topologyclientset.Interface, info MonitorInfo) (*v1alpha2.NodeResourceTopology, error) {
+	if !te.needsResync() {
+		nrtObj, err := te.patchNRT(ctx, cli, info)
+		if err == nil {
+			te.patchCount++
+			return nrtObj, nil
+		}
+	} else {
+		klog.V(2).Infof("nrtupdater forcing resync after %d patches", te.patchCount)
+	}
+
+	nrtObj, err := te.sendObjectUpdate(ctx, cli, info)
+	if err != nil {
+		return nil, err
+	}
+	te.prevNRT = nrtObj
+	te.patchCount = 0
+	return nrtObj, nil
+}
+
+func (te *NRTUpdater) sendObjectUpdate(ctx context.Context, cli topologyclientset.Interface, info MonitorInfo) (*v1alpha2.NodeResourceTopology, error) {
+	nrt, err := cli.TopologyV1alpha2().NodeResourceTopologies().Get(ctx, te.args.Hostname, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		nrtNew := v1alpha2.NodeResourceTopology{
 			ObjectMeta: metav1.ObjectMeta{
@@ -134,30 +257,32 @@ func (te *NRTUpdater) updateWithClient(cli topologyclientset.Interface, info Mon
 			},
 		}
 		te.updateNRTInfo(&nrtNew, info)
+		te.updateOwnerReferences(ctx, &nrtNew)
 
-		nrtCreated, err := cli.TopologyV1alpha2().NodeResourceTopologies().Create(context.TODO(), &nrtNew, metav1.CreateOptions{})
+		nrtCreated, err := cli.TopologyV1alpha2().NodeResourceTopologies().Create(ctx, &nrtNew, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("update failed for NRT instance: %w", err)
+			return nil, fmt.Errorf("update failed for NRT instance: %w", err)
 		}
 		metrics.UpdateNodeResourceTopologyWritesMetric("create", info.UpdateReason())
 		klog.V(2).Infof("nrtupdater created NRT instance: %v", dump.Object(nrtCreated))
-		return nil
+		return nrtCreated, nil
 	}
 
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	nrtMutated := nrt.DeepCopy()
 	te.updateNRTInfo(nrtMutated, info)
+	te.updateOwnerReferences(ctx, nrtMutated)
 
-	nrtUpdated, err := cli.TopologyV1alpha2().NodeResourceTopologies().Update(context.TODO(), nrtMutated, metav1.UpdateOptions{})
+	nrtUpdated, err := cli.TopologyV1alpha2().NodeResourceTopologies().Update(ctx, nrtMutated, metav1.UpdateOptions{})
 	if err != nil {
-		return fmt.Errorf("update failed for NRT instance: %w", err)
+		return nil, fmt.Errorf("update failed for NRT instance: %w", err)
 	}
 	metrics.UpdateNodeResourceTopologyWritesMetric("update", info.UpdateReason())
 	klog.V(7).Infof("nrtupdater changed CRD instance: %v", dump.Object(nrtUpdated))
-	return nil
+	return nrtUpdated, nil
 }
 
 func (te *NRTUpdater) updateNRTInfo(nrt *v1alpha2.NodeResourceTopology, info MonitorInfo) {
@@ -167,16 +292,14 @@ func (te *NRTUpdater) updateNRTInfo(nrt *v1alpha2.NodeResourceTopology, info Mon
 	nrt.Attributes = info.Attributes.DeepCopy()
 	nrt.Attributes = append(nrt.Attributes, te.makeAttributes()...)
 	// TODO: check for duplicate attributes?
-
-	te.updateOwnerReferences(nrt)
 }
 
 // updateOwnerReferences ensure nrt.OwnerReferences include a reference to the Node with the same name as the NRT
 //
 // Check nrt.OwnerReferences for Node references and update it so it has only one Node reference,
 // the one to the Node with the same name as the NRT.
-func (te *NRTUpdater) updateOwnerReferences(nrt *v1alpha2.NodeResourceTopology) {
-	node, err := te.nodeGetter.Get(context.TODO(), nrt.Name, metav1.GetOptions{})
+func (te *NRTUpdater) updateOwnerReferences(ctx context.Context, nrt *v1alpha2.NodeResourceTopology) {
+	node, err := te.nodeGetter.Get(ctx, nrt.Name, metav1.GetOptions{})
 	if err != nil {
 		if errors.Is(err, NotConfigured) {
 			return

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/numalocality/numalocality.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/numalocality/numalocality.go
@@ -1,0 +1,26 @@
+package numalocality
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
+)
+
+// GetNUMAIDs returns the NUMAs affinity for the given topology. The API allows for a resource to be
+// pinned to multiple NUMA nodes depending on the topology manager policy, and the function uses int set
+// to avoid duplicates. It returns a slice of NUMA IDs or an empty slice if the topology is not pinned to
+// any NUMA node.
+func GetNUMAIDs(topo *podresourcesapi.TopologyInfo) []int {
+	if topo == nil || topo.Nodes == nil {
+		return []int{}
+	}
+
+	numaIDs := sets.New[int]()
+	// if Nodes is not given, this means "don't care about locality". It's a legal representation
+	for _, node := range topo.Nodes {
+		// setting node.ID == -1 is also a legal representation for "don't care about locality".
+		if node.ID >= 0 {
+			numaIDs.Insert(int(node.ID))
+		}
+	}
+	return numaIDs.UnsortedList()
+}

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podreadiness/conditioninjector.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podreadiness/conditioninjector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,9 +13,19 @@ import (
 )
 
 type ConditionInjector struct {
-	cs      kubernetes.Interface
-	ns      string
-	podName string
+	cs         kubernetes.Interface
+	ns         string
+	podName    string
+	lastUpdate map[v1.PodConditionType]v1.PodCondition
+}
+
+func NewConditionInjectorWithIdentity(cs kubernetes.Interface, ns, podName string) *ConditionInjector {
+	return &ConditionInjector{
+		cs:         cs,
+		ns:         ns,
+		podName:    podName,
+		lastUpdate: make(map[v1.PodConditionType]v1.PodCondition),
+	}
 }
 
 func NewConditionInjector(cs kubernetes.Interface) (*ConditionInjector, error) {
@@ -27,53 +38,58 @@ func NewConditionInjector(cs kubernetes.Interface) (*ConditionInjector, error) {
 	if !ok {
 		return nil, fmt.Errorf("the env REFERENCE_POD_NAME doesn't exist")
 	}
-
-	return &ConditionInjector{
-		cs:      cs,
-		ns:      nsVal,
-		podName: podVal,
-	}, nil
+	return NewConditionInjectorWithIdentity(cs, nsVal, podVal), nil
 }
 
-func (ci *ConditionInjector) Inject(cond v1.PodCondition) error {
-	conditionExist := false
-	pod, err := ci.cs.CoreV1().Pods(ci.ns).Get(context.TODO(), ci.podName, metav1.GetOptions{})
+func (ci *ConditionInjector) Inject(ctx context.Context, cond v1.PodCondition) error {
+	if oldCond, ok := ci.lastUpdate[cond.Type]; ok && equalPodCondition(oldCond, cond) {
+		// avoid APIServer round trips if nothing changed
+		return nil
+	}
+
+	pod, err := ci.cs.CoreV1().Pods(ci.ns).Get(ctx, ci.podName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
 
-	for pos, podCond := range pod.Status.Conditions {
-		if podCond.Type == cond.Type {
-			conditionExist = true
-			if podCond.Status == cond.Status {
-				// do nothing condition already updated
-				return nil
-			}
-			// update the condition
-			pod.Status.Conditions[pos] = cond
-		}
+	pos := slices.IndexFunc(pod.Status.Conditions, func(c v1.PodCondition) bool {
+		return c.Type == cond.Type
+	})
+	if pos >= 0 {
+		// note this cause an unnecessary update on RTE restart at steady state.
+		// we can re-update conditions with the existing value because of that.
+		// we expect RTE restarts to be rare, so we tolerate this extra write
+		// for now.
+		pod.Status.Conditions[pos] = cond
+		klog.V(4).Infof("updated conditions inplace: %v", pod.Status.Conditions)
+	} else {
+		pod.Status.Conditions = append(pod.Status.Conditions, cond)
+		klog.V(4).Infof("updated conditions adding: %v", pod.Status.Conditions)
 	}
 
-	if !conditionExist {
-		conds := pod.Status.Conditions
-		conds = append(conds, cond)
-		pod.Status.Conditions = conds
+	_, err = ci.cs.CoreV1().Pods(ci.ns).UpdateStatus(ctx, pod, metav1.UpdateOptions{})
+	if err != nil {
+		return err
 	}
 
-	klog.V(4).Infof("pod conditions: %v", pod.Status.Conditions)
-
-	_, err = ci.cs.CoreV1().Pods(ci.ns).UpdateStatus(context.TODO(), pod, metav1.UpdateOptions{})
-	return err
+	ci.lastUpdate[cond.Type] = cond
+	return nil
 }
 
-func (ci *ConditionInjector) Run(condChan <-chan v1.PodCondition) {
-	go func() {
-		for {
-			cond := <-condChan
-			err := ci.Inject(cond)
+func (ci *ConditionInjector) Run(ctx context.Context, condChan <-chan v1.PodCondition) {
+	for {
+		select {
+		case cond := <-condChan:
+			err := ci.Inject(ctx, cond)
 			if err != nil {
 				klog.Errorf("failed to update pod status with condition: %v", cond)
 			}
+		case <-ctx.Done():
+			return
 		}
-	}()
+	}
+}
+
+func equalPodCondition(a, b v1.PodCondition) bool {
+	return a.Type == b.Type && a.Status == b.Status && a.Reason == b.Reason && a.Message == b.Message
 }

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podres/filter/numalocality/numalocality.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podres/filter/numalocality/numalocality.go
@@ -19,6 +19,7 @@ package numalocality
 import (
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 
+	numaloclib "github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/numalocality"
 	podresfilter "github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podres/filter"
 )
 
@@ -46,7 +47,7 @@ func Verify(pr *podresourcesapi.PodResources) podresfilter.Result {
 			}
 		}
 		for _, mem := range cr.Memory {
-			if IsPresent(mem.Topology) {
+			if len(numaloclib.GetNUMAIDs(mem.Topology)) > 0 {
 				return podresfilter.Result{
 					Allow:  true,
 					Ident:  cr.Name,
@@ -55,7 +56,7 @@ func Verify(pr *podresourcesapi.PodResources) podresfilter.Result {
 			}
 		}
 		for _, dev := range cr.Devices {
-			if len(dev.DeviceIds) > 0 && IsPresent(dev.Topology) {
+			if len(dev.DeviceIds) > 0 && len(numaloclib.GetNUMAIDs(dev.Topology)) > 0 {
 				return podresfilter.Result{
 					Allow:  true,
 					Ident:  cr.Name,
@@ -72,24 +73,4 @@ func Verify(pr *podresourcesapi.PodResources) podresfilter.Result {
 // AlwaysPass is deprecated; if needed use pkg/pkodres/filter.VerifyAlwaysPass
 func AlwaysPass(_ *podresourcesapi.PodResources) bool {
 	return true
-}
-
-// Required is deprecated: use Verify instead
-func Required(pr *podresourcesapi.PodResources) bool {
-	got := Verify(pr)
-	return got.Allow
-}
-
-func IsPresent(topo *podresourcesapi.TopologyInfo) bool {
-	if topo == nil || topo.Nodes == nil {
-		return false
-	}
-	// if Nodes is not given, this means "don't care about locality". It's a legal representation.
-	for _, node := range topo.Nodes {
-		// setting node.ID == -1 is also a legal representation for "don't care about locality".
-		if node.ID >= 0 {
-			return true
-		}
-	}
-	return false
 }

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcemonitor/resourcemonitor.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcemonitor/resourcemonitor.go
@@ -36,15 +36,19 @@ import (
 	"k8s.io/klog/v2"
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 
+	"github.com/go-logr/logr"
+
 	ghwoption "github.com/jaypipes/ghw/pkg/option"
 	ghwtopology "github.com/jaypipes/ghw/pkg/topology"
 	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	topologyv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+	"github.com/k8stopologyawareschedwg/numaplacement"
 	"github.com/k8stopologyawareschedwg/podfingerprint"
 
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/metrics"
+	numaloclib "github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/numalocality"
 	podresfilter "github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podres/filter"
-	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podres/filter/numalocality"
+	numalocfilter "github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podres/filter/numalocality"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podres/middleware/podexclude"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/sysinfo"
 )
@@ -52,6 +56,8 @@ import (
 const (
 	defaultPodResourcesTimeout = 10 * time.Second
 	// obtained these values from node e2e tests : https://github.com/kubernetes/kubernetes/blob/82baa26905c94398a0d19e1b1ecf54eb8acb6029/test/e2e_node/util.go#L70
+
+	TopologyManagerPolicySingleNUMANode = "single-numa-node"
 )
 
 type ResourceExclude map[string][]string
@@ -122,7 +128,8 @@ func (sr ScanResponse) SortedZones() v1alpha2.ZoneList {
 }
 
 type ResourceMonitor interface {
-	Scan(excludeList ResourceExclude) (ScanResponse, error)
+	Setup(ctx context.Context) error
+	Scan(ctx context.Context, excludeList ResourceExclude) (ScanResponse, error)
 }
 
 // ToMapSet keeps the original keys, but replaces values with set.String types
@@ -173,18 +180,21 @@ func (nrc perNUMAResourceCounter) String() string {
 type resourceMonitor struct {
 	nodeName          string
 	args              Args
+	tmPolicy          string
 	podResCli         podresourcesapi.PodResourcesListerClient
 	k8sCli            kubernetes.Interface
 	topo              *ghwtopology.Info
 	coreIDToNodeIDMap map[int]int
 	nodeCapacity      perNUMAResourceCounter
 	nodeAllocatable   perNUMAResourceCounter
+	scanIteration     uint64
 }
 
-func NewResourceMonitor(hnd Handle, args Args, options ...func(*resourceMonitor)) (*resourceMonitor, error) {
+func NewResourceMonitor(hnd Handle, args Args, tmPolicy string, options ...func(*resourceMonitor)) *resourceMonitor {
 	rm := &resourceMonitor{
 		podResCli: hnd.PodResCli,
 		k8sCli:    hnd.K8SCli,
+		tmPolicy:  tmPolicy,
 		args:      args,
 	}
 	for _, opt := range options {
@@ -195,43 +205,56 @@ func NewResourceMonitor(hnd Handle, args Args, options ...func(*resourceMonitor)
 		rm.nodeName = os.Getenv("NODE_NAME")
 	}
 
-	klog.Infof("resmon: starting for node %q", rm.nodeName)
+	return rm
+}
+
+func (rm *resourceMonitor) GetScanIteration() string {
+	val := rm.scanIteration
+	rm.scanIteration++
+	return fmt.Sprintf("%v", val)
+}
+
+func (rm *resourceMonitor) Setup(ctx context.Context) error {
+	logger := klog.FromContext(ctx).WithValues("node", rm.nodeName)
+	logger.Info("starting")
 
 	if rm.topo == nil {
 		topo, err := ghwtopology.New(ghwoption.WithPathOverrides(ghwoption.PathOverrides{
-			"/sys": args.SysfsRoot,
+			"/sys": rm.args.SysfsRoot,
 		}))
 		if err != nil {
-			return nil, err
+			return err
 		}
 		rm.topo = topo
 	}
-	klog.V(4).Infof("resmon: machine topology: %s", toJSON(rm.topo))
+	logger.V(4).Info("machine topology", "topology", toJSON(rm.topo))
 
 	rm.coreIDToNodeIDMap = MakeCoreIDToNodeIDMap(rm.topo)
-	klog.V(4).Infof("resmon: CPU mapping [coreid:numaid]: %s", mapIntIntToString(rm.coreIDToNodeIDMap))
+	logger.V(4).Info("CPU mapping", "coreIDToNodeID", mapIntIntToString(rm.coreIDToNodeIDMap))
 
-	if err := rm.updateNodeResources(); err != nil {
-		return nil, err
+	if err := rm.updateNodeResources(ctx); err != nil {
+		return err
 	}
-	klog.V(2).Infof("resmon: initial capacity for node %q: %s", rm.nodeName, rm.nodeCapacity)
-	klog.V(2).Infof("resmon: initial allocatable for node %q: %s", rm.nodeName, rm.nodeAllocatable)
+	logger.V(2).Info("initial capacity", "capacity", rm.nodeCapacity)
+	logger.V(2).Info("initial allocatable", "allocatable", rm.nodeAllocatable)
 
 	if !rm.args.RefreshNodeResources {
-		klog.Infof("resmon: getting node resources once")
+		logger.Info("getting node resources once")
 	} else {
-		klog.Infof("resmon: tracking node resources")
-		if err := addNodeInformerEvent(rm.k8sCli, cache.ResourceEventHandlerFuncs{UpdateFunc: rm.resUpdated}); err != nil {
-			return nil, err
+		logger.Info("tracking node resources")
+		if err := addNodeInformerEvent(ctx, rm.k8sCli, cache.ResourceEventHandlerFuncs{UpdateFunc: func(old, new any) {
+			rm.resUpdated(ctx, old, new)
+		}}); err != nil {
+			return err
 		}
 	}
 
 	if rm.args.Namespace != "" {
-		klog.Infof("resmon: watching namespace %q", rm.args.Namespace)
+		logger.Info("watching namespace", "namespace", rm.args.Namespace)
 	} else {
-		klog.Infof("resmon: watching all namespaces")
+		logger.Info("watching all namespaces")
 	}
-	return rm, nil
+	return nil
 }
 
 func WithTopology(topo *ghwtopology.Info) func(*resourceMonitor) {
@@ -252,30 +275,49 @@ func WithNodeName(name string) func(*resourceMonitor) {
 	}
 }
 
-func (rm *resourceMonitor) Scan(excludeList ResourceExclude) (ScanResponse, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultPodResourcesTimeout)
+func (rm *resourceMonitor) HasSingleNUMANodeTopologyManagerPolicy() bool {
+	return rm.tmPolicy == TopologyManagerPolicySingleNUMANode
+}
+
+// Scan scans the node pods using podresources API, processes the scan response and builds up the returned value.
+func (rm *resourceMonitor) Scan(ctx context.Context, excludeList ResourceExclude) (ScanResponse, error) {
+	logger := klog.FromContext(ctx).WithName("resmon").WithValues("scanID", rm.GetScanIteration())
+
+	ctx, cancel := context.WithTimeout(ctx, defaultPodResourcesTimeout)
 	defer cancel()
 	resp, err := rm.podResCli.List(ctx, &podresourcesapi.ListPodResourcesRequest{})
 	if err != nil {
-		metrics.UpdatePodResourceApiCallsFailureMetric("list")
+		metrics.UpdatePodResourceApiCallsFailuresMetric("list")
 		return ScanResponse{}, err
 	}
 
-	respPodRes := resp.GetPodResources()
-	klog.V(6).Infof("resmon: podresources list: %s", collectPodsFromPodResources(respPodRes))
+	respRawPodRes := resp.GetPodResources()
+	logger.V(6).Info("raw podresources list", "podresources", stringifyPodResources(respRawPodRes))
 
-	st := podfingerprint.MakeStatus(rm.nodeName)
+	numaEligiblePodRes := []*podresourcesapi.PodResources{}
+	for _, pr := range respRawPodRes {
+		nl := numalocfilter.Verify(pr)
+		if !nl.Allow {
+			logger.V(8).Info("podresources item: not eligible for NUMA", "pod", pr.Namespace+"/"+pr.Name, "ident", nl.Ident, "reason", nl.Reason)
+			continue
+		}
+		numaEligiblePodRes = append(numaEligiblePodRes, pr)
+	}
+	logger.V(6).Info("NUMA eligible podresources list", "podresources", stringifyPodResources(numaEligiblePodRes))
+
 	scanRes := ScanResponse{
 		Attributes:  topologyv1alpha2.AttributeList{},
 		Annotations: map[string]string{},
 	}
 
+	var payload numaplacement.Payload
 	if rm.args.PodSetFingerprint {
-		podresVerify := numalocality.Verify
+		st := podfingerprint.MakeStatus(rm.nodeName)
+		pfpPodResources := numaEligiblePodRes
 		if rm.args.PodSetFingerprintMethod == podfingerprint.MethodAll {
-			podresVerify = podresfilter.VerifyAlwaysPass
+			pfpPodResources = respRawPodRes
 		}
-		pfpSign := computePodFingerprintFromPodResources(respPodRes, &st, podresVerify)
+		pfpSign := computePodFingerprintFromPodResources(pfpPodResources, &st, podresfilter.VerifyAlwaysPass)
 		scanRes.Attributes = append(scanRes.Attributes, topologyv1alpha2.AttributeInfo{
 			Name:  podfingerprint.Attribute,
 			Value: pfpSign,
@@ -285,17 +327,30 @@ func (rm *resourceMonitor) Scan(excludeList ResourceExclude) (ScanResponse, erro
 			Value: rm.args.PodSetFingerprintMethod,
 		})
 		scanRes.Annotations[podfingerprint.Annotation] = pfpSign
-		klog.V(6).Infof("resmon: pfp: %s", st.Repr())
+		logger.V(6).Info("pod fingerprint", "status", st.Repr())
 
 		podfingerprint.MarkCompleted(st)
-	}
 
-	allDevs := GetAllContainerDevices(respPodRes, rm.args.Namespace, rm.coreIDToNodeIDMap)
-	allocated := ContainerDevicesToPerNUMAResourceCounters(allDevs)
+		// numaplacement encoding is only done for pods that are eligible for NUMA placement (with
+		// exclusive resources), which are a subset of pods that are participating in PFP (it is
+		// not always the same pods as PFP because it depends on the filter function used)
+		payload, err = ComputeNUMAPlacementPayload(logger, numaEligiblePodRes, rm.tmPolicy, len(rm.topo.Nodes), rm.coreIDToNodeIDMap)
+		logger.V(2).Info("containers NUMA-placement detection", "error", err)
+		if err == nil {
+			metadata := payload.PackMetadata()
+			scanRes.Attributes = append(scanRes.Attributes, topologyv1alpha2.AttributeInfo{
+				Name:  numaplacement.AttributeMetadata,
+				Value: metadata,
+			})
+			logger.V(6).Info("numaplacement metadata", "metadata", metadata)
+		}
+	}
+	allDevs := GetAllContainerDevices(logger, respRawPodRes, rm.args.Namespace, rm.coreIDToNodeIDMap)
+	allocated := ContainerDevicesToPerNUMAResourceCounters(logger, allDevs)
 
 	excludeSet := excludeList.ToMapSet()
 	zones := make(topologyv1alpha2.ZoneList, 0, len(rm.topo.Nodes))
-	// if there are no allocatable resources under a NUMA we might ended up with holes in the NRT objects.
+	// if there are no allocatable resources under a NUMA we might end up with holes in the NRT objects.
 	// this is why we're using the topology info and not the nodeAllocatable
 	for nodeID := range rm.topo.Nodes {
 		zone := topologyv1alpha2.Zone{
@@ -304,9 +359,17 @@ func (rm *resourceMonitor) Scan(excludeList ResourceExclude) (ScanResponse, erro
 			Resources: make(topologyv1alpha2.ResourceInfoList, 0),
 		}
 
+		zoneVector, ok := payload.Vectors[nodeID]
+		if ok {
+			zone.Attributes = append(zone.Attributes, topologyv1alpha2.AttributeInfo{
+				Name:  numaplacement.AttributeVector,
+				Value: zoneVector,
+			})
+		}
+
 		costs, err := makeCostsPerNumaNode(rm.topo.Nodes, nodeID)
 		if err != nil {
-			klog.Warningf("resmon: cannot find costs for NUMA node %d: %v", nodeID, err)
+			logger.V(1).Info("cannot find costs for NUMA node", "nodeID", nodeID, "err", err)
 		} else {
 			zone.Costs = costs
 		}
@@ -341,13 +404,13 @@ func (rm *resourceMonitor) Scan(excludeList ResourceExclude) (ScanResponse, erro
 				// in case of non-native resources, let's tolerate and let's log only when very high levels are requested.
 				// In these cases the admin knows there could be A LOT of data in the logs.
 				if isNativeResource(resName) {
-					klog.Warningf("resmon: zero capacity for native resource %q on NUMA cell %d", resName, nodeID)
+					logger.V(1).Info("zero capacity for native resource", "resource", resName, "numaCell", nodeID)
 				} else {
-					klog.V(5).Infof("resmon: zero capacity for extra resource %q on NUMA cell %d", resName, nodeID)
+					logger.V(5).Info("zero capacity for extra resource", "resource", resName, "numaCell", nodeID)
 				}
 			}
 			if resAlloc > resCapacity {
-				klog.Warningf("resmon: allocated more than capacity for %q on zone %q", resName.String(), zone.Name)
+				logger.V(1).Info("allocated more than capacity", "resource", resName, "zone", zone.Name)
 				// we trust more kubelet than ourselves atm.
 				resCapacity = resAlloc
 			}
@@ -356,7 +419,7 @@ func (rm *resourceMonitor) Scan(excludeList ResourceExclude) (ScanResponse, erro
 
 			resAvail := resAlloc - resUsed
 			if resAvail < 0 {
-				klog.Warningf("resmon: negative size for %q on zone %q", resName.String(), zone.Name)
+				logger.V(1).Info("negative size", "resource", resName, "zone", zone.Name)
 				resAvail = 0
 			}
 
@@ -372,6 +435,62 @@ func (rm *resourceMonitor) Scan(excludeList ResourceExclude) (ScanResponse, erro
 	}
 	scanRes.Zones = zones
 	return scanRes, nil
+}
+
+func ComputeNUMAPlacementPayload(logger logr.Logger, numaEligiblePodRes []*podresourcesapi.PodResources, topologyManagerPolicy string, nodesCount int, coreIDToNodeIDMap map[int]int) (numaplacement.Payload, error) {
+	// computing payload is valuable only on singleNumaNode policy because only under that
+	// condition there will be 1:1 stable mapping between the containers to the NUMA nodes.
+	if topologyManagerPolicy != TopologyManagerPolicySingleNUMANode {
+		return numaplacement.Payload{}, fmt.Errorf("topology manager policy not supported for NUMA placement: %s", topologyManagerPolicy)
+	}
+
+	enc, err := numaplacement.NewEncoder(nodesCount)
+	if err != nil {
+		return numaplacement.Payload{}, fmt.Errorf("while creating NUMA placement encoder: %w", err)
+	}
+
+	// Important:the consumer should apply the same filter on the pods' containers to be able
+	// to properly decode the attributes' values.
+	logger.V(4).Info("collecting containers that are eligible for NUMA placement")
+	for _, pr := range numaEligiblePodRes {
+		for _, cnt := range pr.Containers {
+			cntID := numaplacement.ContainerID{
+				Namespace:     pr.Namespace,
+				PodName:       pr.Name,
+				ContainerName: cnt.Name,
+			}
+			numaNodeID, err := getContainerSingleNUMAPlacement(cnt, coreIDToNodeIDMap)
+			if err != nil {
+				return numaplacement.Payload{}, fmt.Errorf("while getting container NUMA placement: containerID=%s, error=%w", cntID.String(), err)
+			}
+			if numaNodeID == -1 {
+				// it's possible that a container does not belong to specific NUMA node (e.g. using shared pool resources)
+				//  in that case we skip it
+				continue
+			}
+
+			enc, err = enc.Encode(numaplacement.ContainerAffinity{
+				ID:       cntID,
+				NUMANode: numaNodeID,
+			})
+			if err != nil {
+				return numaplacement.Payload{}, fmt.Errorf("while encoding container NUMA affinity: containerID=%s, error=%w", cntID.String(), err)
+			}
+			logger.V(6).Info("encoded container NUMA Affinity", "ident", cntID.String(), "numaNode", numaNodeID)
+		}
+	}
+
+	payload, err := enc.Result()
+	if err != nil {
+		return numaplacement.Payload{}, fmt.Errorf("while getting NUMA placement encoder result: error=%w", err)
+	}
+
+	logger.V(4).Info("encoded NUMA placement payload",
+		"containers", payload.Containers,
+		"numaNodes", payload.NUMANodes,
+		"busiestNode", payload.BusiestNode,
+		"encoding", payload.VectorEncoding)
+	return payload, nil
 }
 
 func (rm *resourceMonitor) updateNodeCapacity() error {
@@ -398,7 +517,8 @@ func (rm *resourceMonitor) updateNodeCapacity() error {
 	return nil
 }
 
-func (rm *resourceMonitor) resUpdated(old, new interface{}) {
+func (rm *resourceMonitor) resUpdated(ctx context.Context, old, new any) {
+	logger := klog.FromContext(ctx)
 	nOld := old.(*v1.Node)
 	nNew := new.(*v1.Node)
 
@@ -406,27 +526,27 @@ func (rm *resourceMonitor) resUpdated(old, new interface{}) {
 		return
 	}
 
-	// the status frequency update are configurable via the node-status-update-frequency option in Kubelet
 	if !reflect.DeepEqual(nOld.Status.Capacity, nNew.Status.Capacity) ||
 		!reflect.DeepEqual(nOld.Status.Allocatable, nNew.Status.Allocatable) {
-		klog.V(2).Infof("resmon: update node resources")
-		if err := rm.updateNodeResources(); err != nil {
-			klog.ErrorS(err, "resmon: while updating node resources")
+		logger.V(2).Info("update node resources")
+		if err := rm.updateNodeResources(ctx); err != nil {
+			logger.Error(err, "while updating node resources")
 		}
 	}
 }
 
-func (rm *resourceMonitor) updateNodeAllocatable() error {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultPodResourcesTimeout)
+func (rm *resourceMonitor) updateNodeAllocatable(ctx context.Context) error {
+	logger := klog.FromContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, defaultPodResourcesTimeout)
 	defer cancel()
 	allocRes, err := rm.podResCli.GetAllocatableResources(ctx, &podresourcesapi.AllocatableResourcesRequest{})
 	if err != nil {
-		metrics.UpdatePodResourceApiCallsFailureMetric("get_allocatable_resources")
+		metrics.UpdatePodResourceApiCallsFailuresMetric("get_allocatable_resources")
 		return err
 	}
 
-	allDevs := NormalizeContainerDevices(klog.V(4), allocRes.GetDevices(), allocRes.GetMemory(), allocRes.GetCpuIds(), rm.coreIDToNodeIDMap)
-	rm.nodeAllocatable = ContainerDevicesToPerNUMAResourceCounters(allDevs)
+	allDevs := NormalizeContainerDevices(logger, allocRes.GetDevices(), allocRes.GetMemory(), allocRes.GetCpuIds(), rm.coreIDToNodeIDMap)
+	rm.nodeAllocatable = ContainerDevicesToPerNUMAResourceCounters(logger, allDevs)
 	return nil
 }
 
@@ -442,11 +562,11 @@ func (rm *resourceMonitor) updateDevicesCapacity() {
 	}
 }
 
-func (rm *resourceMonitor) updateNodeResources() error {
+func (rm *resourceMonitor) updateNodeResources(ctx context.Context) error {
 	if err := rm.updateNodeCapacity(); err != nil {
 		return fmt.Errorf("error while updating node capacity: %w", err)
 	}
-	if err := rm.updateNodeAllocatable(); err != nil {
+	if err := rm.updateNodeAllocatable(ctx); err != nil {
 		return fmt.Errorf("error while updating node allocatable: %w", err)
 	}
 	// there is no trivial way to detect devices capacity from the node.
@@ -455,6 +575,8 @@ func (rm *resourceMonitor) updateNodeResources() error {
 	return nil
 }
 
+// computePodFingerprintFromPodResources computes the pod fingerprint from the given pod resources after applying the filter function to the pod resources.
+// If required that all pods to be included in the fingerprint, pass a no-op verifyFunc that allows all pods.
 func computePodFingerprintFromPodResources(podRes []*podresourcesapi.PodResources, st *podfingerprint.Status, verifyFunc func(*podresourcesapi.PodResources) podresfilter.Result) string {
 	fp := podfingerprint.NewTracingFingerprint(len(podRes), st)
 	for _, pr := range podRes {
@@ -467,34 +589,30 @@ func computePodFingerprintFromPodResources(podRes []*podresourcesapi.PodResource
 	return fp.Sign()
 }
 
-func collectPodsFromPodResources(podRes []*podresourcesapi.PodResources) string {
+func stringifyPodResources(podRes []*podresourcesapi.PodResources) string {
 	var sb strings.Builder
+	sep := ""
 	for _, pr := range podRes {
-		desc := ""
-		nl := numalocality.Verify(pr)
-		if nl.Allow {
-			desc = "/" + nl.Ident + "=" + nl.Reason
-		}
 		// note the separator is 2 spaces
-		sb.WriteString("  " + pr.Namespace + "/" + pr.Name + desc)
+		sb.WriteString(sep + pr.Namespace + "/" + pr.Name)
+		sep = "  "
 	}
 	val := sb.String()
 	if len(val) == 0 {
 		return ""
 	}
-	return val[2:]
+	return val
 }
 
 // GetAllContainerDevices is deprecated and will be unexported in a future version
-func GetAllContainerDevices(podRes []*podresourcesapi.PodResources, namespace string, coreIDToNodeIDMap map[int]int) []*podresourcesapi.ContainerDevices {
+func GetAllContainerDevices(logger logr.Logger, podRes []*podresourcesapi.PodResources, namespace string, coreIDToNodeIDMap map[int]int) []*podresourcesapi.ContainerDevices {
 	allCntRes := []*podresourcesapi.ContainerDevices{}
 	for _, pr := range podRes {
-		// filter by namespace (if given)
 		if namespace != "" && namespace != pr.GetNamespace() {
 			continue
 		}
 		for _, cnt := range pr.GetContainers() {
-			allCntRes = append(allCntRes, NormalizeContainerDevices(klog.V(8), cnt.GetDevices(), cnt.GetMemory(), cnt.GetCpuIds(), coreIDToNodeIDMap)...)
+			allCntRes = append(allCntRes, NormalizeContainerDevices(logger, cnt.GetDevices(), cnt.GetMemory(), cnt.GetCpuIds(), coreIDToNodeIDMap)...)
 		}
 	}
 	return allCntRes
@@ -512,25 +630,24 @@ func ComputePodFingerprint(podRes []*podresourcesapi.PodResources, st *podfinger
 	return fp.Sign()
 }
 
-func NormalizeContainerDevices(lh klog.Verbose, devices []*podresourcesapi.ContainerDevices, memoryBlocks []*podresourcesapi.ContainerMemory, cpuIds []int64, coreIDToNodeIDMap map[int]int) []*podresourcesapi.ContainerDevices {
-	lh.Infof("normalizing container devices: from devices=%d memoryBlocks=%d CPUs=%d", len(devices), len(memoryBlocks), len(cpuIds))
+func NormalizeContainerDevices(logger logr.Logger, devices []*podresourcesapi.ContainerDevices, memoryBlocks []*podresourcesapi.ContainerMemory, cpuIds []int64, coreIDToNodeIDMap map[int]int) []*podresourcesapi.ContainerDevices {
+	logger.V(4).Info("normalizing container devices", "devices", len(devices), "memoryBlocks", len(memoryBlocks), "CPUs", len(cpuIds))
 
-	lh.Infof("normalize Devices count=%d", len(devices))
+	logger.V(4).Info("normalize devices", "count", len(devices))
 	contDevs := append([]*podresourcesapi.ContainerDevices{}, devices...)
 
 	cpusPerNuma := make(map[int][]string)
 	for _, cpuID := range cpuIds {
 		nodeID, ok := coreIDToNodeIDMap[int(cpuID)]
 		if !ok {
-			// this must be logged unconditionally, so we use klog directly
-			klog.Warningf("resmon: cannot find the NUMA node for CPU %d", cpuID)
+			logger.V(1).Info("cannot find the NUMA node for CPU", "cpuID", cpuID)
 			continue
 		}
 		cpusPerNuma[nodeID] = append(cpusPerNuma[nodeID], fmt.Sprintf("%d", cpuID))
 	}
 
 	for nodeID, cpuList := range cpusPerNuma {
-		lh.Infof("normalize CPUs NUMANode=%d, count=%d", nodeID, len(cpuList))
+		logger.V(4).Info("normalize CPUs", "numaNode", nodeID, "count", len(cpuList))
 		contDevs = append(contDevs, &podresourcesapi.ContainerDevices{
 			ResourceName: string(v1.ResourceCPU),
 			DeviceIds:    cpuList,
@@ -549,7 +666,7 @@ func NormalizeContainerDevices(lh klog.Verbose, devices []*podresourcesapi.Conta
 		}
 
 		for _, node := range block.GetTopology().GetNodes() {
-			lh.Infof("normalize MemoryBlocks NUMANode=%d size=%v", node.ID, blockSize)
+			logger.V(4).Info("normalize memory blocks", "numaNode", node.ID, "size", blockSize)
 			contDevs = append(contDevs, &podresourcesapi.ContainerDevices{
 				ResourceName: block.MemoryType,
 				DeviceIds:    []string{fmt.Sprintf("%d", blockSize)},
@@ -562,11 +679,11 @@ func NormalizeContainerDevices(lh klog.Verbose, devices []*podresourcesapi.Conta
 		}
 	}
 
-	lh.Infof("normalized container devices: entries=%d from devices=%d memoryBlocks=%d CPUs=%d", len(contDevs), len(devices), len(memoryBlocks), len(cpuIds))
+	logger.V(4).Info("normalized container devices", "entries", len(contDevs), "devices", len(devices), "memoryBlocks", len(memoryBlocks), "CPUs", len(cpuIds))
 	return contDevs
 }
 
-func ContainerDevicesToPerNUMAResourceCounters(devices []*podresourcesapi.ContainerDevices) perNUMAResourceCounter {
+func ContainerDevicesToPerNUMAResourceCounters(logger logr.Logger, devices []*podresourcesapi.ContainerDevices) perNUMAResourceCounter {
 	perNUMARc := make(perNUMAResourceCounter)
 	for _, device := range devices {
 		resourceName := device.GetResourceName()
@@ -590,7 +707,7 @@ func ContainerDevicesToPerNUMAResourceCounters(devices []*podresourcesapi.Contai
 			perNUMARc[nodeID] = nodeRes
 		}
 	}
-	klog.V(6).Infof("resmon: from devices=%d: %s", len(devices), perNUMARc.String())
+	logger.V(6).Info("container devices to per-NUMA resource counters", "devices", len(devices), "counters", perNUMARc.String())
 	return perNUMARc
 }
 
@@ -656,11 +773,10 @@ func cpuCapacity(topo *ghwtopology.Info, nodeID int) int64 {
 	return int64(logicalCoresPerNUMA)
 }
 
-func addNodeInformerEvent(c kubernetes.Interface, handler cache.ResourceEventHandlerFuncs) error {
+func addNodeInformerEvent(ctx context.Context, c kubernetes.Interface, handler cache.ResourceEventHandlerFuncs) error {
 	factory := informers.NewSharedInformerFactory(c, 0)
 	nodeInformer := factory.Core().V1().Nodes().Informer()
 	_, _ = nodeInformer.AddEventHandler(handler)
-	ctx := context.Background()
 	factory.Start(ctx.Done())
 	if !cache.WaitForCacheSync(ctx.Done(), nodeInformer.HasSynced) {
 		return fmt.Errorf("timed out waiting for caches to sync")
@@ -697,10 +813,57 @@ func mapIntIntToString(mii map[int]int) string {
 	return sb.String()
 }
 
-func toJSON(obj interface{}) string {
+func toJSON(obj any) string {
 	data, err := json.Marshal(obj)
 	if err != nil {
 		return "<ERROR>"
 	}
 	return string(data)
+}
+
+// getContainerSingleNUMAPlacement returns the NUMA node ID for a container under single-numa-node topology manager policy.
+// It relies on kubelet to guarantee that, hence exits the moment it finds the first non (-1) NUMA ID. if no NUMA affinity
+// is found, it returns -1.
+func getContainerSingleNUMAPlacement(cnt *podresourcesapi.ContainerResources, coreIDToNodeIDMap map[int]int) (int, error) {
+	if len(cnt.CpuIds) > 0 {
+		// since this is running on singleNUMANode policy, we can trust that all of the CPUs are on the same NUMA node
+		nodeID, ok := coreIDToNodeIDMap[int(cnt.CpuIds[0])]
+		if !ok {
+			//should never happen with singleNUMANode policy, but if it does we should not encode any data as it would be unreliable.
+			return -1, fmt.Errorf("CPU ID %d not found in coreIDToNodeIDMap", cnt.CpuIds[0])
+		}
+		return nodeID, nil
+	}
+
+	//  resources that are considered host-level resources (like ephemeral storage, devices with excludePolicy:"true", etc.),
+	//  are not considered for NUMA placement and they will not have NUMA topology info thus GetNUMAID will return -1
+	for _, dev := range cnt.Devices {
+		if len(dev.DeviceIds) == 0 {
+			continue
+		}
+		nodeIDs := numaloclib.GetNUMAIDs(dev.Topology)
+		if len(nodeIDs) == 0 {
+			continue
+		}
+
+		if len(nodeIDs) > 1 {
+			// should never happen on singleNUMANode policy
+			return -1, fmt.Errorf("multiple NUMA nodes found for container %s", cnt.Name)
+		}
+		return nodeIDs[0], nil
+	}
+
+	for _, mem := range cnt.Memory {
+		nodeIDs := numaloclib.GetNUMAIDs(mem.Topology)
+		if len(nodeIDs) == 0 {
+			continue
+		}
+
+		if len(nodeIDs) > 1 {
+			// should never happen on singleNUMANode policy
+			return -1, fmt.Errorf("multiple NUMA nodes found for container %s", cnt.Name)
+		}
+		return nodeIDs[0], nil
+	}
+	return -1, nil
 }

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcetopologyexporter/resourceobserver.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcetopologyexporter/resourceobserver.go
@@ -1,7 +1,7 @@
 package resourcetopologyexporter
 
 import (
-	"fmt"
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -24,12 +24,7 @@ type ResourceObserver struct {
 	exposeTiming    bool
 }
 
-func NewResourceObserver(hnd resourcemonitor.Handle, args resourcemonitor.Args) (*ResourceObserver, error) {
-	resMon, err := resourcemonitor.NewResourceMonitor(hnd, args)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize ResourceMonitor: %w", err)
-	}
-
+func NewResourceObserver(resMon resourcemonitor.ResourceMonitor, args resourcemonitor.Args) *ResourceObserver {
 	resObs := ResourceObserver{
 		resMon:          resMon,
 		resourceExclude: args.ResourceExclude,
@@ -38,14 +33,15 @@ func NewResourceObserver(hnd resourcemonitor.Handle, args resourcemonitor.Args) 
 		exposeTiming:    args.ExposeTiming,
 	}
 	resObs.Infos = resObs.infoChan
-	return &resObs, nil
+	return &resObs
 }
 
 func (rm *ResourceObserver) Stop() {
 	rm.stopChan <- struct{}{}
 }
 
-func (rm *ResourceObserver) Run(eventsChan <-chan notification.Event, condChan chan<- v1.PodCondition) {
+func (rm *ResourceObserver) Run(ctx context.Context, eventsChan <-chan notification.Event, condChan chan<- v1.PodCondition) {
+	logger := klog.FromContext(ctx)
 	lastWakeup := time.Now()
 	for {
 		select {
@@ -59,7 +55,7 @@ func (rm *ResourceObserver) Run(eventsChan <-chan notification.Event, condChan c
 			metrics.UpdateWakeupDelayMetric(monInfo.UpdateReason(), float64(tsWakeupDiff.Milliseconds()))
 
 			tsBegin := time.Now()
-			scanRes, err := rm.resMon.Scan(rm.resourceExclude)
+			scanRes, err := rm.resMon.Scan(ctx, rm.resourceExclude)
 			tsEnd := time.Now()
 
 			monInfo.Annotations = scanRes.Annotations
@@ -73,7 +69,7 @@ func (rm *ResourceObserver) Run(eventsChan <-chan notification.Event, condChan c
 
 			condStatus := v1.ConditionTrue
 			if err != nil {
-				klog.Warningf("failed to scan pod resources: %v\n", err)
+				logger.V(1).Info("failed to scan pod resources", "err", err)
 				condStatus = v1.ConditionFalse
 				podreadiness.SetCondition(condChan, podreadiness.PodresourcesFetched, condStatus)
 				continue
@@ -83,8 +79,10 @@ func (rm *ResourceObserver) Run(eventsChan <-chan notification.Event, condChan c
 			tsDiff := tsEnd.Sub(tsBegin)
 			metrics.UpdateOperationDelayMetric("podresources_scan", monInfo.UpdateReason(), float64(tsDiff.Milliseconds()))
 			podreadiness.SetCondition(condChan, podreadiness.PodresourcesFetched, condStatus)
+		case <-ctx.Done():
+			return
 		case <-rm.stopChan:
-			klog.Infof("read stop at %v", time.Now())
+			logger.Info("read stop", "at", time.Now())
 			return
 		}
 	}

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcetopologyexporter/resourcetopologyexporter.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcetopologyexporter/resourcetopologyexporter.go
@@ -8,6 +8,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
+	"github.com/go-logr/logr"
 	topologyclientset "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned"
 
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/kubeconf"
@@ -67,17 +68,19 @@ type Handle struct {
 	NRTCli topologyclientset.Interface
 }
 
-func Execute(hnd Handle, nrtupdaterArgs nrtupdater.Args, resourcemonitorArgs resourcemonitor.Args, rteArgs Args) error {
-	tmConf, err := getTopologyManagerSettings(rteArgs)
+func Execute(ctx context.Context, hnd Handle, nrtupdaterArgs nrtupdater.Args, resourcemonitorArgs resourcemonitor.Args, rteArgs Args) error {
+	logger := klog.FromContext(ctx)
+
+	tmConf, err := getTopologyManagerSettings(logger, rteArgs)
 	if err != nil {
 		return err
 	}
 
 	var nodeGetter nrtupdater.NodeGetter
 	if rteArgs.AddNRTOwnerEnable {
-		nodeGetter, err = nrtupdater.NewCachedNodeGetter(hnd.ResMon.K8SCli, context.Background())
+		nodeGetter, err = nrtupdater.NewCachedNodeGetter(hnd.ResMon.K8SCli, ctx)
 		if err != nil {
-			klog.V(2).Info("Cannot enable 'add-nrt-owner'. Unable to get node info")
+			logger.V(2).Info("Cannot enable 'add-nrt-owner'. Unable to get node info")
 			return fmt.Errorf("Cannot enable 'add-nrt-owner'. %w", err)
 		}
 	} else {
@@ -91,7 +94,7 @@ func Execute(hnd Handle, nrtupdaterArgs nrtupdater.Args, resourcemonitorArgs res
 		if err != nil {
 			return err
 		}
-		condIn.Run(condChan)
+		go condIn.Run(ctx, condChan)
 	}
 
 	eventSource, err := createEventSource(&rteArgs)
@@ -99,11 +102,14 @@ func Execute(hnd Handle, nrtupdaterArgs nrtupdater.Args, resourcemonitorArgs res
 		return err
 	}
 
-	resObs, err := NewResourceObserver(hnd.ResMon, resourcemonitorArgs)
-	if err != nil {
-		return err
+	resMon := resourcemonitor.NewResourceMonitor(hnd.ResMon, resourcemonitorArgs, tmConf.config.Policy)
+	if err := resMon.Setup(ctx); err != nil {
+		return fmt.Errorf("failed to setup ResourceMonitor: %w", err)
 	}
-	go resObs.Run(eventSource.Events(), condChan)
+
+	resObs := NewResourceObserver(resMon, resourcemonitorArgs)
+
+	go resObs.Run(ctx, eventSource.Events(), condChan)
 
 	upd, err := nrtupdater.NewNRTUpdater(nodeGetter, hnd.NRTCli, nrtupdaterArgs, tmConf.config)
 	if err != nil {
@@ -113,9 +119,13 @@ func Execute(hnd Handle, nrtupdaterArgs nrtupdater.Args, resourcemonitorArgs res
 
 	go eventSource.Run()
 
-	eventSource.Wait()  // will never return
-	eventSource.Close() // still we try to clean after ourselves :)
-	return nil          // unreachable
+	select {
+	case <-ctx.Done():
+	}
+	eventSource.Stop()
+	eventSource.Wait()
+	eventSource.Close()
+	return nil
 }
 
 func createEventSource(rteArgs *Args) (notification.EventSource, error) {
@@ -149,7 +159,7 @@ func createEventSource(rteArgs *Args) (notification.EventSource, error) {
 	return es, nil
 }
 
-func getTopologyManagerSettings(rteArgs Args) (tmSettings, error) {
+func getTopologyManagerSettings(logger logr.Logger, rteArgs Args) (tmSettings, error) {
 	if rteArgs.TopologyManagerPolicy != "" && rteArgs.TopologyManagerScope != "" {
 		tmConf := tmSettings{
 			config: nrtupdater.TMConfig{
@@ -157,7 +167,7 @@ func getTopologyManagerSettings(rteArgs Args) (tmSettings, error) {
 				Scope:  rteArgs.TopologyManagerScope,
 			},
 		}
-		klog.Infof("using given Topology Manager policy %q scope %q", tmConf.config.Policy, tmConf.config.Scope)
+		logger.Info("using given Topology Manager settings", "policy", tmConf.config.Policy, "scope", tmConf.config.Scope)
 		return tmConf, nil
 	}
 	if rteArgs.KubeletConfigFile != "" {
@@ -171,7 +181,7 @@ func getTopologyManagerSettings(rteArgs Args) (tmSettings, error) {
 				Scope:  klConfig.TopologyManagerScope,
 			},
 		}
-		klog.Infof("using detected Topology Manager policy %q scope %q", tmConf.config.Policy, tmConf.config.Scope)
+		logger.Info("using detected Topology Manager settings", "policy", tmConf.config.Policy, "scope", tmConf.config.Scope)
 		return tmConf, nil
 	}
 	return tmSettings{}, fmt.Errorf("cannot find the kubelet Topology Manager policy")

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/rte/conditions.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/rte/conditions.go
@@ -77,15 +77,15 @@ var _ = ginkgo.Describe("[RTE][Monitoring] conditions", func() {
 
 	ginkgo.Context("with NRT objects created", func() {
 		ginkgo.It("[release] should have custom RTE conditions under the pod status", func() {
-			gomega.Eventually(func() bool {
-				return waitForPodCondition(e2etestenv.RTELabelName, podreadiness.PodresourcesFetched, corev1.ConditionTrue)
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(waitForPodCondition(e2etestenv.RTELabelName, podreadiness.PodresourcesFetched, corev1.ConditionTrue)).To(gomega.BeTrue(), "pod contains wrong condition value")
 				// wait for twice the poll interval, so the conditions will have enough time to get updated
-			}).WithTimeout(2*timeout).WithPolling(1*time.Second).Should(gomega.BeTrue(), "pod contains wrong condition value")
+			}).WithTimeout(2 * timeout).WithPolling(1 * time.Second).Should(gomega.Succeed())
 
-			gomega.Eventually(func() bool {
-				return waitForPodCondition(e2etestenv.RTELabelName, podreadiness.NodeTopologyUpdated, corev1.ConditionTrue)
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(waitForPodCondition(e2etestenv.RTELabelName, podreadiness.NodeTopologyUpdated, corev1.ConditionTrue)).To(gomega.BeTrue(), "pod contains wrong condition value")
 				// wait for twice the poll interval, so the conditions will have enough time to get updated
-			}).WithTimeout(2*timeout).WithPolling(1*time.Second).Should(gomega.BeTrue(), "pod contains wrong condition value")
+			}).WithTimeout(2 * timeout).WithPolling(1 * time.Second).Should(gomega.Succeed())
 		})
 
 		// EventChain means that the test can be flaky in some specific cases, for example deleted CRD can be re-installed
@@ -96,19 +96,19 @@ var _ = ginkgo.Describe("[RTE][Monitoring] conditions", func() {
 			err := f.ApiExt.ApiextensionsV1().CustomResourceDefinitions().Delete(context.TODO(), crdName, metav1.DeleteOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			gomega.Eventually(func() bool {
-				return waitForPodCondition(e2etestenv.RTELabelName, podreadiness.NodeTopologyUpdated, corev1.ConditionFalse)
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(waitForPodCondition(e2etestenv.RTELabelName, podreadiness.NodeTopologyUpdated, corev1.ConditionFalse)).To(gomega.BeTrue(), "pod contains wrong condition value")
 				// wait for twice the poll interval, so the conditions will have enough time to get updated
-			}).WithTimeout(2*timeout).WithPolling(1*time.Second).Should(gomega.BeTrue(), "pod contains wrong condition value")
+			}).WithTimeout(2 * timeout).WithPolling(1 * time.Second).Should(gomega.Succeed())
 
 			ginkgo.By("recreating the crd")
 			crd.ResourceVersion = ""
 			_, err = f.ApiExt.ApiextensionsV1().CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			gomega.Eventually(func() bool {
-				return waitForPodCondition(e2etestenv.RTELabelName, podreadiness.NodeTopologyUpdated, corev1.ConditionFalse)
-			}).WithTimeout(2*timeout).WithPolling(1*time.Second).Should(gomega.BeTrue(), "pod contains wrong condition value")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(waitForPodCondition(e2etestenv.RTELabelName, podreadiness.NodeTopologyUpdated, corev1.ConditionFalse)).To(gomega.BeTrue(), "pod contains wrong condition value")
+			}).WithTimeout(2 * timeout).WithPolling(1 * time.Second).Should(gomega.Succeed())
 		})
 	})
 })

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/rte/metrics.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/rte/metrics.go
@@ -23,7 +23,6 @@ package rte
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -127,13 +126,15 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 			key := client.ObjectKeyFromObject(rtePod)
 			klog.Infof("executing cmd: %s on pod %q", cmd, key.String())
 			var stdout, stderr []byte
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func(g gomega.Gomega) {
 				var err error
 				stdout, stderr, err = remoteexec.CommandOnPod(f.Ctx, f.K8SCli, rtePod, rteContainerName, cmd...)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed exec command on pod. pod=%q; cmd=%q; err=%v; stderr=%q", key.String(), cmd, err, stderr)
-				return strings.Contains(string(stdout), "operation_delay") &&
-					strings.Contains(string(stdout), "wakeup_delay")
-			}).WithPolling(10*time.Second).WithTimeout(3*time.Minute).Should(gomega.BeTrue(), "failed to get metrics from pod\nstdout=%q\nstderr=%q\n", stdout, stderr)
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "failed exec command on pod. pod=%q; cmd=%q; err=%v; stderr=%q", key.String(), cmd, err, stderr)
+				g.Expect(string(stdout)).To(gomega.And(
+					gomega.ContainSubstring("operation_delay"),
+					gomega.ContainSubstring("wakeup_delay"),
+				), "failed to get metrics from pod\nstdout=%q\nstderr=%q\n", stdout, stderr)
+			}).WithPolling(10 * time.Second).WithTimeout(3 * time.Minute).Should(gomega.Succeed())
 		})
 
 		ginkgo.It("[EventChain] should have some metrics exported over plain http", func() {
@@ -146,13 +147,15 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 			key := client.ObjectKeyFromObject(rtePod)
 			klog.Infof("executing cmd: %s on pod %q", cmd, key.String())
 			var stdout, stderr []byte
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func(g gomega.Gomega) {
 				var err error
 				stdout, stderr, err = remoteexec.CommandOnPod(f.Ctx, f.K8SCli, rtePod, rteContainerName, cmd...)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed exec command on pod. pod=%q; cmd=%q; err=%v; stderr=%q", key.String(), cmd, err, stderr)
-				return strings.Contains(string(stdout), "operation_delay") &&
-					strings.Contains(string(stdout), "wakeup_delay")
-			}).WithPolling(10*time.Second).WithTimeout(3*time.Minute).Should(gomega.BeTrue(), "failed to get metrics from pod\nstdout=%q\nstderr=%q\n", stdout, stderr)
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "failed exec command on pod. pod=%q; cmd=%q; err=%v; stderr=%q", key.String(), cmd, err, stderr)
+				g.Expect(string(stdout)).To(gomega.And(
+					gomega.ContainSubstring("operation_delay"),
+					gomega.ContainSubstring("wakeup_delay"),
+				), "failed to get metrics from pod\nstdout=%q\nstderr=%q\n", stdout, stderr)
+			}).WithPolling(10 * time.Second).WithTimeout(3 * time.Minute).Should(gomega.Succeed())
 		})
 		ginkgo.It("[release] it should report noderesourcetopology writes", func() {
 			if metricsMode != "http" {
@@ -180,13 +183,13 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 			key := client.ObjectKeyFromObject(rtePod)
 			klog.Infof("executing cmd: %s on pod %q", cmd, key.String())
 			var stdout, stderr []byte
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func(g gomega.Gomega) {
 				var err error
 				stdout, stderr, err = remoteexec.CommandOnPod(f.Ctx, f.K8SCli, rtePod, rteContainerName, cmd...)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed exec command on pod. pod=%q; cmd=%q; err=%v; stderr=%q", key.String(), cmd, err, stderr)
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "failed exec command on pod. pod=%q; cmd=%q; err=%v; stderr=%q", key.String(), cmd, err, stderr)
 
-				return strings.Contains(string(stdout), "noderesourcetopology_writes_total")
-			}).WithPolling(10*time.Second).WithTimeout(2*time.Minute).Should(gomega.BeTrue(), "failed to get metrics from pod\nstdout=%q\nstderr=%q\n", stdout, stderr)
+				g.Expect(string(stdout)).To(gomega.ContainSubstring("noderesourcetopology_writes_total"), "failed to get metrics from pod\nstdout=%q\nstderr=%q\n", stdout, stderr)
+			}).WithPolling(10 * time.Second).WithTimeout(2 * time.Minute).Should(gomega.Succeed())
 		})
 	})
 })

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/rte/rte.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/rte/rte.go
@@ -22,13 +22,21 @@ package rte
 
 import (
 	"context"
+	"fmt"
+	"slices"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
+	"github.com/k8stopologyawareschedwg/numaplacement"
+
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	clientset "k8s.io/client-go/kubernetes"
@@ -97,63 +105,51 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 		ginkgo.It("[NotificationFile] it should react to pod changes using the smart poller with notification file", func() {
 			initialNodeTopo := e2enodetopology.GetNodeTopology(f.TopoCli, topologyUpdaterNode.Name)
 
-			stopChan := make(chan struct{})
-			doneChan := make(chan struct{})
-			started := false
+			updateInterval, method, err := estimateUpdateInterval(*initialNodeTopo)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			baselineTimeout := 5*updateInterval + updateIntervalExtraSafety
+			klog.Infof("%s update interval: %s (timeout %s)", method, updateInterval, baselineTimeout)
 
-			go func() {
-				defer ginkgo.GinkgoRecover()
+			ginkgo.By("waiting for a periodic update to find the optimal update window")
+			var baselineNodeTopo *v1alpha2.NodeResourceTopology
+			gomega.Eventually(func(g gomega.Gomega) {
+				var err error
+				baselineNodeTopo, err = f.TopoCli.TopologyV1alpha2().NodeResourceTopologies().Get(context.TODO(), topologyUpdaterNode.Name, metav1.GetOptions{})
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to get the node topology resource")
+				g.Expect(baselineNodeTopo.ObjectMeta.ResourceVersion).ToNot(gomega.Equal(initialNodeTopo.ObjectMeta.ResourceVersion), "resource %s not yet updated - resource version not bumped", topologyUpdaterNode.Name)
+				klog.Infof("resource %s baseline update (resource version %v -> %v)", topologyUpdaterNode.Name, initialNodeTopo.ObjectMeta.ResourceVersion, baselineNodeTopo.ObjectMeta.ResourceVersion)
+			}).WithTimeout(baselineTimeout).WithPolling(1*time.Second).Should(gomega.Succeed(), "didn't get baseline periodic update")
 
-				<-stopChan
-				rtePod, err := e2epods.GetPodOnNode(f.K8SCli, topologyUpdaterNode.Name, e2etestenv.GetNamespaceName(), e2etestenv.RTELabelName)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			ginkgo.By("triggering notification using the file")
+			rtePod, err := e2epods.GetPodOnNode(f.K8SCli, topologyUpdaterNode.Name, e2etestenv.GetNamespaceName(), e2etestenv.RTELabelName)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-				rteContainerName, err := e2ertepod.FindRTEContainerName(rtePod)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			rteContainerName, err := e2ertepod.FindRTEContainerName(rtePod)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-				rteNotifyFilePath, err := e2ertepod.FindNotificationFilePath(rtePod)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			rteNotifyFilePath, err := e2ertepod.FindNotificationFilePath(f.Ctx, f.K8SCli, rtePod)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-				cmd := []string{"/bin/touch", rteNotifyFilePath}
-				_, _, err = remoteexec.CommandOnPod(f.Ctx, f.K8SCli, rtePod, rteContainerName, cmd...)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed exec command %v on pod %q", cmd, client.ObjectKeyFromObject(rtePod).String())
-				klog.Infof("notification triggered, exiting")
-				doneChan <- struct{}{}
-			}()
+			cmd := []string{"/bin/touch", rteNotifyFilePath}
+			_, _, err = remoteexec.CommandOnPod(f.Ctx, f.K8SCli, rtePod, rteContainerName, cmd...)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed exec command %v on pod %q", cmd, client.ObjectKeyFromObject(rtePod).String())
+			klog.Infof("notification triggered")
 
-			ginkgo.By("getting the updated topology")
-			var err error
+			ginkgo.By("waiting for reactive topology update")
 			var finalNodeTopo *v1alpha2.NodeResourceTopology
-			gomega.Eventually(func() bool {
-				if !started {
-					stopChan <- struct{}{}
-					started = true
-				}
-
+			gomega.Eventually(func(g gomega.Gomega) {
 				finalNodeTopo, err = f.TopoCli.TopologyV1alpha2().NodeResourceTopologies().Get(context.TODO(), topologyUpdaterNode.Name, metav1.GetOptions{})
-				if err != nil {
-					klog.Infof("failed to get the node topology resource: %v", err)
-					return false
-				}
-				if finalNodeTopo.ObjectMeta.ResourceVersion == initialNodeTopo.ObjectMeta.ResourceVersion {
-					klog.Infof("resource %s not yet updated - resource version not bumped", topologyUpdaterNode.Name)
-					return false
-				}
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to get the node topology resource")
+				g.Expect(finalNodeTopo.ObjectMeta.ResourceVersion).ToNot(gomega.Equal(baselineNodeTopo.ObjectMeta.ResourceVersion), "resource %s not yet updated - resource version not bumped", topologyUpdaterNode.Name)
 
-				klog.Infof("resource %s updated! - resource version bumped (old %v new %v)", topologyUpdaterNode.Name, initialNodeTopo.ObjectMeta.ResourceVersion, finalNodeTopo.ObjectMeta.ResourceVersion)
+				klog.Infof("resource %s updated! - resource version bumped (old %v new %v)", topologyUpdaterNode.Name, baselineNodeTopo.ObjectMeta.ResourceVersion, finalNodeTopo.ObjectMeta.ResourceVersion)
 
 				reason, ok := finalNodeTopo.Annotations[k8sannotations.RTEUpdate]
-				if !ok {
-					klog.Infof("resource %s missing annotation!", topologyUpdaterNode.Name)
-					return false
-				}
-				klog.Infof("resource %s reason %v expected %v", topologyUpdaterNode.Name, reason, nrtupdater.RTEUpdateReactive)
-				return reason == nrtupdater.RTEUpdateReactive
-			}).WithTimeout(31*time.Second).WithPolling(1*time.Second).Should(gomega.BeTrue(), "didn't get updated node topology info")
+				g.Expect(ok).To(gomega.BeTrue(), "resource %s missing annotation!", topologyUpdaterNode.Name)
+				g.Expect(reason).To(gomega.Equal(nrtupdater.RTEUpdateReactive), "resource %s reason %v expected %v", topologyUpdaterNode.Name, reason, nrtupdater.RTEUpdateReactive)
+			}).WithTimeout(baselineTimeout).WithPolling(1*time.Second).Should(gomega.Succeed(), "didn't get updated node topology info")
+
 			ginkgo.By("checking the topology was updated for the right reason")
-
-			<-doneChan
-
 			gomega.Expect(finalNodeTopo.Annotations).ToNot(gomega.BeNil(), "missing annotations entirely")
 			reason := finalNodeTopo.Annotations[k8sannotations.RTEUpdate]
 			gomega.Expect(reason).To(gomega.Equal(nrtupdater.RTEUpdateReactive), "update reason error: expected %q got %q", nrtupdater.RTEUpdateReactive, reason)
@@ -237,10 +233,6 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 
 			dumpPods(f.K8SCli, topologyUpdaterNode.Name, "reference pods")
 
-			updateInterval, method, err := estimateUpdateInterval(*prevNrt)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			klog.Infof("%s update interval: %s", method, updateInterval)
-
 			sleeperPod := e2epods.MakeGuaranteedSleeperPod("1000m")
 			pod, err := e2epods.CreateSync(f, sleeperPod)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -248,7 +240,8 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 			podNamespace, podName := pod.Namespace, pod.Name
 			ginkgo.DeferCleanup(e2epods.DeletePodSyncByName, f, podNamespace, podName)
 
-			currNrt = getUpdatedNRT(f.TopoCli, topologyUpdaterNode.Name, *prevNrt, updateInterval)
+			updateTimeout := 5 * time.Minute
+			currNrt = getUpdatedNRT(f.TopoCli, topologyUpdaterNode.Name, *prevNrt, updateTimeout)
 
 			pfpChanged := expectPodFingerprint(*prevNrt, "!=", *currNrt)
 			errMessage := "PFP did not change after pod creation"
@@ -262,7 +255,7 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 			err = e2epods.DeletePodSyncByName(f, podNamespace, podName)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			currNrt = getUpdatedNRT(f.TopoCli, topologyUpdaterNode.Name, *prevNrt, updateInterval)
+			currNrt = getUpdatedNRT(f.TopoCli, topologyUpdaterNode.Name, *prevNrt, updateTimeout)
 
 			pfpChanged = expectPodFingerprint(*prevNrt, "!=", *currNrt)
 			errMessage = "PFP did not change after pod deletion"
@@ -271,21 +264,292 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 			}
 			gomega.Expect(pfpChanged).To(gomega.BeTrue(), errMessage)
 		})
+
+		ginkgo.When("[release][numaplacement] testing numaplacement attributes", func() {
+			// Node-level numaplacement.AttributeMetadata is published when pod fingerprinting is enabled; it holds
+			// PackMetadata() from encoded container NUMA affinities (see resourcemonitor Scan + encodeContainerAffinities).
+			// It is not a per-zone field; on single-NUMA nodes the encoder short-circuits and the value may stay empty
+			// or unchanged when pods change.
+			var (
+				initialNRT        *v1alpha2.NodeResourceTopology
+				initialMeta       string
+				initialPayload    numaplacement.Payload
+				initialContainers []numaplacement.ContainerID
+				updateTimeout     time.Duration = 5 * time.Minute
+			)
+
+			ginkgo.BeforeEach(func() {
+				initialNRT = e2enodetopology.GetNodeTopology(f.TopoCli, topologyUpdaterNode.Name)
+				klog.Infof("Initial NRT: %q generation=%v resourceVersion=%v", initialNRT.Name, initialNRT.Generation, initialNRT.ResourceVersion)
+
+				if _, ok := findAttribute(initialNRT.Attributes, podfingerprint.Attribute); !ok {
+					ginkgo.Skip("pod fingerprinting attribute not found - assuming disabled")
+				}
+				tmPolicy, ok := findAttribute(initialNRT.Attributes, "topologyManagerPolicy")
+				if !ok {
+					ginkgo.Skip("topologyManagerPolicy attribute not found")
+				}
+				if tmPolicy != "single-numa-node" {
+					ginkgo.Skip("topologyManagerPolicy is not single-numa-node - numaplacement containers encoding is not supported")
+				}
+				klog.Infof("topologyManagerPolicy is %q", tmPolicy)
+				klog.Infof("initialNRT.Attributes: %v", initialNRT.Attributes)
+
+				initialMeta, ok = findAttribute(initialNRT.Attributes, numaplacement.AttributeMetadata)
+				if !ok {
+					ginkgo.Skip("numaplacement metadata attribute not found")
+				}
+
+				ginkgo.By("checking the metadata is set with the expected data")
+				gomega.Expect(initialMeta).ToNot(gomega.BeEmpty(), "numaplacement metadata is empty")
+				gomega.Expect(initialMeta).To(gomega.HavePrefix(numaplacement.Prefix+numaplacement.Version), "numaplacement metadata is not prefixed properly")
+
+				dumpPods(f.K8SCli, topologyUpdaterNode.Name, "reference pods")
+				initialContainers = dumpContainers(f.K8SCli, topologyUpdaterNode.Name, false)
+
+				initialPayload = numaplacement.Payload{}
+				gomega.Expect(numaplacement.UnpackMetadataInto(&initialPayload, initialMeta)).To(gomega.Succeed())
+				gomega.Expect(initialPayload.NUMANodes).To(gomega.Equal(len(initialNRT.Zones)), "numaplacement metadata must reflect the correct numer of NUMAs as found in the NRT")
+				gomega.Expect(initialPayload.VectorEncoding).To(gomega.Equal(numaplacement.VectorEncodingLEB89), "numaplacement encoding must use LEB89 encoding")
+
+			})
+
+			ginkgo.Context("node-level metadata attribute", func() {
+				ginkgo.It("should remain stable while workloads are unchanged", func() {
+					maxSteps := 3
+					updateInterval, method, err := estimateUpdateInterval(*initialNRT)
+					gomega.Expect(err).ToNot(gomega.HaveOccurred())
+					klog.Infof("%s update interval: %s", method, updateInterval)
+					for step := 0; step < maxSteps; step++ {
+						klog.Infof("waiting for %s: %d/%d", updateInterval, step+1, maxSteps)
+						time.Sleep(updateInterval)
+					}
+
+					// note we don't test that no pods have been added/deleted. This is because the suite is supposed to own the cluster while it runs
+					// IOW, if we don't create/delete pods explicitly, noone else is supposed to do
+					currNrt := e2enodetopology.GetNodeTopology(f.TopoCli, topologyUpdaterNode.Name)
+					klog.Infof("Current NRT: %q generation=%v resourceVersion=%v", currNrt.Name, currNrt.Generation, currNrt.ResourceVersion)
+
+					metaAfter, ok := findAttribute(currNrt.Attributes, numaplacement.AttributeMetadata)
+					gomega.Expect(ok).To(gomega.BeTrue(), "attribute %q missing after wait", numaplacement.AttributeMetadata)
+
+					if initialMeta != metaAfter {
+						infoUponFailure(f, topologyUpdaterNode.Name, initialContainers, "numaplacement metadata attribute changed unexpectedly")
+					}
+
+					gomega.Expect(metaAfter).To(gomega.Equal(initialMeta), "numaplacement metadata attribute changed unexpectedly")
+					currContainers := dumpContainers(f.K8SCli, topologyUpdaterNode.Name, false)
+					gomega.Expect(getContainersListCmpDiff(initialContainers, currContainers)).To(gomega.BeEmpty(), "containers list changed unexpectedly")
+				})
+
+				ginkgo.Context("multi-NUMA nodes", func() {
+					type tableTest struct {
+						expectedQoS                        corev1.PodQOSClass
+						resourcesPerContainer              []corev1.ResourceRequirements
+						eligibleContainersForNUMAPlacement int
+					}
+					ginkgo.BeforeEach(func() {
+						if len(initialNRT.Zones) < 2 {
+							ginkgo.Skip("single NUMA zone in NRT: affinity encoding does not vary with pod set (encoder short-circuit)")
+						}
+					})
+
+					ginkgo.DescribeTable("numaplacement metadata on multi-NUMA nodes when pods are added and removed",
+						func(test tableTest) {
+							ginkgo.By("creating a sleeper pod")
+							sleeperPod := e2epods.MakeSleeperPod(test.resourcesPerContainer)
+							sleeperPod.Spec.NodeName = topologyUpdaterNode.Name
+							pod, err := e2epods.CreateSync(f, sleeperPod)
+							gomega.Expect(err).ToNot(gomega.HaveOccurred())
+							gomega.Expect(pod.Status.QOSClass).To(gomega.Equal(test.expectedQoS))
+
+							podNamespace, podName := pod.Namespace, pod.Name
+							needsCleanup := true
+							ginkgo.DeferCleanup(func() {
+								if needsCleanup {
+									gomega.Expect(e2epods.DeletePodSyncByName(f, podNamespace, podName)).To(gomega.Succeed())
+								}
+							})
+
+							ginkgo.By("getting the updated NRT after pod creation")
+							nrtPostPodCreation := getUpdatedNRT(f.TopoCli, topologyUpdaterNode.Name, *initialNRT, updateTimeout)
+							metaPostPodCreation, ok := findAttribute(nrtPostPodCreation.Attributes, numaplacement.AttributeMetadata)
+							gomega.Expect(ok).To(gomega.BeTrue(), "attribute %q missing after pod creation", numaplacement.AttributeMetadata)
+
+							newPayload := numaplacement.Payload{}
+							gomega.Expect(numaplacement.UnpackMetadataInto(&newPayload, metaPostPodCreation)).To(gomega.Succeed())
+
+							ginkgo.By(fmt.Sprintf("checking the numaplacement metadata after running the test workload. expecting a change? %t", test.eligibleContainersForNUMAPlacement > 0))
+							if test.eligibleContainersForNUMAPlacement > 0 {
+								expectedContainersLen := initialPayload.Containers + test.eligibleContainersForNUMAPlacement
+								failureMessage := "numaplacement info did not change after a workload with exclusive resources was scheduled"
+								if metaPostPodCreation == initialMeta || newPayload.Containers != expectedContainersLen {
+									infoUponFailure(f, topologyUpdaterNode.Name, initialContainers, failureMessage)
+								}
+								gomega.Expect(metaPostPodCreation).ToNot(gomega.Equal(initialMeta), failureMessage)
+								gomega.Expect(newPayload.Containers).To(gomega.Equal(expectedContainersLen), failureMessage)
+							} else {
+								failureMessage := "numaplacement info changed unexpectedly after a workload with non-exclusive resources was scheduled"
+								if metaPostPodCreation != initialMeta || newPayload.Containers != initialPayload.Containers {
+									infoUponFailure(f, topologyUpdaterNode.Name, initialContainers, failureMessage)
+								}
+								gomega.Expect(metaPostPodCreation).To(gomega.Equal(initialMeta), failureMessage)
+								gomega.Expect(newPayload.Containers).To(gomega.Equal(initialPayload.Containers), failureMessage)
+							}
+
+							ginkgo.By("verifying numaplacement attributes for NUMA zone")
+							// we cannot tell which zone(s) will have non empty vectors but we can tell for sure that at least
+							//  the busiest node should NOT have the vector
+							var busiestZoneAttributes v1alpha2.AttributeList
+							for _, zone := range nrtPostPodCreation.Zones {
+								// to be safe from confusing indeces and names, extract the zone id and compare it to the busiest node id in the payload
+								zoneId := strings.TrimPrefix(zone.Name, "node-")
+								zoneIdInt, err := strconv.Atoi(strings.TrimSpace(zoneId))
+								gomega.Expect(err).ToNot(gomega.HaveOccurred())
+								klog.InfoS("zone", "name", zone.Name, "extractedId", zoneIdInt, "busiestNode", newPayload.BusiestNode)
+								if zoneIdInt == newPayload.BusiestNode {
+									busiestZoneAttributes = zone.Attributes
+									break
+								}
+							}
+
+							vecAttr, ok := findAttribute(busiestZoneAttributes, numaplacement.AttributeVector)
+							gomega.Expect(ok).To(gomega.BeFalse(), "found vector attribute on the busiest zone: %q", vecAttr)
+
+							// ASSUMPTION: no containers are eligible for NUMA placement before having this test running.
+							// If this is proved to be incorrect by time, we either need to remove this check or improve
+							// to consider the existing containers.
+							// if there is only one container eligible for NUMA placement it would be on the busiest zone
+							// which also should not have the vector
+							if test.eligibleContainersForNUMAPlacement <= 1 {
+								ginkgo.By("all zones should have empty vectors")
+								for _, zone := range nrtPostPodCreation.Zones {
+									vecAttr, ok := findAttribute(zone.Attributes, numaplacement.AttributeVector)
+									gomega.Expect(ok).To(gomega.BeFalse(), "found vector attribute on zone %q: %q", zone.Name, vecAttr)
+								}
+							}
+
+							ginkgo.By("deleting the pod and checking the numaplacement info is reset to the initial state")
+							gomega.Expect(e2epods.DeletePodSyncByName(f, podNamespace, podName)).To(gomega.Succeed())
+							needsCleanup = false
+
+							afterDeleteNrt := getUpdatedNRT(f.TopoCli, topologyUpdaterNode.Name, *nrtPostPodCreation, updateTimeout)
+							metaAfter, ok := findAttribute(afterDeleteNrt.Attributes, numaplacement.AttributeMetadata)
+							gomega.Expect(ok).To(gomega.BeTrue())
+							failureMessage := "mismatched metadata after pod removal"
+							if metaAfter != initialMeta {
+								infoUponFailure(f, topologyUpdaterNode.Name, initialContainers, failureMessage)
+							}
+							gomega.Expect(metaAfter).To(gomega.Equal(initialMeta), failureMessage)
+						},
+						ginkgo.Entry("guaranteed multi-container pod",
+							tableTest{
+								expectedQoS: corev1.PodQOSGuaranteed,
+								resourcesPerContainer: []corev1.ResourceRequirements{
+									{
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("1000m"),
+											corev1.ResourceMemory: resource.MustParse("250Mi"),
+										},
+									},
+									{
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("500m"),
+											corev1.ResourceMemory: resource.MustParse("250Mi"),
+										},
+									},
+								},
+								eligibleContainersForNUMAPlacement: 2,
+							}),
+						ginkgo.Entry("burstable multi-container pod with no exclusive resources",
+							tableTest{
+								expectedQoS: corev1.PodQOSBurstable,
+								resourcesPerContainer: []corev1.ResourceRequirements{
+									{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("1000m"),
+											corev1.ResourceMemory: resource.MustParse("250Mi"),
+										},
+									},
+									{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("500m"),
+											corev1.ResourceMemory: resource.MustParse("32Mi"),
+										},
+									},
+								},
+								eligibleContainersForNUMAPlacement: 0,
+							}),
+						ginkgo.Entry("burstable multi-container pod with exclusive resource on one container only",
+							tableTest{
+								expectedQoS: corev1.PodQOSBurstable,
+								resourcesPerContainer: []corev1.ResourceRequirements{
+									{
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU: resource.MustParse("1000m"),
+											corev1.ResourceName(e2etestenv.GetDeviceName()): resource.MustParse("1"),
+										},
+									},
+									{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("500m"),
+											corev1.ResourceMemory: resource.MustParse("32Mi"),
+										},
+									},
+								},
+								eligibleContainersForNUMAPlacement: 1,
+							},
+						),
+						ginkgo.Entry("best effort pod - nothing exclusive",
+							tableTest{
+								expectedQoS: corev1.PodQOSBestEffort,
+								resourcesPerContainer: []corev1.ResourceRequirements{
+									{
+										Limits: corev1.ResourceList{},
+									},
+									{
+										Limits: corev1.ResourceList{},
+									},
+								},
+								eligibleContainersForNUMAPlacement: 0,
+							}),
+						ginkgo.Entry("best effort multi-container pod with exclusive resource on one container only",
+							tableTest{
+								expectedQoS: corev1.PodQOSBestEffort,
+								resourcesPerContainer: []corev1.ResourceRequirements{
+									{
+										Limits: corev1.ResourceList{
+											corev1.ResourceName(e2etestenv.GetDeviceName()): resource.MustParse("1"),
+										},
+									},
+									{
+										Limits: corev1.ResourceList{},
+									},
+								},
+								eligibleContainersForNUMAPlacement: 1,
+							},
+						),
+					)
+				})
+			})
+		})
 	})
+
 	ginkgo.Context("with refresh-node-resources enabled", func() {
 		ginkgo.It("[NodeRefresh] should be able to detect devices", func() {
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func(g gomega.Gomega) {
 				nrt := e2enodetopology.GetNodeTopology(f.TopoCli, topologyUpdaterNode.Name)
 				devName := e2etestenv.GetDeviceName()
+				found := false
 				for _, zone := range nrt.Zones {
 					for _, res := range zone.Resources {
 						if res.Name == devName {
-							return true
+							found = true
 						}
 					}
 				}
-				return false
-			}).WithTimeout(30*time.Second).WithPolling(10*time.Second).Should(gomega.BeTrue(), "device: %q was not found in NRT: %q", e2etestenv.GetDeviceName(), topologyUpdaterNode.Name)
+				g.Expect(found).To(gomega.BeTrue(), "device: %q was not found in NRT: %q", devName, topologyUpdaterNode.Name)
+			}).WithTimeout(30 * time.Second).WithPolling(10 * time.Second).Should(gomega.Succeed())
 		})
 
 		ginkgo.It("[NodeRefresh] should log the refresh message", func() {
@@ -295,31 +559,53 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 			rteContainerName, err := e2ertepod.FindRTEContainerName(rtePod)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func(g gomega.Gomega) {
 				logs, err := e2epods.GetLogsForPod(f.K8SCli, rtePod.Namespace, rtePod.Name, rteContainerName)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				g.Expect(err).ToNot(gomega.HaveOccurred())
 
-				return strings.Contains(logs, "tracking node resources") || strings.Contains(logs, "update node resources")
-			}).WithTimeout(42*time.Second).WithPolling(5*time.Second).Should(gomega.BeTrue(), "container: %q in pod: %q doesn't contains the refresh log message", rteContainerName, rtePod.Name)
+				g.Expect(logs).To(gomega.Or(
+					gomega.ContainSubstring("tracking node resources"),
+					gomega.ContainSubstring("update node resources"),
+				), "container: %q in pod: %q doesn't contain the refresh log message", rteContainerName, rtePod.Name)
+			}).WithTimeout(42 * time.Second).WithPolling(5 * time.Second).Should(gomega.Succeed())
 		})
 	})
 })
 
+func infoUponFailure(f *fixture.Fixture, nodeName string, initialContainers []numaplacement.ContainerID, message string) {
+	dumpPods(f.K8SCli, nodeName, message)
+	currContainers := dumpContainers(f.K8SCli, nodeName, true)
+	klog.Infof("containers list diff: %s", getContainersListCmpDiff(initialContainers, currContainers))
+	_ = dumpRTELogs(f.K8SCli, nodeName)
+}
+
 func getUpdatedNRT(topologyClient *topologyclientset.Clientset, nodeName string, prevNrt v1alpha2.NodeResourceTopology, timeout time.Duration) *v1alpha2.NodeResourceTopology {
+	ginkgo.GinkgoHelper()
+	effectiveTimeout := timeout + updateIntervalExtraSafety
+	klog.Infof("waiting for NRT %q update: timeout %v (base %v + safety %v) prev resourceVersion=%v", nodeName, effectiveTimeout, timeout, updateIntervalExtraSafety, prevNrt.ObjectMeta.ResourceVersion)
 	var err error
 	var currNrt *v1alpha2.NodeResourceTopology
-	gomega.EventuallyWithOffset(1, func() bool {
+	count := 0
+	stablePFP := ""
+	gomega.Eventually(func(g gomega.Gomega) {
 		currNrt, err = topologyClient.TopologyV1alpha2().NodeResourceTopologies().Get(context.TODO(), nodeName, metav1.GetOptions{})
-		if err != nil {
-			klog.Infof("failed to get the node topology resource: %v", err)
-			return false
+		g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to get the node topology resource")
+		g.Expect(currNrt.ObjectMeta.ResourceVersion).ToNot(gomega.Equal(prevNrt.ObjectMeta.ResourceVersion), "resource %s not yet updated - resource version not bumped", nodeName)
+
+		currentPFP, ok := currNrt.Annotations[podfingerprint.Annotation]
+		g.Expect(ok).To(gomega.BeTrue(), "pod fingerprint annotation not found in NRT %q", nodeName)
+
+		if stablePFP == "" {
+			stablePFP = currentPFP
+		} else if stablePFP != currentPFP {
+			stablePFP = currentPFP
+			count = 0
 		}
-		if currNrt.ObjectMeta.ResourceVersion == prevNrt.ObjectMeta.ResourceVersion {
-			klog.Infof("resource %s not yet updated - resource version not bumped", nodeName)
-			return false
-		}
-		return true
-	}).WithTimeout(timeout+updateIntervalExtraSafety).WithPolling(1*time.Second).Should(gomega.BeTrue(), "didn't get updated node topology info")
+		count++
+		klog.InfoS("PFP stabilization", "PFP", currentPFP, "count", count)
+		g.Expect(count).To(gomega.Equal(5), "PFP did not stabilize yet")
+	}).WithTimeout(effectiveTimeout).WithPolling(10*time.Second).Should(gomega.Succeed(), "NRT did not settle")
+
 	return currNrt
 }
 
@@ -338,6 +624,45 @@ func dumpPods(cs clientset.Interface, nodeName, message string) {
 	klog.Infof("END pods running on %q: %s", nodeName, message)
 }
 
+func dumpContainers(cs clientset.Interface, nodeName string, printInfo bool) []numaplacement.ContainerID {
+	nodeSelector := fields.Set{
+		"spec.nodeName": nodeName,
+	}.AsSelector().String()
+
+	pods, err := cs.CoreV1().Pods(e2etestenv.GetNamespaceName()).List(context.TODO(), metav1.ListOptions{FieldSelector: nodeSelector})
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	containers := []numaplacement.ContainerID{}
+	containersSB := strings.Builder{}
+	for _, pod := range pods.Items {
+		for _, container := range pod.Spec.Containers {
+			cntID := numaplacement.ContainerID{
+				Namespace:     pod.Namespace,
+				PodName:       pod.Name,
+				ContainerName: container.Name,
+			}
+			containers = append(containers, cntID)
+			containersSB.WriteString(cntID.String() + "\n")
+		}
+	}
+
+	if printInfo {
+		klog.InfoS("Containers IDs running on node", "node", nodeName, "containers", containersSB.String())
+	}
+	return containers
+}
+
+func getContainersListCmpDiff(initialContainers, currentContainers []numaplacement.ContainerID) string {
+	initialCopy := slices.Clone(initialContainers)
+	currentCopy := slices.Clone(currentContainers)
+	sort.Slice(initialCopy, func(i, j int) bool {
+		return initialCopy[i].String() < initialCopy[j].String()
+	})
+	sort.Slice(currentCopy, func(i, j int) bool {
+		return currentCopy[i].String() < currentCopy[j].String()
+	})
+	return cmp.Diff(initialCopy, currentCopy)
+}
 func expectPodFingerprint(nrt1 v1alpha2.NodeResourceTopology, mode string, nrt2 v1alpha2.NodeResourceTopology) bool {
 	pfp1, ok1 := extractPFP(nrt1)
 	if !ok1 {
@@ -406,7 +731,8 @@ func estimateUpdateInterval(nrt v1alpha2.NodeResourceTopology) (time.Duration, s
 		return fallbackInterval, "estimated", nil
 	}
 	updateInterval, err := time.ParseDuration(updateIntervalAnn)
-	if err != nil {
+	if err != nil || updateInterval <= 0 {
+		klog.Warningf("annotation %q has unusable value %q (parsed=%v err=%v), falling back to %v", k8sannotations.UpdateInterval, updateIntervalAnn, updateInterval, err, fallbackInterval)
 		return fallbackInterval, "estimated", err
 	}
 	return updateInterval, "computed", nil

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/topology_updater/topology_updater.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/topology_updater/topology_updater.go
@@ -24,7 +24,6 @@ package topology_updater
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -111,24 +110,12 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 				Kind:       "Node",
 				UID:        topologyUpdaterNode.UID,
 			}
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func(g gomega.Gomega) {
 				finalNodeTopo, err := f.TopoCli.TopologyV1alpha2().NodeResourceTopologies().Get(context.TODO(), topologyUpdaterNode.Name, metav1.GetOptions{})
-				if err != nil {
-					klog.Infof("failed to get the node topology resource: %v", err)
-					return false
-				}
-
-				if len(finalNodeTopo.OwnerReferences) != 1 {
-					klog.Infof("Too many OwnerReferences: expected=1; got=%d", len(finalNodeTopo.OwnerReferences))
-					klog.Infof("%+#v", finalNodeTopo.OwnerReferences)
-					return false
-				}
-				if !reflect.DeepEqual(finalNodeTopo.OwnerReferences[0], expectedOwnerReference) {
-					klog.Infof("Unexpected OwnerReference: expected=%+#v; got=%+#v", expectedOwnerReference, finalNodeTopo.OwnerReferences[0])
-					return false
-				}
-				return true
-			}).WithTimeout(5*timeout).WithPolling(5*time.Second).Should(gomega.BeTrue(), "didn't get updated node topology info")
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to get the node topology resource")
+				g.Expect(finalNodeTopo.OwnerReferences).To(gomega.HaveLen(1), "unexpected number of OwnerReferences")
+				g.Expect(finalNodeTopo.OwnerReferences[0]).To(gomega.Equal(expectedOwnerReference), "unexpected OwnerReference")
+			}).WithTimeout(5*timeout).WithPolling(5*time.Second).Should(gomega.Succeed(), "didn't get updated node topology info")
 		})
 		ginkgo.It("it should not account for any cpus if a container doesn't request exclusive cpus (best effort QOS)", func() {
 			devName := e2etestenv.GetDeviceName()
@@ -136,7 +123,7 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 			ginkgo.By("getting the initial topology information")
 			initialNodeTopo := e2enodetopology.GetNodeTopologyWithResource(f.TopoCli, topologyUpdaterNode.Name, devName)
 			ginkgo.By("creating a pod consuming resources from the shared, non-exclusive CPU pool (best-effort QoS)")
-			sleeperPod := e2epods.MakeBestEffortSleeperPod()
+			sleeperPod := e2epods.MakeSleeperPod([]corev1.ResourceRequirements{{}})
 
 			pod, err := e2epods.CreateSync(f, sleeperPod)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -231,14 +218,11 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 
 			ginkgo.By("getting the updated topology")
 			var finalNodeTopo *v1alpha2.NodeResourceTopology
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func(g gomega.Gomega) {
 				finalNodeTopo, err = f.TopoCli.TopologyV1alpha2().NodeResourceTopologies().Get(context.TODO(), topologyUpdaterNode.Name, metav1.GetOptions{})
-				if err != nil {
-					klog.Infof("failed to get the node topology resource: %v", err)
-					return false
-				}
-				return finalNodeTopo.ObjectMeta.Generation != initialNodeTopo.ObjectMeta.Generation
-			}).WithTimeout(5*timeout).WithPolling(5*time.Second).Should(gomega.BeTrue(), "didn't get updated node topology info")
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to get the node topology resource")
+				g.Expect(finalNodeTopo.ObjectMeta.Generation).ToNot(gomega.Equal(initialNodeTopo.ObjectMeta.Generation), "resource %s not yet updated - generation not bumped", topologyUpdaterNode.Name)
+			}).WithTimeout(5*timeout).WithPolling(5*time.Second).Should(gomega.Succeed(), "didn't get updated node topology info")
 			klog.Infof("final topology information: %#v", initialNodeTopo)
 
 			ginkgo.By("checking the changes in the updated topology")

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/nodetopology/nodetopology.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/nodetopology/nodetopology.go
@@ -47,21 +47,18 @@ func GetNodeTopology(topologyClient *topologyclientset.Clientset, nodeName strin
 }
 
 func GetNodeTopologyWithResource(topologyClient *topologyclientset.Clientset, nodeName, resName string) *v1alpha2.NodeResourceTopology {
+	ginkgo.GinkgoHelper()
 	ginkgo.By(fmt.Sprintf("getting NRT for node=%q resource=%q", nodeName, resName))
 
 	var nodeTopology *v1alpha2.NodeResourceTopology
 	var err error
-	gomega.EventuallyWithOffset(1, func() bool {
+	gomega.Eventually(func(g gomega.Gomega) {
 		nodeTopology, err = topologyClient.TopologyV1alpha2().NodeResourceTopologies().Get(context.TODO(), nodeName, metav1.GetOptions{})
-		if err != nil {
-			klog.Infof("failed to get the node topology resource: %v", err)
-			return false
+		g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to get the node topology resource")
+		if resName != "" {
+			g.Expect(containsResource(nodeTopology, resName)).To(gomega.BeTrue(), "the node topology data doesn't include resource %q", resName)
 		}
-		if resName == "" {
-			return true
-		}
-		return containsResource(nodeTopology, resName)
-	}).WithTimeout(time.Minute).WithPolling(5 * time.Second).Should(gomega.BeTrue())
+	}).WithTimeout(time.Minute).WithPolling(5 * time.Second).Should(gomega.Succeed())
 
 	return nodeTopology
 }

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/pods/pods.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/pods/pods.go
@@ -42,51 +42,49 @@ const (
 )
 
 func MakeGuaranteedSleeperPod(cpuLimit string) *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "sleeper-gu-pod",
-		},
-		Spec: corev1.PodSpec{
-			NodeSelector:  map[string]string{e2etestconsts.TestNodeLabel: ""},
-			RestartPolicy: corev1.RestartPolicyNever,
-			Containers: []corev1.Container{
-				{
-					Name:  "sleeper-gu-cnt",
-					Image: CentosImage,
-					// 1 hour (or >= 1h in general) is "forever" for our purposes
-					Command: []string{"/bin/sleep", "1h"},
-					Resources: corev1.ResourceRequirements{
-						Limits: corev1.ResourceList{
-							// we use 1 core because that's the minimal meaningful quantity
-							corev1.ResourceName(corev1.ResourceCPU): resource.MustParse(cpuLimit),
-							// any random reasonable amount is fine
-							corev1.ResourceName(corev1.ResourceMemory): resource.MustParse("100Mi"),
-						},
-					},
-				},
+	return MakeSleeperPod([]corev1.ResourceRequirements{
+		{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(cpuLimit),
+				corev1.ResourceMemory: resource.MustParse("100Mi"),
 			},
 		},
-	}
+	})
 }
 
-func MakeBestEffortSleeperPod() *corev1.Pod {
-	return &corev1.Pod{
+func MakeSleeperPod(resourcesPerContainer []corev1.ResourceRequirements) *corev1.Pod {
+	containers := []corev1.Container{}
+	for idx, resources := range resourcesPerContainer {
+		cnt := corev1.Container{
+			Name:  "sleeper-cnt" + strconv.Itoa(idx),
+			Image: CentosImage,
+			// 1 hour (or >= 1h in general) is "forever" for our purposes
+			Command:   []string{"/bin/sleep", "1h"},
+			Resources: resources,
+		}
+		containers = append(containers, cnt)
+	}
+
+	if len(resourcesPerContainer) == 0 {
+		containers = append(containers, corev1.Container{
+			Name:  "sleeper-cnt",
+			Image: CentosImage,
+			// 1 hour (or >= 1h in general) is "forever" for our purposes
+			Command: []string{"/bin/sleep", "1h"},
+		})
+	}
+	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "sleeper-be-pod",
+			Name: "sleeper-pod",
 		},
 		Spec: corev1.PodSpec{
 			NodeSelector:  map[string]string{e2etestconsts.TestNodeLabel: ""},
 			RestartPolicy: corev1.RestartPolicyNever,
-			Containers: []corev1.Container{
-				{
-					Name:  "sleeper-be-cnt",
-					Image: CentosImage,
-					// 1 hour (or >= 1h in general) is "forever" for our purposes
-					Command: []string{"/bin/sleep", "1h"},
-				},
-			},
+			Containers:    containers,
 		},
 	}
+
+	return pod
 }
 
 func DeletePodSyncByName(f *fixture.Fixture, podNamespace, podName string) error {

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/pods/rtepod/rtepod.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/pods/rtepod/rtepod.go
@@ -18,11 +18,15 @@ limitations under the License.
 package rtepod
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -77,7 +81,8 @@ func FindRTEContainerName(rtePod *corev1.Pod) (string, error) {
 	return "", fmt.Errorf("no container uses %q as command or argument", rteExecutable)
 }
 
-func FindNotificationFilePath(rtePod *corev1.Pod) (string, error) {
+func FindNotificationFilePath(ctx context.Context, cli *kubernetes.Clientset, rtePod *corev1.Pod) (string, error) {
+	// try CLI args first (legacy)
 	for idx := 0; idx < len(rtePod.Spec.Containers); idx++ {
 		cnt := rtePod.Spec.Containers[idx] // shortcut
 		if len(cnt.Command) > 0 && strings.Contains(cnt.Command[0], rteExecutable) {
@@ -88,7 +93,39 @@ func FindNotificationFilePath(rtePod *corev1.Pod) (string, error) {
 			}
 		}
 	}
-	return "", fmt.Errorf("no container uses %q as an argument option", notificationFileOption)
+	return findNotifyFilePathFromConfigMap(ctx, cli, rtePod)
+}
+
+func findNotifyFilePathFromConfigMap(ctx context.Context, cli *kubernetes.Clientset, rtePod *corev1.Pod) (string, error) {
+	for _, vol := range rtePod.Spec.Volumes {
+		if vol.ConfigMap == nil {
+			continue
+		}
+		if !strings.Contains(vol.ConfigMap.Name, "daemon") {
+			continue
+		}
+		cm, err := cli.CoreV1().ConfigMaps(rtePod.Namespace).Get(ctx, vol.ConfigMap.Name, metav1.GetOptions{})
+		if err != nil {
+			return "", fmt.Errorf("failed to get configmap %q: %w", vol.ConfigMap.Name, err)
+		}
+		data, ok := cm.Data["config.yaml"]
+		if !ok {
+			continue
+		}
+		var cfg map[string]any
+		if err := yaml.Unmarshal([]byte(data), &cfg); err != nil {
+			continue
+		}
+		te, ok := cfg["topologyExporter"].(map[string]any)
+		if !ok {
+			continue
+		}
+		notifyPath, ok := te["notifyFilePath"].(string)
+		if ok && notifyPath != "" {
+			return notifyPath, nil
+		}
+	}
+	return "", fmt.Errorf("cannot find notification file path from CLI args or daemon configmap")
 }
 
 func isRTEContainer(cnt corev1.Container) bool {

--- a/vendor/k8s.io/apimachinery/pkg/util/jsonmergepatch/patch.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/jsonmergepatch/patch.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jsonmergepatch
+
+import (
+	"fmt"
+	"reflect"
+
+	"gopkg.in/evanphx/json-patch.v4"
+	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apimachinery/pkg/util/mergepatch"
+)
+
+// Create a 3-way merge patch based-on JSON merge patch.
+// Calculate addition-and-change patch between current and modified.
+// Calculate deletion patch between original and modified.
+func CreateThreeWayJSONMergePatch(original, modified, current []byte, fns ...mergepatch.PreconditionFunc) ([]byte, error) {
+	if len(original) == 0 {
+		original = []byte(`{}`)
+	}
+	if len(modified) == 0 {
+		modified = []byte(`{}`)
+	}
+	if len(current) == 0 {
+		current = []byte(`{}`)
+	}
+
+	addAndChangePatch, err := jsonpatch.CreateMergePatch(current, modified)
+	if err != nil {
+		return nil, err
+	}
+	// Only keep addition and changes
+	addAndChangePatch, addAndChangePatchObj, err := keepOrDeleteNullInJsonPatch(addAndChangePatch, false)
+	if err != nil {
+		return nil, err
+	}
+
+	deletePatch, err := jsonpatch.CreateMergePatch(original, modified)
+	if err != nil {
+		return nil, err
+	}
+	// Only keep deletion
+	deletePatch, deletePatchObj, err := keepOrDeleteNullInJsonPatch(deletePatch, true)
+	if err != nil {
+		return nil, err
+	}
+
+	hasConflicts, err := mergepatch.HasConflicts(addAndChangePatchObj, deletePatchObj)
+	if err != nil {
+		return nil, err
+	}
+	if hasConflicts {
+		return nil, mergepatch.NewErrConflict(mergepatch.ToYAMLOrError(addAndChangePatchObj), mergepatch.ToYAMLOrError(deletePatchObj))
+	}
+	patch, err := jsonpatch.MergePatch(deletePatch, addAndChangePatch)
+	if err != nil {
+		return nil, err
+	}
+
+	var patchMap map[string]interface{}
+	err = json.Unmarshal(patch, &patchMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal patch for precondition check: %s", patch)
+	}
+	meetPreconditions, err := meetPreconditions(patchMap, fns...)
+	if err != nil {
+		return nil, err
+	}
+	if !meetPreconditions {
+		return nil, mergepatch.NewErrPreconditionFailed(patchMap)
+	}
+
+	return patch, nil
+}
+
+// keepOrDeleteNullInJsonPatch takes a json-encoded byte array and a boolean.
+// It returns a filtered object and its corresponding json-encoded byte array.
+// It is a wrapper of func keepOrDeleteNullInObj
+func keepOrDeleteNullInJsonPatch(patch []byte, keepNull bool) ([]byte, map[string]interface{}, error) {
+	var patchMap map[string]interface{}
+	err := json.Unmarshal(patch, &patchMap)
+	if err != nil {
+		return nil, nil, err
+	}
+	filteredMap, err := keepOrDeleteNullInObj(patchMap, keepNull)
+	if err != nil {
+		return nil, nil, err
+	}
+	o, err := json.Marshal(filteredMap)
+	return o, filteredMap, err
+}
+
+// keepOrDeleteNullInObj will keep only the null value and delete all the others,
+// if keepNull is true. Otherwise, it will delete all the null value and keep the others.
+func keepOrDeleteNullInObj(m map[string]interface{}, keepNull bool) (map[string]interface{}, error) {
+	filteredMap := make(map[string]interface{})
+	var err error
+	for key, val := range m {
+		switch {
+		case keepNull && val == nil:
+			filteredMap[key] = nil
+		case val != nil:
+			switch typedVal := val.(type) {
+			case map[string]interface{}:
+				// Explicitly-set empty maps are treated as values instead of empty patches
+				if len(typedVal) == 0 {
+					if !keepNull {
+						filteredMap[key] = typedVal
+					}
+					continue
+				}
+
+				var filteredSubMap map[string]interface{}
+				filteredSubMap, err = keepOrDeleteNullInObj(typedVal, keepNull)
+				if err != nil {
+					return nil, err
+				}
+
+				// If the returned filtered submap was empty, this is an empty patch for the entire subdict, so the key
+				// should not be set
+				if len(filteredSubMap) != 0 {
+					filteredMap[key] = filteredSubMap
+				}
+
+			case []interface{}, string, float64, bool, int64, nil:
+				// Lists are always replaced in Json, no need to check each entry in the list.
+				if !keepNull {
+					filteredMap[key] = val
+				}
+			default:
+				return nil, fmt.Errorf("unknown type: %v", reflect.TypeOf(typedVal))
+			}
+		}
+	}
+	return filteredMap, nil
+}
+
+func meetPreconditions(patchObj map[string]interface{}, fns ...mergepatch.PreconditionFunc) (bool, error) {
+	// Apply the preconditions to the patch, and return an error if any of them fail.
+	for _, fn := range fns {
+		if !fn(patchObj) {
+			return false, fmt.Errorf("precondition failed for: %v", patchObj)
+		}
+	}
+	return true, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -163,7 +163,7 @@ github.com/josharian/intern
 # github.com/json-iterator/go v1.1.12
 ## explicit; go 1.12
 github.com/json-iterator/go
-# github.com/k8stopologyawareschedwg/deployer v0.24.0
+# github.com/k8stopologyawareschedwg/deployer v0.24.2
 ## explicit; go 1.25.0
 github.com/k8stopologyawareschedwg/deployer/pkg/assets/rte
 github.com/k8stopologyawareschedwg/deployer/pkg/assets/selinux

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -196,10 +196,14 @@ github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/client
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned/scheme
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned/typed/topology/v1alpha1
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned/typed/topology/v1alpha2
+# github.com/k8stopologyawareschedwg/numaplacement v0.1.0
+## explicit; go 1.21
+github.com/k8stopologyawareschedwg/numaplacement
+github.com/k8stopologyawareschedwg/numaplacement/leb89
 # github.com/k8stopologyawareschedwg/podfingerprint v0.2.3
 ## explicit; go 1.18
 github.com/k8stopologyawareschedwg/podfingerprint
-# github.com/k8stopologyawareschedwg/resource-topology-exporter v0.24.0
+# github.com/k8stopologyawareschedwg/resource-topology-exporter v0.25.0
 ## explicit; go 1.25.0
 github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config
 github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/dump
@@ -211,6 +215,7 @@ github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/metrics
 github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/metrics/server
 github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/notification
 github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nrtupdater
+github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/numalocality
 github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podreadiness
 github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podres
 github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podres/filter
@@ -737,6 +742,7 @@ k8s.io/apimachinery/pkg/util/httpstream/spdy
 k8s.io/apimachinery/pkg/util/httpstream/wsstream
 k8s.io/apimachinery/pkg/util/intstr
 k8s.io/apimachinery/pkg/util/json
+k8s.io/apimachinery/pkg/util/jsonmergepatch
 k8s.io/apimachinery/pkg/util/managedfields
 k8s.io/apimachinery/pkg/util/managedfields/internal
 k8s.io/apimachinery/pkg/util/mergepatch


### PR DESCRIPTION
Update the scheduler config to activate the prefilter plugin needed for preemption support, and bump the `deployer` dependency to consume the latest configuration option. See commits for additional details. 