### PR TITLE
ci: ship /bin/numazone alias in numacell test image

### DIFF
--- a/test/deviceplugin/cmd/numacell/Dockerfile
+++ b/test/deviceplugin/cmd/numacell/Dockerfile
@@ -7,4 +7,6 @@ RUN make build-numacell
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/numacell /bin/numacell
+# Temporary compatibility path for the upcoming numazone rename.
+COPY --from=builder /go/src/github.com/openshift-kni/numaresources-operator/bin/numacell /bin/numazone
 ENTRYPOINT ["/bin/numacell", "-alsologtostderr", "-v", "3"]


### PR DESCRIPTION
The numacell productization work(https://github.com/openshift-kni/numaresources-operator/pull/4747) renames the device plugin to numazone and updates DaemonSet manifests to run Command /bin/numazone. That change cannot land cleanly while quay.io/openshift-kni/numacell-device-plugin:test-ci only provides /bin/numacell, and the new release workflow cannot be used from main until productization merges.

Install the existing numacell binary at /bin/numazone as well so a refresh of the current test image unblocks productization e2e without renaming the quay repository yet.

ENTRYPOINT is kept intact so that the current main stays compatible with existing manifests and default image behavior. Productization PR will override the entrypoint and can use the new path immediately after the image is republished.