### PR TITLE
CNF-26427: switch operator runtime base image to ubi9-minimal-pqc

### DIFF
--- a/.konflux/operator/konflux.Dockerfile
+++ b/.konflux/operator/konflux.Dockerfile
@@ -11,7 +11,7 @@ ENV GOTAGS="strictfipsruntime"
 # Build
 RUN make binary-all
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:7c372902c8d211db2d25c8277ba534a73b92742a334874dced829a63b0f21221
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest@sha256:e7f7720259142a68a8087fb4df9d21a91189863aa083e9b27c2c2801878ef5c4
 
 ARG OPENSHIFT_VERSION
 

--- a/Makefile
+++ b/Makefile
@@ -719,8 +719,8 @@ konflux-update-rpm-lock-operator: sync-git-submodules ## Update the rpm lock fil
 	@echo "Updating rpm lock file for the operator..."
 	$(MAKE) -C $(PROJECT_DIR)/telco5g-konflux/scripts/rpm-lock generate-rhel9-locks \
 		LOCK_SCRIPT_TARGET_DIR=$(PROJECT_DIR)/.konflux/operator/tmp/ \
-		RHEL9_EXECUTION_IMAGE=$$(grep -E '^FROM registry.access.redhat.com/ubi9/ubi-minimal' $(PROJECT_DIR)/.konflux/operator/konflux.Dockerfile | sed 's|FROM ||' | sed 's|ubi-minimal|ubi|g' | sed 's|@.*||') \
-		RHEL9_IMAGE_TO_LOCK=$$(grep -E '^FROM registry.access.redhat.com/ubi9/ubi-minimal' $(PROJECT_DIR)/.konflux/operator/konflux.Dockerfile | sed 's|FROM ||')
+		RHEL9_EXECUTION_IMAGE=$$(grep -E '^FROM .*/ubi9/ubi-minimal' $(PROJECT_DIR)/.konflux/operator/konflux.Dockerfile | sed 's|FROM ||' | sed 's|ubi-minimal[^:]*|ubi|' | sed 's|@.*||') \
+		RHEL9_IMAGE_TO_LOCK=$$(grep -E '^FROM .*/ubi9/ubi-minimal' $(PROJECT_DIR)/.konflux/operator/konflux.Dockerfile | sed 's|FROM ||')
 	@echo "Update rpms.lock.yaml with new contents..."
 	cp $(PROJECT_DIR)/.konflux/operator/tmp/rpms.lock.yaml $(PROJECT_DIR)/.konflux/operator/rpms.lock.yaml
 	# intentionally keep operator/tmp/ directory for debugging purposes


### PR DESCRIPTION
Switch the Konflux operator runtime image from ubi9/ubi-minimal to ubi9/ubi-minimal-pqc to enable the DEFAULT:PQ crypto policy, as required by [OCPSTRAT-3113](https://redhat.atlassian.net/browse/OCPSTRAT-3113) for platform-wide PQC consistency. 

Verified that rpms.in.yaml and rpms.lock.yaml require no update for the new base image.