### PR TITLE
Update FBC base image namespace from openshift4 to openshift5 for OCP 5.0

### DIFF
--- a/.konflux/Dockerfile.catalog
+++ b/.konflux/Dockerfile.catalog
@@ -1,5 +1,5 @@
 # The opm image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-ARG OPM_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9:v5.0
+ARG OPM_IMAGE=registry.redhat.io/openshift5/ose-operator-registry-rhel9:v5.0
 
 # Run the catalog
 FROM ${OPM_IMAGE}


### PR DESCRIPTION
## Summary

Update the FBC catalog base image reference from the `openshift4` namespace to `openshift5`.

## Details

The `ose-operator-registry-rhel9:v5.0` image is being **removed from the `openshift4` namespace on August 19th** ([RELENG-536](https://redhat.atlassian.net/browse/RELENG-536)). The canonical location is now `registry.redhat.io/openshift5/ose-operator-registry-rhel9:v5.0`.

Without this change, FBC catalog builds targeting OCP 5.0 will fail with an image pull error after the effective date.

## Change

In `.konflux/Dockerfile.catalog`:
```diff
-ARG OPM_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9:v5.0
+ARG OPM_IMAGE=registry.redhat.io/openshift5/ose-operator-registry-rhel9:v5.0
```

Supersedes #4980.

Made with [Cursor](https://cursor.com)