### PR TITLE
CNF-26586: update registry path from openshift4 to openshift5

### DIFF
--- a/.konflux/bundle/bundle.konflux.Dockerfile
+++ b/.konflux/bundle/bundle.konflux.Dockerfile
@@ -36,7 +36,7 @@ FROM scratch
 ARG OPENSHIFT_VERSION
 
 LABEL com.redhat.component="numaresources-operator-bundle-container"
-LABEL name="openshift4/numaresources-operator-bundle"
+LABEL name="openshift5/numaresources-operator-bundle"
 LABEL summary="NUMA resources operator for OpenShift"
 LABEL io.k8s.display-name="numaresources-operator"
 LABEL io.k8s.description="NUMA resurces support for OpenShift"

--- a/.konflux/bundle/overlay/map_images.in.yaml
+++ b/.konflux/bundle/overlay/map_images.in.yaml
@@ -1,4 +1,4 @@
 # Do not modify the manager 'key' value: 'manager'
 - key: manager
-  staging: registry.stage.redhat.io/openshift4/numaresources-rhel9-operator
-  production: registry.redhat.io/openshift4/numaresources-rhel9-operator
+  staging: registry.stage.redhat.io/openshift5/numaresources-rhel9-operator
+  production: registry.redhat.io/openshift5/numaresources-rhel9-operator

--- a/.konflux/catalog/catalog-idms.yaml
+++ b/.konflux/catalog/catalog-idms.yaml
@@ -8,6 +8,9 @@ spec:
   imageDigestMirrors:
   - mirrors:
     - quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-5-0
+    source: registry.redhat.io/openshift4/numaresources-operator-bundle
+  - mirrors:
+    - quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-5-0
     source: registry.redhat.io/openshift5/numaresources-operator-bundle
 
 

--- a/.konflux/catalog/catalog-idms.yaml
+++ b/.konflux/catalog/catalog-idms.yaml
@@ -8,6 +8,6 @@ spec:
   imageDigestMirrors:
   - mirrors:
     - quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-5-0
-    source: registry.redhat.io/openshift4/numaresources-operator-bundle
+    source: registry.redhat.io/openshift5/numaresources-operator-bundle
 
 

--- a/.konflux/catalog/fbc-images-resolvable-integration-test-idms.yaml
+++ b/.konflux/catalog/fbc-images-resolvable-integration-test-idms.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   imageDigestMirrors:
   - mirrors:
-    - registry.stage.redhat.io/openshift4/numaresources-rhel9-operator
-    source: registry.redhat.io/openshift4/numaresources-rhel9-operator
+    - registry.stage.redhat.io/openshift5/numaresources-rhel9-operator
+    source: registry.redhat.io/openshift5/numaresources-rhel9-operator
   - mirrors:
-    - registry.stage.redhat.io/openshift4/numaresources-operator-bundle
-    source: registry.redhat.io/openshift4/numaresources-operator-bundle
+    - registry.stage.redhat.io/openshift5/numaresources-operator-bundle
+    source: registry.redhat.io/openshift5/numaresources-operator-bundle

--- a/.konflux/catalog/fbc-images-resolvable-integration-test-idms.yaml
+++ b/.konflux/catalog/fbc-images-resolvable-integration-test-idms.yaml
@@ -6,6 +6,12 @@ metadata:
 spec:
   imageDigestMirrors:
   - mirrors:
+    - registry.stage.redhat.io/openshift4/numaresources-rhel9-operator
+    source: registry.redhat.io/openshift4/numaresources-rhel9-operator
+  - mirrors:
+    - registry.stage.redhat.io/openshift4/numaresources-operator-bundle
+    source: registry.redhat.io/openshift4/numaresources-operator-bundle
+  - mirrors:
     - registry.stage.redhat.io/openshift5/numaresources-rhel9-operator
     source: registry.redhat.io/openshift5/numaresources-rhel9-operator
   - mirrors:

--- a/.konflux/must-gather/must-gather.konflux.Dockerfile
+++ b/.konflux/must-gather/must-gather.konflux.Dockerfile
@@ -32,7 +32,7 @@ COPY --from=mgbuilder /usr/libexec/must-gather/numaresources-operator/* /usr/bin
 ENTRYPOINT ["/usr/bin/gather"]
 
 LABEL com.redhat.component="numaresources-must-gather-container" \
-    name="openshift4/numaresources-must-gather-rhel9" \
+    name="openshift5/numaresources-must-gather-rhel9" \
     summary="numa resources data gathering image" \
     io.openshift.expose-services="" \
     io.openshift.tags="data,images" \

--- a/.konflux/operator/konflux.Dockerfile
+++ b/.konflux/operator/konflux.Dockerfile
@@ -27,7 +27,7 @@ RUN microdnf install -y hwdata && \
 USER 65532:65532
 ENTRYPOINT ["/bin/numaresources-operator"]
 LABEL com.redhat.component="numaresources-operator-container" \
-      name="openshift4/numaresources-rhel9-operator" \
+      name="openshift5/numaresources-rhel9-operator" \
       summary="numaresources-operator" \
       io.openshift.expose-services="" \
       io.openshift.tags="operator" \

--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -6,8 +6,8 @@ spec:
   imageDigestMirrors:
   - mirrors:
     - quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-5-0
-    source: registry.redhat.io/openshift4/numaresources-rhel9-operator
+    source: registry.redhat.io/openshift5/numaresources-rhel9-operator
   - mirrors:
     - quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-5-0
-    source: registry.redhat.io/openshift4/numaresources-operator-bundle
+    source: registry.redhat.io/openshift5/numaresources-operator-bundle
 

--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -6,6 +6,12 @@ spec:
   imageDigestMirrors:
   - mirrors:
     - quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-5-0
+    source: registry.redhat.io/openshift4/numaresources-rhel9-operator
+  - mirrors:
+    - quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-5-0
+    source: registry.redhat.io/openshift4/numaresources-operator-bundle
+  - mirrors:
+    - quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-5-0
     source: registry.redhat.io/openshift5/numaresources-rhel9-operator
   - mirrors:
     - quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-5-0


### PR DESCRIPTION
## Summary
- Update container image registry namespace from `openshift4/` to `openshift5/` for OCP 5.0 across all non-submodule references.
- Affected files: Konflux Dockerfiles (operator, bundle, must-gather), IDMS/mirror-set YAMLs, overlay mappings, and getdigests tooling.
- Base images (`ose-operator-registry`, `ose-must-gather`) intentionally left as `openshift4` for now.

## Jira
https://redhat.atlassian.net/browse/CNF-26586


Made with [Cursor](https://cursor.com)