### PR TITLE
e2e: serial: adding the preemption for active topics

### DIFF
--- a/internal/api/features/_topics.json
+++ b/internal/api/features/_topics.json
@@ -24,6 +24,7 @@
     "netpols",
     "introspection",
     "mgselinuxcollect",
-    "tlscompliance"
+    "tlscompliance",
+    "preemption"
   ]
 }


### PR DESCRIPTION
D/s skip list is (tests topics.json active) − (operator
inspect-features active). Without preemption in active, it
never gets skipped and runs on all releases. Disable on 5.0
d/s until ready.