### PR TITLE
CNF-26511: Upstream catalog-template update — NUMA Resources Operator 4.12.17

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-12@sha256:4dd4c44c99dd5acb8b1120af1c769794ce94c314305c94ff255709c41e3e3b19
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-4-12@sha256:a4eed5637a3bb8b8f210bcb69889661ce04946da62fe3b226015b4f36af9ba52

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -54,6 +54,10 @@ entries:
       - name: numaresources-operator.v4.12.17
         replaces: numaresources-operator.v4.12.16
         skipRange: '>=4.11.0 <4.12.17'
+      # v4.12.18
+      - name: numaresources-operator.v4.12.18
+        replaces: numaresources-operator.v4.12.17
+        skipRange: '>=4.11.0 <4.12.18'
     name: "4.12"
     package: numaresources-operator
     schema: olm.channel
@@ -102,6 +106,10 @@ entries:
       - name: numaresources-operator.v4.12.17
         replaces: numaresources-operator.v4.12.16
         skipRange: '>=4.11.0 <4.12.17'
+      # v4.12.18
+      - name: numaresources-operator.v4.12.18
+        replaces: numaresources-operator.v4.12.17
+        skipRange: '>=4.11.0 <4.12.18'
     name: stable
     package: numaresources-operator
     schema: olm.channel
@@ -148,6 +156,9 @@ entries:
   - image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:cfd1ca34d7178f3ced5b08f80f2b258968eca907582bc1bd30502585c7e0b14c
     schema: olm.bundle
     # v4.12.17 bundle
+  - image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:94901941b1699a4699ec50ccdc5457f20ffdf85e2987ae82fbfda1673bb60029
+    schema: olm.bundle
+    # v4.12.18 bundle
     # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for NUMA Resources Operator 4.12.17 → 4.12.18.

Generated by release-automator-konflux.