### PR TITLE
ci: fix mcp crd path

### DIFF
--- a/hack/deploy-mco-crds.sh
+++ b/hack/deploy-mco-crds.sh
@@ -3,7 +3,7 @@
 source hack/common.sh
 
 # Specify the URL link to the machine config pool CRD
-CRD_MACHINE_CONFIG_POOL_URL="https://raw.githubusercontent.com/openshift/api/refs/heads/master/payload-manifests/crds/0000_80_machine-config_01_machineconfigpools-SelfManagedHA.crd.yaml"
+CRD_MACHINE_CONFIG_POOL_URL="https://raw.githubusercontent.com/openshift/api/refs/heads/master/payload-manifests/crds/0000_80_machine-config_01_machineconfigpools.crd.yaml"
 # Specify the URL link to the kubeletconfig CRD
 CRD_KUBELET_CONFIG_URL="https://raw.githubusercontent.com/openshift/api/refs/heads/master/payload-manifests/crds/0000_80_machine-config_01_kubeletconfigs-Default.crd.yaml"
 


### PR DESCRIPTION
Path has been moved again, we need to find a better way to make it more stable. for now lets set the new path to unblock ci.