### PR TITLE
Revert "ci: fix mcp crd path"

### DIFF
--- a/hack/deploy-mco-crds.sh
+++ b/hack/deploy-mco-crds.sh
@@ -3,7 +3,7 @@
 source hack/common.sh
 
 # Specify the URL link to the machine config pool CRD
-CRD_MACHINE_CONFIG_POOL_URL="https://raw.githubusercontent.com/openshift/api/refs/heads/master/payload-manifests/crds/0000_80_machine-config_01_machineconfigpools.crd.yaml"
+CRD_MACHINE_CONFIG_POOL_URL="https://raw.githubusercontent.com/openshift/api/refs/heads/master/payload-manifests/crds/0000_80_machine-config_01_machineconfigpools-SelfManagedHA.crd.yaml"
 # Specify the URL link to the kubeletconfig CRD
 CRD_KUBELET_CONFIG_URL="https://raw.githubusercontent.com/openshift/api/refs/heads/master/payload-manifests/crds/0000_80_machine-config_01_kubeletconfigs-Default.crd.yaml"
 


### PR DESCRIPTION
Reverts openshift-kni/numaresources-operator#5041
This Revert is due to `https://github.com/openshift/api/commit/af5c920502e23802ac1aec0eeb47740520dcb3d6#diff-3c9de348632274f76706a3b0e51e8a6a454c58b4a3b0589c03a41dac0db4f334`