### PR TITLE
rbac: add required NetworkPolicy RBAC verbs for OCP 5.0 compliance

### DIFF
--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -66,7 +66,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-08-18T10:28:38Z"
+    createdAt: "2026-08-19T14:55:27Z"
     features.operators.openshift.io/cnf: "true"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -906,7 +906,9 @@ spec:
           - networkpolicies
           verbs:
           - create
+          - delete
           - list
+          - update
           - watch
         - apiGroups:
           - networking.k8s.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -396,7 +396,9 @@ rules:
   - networkpolicies
   verbs:
   - create
+  - delete
   - list
+  - update
   - watch
 - apiGroups:
   - networking.k8s.io

--- a/internal/controller/numaresourcesoperator_controller.go
+++ b/internal/controller/numaresourcesoperator_controller.go
@@ -109,7 +109,7 @@ type NUMAResourcesOperatorReconciler struct {
 // Namespace Scoped
 //+kubebuilder:rbac:groups="",resources=services,verbs=create;list;watch,namespace="numaresources"
 //+kubebuilder:rbac:groups="",resources=services,resourceNames=numaresources-rte-metrics-service,verbs=get;update,namespace="numaresources"
-//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;list;watch,namespace="numaresources"
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;list;update;watch,namespace="numaresources"
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,resourceNames=rte-default-deny-all;rte-egress-to-api-server,verbs=get;update,namespace="numaresources"
 //+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=create;delete;get;list;update;watch,namespace="numaresources"
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=create;list;watch,namespace="numaresources"

--- a/internal/controller/numaresourcesscheduler_controller.go
+++ b/internal/controller/numaresourcesscheduler_controller.go
@@ -81,7 +81,7 @@ type NUMAResourcesSchedulerReconciler struct {
 }
 
 // Namespace Scoped
-//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;list;watch,namespace="numaresources"
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;list;update;watch,namespace="numaresources"
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,resourceNames=scheduler-default-deny-all;scheduler-egress-to-api-server,verbs=get;update,namespace="numaresources"
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=create;list;watch,namespace="numaresources"
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,resourceNames=topology-aware-scheduler-leader-elect,verbs=get;update,namespace="numaresources"


### PR DESCRIPTION
Update kubebuilder RBAC markers for `networking.k8s.io/networkpolicies` to include `delete` and `update`, then regenerate manifests and bundle CSV. 
This satisfies the `olm.required_network_policy_rbac_for_operands` Conforma policy, which is conforma (konflux) release-blocking s as of Aug 8, 2026.

Assisted-by: Cursor AI