### PR TITLE
CNF-26586: remove openshift4 entry from catalog-idms

### DIFF
--- a/.konflux/catalog/catalog-idms.yaml
+++ b/.konflux/catalog/catalog-idms.yaml
@@ -8,9 +8,6 @@ spec:
   imageDigestMirrors:
   - mirrors:
     - quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-5-0
-    source: registry.redhat.io/openshift4/numaresources-operator-bundle
-  - mirrors:
-    - quay.io/redhat-user-workloads/telco-5g-tenant/numaresources-operator-bundle-5-0
     source: registry.redhat.io/openshift5/numaresources-operator-bundle
 
 


### PR DESCRIPTION
- Remove the transitional openshift4 mirror entry from catalog-idms.yaml, keeping only the openshift5 source reference.

- Follow-up to https://github.com/openshift-kni/numaresources-operator/pull/4986.