### PR TITLE
api: ng-config: allow disabling NUMA placement reporting [20260824]

### DIFF
--- a/api/v1/numaresourcesoperator_defaults.go
+++ b/api/v1/numaresourcesoperator_defaults.go
@@ -41,26 +41,34 @@ func (ngc *NodeGroupConfig) SetDefaults() {
 	if ngc.InfoRefreshPause == nil {
 		ngc.InfoRefreshPause = defaultInfoRefreshPause()
 	}
+	if ngc.NUMAPlacement == nil {
+		ngc.NUMAPlacement = defaultNUMAPlacement()
+	}
 }
 
 func defaultPodsFingerprinting() *PodsFingerprintingMode {
-	podsFp := PodsFingerprintingEnabledExclusiveResources
-	return &podsFp
+	v := PodsFingerprintingEnabledExclusiveResources
+	return &v
 }
 
 func defaultInfoRefreshMode() *InfoRefreshMode {
-	refMode := InfoRefreshPeriodic
-	return &refMode
+	v := InfoRefreshPeriodic
+	return &v
 }
 
 func defaultInfoRefreshPeriod() *metav1.Duration {
-	period := metav1.Duration{
+	v := metav1.Duration{
 		Duration: 10 * time.Second,
 	}
-	return &period
+	return &v
 }
 
 func defaultInfoRefreshPause() *InfoRefreshPauseMode {
-	infoRefreshPause := InfoRefreshPauseDisabled
-	return &infoRefreshPause
+	v := InfoRefreshPauseDisabled
+	return &v
+}
+
+func defaultNUMAPlacement() *NUMAPlacementMode {
+	v := NUMAPlacementContainer
+	return &v
 }

--- a/api/v1/numaresourcesoperator_defaults_test.go
+++ b/api/v1/numaresourcesoperator_defaults_test.go
@@ -39,6 +39,7 @@ func TestNodeGroupConfigDefaultMethod(t *testing.T) {
 				InfoRefreshMode:    defaultInfoRefreshMode(),
 				InfoRefreshPeriod:  defaultInfoRefreshPeriod(),
 				InfoRefreshPause:   defaultInfoRefreshPause(),
+				NUMAPlacement:      defaultNUMAPlacement(),
 			},
 		},
 		{
@@ -51,6 +52,7 @@ func TestNodeGroupConfigDefaultMethod(t *testing.T) {
 				InfoRefreshMode:    defaultInfoRefreshMode(),
 				InfoRefreshPeriod:  ptrToDuration(42 * time.Second),
 				InfoRefreshPause:   defaultInfoRefreshPause(),
+				NUMAPlacement:      defaultNUMAPlacement(),
 			},
 		},
 		{
@@ -63,6 +65,20 @@ func TestNodeGroupConfigDefaultMethod(t *testing.T) {
 				InfoRefreshMode:    defaultInfoRefreshMode(),
 				InfoRefreshPeriod:  defaultInfoRefreshPeriod(),
 				InfoRefreshPause:   ptrToRTEMode(InfoRefreshPauseEnabled),
+				NUMAPlacement:      defaultNUMAPlacement(),
+			},
+		},
+		{
+			name: "partial fill: numaPlacement",
+			val: NodeGroupConfig{
+				NUMAPlacement: ptrToNPMode(NUMAPlacementNone),
+			},
+			expected: NodeGroupConfig{
+				PodsFingerprinting: defaultPodsFingerprinting(),
+				InfoRefreshMode:    defaultInfoRefreshMode(),
+				InfoRefreshPeriod:  defaultInfoRefreshPeriod(),
+				InfoRefreshPause:   defaultInfoRefreshPause(),
+				NUMAPlacement:      ptrToNPMode(NUMAPlacementNone),
 			},
 		},
 	}
@@ -86,12 +102,14 @@ func TestNodeGroupConfigDefault(t *testing.T) {
 		Duration: 10 * time.Second,
 	}
 	infoRefreshPause := InfoRefreshPauseDisabled
+	numaPlacement := NUMAPlacementContainer
 
 	exp := toJSON(NodeGroupConfig{
 		PodsFingerprinting: &podsFp,
 		InfoRefreshMode:    &refMode,
 		InfoRefreshPeriod:  &period,
 		InfoRefreshPause:   &infoRefreshPause,
+		NUMAPlacement:      &numaPlacement,
 	})
 	got := toJSON(DefaultNodeGroupConfig())
 
@@ -117,4 +135,8 @@ func ptrToDuration(d time.Duration) *metav1.Duration {
 
 func ptrToRTEMode(m InfoRefreshPauseMode) *InfoRefreshPauseMode {
 	return &m
+}
+
+func ptrToNPMode(v NUMAPlacementMode) *NUMAPlacementMode {
+	return &v
 }

--- a/api/v1/numaresourcesoperator_normalize.go
+++ b/api/v1/numaresourcesoperator_normalize.go
@@ -49,6 +49,9 @@ func (current NodeGroupConfig) Merge(updated NodeGroupConfig) NodeGroupConfig {
 	if updated.InfoRefreshPause != nil {
 		conf.InfoRefreshPause = updated.InfoRefreshPause
 	}
+	if updated.NUMAPlacement != nil {
+		conf.NUMAPlacement = updated.NUMAPlacement
+	}
 	return conf
 }
 

--- a/api/v1/numaresourcesoperator_normalize_test.go
+++ b/api/v1/numaresourcesoperator_normalize_test.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func TestNodeGroupNormalizeConfigKeepsTolerations(t *testing.T) {
@@ -86,7 +87,8 @@ func TestNodeGroupConfigMerge(t *testing.T) {
 				InfoRefreshPeriod: &metav1.Duration{
 					Duration: 42 * time.Second,
 				},
-				InfoRefreshPause: ptrToRTEMode(InfoRefreshPauseEnabled),
+				InfoRefreshPause: ptr.To(InfoRefreshPauseEnabled),
+				NUMAPlacement:    ptr.To(NUMAPlacementNone),
 			},
 			expected: NodeGroupConfig{
 				PodsFingerprinting: &podsFp,
@@ -94,7 +96,8 @@ func TestNodeGroupConfigMerge(t *testing.T) {
 				InfoRefreshPeriod: &metav1.Duration{
 					Duration: 42 * time.Second,
 				},
-				InfoRefreshPause: ptrToRTEMode(InfoRefreshPauseEnabled),
+				InfoRefreshPause: ptr.To(InfoRefreshPauseEnabled),
+				NUMAPlacement:    ptr.To(NUMAPlacementNone),
 			},
 		},
 	}

--- a/api/v1/numaresourcesoperator_types.go
+++ b/api/v1/numaresourcesoperator_types.go
@@ -77,6 +77,17 @@ const (
 	InfoRefreshPauseEnabled InfoRefreshPauseMode = "Enabled"
 )
 
+// +kubebuilder:validation:Enum=container;none
+type NUMAPlacementMode string
+
+const (
+	// NUMAPlacementContainer enables container NUMA placement reporting in NRT. It is the default.
+	NUMAPlacementContainer NUMAPlacementMode = "container"
+
+	// NUMAPlacementNone disables container NUMA placement reporting in NRT. Used to disable NUMA-aware eviction during default preemption.
+	NUMAPlacementNone NUMAPlacementMode = "none"
+)
+
 // +kubebuilder:validation:Enum=Periodic;Events;PeriodicAndEvents
 type InfoRefreshMode string
 
@@ -109,6 +120,11 @@ type NodeGroupConfig struct {
 	// +optional
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable or disable the RTE pause setting",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	InfoRefreshPause *InfoRefreshPauseMode `json:"infoRefreshPause,omitempty"`
+	// NUMAPlacement selects the NUMA placement reporting mode in NRT for the machines belonging to this group.
+	// Valid values are: "container", "none". Defaults to "container".
+	// +optional
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="NUMA placement reporting mode",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	NUMAPlacement *NUMAPlacementMode `json:"numaPlacement,omitempty"`
 	// Tolerations overrides tolerations to be set into RTE daemonsets for this NodeGroup. If not empty, the tolerations will be the one set here.
 	// Leave empty to make the system use the default tolerations.
 	// +optional
@@ -235,7 +251,7 @@ func (ngc *NodeGroupConfig) ToString() string {
 		return "nil"
 	}
 	ngc.SetDefaults()
-	return fmt.Sprintf("PodsFingerprinting mode: %s InfoRefreshMode: %s InfoRefreshPeriod: %s InfoRefreshPause: %s Tolerations: %+v", *ngc.PodsFingerprinting, *ngc.InfoRefreshMode, *ngc.InfoRefreshPeriod, *ngc.InfoRefreshPause, ngc.Tolerations)
+	return fmt.Sprintf("PodsFingerprinting mode: %s InfoRefreshMode: %s InfoRefreshPeriod: %s InfoRefreshPause: %s NUMAPlacement mode: %s Tolerations: %+v", *ngc.PodsFingerprinting, *ngc.InfoRefreshMode, *ngc.InfoRefreshPeriod, *ngc.InfoRefreshPause, *ngc.NUMAPlacement, ngc.Tolerations)
 }
 
 func (ng *NodeGroup) GetName() string {

--- a/api/v1/numaresourcesoperator_types_test.go
+++ b/api/v1/numaresourcesoperator_types_test.go
@@ -70,7 +70,7 @@ func TestNodeGroupConfigToString(t *testing.T) {
 					},
 				},
 			},
-			expected: "PodsFingerprinting mode: Disabled InfoRefreshMode: Events InfoRefreshPeriod: {33s} InfoRefreshPause: Enabled Tolerations: [{Key:foo Operator: Value:1 Effect:NoSchedule TolerationSeconds:<nil>}]",
+			expected: "PodsFingerprinting mode: Disabled InfoRefreshMode: Events InfoRefreshPeriod: {33s} InfoRefreshPause: Enabled NUMAPlacement mode: container Tolerations: [{Key:foo Operator: Value:1 Effect:NoSchedule TolerationSeconds:<nil>}]",
 		},
 	}
 
@@ -155,7 +155,7 @@ func TestNodeGroupToString(t *testing.T) {
 					"ann2": "val2",
 				},
 			},
-			expected: "PoolName: pn MCPSelector: <missing> Config: PodsFingerprinting mode: Disabled InfoRefreshMode: Events InfoRefreshPeriod: {10s} InfoRefreshPause: Disabled Tolerations: [] Annotations: ann1=val1,ann2=val2",
+			expected: "PoolName: pn MCPSelector: <missing> Config: PodsFingerprinting mode: Disabled InfoRefreshMode: Events InfoRefreshPeriod: {10s} InfoRefreshPause: Disabled NUMAPlacement mode: container Tolerations: [] Annotations: ann1=val1,ann2=val2",
 		},
 		{
 			name: "many annotations",
@@ -173,7 +173,7 @@ func TestNodeGroupToString(t *testing.T) {
 					"ann9": "valA",
 				},
 			},
-			expected: "PoolName: pn MCPSelector: <missing> Config: PodsFingerprinting mode: Disabled InfoRefreshMode: Events InfoRefreshPeriod: {10s} InfoRefreshPause: Disabled Tolerations: [] Annotations: ann1=val1,ann2=val2,ann3=val7,ann5=val4,ann9=valA",
+			expected: "PoolName: pn MCPSelector: <missing> Config: PodsFingerprinting mode: Disabled InfoRefreshMode: Events InfoRefreshPeriod: {10s} InfoRefreshPause: Disabled NUMAPlacement mode: container Tolerations: [] Annotations: ann1=val1,ann2=val2,ann3=val7,ann5=val4,ann9=valA",
 		},
 	}
 	for _, tc := range testcases {

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -404,6 +404,11 @@ func (in *NodeGroupConfig) DeepCopyInto(out *NodeGroupConfig) {
 		*out = new(InfoRefreshPauseMode)
 		**out = **in
 	}
+	if in.NUMAPlacement != nil {
+		in, out := &in.NUMAPlacement, &out.NUMAPlacement
+		*out = new(NUMAPlacementMode)
+		**out = **in
+	}
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations
 		*out = make([]corev1.Toleration, len(*in))

--- a/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/bundle/manifests/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -98,6 +98,14 @@ spec:
                           description: InfoRefreshPeriod sets the topology info refresh
                             period. Use explicit 0 to disable.
                           type: string
+                        numaPlacement:
+                          description: |-
+                            NUMAPlacement selects the NUMA placement reporting mode in NRT for the machines belonging to this group.
+                            Valid values are: "container", "none". Defaults to "container".
+                          enum:
+                          - container
+                          - none
+                          type: string
                         podsFingerprinting:
                           description: PodsFingerprinting defines if pod fingerprint
                             should be reported for the machines belonging to this
@@ -357,6 +365,14 @@ spec:
                           description: InfoRefreshPeriod sets the topology info refresh
                             period. Use explicit 0 to disable.
                           type: string
+                        numaPlacement:
+                          description: |-
+                            NUMAPlacement selects the NUMA placement reporting mode in NRT for the machines belonging to this group.
+                            Valid values are: "container", "none". Defaults to "container".
+                          enum:
+                          - container
+                          - none
+                          type: string
                         podsFingerprinting:
                           description: PodsFingerprinting defines if pod fingerprint
                             should be reported for the machines belonging to this
@@ -452,6 +468,14 @@ spec:
                         infoRefreshPeriod:
                           description: InfoRefreshPeriod sets the topology info refresh
                             period. Use explicit 0 to disable.
+                          type: string
+                        numaPlacement:
+                          description: |-
+                            NUMAPlacement selects the NUMA placement reporting mode in NRT for the machines belonging to this group.
+                            Valid values are: "container", "none". Defaults to "container".
+                          enum:
+                          - container
+                          - none
                           type: string
                         podsFingerprinting:
                           description: PodsFingerprinting defines if pod fingerprint

--- a/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/numaresources-operator.clusterserviceversion.yaml
@@ -66,7 +66,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-08-19T14:55:27Z"
+    createdAt: "2026-08-24T14:02:44Z"
     features.operators.openshift.io/cnf: "true"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -136,6 +136,13 @@ spec:
           explicit 0 to disable.
         displayName: Topology info refresh period setting
         path: nodeGroups[0].config.infoRefreshPeriod
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          NUMAPlacement selects the NUMA placement reporting mode in NRT for the machines belonging to this group.
+          Valid values are: "container", "none". Defaults to "container".
+        displayName: NUMA placement reporting mode
+        path: nodeGroups[0].config.numaPlacement
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: PodsFingerprinting defines if pod fingerprint should be reported

--- a/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
+++ b/config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml
@@ -98,6 +98,14 @@ spec:
                           description: InfoRefreshPeriod sets the topology info refresh
                             period. Use explicit 0 to disable.
                           type: string
+                        numaPlacement:
+                          description: |-
+                            NUMAPlacement selects the NUMA placement reporting mode in NRT for the machines belonging to this group.
+                            Valid values are: "container", "none". Defaults to "container".
+                          enum:
+                          - container
+                          - none
+                          type: string
                         podsFingerprinting:
                           description: PodsFingerprinting defines if pod fingerprint
                             should be reported for the machines belonging to this
@@ -357,6 +365,14 @@ spec:
                           description: InfoRefreshPeriod sets the topology info refresh
                             period. Use explicit 0 to disable.
                           type: string
+                        numaPlacement:
+                          description: |-
+                            NUMAPlacement selects the NUMA placement reporting mode in NRT for the machines belonging to this group.
+                            Valid values are: "container", "none". Defaults to "container".
+                          enum:
+                          - container
+                          - none
+                          type: string
                         podsFingerprinting:
                           description: PodsFingerprinting defines if pod fingerprint
                             should be reported for the machines belonging to this
@@ -452,6 +468,14 @@ spec:
                         infoRefreshPeriod:
                           description: InfoRefreshPeriod sets the topology info refresh
                             period. Use explicit 0 to disable.
+                          type: string
+                        numaPlacement:
+                          description: |-
+                            NUMAPlacement selects the NUMA placement reporting mode in NRT for the machines belonging to this group.
+                            Valid values are: "container", "none". Defaults to "container".
+                          enum:
+                          - container
+                          - none
                           type: string
                         podsFingerprinting:
                           description: PodsFingerprinting defines if pod fingerprint

--- a/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/numaresources-operator.clusterserviceversion.yaml
@@ -73,6 +73,13 @@ spec:
         path: nodeGroups[0].config.infoRefreshPeriod
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          NUMAPlacement selects the NUMA placement reporting mode in NRT for the machines belonging to this group.
+          Valid values are: "container", "none". Defaults to "container".
+        displayName: NUMA placement reporting mode
+        path: nodeGroups[0].config.numaPlacement
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: PodsFingerprinting defines if pod fingerprint should be reported
           for the machines belonging to this group
         displayName: Enable or disable the pods fingerprinting setting

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/k8stopologyawareschedwg/deployer v0.24.2
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.2
 	github.com/k8stopologyawareschedwg/podfingerprint v0.2.3
-	github.com/k8stopologyawareschedwg/resource-topology-exporter v0.25.0
+	github.com/k8stopologyawareschedwg/resource-topology-exporter v0.25.1
 	github.com/mdomke/git-semver v1.0.0
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/k8stopologyawareschedwg/numaplacement v0.1.0 h1:Y1GxVAAc+FVewXRdnPfXT
 github.com/k8stopologyawareschedwg/numaplacement v0.1.0/go.mod h1:wU3DV2l+5mzMLufnTYhtsiyXqiNwfDMN0Hq29c+qXU4=
 github.com/k8stopologyawareschedwg/podfingerprint v0.2.3 h1:nVKmzn6g7CHhDtB+jG85Db/B/ALRY9VLh5ueAfVPEHU=
 github.com/k8stopologyawareschedwg/podfingerprint v0.2.3/go.mod h1:E0bjgihZTSwRIJVjNV45Lm0C/j5w+YkGSnfpYXoI8Ws=
-github.com/k8stopologyawareschedwg/resource-topology-exporter v0.25.0 h1:GvZiWAoY8CTEHPB49BLKHhe+NjkrXdQKjawZAZKi0QU=
-github.com/k8stopologyawareschedwg/resource-topology-exporter v0.25.0/go.mod h1:HuyWeTKYUZ3KKKPn6VOSOGGYcMpdheJyrvcMAh/6e+A=
+github.com/k8stopologyawareschedwg/resource-topology-exporter v0.25.1 h1:IPKGAD2uPMWfjzdOxNCiipiO6I5WvycoJY/O6u8cFbA=
+github.com/k8stopologyawareschedwg/resource-topology-exporter v0.25.1/go.mod h1:HuyWeTKYUZ3KKKPn6VOSOGGYcMpdheJyrvcMAh/6e+A=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=

--- a/internal/controller/numaresourcesoperator_controller_test.go
+++ b/internal/controller/numaresourcesoperator_controller_test.go
@@ -634,14 +634,16 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 					nroUpdated := &nropv1.NUMAResourcesOperator{}
 					Expect(reconciler.Client.Get(context.TODO(), client.ObjectKeyFromObject(nro), nroUpdated)).ToNot(HaveOccurred())
 
+					expectedConf := conf
+					expectedConf.SetDefaults()
 					Expect(nroUpdated.Status.NodeGroups).To(HaveLen(1))
-					Expect(nroUpdated.Status.NodeGroups[0].Config).To(Equal(conf), "operator status was not updated under NodeGroupStatus field")
+					Expect(nroUpdated.Status.NodeGroups[0].Config).To(Equal(expectedConf), "operator status was not updated under NodeGroupStatus field")
 
 					if platf != platform.HyperShift {
 						Expect(nroUpdated.Status.MachineConfigPools).To(HaveLen(1))
 						Expect(nroUpdated.Status.MachineConfigPools[0].Name).To(Equal(pn))
 						Expect(nroUpdated.Status.MachineConfigPools[0].Config).ToNot(BeNil(), "operator status contains nil config")
-						Expect(*nroUpdated.Status.MachineConfigPools[0].Config).To(Equal(conf), "operator status was not updated")
+						Expect(*nroUpdated.Status.MachineConfigPools[0].Config).To(Equal(expectedConf), "operator status was not updated")
 					}
 				})
 
@@ -816,6 +818,68 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 					Expect(args).ToNot(ContainElement(ContainSubstring("--no-publish")), "malformed args: %v", args)
 				})
 
+				It("should enable container NUMA placement reporting by default", func(ctx context.Context) {
+					conf := nropv1.DefaultNodeGroupConfig()
+
+					nro := testobjs.NewNUMAResourcesOperatorWithNodeGroupConfig(objectnames.DefaultNUMAResourcesOperatorCrName, pn, &conf)
+
+					var reconciler *NUMAResourcesOperatorReconciler
+					if platf == platform.HyperShift {
+						reconciler = reconcileObjectsHypershift(nro)
+					} else {
+						reconciler = reconcileObjectsOpenshift(nro, mcp)
+					}
+
+					dsKey := client.ObjectKey{
+						Name:      objectnames.GetComponentName(nro.Name, pn),
+						Namespace: testNamespace,
+					}
+					ds := &appsv1.DaemonSet{}
+					Expect(reconciler.Client.Get(ctx, dsKey, ds)).ToNot(HaveOccurred())
+
+					args := ds.Spec.Template.Spec.Containers[0].Args
+					Expect(args).To(ContainElement("--numa-placement=container"), "malformed args: %v", args)
+
+					nroUpdated := &nropv1.NUMAResourcesOperator{}
+					Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(nro), nroUpdated)).ToNot(HaveOccurred())
+					Expect(*nroUpdated.Status.NodeGroups[0].Config.NUMAPlacement).To(Equal(nropv1.NUMAPlacementContainer), "node group config was not updated under NodeGroupStatus field")
+					if platf != platform.HyperShift {
+						Expect(*nroUpdated.Status.MachineConfigPools[0].Config.NUMAPlacement).To(Equal(nropv1.NUMAPlacementContainer), "node group config was not updated in the operator status")
+					}
+				})
+
+				It("should allow to disable container NUMA placement reporting", func(ctx context.Context) {
+					numaPlacement := nropv1.NUMAPlacementNone
+					conf := nropv1.NodeGroupConfig{
+						NUMAPlacement: &numaPlacement,
+					}
+					nro := testobjs.NewNUMAResourcesOperatorWithNodeGroupConfig(objectnames.DefaultNUMAResourcesOperatorCrName, pn, &conf)
+
+					var reconciler *NUMAResourcesOperatorReconciler
+					if platf == platform.HyperShift {
+						reconciler = reconcileObjectsHypershift(nro)
+					} else {
+						reconciler = reconcileObjectsOpenshift(nro, mcp)
+					}
+
+					dsKey := client.ObjectKey{
+						Name:      objectnames.GetComponentName(nro.Name, pn),
+						Namespace: testNamespace,
+					}
+					ds := &appsv1.DaemonSet{}
+					Expect(reconciler.Client.Get(ctx, dsKey, ds)).ToNot(HaveOccurred())
+
+					args := ds.Spec.Template.Spec.Containers[0].Args
+					Expect(args).To(ContainElement("--numa-placement=none"), "malformed args: %v", args)
+
+					nroUpdated := &nropv1.NUMAResourcesOperator{}
+					Expect(reconciler.Client.Get(ctx, client.ObjectKeyFromObject(nro), nroUpdated)).ToNot(HaveOccurred())
+					Expect(*nroUpdated.Status.NodeGroups[0].Config.NUMAPlacement).To(Equal(numaPlacement), "node group config was not updated under NodeGroupStatus field")
+					if platf != platform.HyperShift {
+						Expect(*nroUpdated.Status.MachineConfigPools[0].Config.NUMAPlacement).To(Equal(numaPlacement), "node group config was not updated in the operator status")
+					}
+				})
+
 				It("should allow to disabling NRT updates and enabling it back", func() {
 					rteMode := nropv1.InfoRefreshPauseEnabled
 					conf := nropv1.NodeGroupConfig{
@@ -940,9 +1004,11 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 
 					nroUpdated := &nropv1.NUMAResourcesOperator{}
 					Expect(reconciler.Client.Get(context.TODO(), client.ObjectKeyFromObject(nro), nroUpdated)).ToNot(HaveOccurred())
-					Expect(nroUpdated.Status.NodeGroups[0].Config).To(Equal(confUpdated), "node group config was not updated under NodeGroupStatus field")
+					expectedConf := confUpdated
+					expectedConf.SetDefaults()
+					Expect(nroUpdated.Status.NodeGroups[0].Config).To(Equal(expectedConf), "node group config was not updated under NodeGroupStatus field")
 					if platf != platform.HyperShift {
-						Expect(*nroUpdated.Status.MachineConfigPools[0].Config).To(Equal(confUpdated), "node group config was not updated in the operator status")
+						Expect(*nroUpdated.Status.MachineConfigPools[0].Config).To(Equal(expectedConf), "node group config was not updated in the operator status")
 					}
 				})
 

--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -234,6 +234,10 @@ func DaemonSetArgs(ds *appsv1.DaemonSet, conf nropv1.NodeGroupConfig, metricsTLS
 
 	flags.SetOption("--add-nrt-owner", "false")
 
+	numaPlacement := getNUMAPlacementMode(&conf)
+	klog.V(2).InfoS("DaemonSet update: NUMA placement reporting", "daemonset", ds.Name, "mode", numaPlacement)
+	flags.SetOption("--numa-placement", string(numaPlacement))
+
 	cnt.Args = flags.Argv()
 	return nil
 }
@@ -356,4 +360,13 @@ func isInfoRefreshPauseEnabled(conf *nropv1.NodeGroupConfig) bool {
 		conf = &cfg
 	}
 	return *conf.InfoRefreshPause == nropv1.InfoRefreshPauseEnabled
+}
+
+func getNUMAPlacementMode(conf *nropv1.NodeGroupConfig) nropv1.NUMAPlacementMode {
+	cfg := nropv1.DefaultNodeGroupConfig()
+	if conf == nil || conf.NUMAPlacement == nil {
+		// not specified -> use defaults
+		conf = &cfg
+	}
+	return *conf.NUMAPlacement
 }

--- a/pkg/objectupdate/rte/rte_test.go
+++ b/pkg/objectupdate/rte/rte_test.go
@@ -28,6 +28,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
 	objtls "github.com/openshift-kni/numaresources-operator/pkg/objectupdate/tls"
@@ -89,7 +90,7 @@ func TestUpdateDaemonSetArgs(t *testing.T) {
 			name: "defaults",
 			conf: nropv1.DefaultNodeGroupConfig(),
 			expectedArgs: []string{
-				"--pods-fingerprint", "--pods-fingerprint-method=with-exclusive-resources", "--refresh-node-resources", "--add-nrt-owner=false", "--sleep-interval=10s", "--metrics-mode=httptls",
+				"--pods-fingerprint", "--pods-fingerprint-method=with-exclusive-resources", "--refresh-node-resources", "--add-nrt-owner=false", "--sleep-interval=10s", "--metrics-mode=httptls", "--numa-placement=container",
 			},
 		},
 		{
@@ -97,7 +98,7 @@ func TestUpdateDaemonSetArgs(t *testing.T) {
 			conf:       nropv1.DefaultNodeGroupConfig(),
 			metricsTLS: objtls.NewSettings(&tls.Config{MinVersion: tls.VersionTLS12, CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256}}),
 			expectedArgs: []string{
-				"--pods-fingerprint", "--pods-fingerprint-method=with-exclusive-resources", "--refresh-node-resources", "--add-nrt-owner=false", "--sleep-interval=10s", "--metrics-mode=httptls",
+				"--pods-fingerprint", "--pods-fingerprint-method=with-exclusive-resources", "--refresh-node-resources", "--add-nrt-owner=false", "--sleep-interval=10s", "--metrics-mode=httptls", "--numa-placement=container",
 				"--metrics-tls-min-version=VersionTLS12", "--metrics-tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 			},
 		},
@@ -109,7 +110,7 @@ func TestUpdateDaemonSetArgs(t *testing.T) {
 				},
 			},
 			expectedArgs: []string{
-				"--pods-fingerprint", "--pods-fingerprint-method=with-exclusive-resources", "--refresh-node-resources", "--add-nrt-owner=false", "--sleep-interval=32s", "--metrics-mode=httptls",
+				"--pods-fingerprint", "--pods-fingerprint-method=with-exclusive-resources", "--refresh-node-resources", "--add-nrt-owner=false", "--sleep-interval=32s", "--metrics-mode=httptls", "--numa-placement=container",
 			},
 		},
 		{
@@ -118,7 +119,7 @@ func TestUpdateDaemonSetArgs(t *testing.T) {
 				PodsFingerprinting: &pfpEnabled,
 			},
 			expectedArgs: []string{
-				"--pods-fingerprint", "--pods-fingerprint-method=all", "--refresh-node-resources", "--add-nrt-owner=false", "--sleep-interval=10s", "--metrics-mode=httptls",
+				"--pods-fingerprint", "--pods-fingerprint-method=all", "--refresh-node-resources", "--add-nrt-owner=false", "--sleep-interval=10s", "--metrics-mode=httptls", "--numa-placement=container",
 			},
 		},
 		{
@@ -127,7 +128,7 @@ func TestUpdateDaemonSetArgs(t *testing.T) {
 				PodsFingerprinting: &pfpDisabled,
 			},
 			expectedArgs: []string{
-				"--refresh-node-resources", "--add-nrt-owner=false", "--sleep-interval=10s", "--metrics-mode=httptls",
+				"--refresh-node-resources", "--add-nrt-owner=false", "--sleep-interval=10s", "--metrics-mode=httptls", "--numa-placement=container",
 			},
 		},
 		{
@@ -136,7 +137,7 @@ func TestUpdateDaemonSetArgs(t *testing.T) {
 				InfoRefreshMode: &refreshEvents,
 			},
 			expectedArgs: []string{
-				"--pods-fingerprint", "--pods-fingerprint-method=with-exclusive-resources", "--refresh-node-resources", "--add-nrt-owner=false", "--notify-file=/run/rte/notify", "--metrics-mode=httptls",
+				"--pods-fingerprint", "--pods-fingerprint-method=with-exclusive-resources", "--refresh-node-resources", "--add-nrt-owner=false", "--notify-file=/run/rte/notify", "--metrics-mode=httptls", "--numa-placement=container",
 			},
 		},
 		{
@@ -145,7 +146,7 @@ func TestUpdateDaemonSetArgs(t *testing.T) {
 				InfoRefreshMode: &refreshPeriodic,
 			},
 			expectedArgs: []string{
-				"--pods-fingerprint", "--pods-fingerprint-method=with-exclusive-resources", "--refresh-node-resources", "--add-nrt-owner=false", "--sleep-interval=10s", "--metrics-mode=httptls",
+				"--pods-fingerprint", "--pods-fingerprint-method=with-exclusive-resources", "--refresh-node-resources", "--add-nrt-owner=false", "--sleep-interval=10s", "--metrics-mode=httptls", "--numa-placement=container",
 			},
 		},
 		{
@@ -154,7 +155,7 @@ func TestUpdateDaemonSetArgs(t *testing.T) {
 				InfoRefreshPause: &infoRefreshPauseEnabled,
 			},
 			expectedArgs: []string{
-				"--pods-fingerprint", "--pods-fingerprint-method=with-exclusive-resources", "--no-publish", "--refresh-node-resources", "--add-nrt-owner=false", "--sleep-interval=10s", "--metrics-mode=httptls",
+				"--pods-fingerprint", "--pods-fingerprint-method=with-exclusive-resources", "--no-publish", "--refresh-node-resources", "--add-nrt-owner=false", "--sleep-interval=10s", "--metrics-mode=httptls", "--numa-placement=container",
 			},
 		},
 		{
@@ -163,7 +164,25 @@ func TestUpdateDaemonSetArgs(t *testing.T) {
 				InfoRefreshPause: &infoRefreshPauseDisabled,
 			},
 			expectedArgs: []string{
-				"--pods-fingerprint", "--pods-fingerprint-method=with-exclusive-resources", "--refresh-node-resources", "--add-nrt-owner=false", "--sleep-interval=10s", "--metrics-mode=httptls",
+				"--pods-fingerprint", "--pods-fingerprint-method=with-exclusive-resources", "--refresh-node-resources", "--add-nrt-owner=false", "--sleep-interval=10s", "--metrics-mode=httptls", "--numa-placement=container",
+			},
+		},
+		{
+			name: "disable container NUMA placement reporting",
+			conf: nropv1.NodeGroupConfig{
+				NUMAPlacement: ptr.To(nropv1.NUMAPlacementNone),
+			},
+			expectedArgs: []string{
+				"--pods-fingerprint", "--pods-fingerprint-method=with-exclusive-resources", "--refresh-node-resources", "--add-nrt-owner=false", "--sleep-interval=10s", "--metrics-mode=httptls", "--numa-placement=none",
+			},
+		},
+		{
+			name: "precisely enable container NUMA placement reporting",
+			conf: nropv1.NodeGroupConfig{
+				NUMAPlacement: ptr.To(nropv1.NUMAPlacementContainer),
+			},
+			expectedArgs: []string{
+				"--pods-fingerprint", "--pods-fingerprint-method=with-exclusive-resources", "--refresh-node-resources", "--add-nrt-owner=false", "--sleep-interval=10s", "--metrics-mode=httptls", "--numa-placement=container",
 			},
 		},
 	}

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/cfgdispatch.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/cfgdispatch.go
@@ -99,16 +99,13 @@ func (cm configMap) Value(key string, out_ any) error {
 	}
 }
 
-type confBinding struct {
+type Binding struct {
 	key string
 	out any
 }
 
-func dispatchConfObj(obj map[string]interface{}, pArgs *ProgArgs) error {
-	var err error
-	cm := configMap(obj)
-
-	cbs := []confBinding{
+func MakeBindings(pArgs *ProgArgs) []Binding {
+	return []Binding{
 		{key: "global.debug", out: &pArgs.Global.Debug},
 		{key: "global.verbose", out: &pArgs.Global.Verbose},
 		{key: "global.kubeconfig", out: &pArgs.Global.KubeConfig},
@@ -125,6 +122,7 @@ func dispatchConfObj(obj map[string]interface{}, pArgs *ProgArgs) error {
 		{key: "resourceMonitor.exposeTiming", out: &pArgs.Resourcemonitor.ExposeTiming},
 		{key: "resourceMonitor.podSetFingerprintStatusFile", out: &pArgs.Resourcemonitor.PodSetFingerprintStatusFile},
 		{key: "resourceMonitor.excludeTerminalPods", out: &pArgs.Resourcemonitor.ExcludeTerminalPods},
+		{key: "resourceMonitor.numaPlacement", out: &pArgs.Resourcemonitor.NUMAPlacement},
 		{key: "topologyExporter.kubeletConfigFile", out: &pArgs.RTE.KubeletConfigFile},
 		{key: "topologyExporter.podResourcesSocketPath", out: &pArgs.RTE.PodResourcesSocketPath},
 		{key: "topologyExporter.sleepInterval", out: &pArgs.RTE.SleepInterval},
@@ -142,8 +140,13 @@ func dispatchConfObj(obj map[string]interface{}, pArgs *ProgArgs) error {
 		{key: "topologyExporter.metricsTLS.minTLSVersion", out: &pArgs.RTE.MetricsTLSCfg.MinTLSVersion},
 		{key: "topologyExporter.metricsTLS.cipherSuites", out: &pArgs.RTE.MetricsTLSCfg.CipherSuites},
 	}
+}
 
-	for _, cb := range cbs {
+func dispatchConfObj(obj map[string]interface{}, pArgs *ProgArgs) error {
+	var err error
+	cm := configMap(obj)
+
+	for _, cb := range MakeBindings(pArgs) {
 		err = cm.Value(cb.key, cb.out)
 		if err != nil {
 			return err

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/defaults.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/defaults.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/k8stopologyawareschedwg/podfingerprint"
 	metricssrv "github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/metrics/server"
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcemonitor"
 )
 
 const (
@@ -34,6 +35,7 @@ func SetDefaults(pArgs *ProgArgs) {
 	pArgs.Resourcemonitor.SysfsRoot = "/sys"
 	pArgs.Resourcemonitor.PodSetFingerprint = true
 	pArgs.Resourcemonitor.PodSetFingerprintMethod = podfingerprint.MethodWithExclusiveResources
+	pArgs.Resourcemonitor.NUMAPlacement = resourcemonitor.NUMAPlacementModeContainer
 	pArgs.RTE.SleepInterval = 60 * time.Second
 	pArgs.RTE.KubeletConfigFile = "/podresources/config.yaml"
 	pArgs.RTE.PodResourcesSocketPath = "unix:///podresources/kubelet.sock"

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/flags.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/flags.go
@@ -62,6 +62,7 @@ func FromFlags(pArgs *ProgArgs, args ...string) (string, string, error) {
 	CommandLine.BoolVar(&pArgs.Resourcemonitor.RefreshNodeResources, "refresh-node-resources", pArgs.Resourcemonitor.RefreshNodeResources, "If enable, track changes in node's resources")
 	CommandLine.StringVar(&pArgs.Resourcemonitor.PodSetFingerprintStatusFile, "pods-fingerprint-status-file", pArgs.Resourcemonitor.PodSetFingerprintStatusFile, "File to dump the pods fingerprint status. Use empty string to disable.")
 	CommandLine.BoolVar(&pArgs.Resourcemonitor.ExcludeTerminalPods, "exclude-terminal-pods", pArgs.Resourcemonitor.ExcludeTerminalPods, "If enable, exclude terminal pods from podresource API List call")
+	CommandLine.StringVar(&pArgs.Resourcemonitor.NUMAPlacement, "numa-placement", pArgs.Resourcemonitor.NUMAPlacement, fmt.Sprintf("Select the NUMA placement reporting mode. Use %q to enable container-level NUMA placement in NRT attributes. Use %q to disable.", resourcemonitor.NUMAPlacementModeContainer, resourcemonitor.NUMAPlacementModeNone))
 	CommandLine.StringVar(&pArgs.Resourcemonitor.PodSetFingerprintMethod, "pods-fingerprint-method", pArgs.Resourcemonitor.PodSetFingerprintMethod, fmt.Sprintf("Select the method to compute the pods fingerprint. Valid options: %s.", resourcemonitor.PFPMethodSupported()))
 
 	CommandLine.StringVar(&pArgs.RTE.TopologyManagerPolicy, "topology-manager-policy", pArgs.RTE.TopologyManagerPolicy, "Explicitly set the topology manager policy instead of reading from the kubelet.")

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/validation.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config/validation.go
@@ -40,6 +40,9 @@ func Validate(pArgs *ProgArgs) error {
 	if _, err := resourcemonitor.PFPMethodIsSupported(pArgs.Resourcemonitor.PodSetFingerprintMethod); err != nil {
 		return err
 	}
+	if _, err := resourcemonitor.NUMAPlacementModeIsSupported(pArgs.Resourcemonitor.NUMAPlacement); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcemonitor/resourcemonitor.go
+++ b/vendor/github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcemonitor/resourcemonitor.go
@@ -58,6 +58,9 @@ const (
 	// obtained these values from node e2e tests : https://github.com/kubernetes/kubernetes/blob/82baa26905c94398a0d19e1b1ecf54eb8acb6029/test/e2e_node/util.go#L70
 
 	TopologyManagerPolicySingleNUMANode = "single-numa-node"
+
+	NUMAPlacementModeContainer = "container"
+	NUMAPlacementModeNone      = "none"
 )
 
 type ResourceExclude map[string][]string
@@ -81,6 +84,7 @@ type Args struct {
 	PodSetFingerprintStatusFile string          `json:"podSetFingerprintStatusFile,omitempty"`
 	PodExclude                  podexclude.List `json:"podExclude,omitempty"`
 	ExcludeTerminalPods         bool            `json:"excludeTerminalPods,omitempty"`
+	NUMAPlacement               string          `json:"numaPlacement,omitempty"`
 }
 
 func (args Args) Clone() Args {
@@ -95,6 +99,7 @@ func (args Args) Clone() Args {
 		PodSetFingerprintStatusFile: args.PodSetFingerprintStatusFile,
 		PodExclude:                  args.PodExclude.Clone(),
 		ExcludeTerminalPods:         args.ExcludeTerminalPods,
+		NUMAPlacement:               args.NUMAPlacement,
 	}
 }
 
@@ -310,6 +315,7 @@ func (rm *resourceMonitor) Scan(ctx context.Context, excludeList ResourceExclude
 		Annotations: map[string]string{},
 	}
 
+	containerNUMAPlacementEnabled := (rm.args.NUMAPlacement == NUMAPlacementModeContainer)
 	var payload numaplacement.Payload
 	if rm.args.PodSetFingerprint {
 		st := podfingerprint.MakeStatus(rm.nodeName)
@@ -334,15 +340,17 @@ func (rm *resourceMonitor) Scan(ctx context.Context, excludeList ResourceExclude
 		// numaplacement encoding is only done for pods that are eligible for NUMA placement (with
 		// exclusive resources), which are a subset of pods that are participating in PFP (it is
 		// not always the same pods as PFP because it depends on the filter function used)
-		payload, err = ComputeNUMAPlacementPayload(logger, numaEligiblePodRes, rm.tmPolicy, len(rm.topo.Nodes), rm.coreIDToNodeIDMap)
-		logger.V(2).Info("containers NUMA-placement detection", "error", err)
-		if err == nil {
-			metadata := payload.PackMetadata()
-			scanRes.Attributes = append(scanRes.Attributes, topologyv1alpha2.AttributeInfo{
-				Name:  numaplacement.AttributeMetadata,
-				Value: metadata,
-			})
-			logger.V(6).Info("numaplacement metadata", "metadata", metadata)
+		if containerNUMAPlacementEnabled {
+			payload, err = ComputeNUMAPlacementPayload(logger, numaEligiblePodRes, rm.tmPolicy, len(rm.topo.Nodes), rm.coreIDToNodeIDMap)
+			logger.V(2).Info("containers NUMA-placement detection", "error", err)
+			if err == nil {
+				metadata := payload.PackMetadata()
+				scanRes.Attributes = append(scanRes.Attributes, topologyv1alpha2.AttributeInfo{
+					Name:  numaplacement.AttributeMetadata,
+					Value: metadata,
+				})
+				logger.V(6).Info("numaplacement metadata", "metadata", metadata)
+			}
 		}
 	}
 	allDevs := GetAllContainerDevices(logger, respRawPodRes, rm.args.Namespace, rm.coreIDToNodeIDMap)
@@ -359,12 +367,14 @@ func (rm *resourceMonitor) Scan(ctx context.Context, excludeList ResourceExclude
 			Resources: make(topologyv1alpha2.ResourceInfoList, 0),
 		}
 
-		zoneVector, ok := payload.Vectors[nodeID]
-		if ok {
-			zone.Attributes = append(zone.Attributes, topologyv1alpha2.AttributeInfo{
-				Name:  numaplacement.AttributeVector,
-				Value: zoneVector,
-			})
+		if containerNUMAPlacementEnabled {
+			zoneVector, ok := payload.Vectors[nodeID]
+			if ok {
+				zone.Attributes = append(zone.Attributes, topologyv1alpha2.AttributeInfo{
+					Name:  numaplacement.AttributeVector,
+					Value: zoneVector,
+				})
+			}
 		}
 
 		costs, err := makeCostsPerNumaNode(rm.topo.Nodes, nodeID)
@@ -803,6 +813,17 @@ func PFPMethodIsSupported(value string) (string, error) {
 		return val, nil
 	}
 	return val, fmt.Errorf("unsupported method  %q", value)
+}
+
+// NUMAPlacementModeIsSupported checks that value is a recognised NUMA placement
+// reporting mode: NUMAPlacementModeContainer or NUMAPlacementModeNone. Unlike the
+// other IsSupported helpers, the empty string is not a valid value: the mode must
+// be set explicitly.
+func NUMAPlacementModeIsSupported(value string) (string, error) {
+	if value == NUMAPlacementModeContainer || value == NUMAPlacementModeNone {
+		return value, nil
+	}
+	return value, fmt.Errorf("unsupported numa placement mode %q: must be %q or %q", value, NUMAPlacementModeContainer, NUMAPlacementModeNone)
 }
 
 func mapIntIntToString(mii map[int]int) string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -203,7 +203,7 @@ github.com/k8stopologyawareschedwg/numaplacement/leb89
 # github.com/k8stopologyawareschedwg/podfingerprint v0.2.3
 ## explicit; go 1.18
 github.com/k8stopologyawareschedwg/podfingerprint
-# github.com/k8stopologyawareschedwg/resource-topology-exporter v0.25.0
+# github.com/k8stopologyawareschedwg/resource-topology-exporter v0.25.1
 ## explicit; go 1.25.0
 github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/config
 github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/dump


### PR DESCRIPTION
RTE provides an flag to control NUMA placement reporting in NRT. This is particularly handy to disable NRT scheduler preemption because we know that the scheduler needs the conatiners localities to operate on postFilter preemption, and when NUMA placement data is not provided it will do the normal flow of filtering without any eviction. The goal of this is to have a backup path in case any false evictions are happening, especially because the preemption is enabled by default.

AI-attribution: AIA PAI Hin R Cursor 3.1.7 v1.0