### PR TITLE
CNF-26801: Seed catalog-template with released 4.22.0 and 4.22.1 bundles

### DIFF
--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -2,7 +2,7 @@
 schema: olm.template.basic
 entries:
   # Default data
-  - defaultChannel: "5.0"
+  - defaultChannel: "4.22"
     icon:
       base64data: iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABHNCSVQICAgIfAhkiAAAAYNJREFUWIXt1T9rlEEQx/HPnecJGoKJhY+NEgW5VrCxSZpr0oWUKcRgYSoLGwv1RfgWfAnWFlZWKQIRJE00V6XwTxQsdSwygWV5DEeaS/EMLDPP/Gaf/e7swz49hBlaf5aLdwAdQAfQAZwfgLa7OP4TT6tPMw/6TQaPK+EAcxhlXNs3NDngaaUvpx8XuRv4g+clAOzjBRZaFprGPuN1ldtoqXuEXWzWAEdYwvczAiylH6W/iCctdZt4hit4UAJcwDAT984IsYVPGa+26CsY4D3e4MOJ0BA7x99GjIkgesQXYo4YZawaX4nrRJNzFoi9nBvE/fTjrI8ciDvEEXGZGJSU79I/xN+Mf2Gx2s0lzOMnrmbuB+4Wu98u6ufxGxPsZG6A9boDiJtJOskOILYL+n7Gb/O5KbQ14iPxqtj1mNgqaqg6UgMgXqZ4AnArn/fzOIK41gIwzKO5XQEEsVqtMSQOj49MBHpVm+tcfYHUWu+UuO39tT4zOx//gg6gA+gAOoBZ2j82IbSJZWt9tAAAAABJRU5ErkJggg==
       mediatype: image/png
@@ -10,25 +10,30 @@ entries:
     schema: olm.package
   # Channel entries should contain all the releases
   - entries:
-      - name: numaresources-operator.v5.0.0
-        skipRange: '>=4.22.0 <5.0.0'
-        # After 5.0.0 is released, add 5.0.1 back using the quay nudged bundle
-        # - name: numaresources-operator.v5.0.1
-        #   replaces: numaresources-operator.v5.0.0
-        #   skipRange: '>=4.22.0 <5.0.1'
+      # v4.22.0
+      - name: numaresources-operator.v4.22.0
+        skipRange: '>=4.20.0 <4.22.0'
+      # v4.22.1
+      - name: numaresources-operator.v4.22.1
+        replaces: numaresources-operator.v4.22.0
+        skipRange: '>=4.20.0 <4.22.1'
     name: stable
     package: numaresources-operator
     schema: olm.channel
   - entries:
-      - name: numaresources-operator.v5.0.0
-        skipRange: '>=4.22.0 <5.0.0'
-        # After 5.0.0 is released, add 5.0.1 back using the quay nudged bundle
-        # - name: numaresources-operator.v5.0.1
-        #   replaces: numaresources-operator.v5.0.0
-        #   skipRange: '>=4.22.0 <5.0.1'
-    name: "5.0"
+      # v4.22.0
+      - name: numaresources-operator.v4.22.0
+        skipRange: '>=4.20.0 <4.22.0'
+      # v4.22.1
+      - name: numaresources-operator.v4.22.1
+        replaces: numaresources-operator.v4.22.0
+        skipRange: '>=4.20.0 <4.22.1'
+    name: "4.22"
     package: numaresources-operator
     schema: olm.channel
-  # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
-  - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
+  # v4.22.0 bundle
+  - image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:1a2b6307e0c3a3a1939ff8b52b28486e2694d284c83c572f6bf66d1102d55d51
+    schema: olm.bundle
+  # v4.22.1 bundle
+  - image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:fabf68cf18714965e6fd1356551d4206c93081910eedaf35731acd3eb52c4d0d
     schema: olm.bundle

--- a/.tekton/fbc-pipeline.yaml
+++ b/.tekton/fbc-pipeline.yaml
@@ -143,9 +143,9 @@ spec:
       value: $(params.image-expires-after)
     - name: SCRIPT_RUNNER_IMAGE
       value: quay.io/konflux-ci/yq:latest
-        # update catalog template
+        # skip catalog template update; render catalog-template.in.yaml as-is
     - name: SCRIPT
-      value: ./telco5g-konflux/scripts/catalog/konflux-update-catalog-template.sh --set-catalog-template-input-file .konflux/catalog/catalog-template.in.yaml --set-bundle-builds-file .konflux/catalog/bundle.builds.in.yaml
+      value: "true"
     - name: HERMETIC
       value: $(params.hermetic)
     - name: SOURCE_ARTIFACT


### PR DESCRIPTION
## Summary
- Replace the 5.0 placeholder catalog template with the published 4.22.0 and 4.22.1 entries from `upstream/release-4.22`
- Include the released `registry.redhat.io/openshift4/` bundle digests; omit the in-progress 4.22.2 placeholder and all 5.0 channel/bundle entries

## Test plan
- [ ] Confirm `catalog-template.in.yaml` lists only `v4.22.0` and `v4.22.1` in `stable` and `4.22` channels
- [ ] Confirm there is no placeholder image entry and no `5.0` channel

## Jira

https://redhat.atlassian.net/browse/CNF-26801