### PR TITLE
CNF-26801: Revert catalog-template 4.22 seed after FBC release

### DIFF
--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -2,7 +2,7 @@
 schema: olm.template.basic
 entries:
   # Default data
-  - defaultChannel: "4.22"
+  - defaultChannel: "5.0"
     icon:
       base64data: iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABHNCSVQICAgIfAhkiAAAAYNJREFUWIXt1T9rlEEQx/HPnecJGoKJhY+NEgW5VrCxSZpr0oWUKcRgYSoLGwv1RfgWfAnWFlZWKQIRJE00V6XwTxQsdSwygWV5DEeaS/EMLDPP/Gaf/e7swz49hBlaf5aLdwAdQAfQAZwfgLa7OP4TT6tPMw/6TQaPK+EAcxhlXNs3NDngaaUvpx8XuRv4g+clAOzjBRZaFprGPuN1ldtoqXuEXWzWAEdYwvczAiylH6W/iCctdZt4hit4UAJcwDAT984IsYVPGa+26CsY4D3e4MOJ0BA7x99GjIkgesQXYo4YZawaX4nrRJNzFoi9nBvE/fTjrI8ciDvEEXGZGJSU79I/xN+Mf2Gx2s0lzOMnrmbuB+4Wu98u6ufxGxPsZG6A9boDiJtJOskOILYL+n7Gb/O5KbQ14iPxqtj1mNgqaqg6UgMgXqZ4AnArn/fzOIK41gIwzKO5XQEEsVqtMSQOj49MBHpVm+tcfYHUWu+UuO39tT4zOx//gg6gA+gAOoBZ2j82IbSJZWt9tAAAAABJRU5ErkJggg==
       mediatype: image/png
@@ -10,30 +10,25 @@ entries:
     schema: olm.package
   # Channel entries should contain all the releases
   - entries:
-      # v4.22.0
-      - name: numaresources-operator.v4.22.0
-        skipRange: '>=4.20.0 <4.22.0'
-      # v4.22.1
-      - name: numaresources-operator.v4.22.1
-        replaces: numaresources-operator.v4.22.0
-        skipRange: '>=4.20.0 <4.22.1'
+      - name: numaresources-operator.v5.0.0
+        skipRange: '>=4.22.0 <5.0.0'
+        # After 5.0.0 is released, add 5.0.1 back using the quay nudged bundle
+        # - name: numaresources-operator.v5.0.1
+        #   replaces: numaresources-operator.v5.0.0
+        #   skipRange: '>=4.22.0 <5.0.1'
     name: stable
     package: numaresources-operator
     schema: olm.channel
   - entries:
-      # v4.22.0
-      - name: numaresources-operator.v4.22.0
-        skipRange: '>=4.20.0 <4.22.0'
-      # v4.22.1
-      - name: numaresources-operator.v4.22.1
-        replaces: numaresources-operator.v4.22.0
-        skipRange: '>=4.20.0 <4.22.1'
-    name: "4.22"
+      - name: numaresources-operator.v5.0.0
+        skipRange: '>=4.22.0 <5.0.0'
+        # After 5.0.0 is released, add 5.0.1 back using the quay nudged bundle
+        # - name: numaresources-operator.v5.0.1
+        #   replaces: numaresources-operator.v5.0.0
+        #   skipRange: '>=4.22.0 <5.0.1'
+    name: "5.0"
     package: numaresources-operator
     schema: olm.channel
-  # v4.22.0 bundle
-  - image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:1a2b6307e0c3a3a1939ff8b52b28486e2694d284c83c572f6bf66d1102d55d51
-    schema: olm.bundle
-  # v4.22.1 bundle
-  - image: registry.redhat.io/openshift4/numaresources-operator-bundle@sha256:fabf68cf18714965e6fd1356551d4206c93081910eedaf35731acd3eb52c4d0d
+  # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
+  - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle

--- a/.tekton/fbc-pipeline.yaml
+++ b/.tekton/fbc-pipeline.yaml
@@ -143,9 +143,9 @@ spec:
       value: $(params.image-expires-after)
     - name: SCRIPT_RUNNER_IMAGE
       value: quay.io/konflux-ci/yq:latest
-        # skip catalog template update; render catalog-template.in.yaml as-is
+        # update catalog template
     - name: SCRIPT
-      value: "true"
+      value: ./telco5g-konflux/scripts/catalog/konflux-update-catalog-template.sh --set-catalog-template-input-file .konflux/catalog/catalog-template.in.yaml --set-bundle-builds-file .konflux/catalog/bundle.builds.in.yaml
     - name: HERMETIC
       value: $(params.hermetic)
     - name: SOURCE_ARTIFACT


### PR DESCRIPTION
## Summary
- Revert the 4.22.0/4.22.1 catalog seed from #5134 now that the 5.0 FBC snapshot has been released
- Restore the 5.0 placeholder catalog template and re-enable `konflux-update-catalog-template.sh` in the FBC pipeline

## Test plan
- [ ] Confirm `catalog-template.in.yaml` has `defaultChannel: "5.0"`, `stable`/`5.0` channels with `v5.0.0`, and the placeholder bundle image
- [ ] Confirm `.tekton/fbc-pipeline.yaml` runs `konflux-update-catalog-template.sh` again

## Jira

https://redhat.atlassian.net/browse/CNF-26801


Made with [Cursor](https://cursor.com)