### PR TITLE
pkg: introduce and use the iter package

### DIFF
--- a/api/v1/numaresourcesoperator_types.go
+++ b/api/v1/numaresourcesoperator_types.go
@@ -18,6 +18,7 @@ package v1
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 
@@ -299,11 +300,7 @@ func (ng *NodeGroup) ToString() string {
 
 func annsToString(anns map[string]string) string {
 	items := make([]string, 0, len(anns))
-	keys := make([]string, 0, len(anns)) // TODO: use `keys := slices.Collect(maps.Keys(anns))` when we move to 1.23
-	for key := range anns {
-		keys = append(keys, key)
-	}
-	slices.Sort(keys)
+	keys := slices.Sorted(maps.Keys(anns))
 	for _, key := range keys {
 		items = append(items, key+"="+anns[key])
 	}

--- a/internal/baseload/baseload.go
+++ b/internal/baseload/baseload.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/openshift-kni/numaresources-operator/internal/podlist"
 	"github.com/openshift-kni/numaresources-operator/internal/resourcelist"
+	nroiter "github.com/openshift-kni/numaresources-operator/pkg/iter"
 )
 
 type Load struct {
@@ -50,7 +51,7 @@ func FromPods(nodeName string, pods []corev1.Pod) Load {
 
 	for _, pod := range pods {
 		// TODO: we assume a steady state - aka we ignore InitContainers
-		for _, cnt := range pod.Spec.Containers {
+		for cnt := range nroiter.OnContainers(&pod.Spec, nroiter.Containers) {
 			for resName, resQty := range cnt.Resources.Requests {
 				qty := nl.Resources[resName]
 				qty.Add(resQty)

--- a/internal/controller/numaresourcesoperator_controller_test.go
+++ b/internal/controller/numaresourcesoperator_controller_test.go
@@ -56,6 +56,7 @@ import (
 	testobjs "github.com/openshift-kni/numaresources-operator/internal/objects"
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
 	"github.com/openshift-kni/numaresources-operator/pkg/images"
+	nroiter "github.com/openshift-kni/numaresources-operator/pkg/iter"
 	rtemetricsmanifests "github.com/openshift-kni/numaresources-operator/pkg/metrics/manifests/monitor"
 	nrosched "github.com/openshift-kni/numaresources-operator/pkg/numaresourcesscheduler"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectnames"
@@ -2527,7 +2528,7 @@ var _ = Describe("Test NUMAResourcesOperator Reconcile", func() {
 			var ds appsv1.DaemonSet
 			Expect(reconciler.Client.Get(context.TODO(), dsKey, &ds)).To(Succeed())
 
-			for _, cnt := range ds.Spec.Template.Spec.Containers {
+			for cnt := range nroiter.OnContainers(&ds.Spec.Template.Spec, nroiter.Containers) {
 				Expect(cnt.TerminationMessagePolicy).To(Equal(corev1.TerminationMessageFallbackToLogsOnError))
 			}
 		})

--- a/pkg/images/fetch.go
+++ b/pkg/images/fetch.go
@@ -25,6 +25,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil"
+
+	"github.com/openshift-kni/numaresources-operator/pkg/iter"
 )
 
 const (
@@ -72,8 +74,7 @@ func findContainerByName(pod *corev1.Pod, containerName string) (*corev1.Contain
 		return &pod.Spec.Containers[0], nil
 	}
 
-	for idx := 0; idx < len(pod.Spec.Containers); idx++ {
-		cnt := &pod.Spec.Containers[idx]
+	for cnt := range iter.OnContainers(&pod.Spec, iter.Containers) {
 		if cnt.Name == containerName {
 			return cnt, nil
 		}

--- a/pkg/iter/iter.go
+++ b/pkg/iter/iter.go
@@ -1,0 +1,61 @@
+package iter
+
+import (
+	"iter"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// ContainerType signifies container type
+type ContainerType int
+
+const (
+	// Containers is for normal containers
+	Containers ContainerType = 1 << iota
+	// InitContainers is for init containers
+	InitContainers
+	// EphemeralContainers is for ephemeral containers
+	EphemeralContainers
+)
+
+func (ct ContainerType) String() string {
+	switch ct {
+	case Containers:
+		return "app"
+	case InitContainers:
+		return "init"
+	case EphemeralContainers:
+		return "eph"
+	default:
+		return "UNK"
+	}
+}
+
+// OnContainers is a clone of k8s.io/kubernetes/pkg/api/v1/pod.ContainerIter 1.37.0
+// ContainerIter returns an iterator over all containers in the given pod spec with a masked type.
+// The iteration order is InitContainers, then main Containers, then EphemeralContainers.
+func OnContainers(podSpec *v1.PodSpec, mask ContainerType) iter.Seq2[*v1.Container, ContainerType] {
+	return func(yield func(*v1.Container, ContainerType) bool) {
+		if mask&InitContainers != 0 {
+			for i := range podSpec.InitContainers {
+				if !yield(&podSpec.InitContainers[i], InitContainers) {
+					return
+				}
+			}
+		}
+		if mask&Containers != 0 {
+			for i := range podSpec.Containers {
+				if !yield(&podSpec.Containers[i], Containers) {
+					return
+				}
+			}
+		}
+		if mask&EphemeralContainers != 0 {
+			for i := range podSpec.EphemeralContainers {
+				if !yield((*v1.Container)(&podSpec.EphemeralContainers[i].EphemeralContainerCommon), EphemeralContainers) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -36,6 +36,7 @@ import (
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
 	"github.com/openshift-kni/numaresources-operator/pkg/hash"
+	nroiter "github.com/openshift-kni/numaresources-operator/pkg/iter"
 	"github.com/openshift-kni/numaresources-operator/pkg/objectupdate/envvar"
 	objtls "github.com/openshift-kni/numaresources-operator/pkg/objectupdate/tls"
 )
@@ -260,8 +261,7 @@ func ContainerConfig(ds *appsv1.DaemonSet, name string) error {
 }
 
 func AllContainersTerminationMessagePolicy(ds *appsv1.DaemonSet) {
-	for idx := range ds.Spec.Template.Spec.Containers {
-		cnt := &ds.Spec.Template.Spec.Containers[idx]
+	for cnt := range nroiter.OnContainers(&ds.Spec.Template.Spec, nroiter.Containers) {
 		oldPolicy := cnt.TerminationMessagePolicy
 		cnt.TerminationMessagePolicy = corev1.TerminationMessageFallbackToLogsOnError
 		klog.V(5).InfoS("container termination message policy", "container", cnt.Name, "previous", oldPolicy, "current", cnt.TerminationMessagePolicy)

--- a/pkg/objectupdate/rte/rte_test.go
+++ b/pkg/objectupdate/rte/rte_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
+	nroiter "github.com/openshift-kni/numaresources-operator/pkg/iter"
 	objtls "github.com/openshift-kni/numaresources-operator/pkg/objectupdate/tls"
 )
 
@@ -470,7 +471,7 @@ func TestAllContainersTerminationMessagePolicy(t *testing.T) {
 	ds := testDs.DeepCopy()
 	AllContainersTerminationMessagePolicy(ds)
 
-	for _, cnt := range ds.Spec.Template.Spec.Containers {
+	for cnt := range nroiter.OnContainers(&ds.Spec.Template.Spec, nroiter.Containers) {
 		if cnt.TerminationMessagePolicy != corev1.TerminationMessageFallbackToLogsOnError {
 			t.Errorf("container %q termination message policy unexpectedly set to %q", cnt.Name, cnt.TerminationMessagePolicy)
 		}

--- a/test/e2e/install/install_test.go
+++ b/test/e2e/install/install_test.go
@@ -48,6 +48,7 @@ import (
 	nropmcp "github.com/openshift-kni/numaresources-operator/internal/machineconfigpools"
 	"github.com/openshift-kni/numaresources-operator/internal/podlogs"
 	nrowait "github.com/openshift-kni/numaresources-operator/internal/wait"
+	nroiter "github.com/openshift-kni/numaresources-operator/pkg/iter"
 	"github.com/openshift-kni/numaresources-operator/pkg/loglevel"
 	"github.com/openshift-kni/numaresources-operator/pkg/status"
 	rteconfig "github.com/openshift-kni/numaresources-operator/rte/pkg/config"
@@ -327,7 +328,7 @@ var _ = Describe("[Install] durability", Serial, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			unrestricted := false
-			for _, cnt := range nropPod.Spec.Containers {
+			for cnt := range nroiter.OnContainers(&nropPod.Spec, nroiter.Containers) {
 				for _, env := range cnt.Env {
 					if env.Name == "EXPORTER_IMAGE_RESTRICTION" && env.Value == "false" {
 						unrestricted = true

--- a/test/e2e/serial/tests/introspection.go
+++ b/test/e2e/serial/tests/introspection.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	nropv1 "github.com/openshift-kni/numaresources-operator/api/v1"
+	nroiter "github.com/openshift-kni/numaresources-operator/pkg/iter"
 	"github.com/openshift-kni/numaresources-operator/test/e2e/label"
 	e2eclient "github.com/openshift-kni/numaresources-operator/test/internal/clients"
 	"github.com/openshift-kni/numaresources-operator/test/internal/deploy"
@@ -49,7 +50,7 @@ var _ = Describe("[serial] numaresources operator introspection", Serial, Label(
 			pod, err := deploy.FindNUMAResourcesOperatorPod(ctx, e2eclient.Client, &nropObj)
 			Expect(err).ToNot(HaveOccurred())
 
-			for _, cnt := range pod.Spec.Containers {
+			for cnt := range nroiter.OnContainers(&pod.Spec, nroiter.Containers) {
 				Expect(cnt.TerminationMessagePolicy).To(Equal(corev1.TerminationMessageFallbackToLogsOnError))
 			}
 		})
@@ -61,7 +62,7 @@ var _ = Describe("[serial] numaresources operator introspection", Serial, Label(
 			Expect(dss).ToNot(BeEmpty(), "unexpected DaemonSet count: %d", len(dss))
 
 			for _, ds := range dss {
-				for _, cnt := range ds.Spec.Template.Spec.Containers {
+				for cnt := range nroiter.OnContainers(&ds.Spec.Template.Spec, nroiter.Containers) {
 					Expect(cnt.TerminationMessagePolicy).To(Equal(corev1.TerminationMessageFallbackToLogsOnError))
 				}
 			}

--- a/test/e2e/serial/tests/scheduler_cache_stall.go
+++ b/test/e2e/serial/tests/scheduler_cache_stall.go
@@ -37,6 +37,7 @@ import (
 	intnrt "github.com/openshift-kni/numaresources-operator/internal/noderesourcetopology"
 	e2ereslist "github.com/openshift-kni/numaresources-operator/internal/resourcelist"
 	"github.com/openshift-kni/numaresources-operator/internal/wait"
+	nroiter "github.com/openshift-kni/numaresources-operator/pkg/iter"
 	"github.com/openshift-kni/numaresources-operator/test/e2e/label"
 	serialconfig "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 	e2efixture "github.com/openshift-kni/numaresources-operator/test/internal/fixture"
@@ -531,8 +532,7 @@ var _ = Describe("[serial][scheduler][cache] scheduler cache stall", Label("sche
 						corev1.ResourceCPU:    resource.MustParse("100m"),
 						corev1.ResourceMemory: resource.MustParse("256Mi"),
 					}
-					for idx := 0; idx < len(idleJob.Spec.Template.Spec.Containers); idx++ {
-						cnt := &idleJob.Spec.Template.Spec.Containers[idx] // shortcut
+					for cnt := range nroiter.OnContainers(&idleJob.Spec.Template.Spec, nroiter.Containers) {
 						cnt.Resources = corev1.ResourceRequirements{
 							Requests: jobRequiredRes,
 						}
@@ -547,8 +547,7 @@ var _ = Describe("[serial][scheduler][cache] scheduler cache stall", Label("sche
 						corev1.ResourceCPU:    resource.MustParse("100m"),
 						corev1.ResourceMemory: resource.MustParse("256Mi"),
 					}
-					for idx := 0; idx < len(idleJob.Spec.Template.Spec.Containers); idx++ {
-						cnt := &idleJob.Spec.Template.Spec.Containers[idx] // shortcut
+					for cnt := range nroiter.OnContainers(&idleJob.Spec.Template.Spec, nroiter.Containers) {
 						cnt.Resources = corev1.ResourceRequirements{
 							Limits: jobRequiredRes,
 						}
@@ -560,8 +559,7 @@ var _ = Describe("[serial][scheduler][cache] scheduler cache stall", Label("sche
 						corev1.ResourceCPU:    resource.MustParse("1"),
 						corev1.ResourceMemory: resource.MustParse("256Mi"),
 					}
-					for idx := 0; idx < len(idleJob.Spec.Template.Spec.Containers); idx++ {
-						cnt := &idleJob.Spec.Template.Spec.Containers[idx] // shortcut
+					for cnt := range nroiter.OnContainers(&idleJob.Spec.Template.Spec, nroiter.Containers) {
 						cnt.Resources = corev1.ResourceRequirements{
 							Limits: jobRequiredRes,
 						}
@@ -682,11 +680,8 @@ var _ = Describe("[serial][scheduler][cache] scheduler cache stall", Label("sche
 })
 
 func dumpPodResources(pod *corev1.Pod) {
-	for _, ctr := range pod.Spec.InitContainers {
-		klog.InfoS("dump pod resources", "pod", pod.Namespace+"/"+pod.Name, "init container", ctr.Name, "node", pod.Spec.NodeName, "resourceRequests", e2ereslist.ToString(ctr.Resources.Requests), "resourceLimits", e2ereslist.ToString(ctr.Resources.Limits))
-	}
-	for _, ctr := range pod.Spec.Containers {
-		klog.InfoS("dump pod resources", "pod", pod.Namespace+"/"+pod.Name, "app container", ctr.Name, "node", pod.Spec.NodeName, "resourceRequests", e2ereslist.ToString(ctr.Resources.Requests), "resourceLimits", e2ereslist.ToString(ctr.Resources.Limits))
+	for ctr, ctrType := range nroiter.OnContainers(&pod.Spec, nroiter.InitContainers|nroiter.Containers) {
+		klog.InfoS("dump pod resources", "pod", pod.Namespace+"/"+pod.Name, "containerType", ctrType, "containerName", ctr.Name, "node", pod.Spec.NodeName, "resourceRequests", e2ereslist.ToString(ctr.Resources.Requests), "resourceLimits", e2ereslist.ToString(ctr.Resources.Limits))
 	}
 }
 

--- a/test/internal/objects/pod.go
+++ b/test/internal/objects/pod.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/openshift-kni/numaresources-operator/internal/resourcelist"
+	nroiter "github.com/openshift-kni/numaresources-operator/pkg/iter"
 	"github.com/openshift-kni/numaresources-operator/test/internal/images"
 )
 
@@ -105,10 +106,7 @@ func GetEventsForPod(k8sCli kubernetes.Interface, podNamespace, podName string) 
 func DumpPODResourceRequirements(pod *corev1.Pod) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "resource requirements for pod %s/%s:\n", pod.Namespace, pod.Name)
-	allContainers := []corev1.Container{}
-	allContainers = append(allContainers, pod.Spec.Containers...)
-	allContainers = append(allContainers, pod.Spec.InitContainers...)
-	for _, container := range allContainers {
+	for container := range nroiter.OnContainers(&pod.Spec, nroiter.InitContainers|nroiter.Containers) {
 		fmt.Fprintf(&sb, "+- container %q: %s\n", container.Name, resourcelist.ToString(container.Resources.Limits))
 	}
 	fmt.Fprintf(&sb, "---\n")


### PR DESCRIPTION
the iter package borrows the code from podutil.ContainerIter,
to make us avoid to depend (again) on `k8s.io/kubernetes`.

Besides trivial rename, the package is intentional backward compatible
with the borrowed kube code; we may consider to extend in the future.

The benefit of this approach (iterator) is the following:
the pre-iterator standard pattern of using `append(pod.Spec.InitContainers, pod.Spec.Containers...)`
to iterate over containers was causeing allocation of backing slices and
copies, creating GC pressure.

We now have a kube utility to iterate in place, let's use it.
No intended change of behavior.
Note: this means the previous code MUST not mutate containers - that was
never the intent anyway, but this change may now expose latent hidden bugs.