### PR TITLE
chore: fix iterator copyright boilerplate

### DIFF
--- a/pkg/iter/iter.go
+++ b/pkg/iter/iter.go
@@ -1,3 +1,21 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+taken from github.com/kubernetes/kubernetes/pkg/api/pod/util.go@f54c212e3a2f75d674b717a9b29052b20b60aefc
+*/
+
 package iter
 
 import (


### PR DESCRIPTION
it was already easily inferrable, but let's make it really obvious and explicit.

followup of #5179