### PR TITLE
konflux: update golang builders to 1.26

### DIFF
--- a/.konflux/must-gather/must-gather.konflux.Dockerfile
+++ b/.konflux/must-gather/must-gather.konflux.Dockerfile
@@ -1,5 +1,5 @@
 # follow https://brewweb.engineering.redhat.com/brew/packageinfo?packageID=70135
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25@sha256:c5d1bbc9c6ba9403017a30c2c71e9e28c9f43ffed2e60573a6de20e8ac753689 as tool-builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26@sha256:e74b03198cccc24c24a27071ad4d6c2edcfe0bb10c6de99c609ce6e3c06d6d04 as tool-builder
 
 WORKDIR /go/src/github.com/openshift-kni/numaresources-operator
 COPY . .

--- a/.konflux/operator/konflux.Dockerfile
+++ b/.konflux/operator/konflux.Dockerfile
@@ -1,5 +1,5 @@
 # follow https://brewweb.engineering.redhat.com/brew/packageinfo?packageID=70135
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25@sha256:c5d1bbc9c6ba9403017a30c2c71e9e28c9f43ffed2e60573a6de20e8ac753689 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26@sha256:e74b03198cccc24c24a27071ad4d6c2edcfe0bb10c6de99c609ce6e3c06d6d04 as builder
 
 WORKDIR /go/src/github.com/openshift-kni/numaresources-operator
 COPY . .


### PR DESCRIPTION
Bump the golang builders in the konflux Dockerfiles to 1.26, aligned with the upstream Dockerfile updates.